### PR TITLE
fix(ui): clean up timed-out channel wizard starts

### DIFF
--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -131,6 +131,67 @@ describe("ChannelWizardController", () => {
     expect(cancelled).toContain("s-stale");
   });
 
+  it("cancels a session created after a local start timeout so retry can proceed", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveFirstStart: (value: unknown) => void = () => {};
+      let runningSession: string | null = null;
+      let startCount = 0;
+      const { controller, request } = createController(async (method, params) => {
+        if (method === "wizard.start") {
+          startCount += 1;
+          if (startCount === 1) {
+            runningSession = "s-timeout";
+            return await new Promise((resolve) => {
+              resolveFirstStart = resolve;
+            });
+          }
+          if (runningSession) {
+            throw new Error("wizard already running");
+          }
+          return { sessionId: "s-retry", done: false, status: "running", step: selectStep };
+        }
+        if (method === "wizard.cancel") {
+          const sessionId = (params as { sessionId?: string }).sessionId;
+          if (sessionId === runningSession) {
+            runningSession = null;
+          }
+          return { status: "cancelled" };
+        }
+        throw new Error(`unexpected ${method}`);
+      });
+
+      const timedOutStart = controller.start("telegram");
+      await vi.advanceTimersByTimeAsync(120_000);
+      await timedOutStart;
+      expect(controller.state).toMatchObject({
+        phase: "error",
+        message: "Error: wizard request timed out: wizard.start",
+      });
+
+      resolveFirstStart({
+        sessionId: "s-timeout",
+        done: false,
+        status: "running",
+        step: selectStep,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(request).toHaveBeenCalledWith("wizard.cancel", { sessionId: "s-timeout" });
+      expect(runningSession).toBeNull();
+
+      await controller.start("telegram");
+      expect(startCount).toBe(2);
+      expect(controller.state).toMatchObject({
+        phase: "step",
+        step: { id: "step-select" },
+        busy: false,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses the gateway-reported channels for completion", async () => {
     const { controller } = createController(async (method) => {
       if (method === "wizard.start") {

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -192,6 +192,36 @@ describe("ChannelWizardController", () => {
     }
   });
 
+  it("does not cancel a terminal start result that arrives after the local timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveStart: (value: unknown) => void = () => {};
+      const { controller, request } = createController(async (method) => {
+        if (method === "wizard.start") {
+          return await new Promise((resolve) => {
+            resolveStart = resolve;
+          });
+        }
+        if (method === "wizard.cancel") {
+          return { status: "cancelled" };
+        }
+        throw new Error(`unexpected ${method}`);
+      });
+
+      const timedOutStart = controller.start("telegram");
+      await vi.advanceTimersByTimeAsync(120_000);
+      await timedOutStart;
+
+      resolveStart({ sessionId: "s-done", done: true, status: "done" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(request.mock.calls.filter(([method]) => method === "wizard.cancel")).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses the gateway-reported channels for completion", async () => {
     const { controller } = createController(async (method) => {
       if (method === "wizard.start") {

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -6,21 +6,29 @@ type WizardGatewayClient = {
 };
 
 // The browser gateway client does not expose per-request timeouts, so race a
-// local ceiling; stale late responses are cleaned up by the generation guard.
+// local ceiling; timed-out or superseded late responses are cleaned up explicitly.
 async function requestWithTimeout<T>(
   client: WizardGatewayClient,
   method: string,
   params: unknown,
+  onLateResult?: (result: T) => void,
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const request = client.request<T>(method, params).then((result) => {
+    if (timedOut) {
+      onLateResult?.(result);
+    }
+    return result;
+  });
   try {
     return await Promise.race([
-      client.request<T>(method, params),
+      request,
       new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`wizard request timed out: ${method}`)),
-          WIZARD_STEP_TIMEOUT_MS,
-        );
+        timer = setTimeout(() => {
+          timedOut = true;
+          reject(new Error(`wizard request timed out: ${method}`));
+        }, WIZARD_STEP_TIMEOUT_MS);
       }),
     ]);
   } finally {
@@ -114,10 +122,23 @@ export class ChannelWizardController {
     this.stepIndex = 0;
     this.setState({ phase: "starting", channel });
     try {
-      const result = await requestWithTimeout<WizardNextResult>(client, "wizard.start", {
-        flow: "channels",
-        ...(channel ? { channel } : {}),
-      });
+      const result = await requestWithTimeout<WizardNextResult>(
+        client,
+        "wizard.start",
+        {
+          flow: "channels",
+          ...(channel ? { channel } : {}),
+        },
+        (lateResult) => {
+          // A local timeout cannot stop the gateway request. If it eventually
+          // creates a running session, release it so a retry is not blocked.
+          if (lateResult.sessionId && !lateResult.done) {
+            void client
+              .request("wizard.cancel", { sessionId: lateResult.sessionId })
+              .catch(() => {});
+          }
+        },
+      );
       if (this.generation !== generation) {
         // The modal was closed/superseded mid-start, but the gateway already
         // created a running session; cancel it or later starts get rejected.

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -5,8 +5,8 @@ type WizardGatewayClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
 };
 
-// The browser gateway client does not expose per-request timeouts, so race a
-// local ceiling; timed-out or superseded late responses are cleaned up explicitly.
+// Keep the wire request alive behind a local ceiling: protocol-level timeouts
+// discard late responses, but wizard.start carries the session id needed for cleanup.
 async function requestWithTimeout<T>(
   client: WizardGatewayClient,
   method: string,
@@ -67,6 +67,15 @@ type WizardNextResult = {
   channels?: string[];
   accounts?: Array<{ channel: string; accountId: string }>;
 };
+
+function cancelRunningWizardResult(client: WizardGatewayClient, result: WizardNextResult): void {
+  if (!result.sessionId || result.done) {
+    return;
+  }
+  // A start response can outlive its owning UI generation. Release only live
+  // sessions; the gateway already purges terminal results before responding.
+  void client.request("wizard.cancel", { sessionId: result.sessionId }).catch(() => {});
+}
 
 export type ChannelWizardState =
   | { phase: "idle" }
@@ -129,22 +138,12 @@ export class ChannelWizardController {
           flow: "channels",
           ...(channel ? { channel } : {}),
         },
-        (lateResult) => {
-          // A local timeout cannot stop the gateway request. If it eventually
-          // creates a running session, release it so a retry is not blocked.
-          if (lateResult.sessionId && !lateResult.done) {
-            void client
-              .request("wizard.cancel", { sessionId: lateResult.sessionId })
-              .catch(() => {});
-          }
-        },
+        (lateResult) => cancelRunningWizardResult(client, lateResult),
       );
       if (this.generation !== generation) {
         // The modal was closed/superseded mid-start, but the gateway already
         // created a running session; cancel it or later starts get rejected.
-        if (result.sessionId && !result.done) {
-          void client.request("wizard.cancel", { sessionId: result.sessionId }).catch(() => {});
-        }
+        cancelRunningWizardResult(client, result);
         return;
       }
       this.sessionId = result.sessionId ?? null;


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

When a Channel Wizard start request exceeds the Control UI's local timeout, the gateway request keeps running. If its response arrives later with a live session, the UI previously discarded it without cancelling that session, so subsequent setup attempts could fail with `wizard already running`.

## Why This Change Was Made

Observe results that arrive after the local request timeout and cancel any live wizard session they created. The existing generation guard still handles starts superseded by closing or restarting the modal, while the timeout path now has equivalent cleanup.

## User Impact

Channel setup can be retried after a delayed start response instead of remaining blocked by an orphaned Gateway wizard session.

## Evidence

- Fresh exact-head Control UI-to-Gateway browser proof at `0ac768960f595e2d97aea560b4397a3aa4354f45`: the first `wizard.start` was held pending; advancing the browser clock by the production `120000 ms` timeout rendered the real timeout state; a late live response for `s-timeout` emitted exactly one `wizard.cancel({ sessionId: "s-timeout" })`; closing and retrying emitted the second `wizard.start` and reached a live selection step. Final counts: `start = 2`, `cancel = 1`.
- [Inspectable browser timeline, test output, and artifact hashes](https://github.com/IWhatsskill/openclaw/blob/ed608f066165b2fa20b0f64dfd2f6a14c4eef5b5/proof-assets/pr-110146/proof.md)
- Operator-attested exact-head runtime media:

**Timed-out start**

<img width="1440" height="900" alt="timeout" src="https://github.com/user-attachments/assets/47898878-0f62-4bfb-8ac7-4789297e3ce3" />

**Successful retry after late-session cleanup**

<img width="1440" height="900" alt="retry-success" src="https://github.com/user-attachments/assets/a562272a-fdd4-486b-9058-aee99a7a7a17" />

**Timeout and retry video**

[timeout-retry.webm](https://github.com/user-attachments/assets/8d783fdd-3078-47d5-9636-807ab856699a)

- `node node_modules/vitest/vitest.mjs run --root ui --config vitest.config.ts src/pages/channels/wizard-controller.test.ts --reporter=verbose` — 1 file passed, 9 tests passed, including timeout, late result, cancellation, and successful retry.
- `node scripts/run-vitest.mjs src/gateway/gateway.test.ts -t "routes wizard.start flow channels to the channel wizard runner" --reporter=verbose` — 1 real WebSocket Gateway lifecycle test passed (10 unrelated tests skipped).
- The late fire-and-forget `wizard.cancel` call at this head explicitly terminates with `.catch(() => {})`, so a rejected cleanup request is observed and does not create an unhandled rejection.
- `pnpm tsgo:ui` — passed.
- `pnpm exec oxlint ui/src/pages/channels/wizard-controller.ts ui/src/pages/channels/wizard-controller.test.ts` — 0 warnings and 0 errors.
- `pnpm exec oxfmt --check ui/src/pages/channels/wizard-controller.ts ui/src/pages/channels/wizard-controller.test.ts` — passed.
- `git diff --check` — passed.
