### PR TITLE
fix(googlechat): surface reply send failures instead of silently dropping chunks

### DIFF
--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -80,31 +80,27 @@ export async function deliverGoogleChatReply(params: {
     if (!chunk) {
       continue;
     }
-    try {
-      if (firstTextChunk && typingMessage) {
+    if (firstTextChunk && typingMessage) {
+      try {
         await updateGoogleChatMessage({
           account,
           messageName: typingMessage.name,
           text: chunk,
         });
-      } else {
-        await sendTextMessage(chunk);
-      }
-      firstTextChunk = false;
-      statusSink?.({ lastOutboundAt: Date.now() });
-    } catch (err) {
-      runtime.error?.(`Google Chat message send failed: ${String(err)}`);
-      if (firstTextChunk && typingMessage) {
+        firstTextChunk = false;
+        statusSink?.({ lastOutboundAt: Date.now() });
+        continue;
+      } catch (err) {
+        // The typing placeholder may already be gone; resend the chunk as a new
+        // message below. Only the resend failing counts as a delivery failure.
+        runtime.error?.(`Google Chat message send failed: ${String(err)}`);
         typingMessage = undefined;
-        try {
-          await sendTextMessage(chunk);
-          statusSink?.({ lastOutboundAt: Date.now() });
-        } catch (fallbackErr) {
-          runtime.error?.(`Google Chat message fallback send failed: ${String(fallbackErr)}`);
-        } finally {
-          firstTextChunk = false;
-        }
       }
     }
+    // Core delivery contract: a failed send must reject so the reply dispatcher
+    // routes to onError instead of recording a dropped chunk as delivered.
+    await sendTextMessage(chunk);
+    firstTextChunk = false;
+    statusSink?.({ lastOutboundAt: Date.now() });
   }
 }

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -67,6 +67,13 @@ export async function deliverGoogleChatReply(params: {
 
   const chunkLimit = account.config.textChunkLimit ?? 4000;
   const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
+  const recordOutboundStatus = () => {
+    try {
+      statusSink?.({ lastOutboundAt: Date.now() });
+    } catch (err) {
+      runtime.error?.(`Google Chat outbound status update failed: ${String(err)}`);
+    }
+  };
   const sendTextMessage = async (chunk: string) => {
     await sendGoogleChatMessage({
       account,
@@ -87,20 +94,22 @@ export async function deliverGoogleChatReply(params: {
           messageName: typingMessage.name,
           text: chunk,
         });
-        firstTextChunk = false;
-        statusSink?.({ lastOutboundAt: Date.now() });
-        continue;
       } catch (err) {
         // The typing placeholder may already be gone; resend the chunk as a new
         // message below. Only the resend failing counts as a delivery failure.
         runtime.error?.(`Google Chat message send failed: ${String(err)}`);
         typingMessage = undefined;
       }
+      if (typingMessage) {
+        firstTextChunk = false;
+        recordOutboundStatus();
+        continue;
+      }
     }
     // Core delivery contract: a failed send must reject so the reply dispatcher
     // routes to onError instead of recording a dropped chunk as delivered.
     await sendTextMessage(chunk);
     firstTextChunk = false;
-    statusSink?.({ lastOutboundAt: Date.now() });
+    recordOutboundStatus();
   }
 }

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -90,7 +90,7 @@ function createStubHandler(params: { failCreateIndexes: Set<number>; patchStatus
         return;
       }
       const messageMatch = url.pathname.match(/^\/v1\/(spaces\/[^/]+\/messages\/[^/]+)$/);
-      if (req.method === "PATCH" && messageMatch) {
+      if (req.method === "PATCH" && messageMatch?.[1]) {
         patchAttempts.push(messageMatch[1]);
         json(params.patchStatus ?? 200, {
           error: { code: 404, message: "stub: message not found", status: "NOT_FOUND" },

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -1,0 +1,239 @@
+// Google Chat reply delivery failure propagation covered against a real HTTP stub.
+//
+// These tests drive the production stack end to end: deliverGoogleChatReply ->
+// sendGoogleChatMessage -> withGoogleChatResponse -> fetchWithSsrFGuard ->
+// google-auth-library token exchange, with only global fetch stubbed to reroute
+// oauth2.googleapis.com and chat.googleapis.com to a loopback impersonator.
+// The service account key is a throwaway RSA key generated in-process; no real
+// credentials or network access are involved.
+import { generateKeyPairSync } from "node:crypto";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { deliverGoogleChatReply } from "./monitor-reply-delivery.js";
+import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+const account = {
+  accountId: "default",
+  enabled: true,
+  credentialSource: "inline",
+  credentials: {
+    type: "service_account",
+    client_email: "stub-bot@stub-project.iam.gserviceaccount.com",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    auth_uri: "https://accounts.google.com/o/oauth2/auth",
+    token_uri: "https://oauth2.googleapis.com/token",
+    auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+    client_x509_cert_url:
+      "https://www.googleapis.com/robot/v1/metadata/x509/stub-bot%40stub-project.iam.gserviceaccount.com",
+  },
+  config: {},
+} as unknown as ResolvedGoogleChatAccount;
+
+const config = {} as OpenClawConfig;
+
+const CHUNKS = [
+  "First chunk of the assistant reply.",
+  "Second chunk of the assistant reply.",
+  "Third chunk of the assistant reply.",
+];
+
+const core = {
+  channel: {
+    text: {
+      resolveChunkMode: () => "markdown",
+      // Deterministic 3-chunk split standing in for the core chunker; the
+      // chunker is not the changed surface, the per-chunk send loop is.
+      chunkMarkdownTextWithMode: () => CHUNKS,
+    },
+  },
+} as unknown as GoogleChatCoreRuntime;
+
+type CreateAttempt = { text?: string; status: number };
+
+function createStubHandler(params: { failCreateIndexes: Set<number>; patchStatus?: number }) {
+  const createAttempts: CreateAttempt[] = [];
+  const patchAttempts: string[] = [];
+  const handler = (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://stub.invalid");
+      const json = (status: number, payload: unknown) => {
+        res.statusCode = status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(payload));
+      };
+      if (req.method === "POST" && url.pathname === "/token") {
+        json(200, { access_token: "ya29.stub-token", token_type: "Bearer", expires_in: 3600 });
+        return;
+      }
+      const messagesMatch = url.pathname.match(/^\/v1\/(spaces\/[^/]+)\/messages$/);
+      if (req.method === "POST" && messagesMatch) {
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { text?: string };
+        const index = createAttempts.length + 1;
+        const status = params.failCreateIndexes.has(index) ? 500 : 200;
+        createAttempts.push({ text: body.text, status });
+        if (status === 500) {
+          json(500, {
+            error: { code: 500, message: "stub: backend unavailable", status: "INTERNAL" },
+          });
+        } else {
+          json(200, { name: `${messagesMatch[1]}/messages/stub-m${index}` });
+        }
+        return;
+      }
+      const messageMatch = url.pathname.match(/^\/v1\/(spaces\/[^/]+\/messages\/[^/]+)$/);
+      if (req.method === "PATCH" && messageMatch) {
+        patchAttempts.push(messageMatch[1]);
+        json(params.patchStatus ?? 200, {
+          error: { code: 404, message: "stub: message not found", status: "NOT_FOUND" },
+        });
+        return;
+      }
+      json(400, { error: { code: 400, message: "stub: unhandled request" } });
+    });
+  };
+  return { handler, createAttempts, patchAttempts };
+}
+
+function stubGoogleHostsFetch() {
+  const realFetch = globalThis.fetch;
+  let stubBaseUrl: string | undefined;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    const url = new URL(rawUrl);
+    if (url.hostname === "chat.googleapis.com" || url.hostname === "oauth2.googleapis.com") {
+      if (!stubBaseUrl) {
+        throw new Error("stub server base URL not installed");
+      }
+      return await realFetch(`${stubBaseUrl}${url.pathname}${url.search}`, init);
+    }
+    return await realFetch(input, init);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return {
+    fetchMock,
+    pointAtStub: (baseUrl: string) => {
+      stubBaseUrl = baseUrl;
+    },
+  };
+}
+
+type DeliveryOutcome = {
+  outcome: "delivered" | "failed-deliver";
+  deliverError?: unknown;
+  onErrorCalls: Array<{ err: unknown; kind: string }>;
+  errorLines: string[];
+};
+
+async function runDelivery(params: { withTypingMessage?: boolean }): Promise<DeliveryOutcome> {
+  const errorLines: string[] = [];
+  const runtime: GoogleChatRuntimeEnv = {
+    error: (line: string) => {
+      errorLines.push(line);
+    },
+  };
+  const onErrorCalls: Array<{ err: unknown; kind: string }> = [];
+  // Mirror of monitor.ts: the channel deliver callback awaits
+  // deliverGoogleChatReply, and the core reply dispatcher only treats a throw
+  // as a failed delivery (src/auto-reply/reply/reply-dispatcher.ts).
+  try {
+    await deliverGoogleChatReply({
+      payload: { text: CHUNKS.join("\n\n"), replyToId: "spaces/AAA/threads/root" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      ...(params.withTypingMessage
+        ? {
+            typingMessage: {
+              name: "spaces/AAA/messages/typing",
+              thread: "spaces/AAA/threads/root",
+            },
+          }
+        : {}),
+    });
+    return { outcome: "delivered", onErrorCalls, errorLines };
+  } catch (err) {
+    onErrorCalls.push({ err, kind: "text" });
+    return { outcome: "failed-deliver", deliverError: err, onErrorCalls, errorLines };
+  }
+}
+
+describe("Google Chat reply delivery failure propagation (integration)", () => {
+  let fetchControl: ReturnType<typeof stubGoogleHostsFetch>;
+
+  beforeEach(() => {
+    fetchControl = stubGoogleHostsFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces a failed non-first chunk send as a dispatcher-visible delivery failure", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set([2]) });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({});
+
+      expect(result.outcome).toBe("failed-deliver");
+      expect(result.deliverError).toBeInstanceOf(Error);
+      expect((result.deliverError as Error).message).toContain("Google Chat API 500");
+      expect((result.deliverError as Error).message).toContain("stub: backend unavailable");
+      expect(result.onErrorCalls).toHaveLength(1);
+      // The failing create rejects the whole delivery: the third chunk is never attempted.
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 500]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual([CHUNKS[0], CHUNKS[1]]);
+      // Both Google hosts went through the production fetch path.
+      const requestedUrls = fetchControl.fetchMock.mock.calls.map((call) => {
+        const input = call[0] as RequestInfo | URL;
+        return input instanceof Request ? input.url : String(input);
+      });
+      expect(requestedUrls.some((url) => url.startsWith("https://oauth2.googleapis.com/"))).toBe(
+        true,
+      );
+      expect(
+        requestedUrls.filter((url) => url.startsWith("https://chat.googleapis.com/")),
+      ).toHaveLength(2);
+    });
+  });
+
+  it("rejects when the resend after a typing-placeholder update failure also fails", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set([1]), patchStatus: 404 });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({ withTypingMessage: true });
+
+      expect(result.outcome).toBe("failed-deliver");
+      expect((result.deliverError as Error).message).toContain("Google Chat API 500");
+      expect(result.onErrorCalls).toHaveLength(1);
+      expect(stub.patchAttempts).toEqual(["spaces/AAA/messages/typing"]);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([500]);
+      // The recoverable placeholder failure stays logged, not fatal; only the
+      // resend failure becomes the delivery error.
+      expect(result.errorLines.some((line) => line.includes("Google Chat API 404"))).toBe(true);
+    });
+  });
+
+  it("delivers every chunk when all message creates succeed", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set() });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({});
+
+      expect(result.outcome).toBe("delivered");
+      expect(result.onErrorCalls).toHaveLength(0);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 200, 200]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual(CHUNKS);
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -133,7 +133,10 @@ type DeliveryOutcome = {
   errorLines: string[];
 };
 
-async function runDelivery(params: { withTypingMessage?: boolean }): Promise<DeliveryOutcome> {
+async function runDelivery(params: {
+  withTypingMessage?: boolean;
+  statusSink?: Parameters<typeof deliverGoogleChatReply>[0]["statusSink"];
+}): Promise<DeliveryOutcome> {
   const errorLines: string[] = [];
   const runtime: GoogleChatRuntimeEnv = {
     error: (line: string) => {
@@ -152,6 +155,7 @@ async function runDelivery(params: { withTypingMessage?: boolean }): Promise<Del
       runtime,
       core,
       config,
+      ...(params.statusSink ? { statusSink: params.statusSink } : {}),
       ...(params.withTypingMessage
         ? {
             typingMessage: {
@@ -221,6 +225,44 @@ describe("Google Chat reply delivery failure propagation (integration)", () => {
       // The recoverable placeholder failure stays logged, not fatal; only the
       // resend failure becomes the delivery error.
       expect(result.errorLines.some((line) => line.includes("Google Chat API 404"))).toBe(true);
+    });
+  });
+
+  it("recovers from a missing typing placeholder without duplicating any chunk", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set(), patchStatus: 404 });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({ withTypingMessage: true });
+
+      expect(result.outcome).toBe("delivered");
+      expect(result.onErrorCalls).toHaveLength(0);
+      expect(stub.patchAttempts).toEqual(["spaces/AAA/messages/typing"]);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 200, 200]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual(CHUNKS);
+      expect(result.errorLines.some((line) => line.includes("Google Chat API 404"))).toBe(true);
+    });
+  });
+
+  it("does not resend a delivered chunk when outbound status reporting fails", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set() });
+    const statusSink = vi.fn(() => {
+      throw new Error("status unavailable");
+    });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({ withTypingMessage: true, statusSink });
+
+      expect(result.outcome).toBe("delivered");
+      expect(result.onErrorCalls).toHaveLength(0);
+      expect(stub.patchAttempts).toEqual(["spaces/AAA/messages/typing"]);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 200]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual(CHUNKS.slice(1));
+      expect(statusSink).toHaveBeenCalledTimes(CHUNKS.length);
+      expect(result.errorLines).toEqual([
+        "Google Chat outbound status update failed: Error: status unavailable",
+        "Google Chat outbound status update failed: Error: status unavailable",
+        "Google Chat outbound status update failed: Error: status unavailable",
+      ]);
     });
   });
 

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -107,6 +107,53 @@ describe("Google Chat reply delivery", () => {
     );
   });
 
+  it("rejects when a later text chunk send fails instead of dropping it silently", async () => {
+    const core = createCore({ chunks: ["first chunk", "second chunk", "third chunk"] });
+    const runtime = createRuntime();
+    const sendError = new Error("API 500");
+    mocks.sendGoogleChatMessage
+      .mockResolvedValueOnce({ messageName: "spaces/AAA/messages/one" })
+      .mockRejectedValueOnce(sendError);
+
+    await expect(
+      deliverGoogleChatReply({
+        payload: { text: "three chunks", replyToId: "spaces/AAA/threads/root" },
+        account,
+        spaceId: "spaces/AAA",
+        runtime,
+        core,
+        config,
+      }),
+    ).rejects.toBe(sendError);
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the fallback resend after a typing update failure also fails", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    const fallbackError = new Error("quota exceeded");
+    mocks.updateGoogleChatMessage.mockRejectedValueOnce(new Error("message not found"));
+    mocks.sendGoogleChatMessage.mockRejectedValueOnce(fallbackError);
+
+    await expect(
+      deliverGoogleChatReply({
+        payload: { text: "only chunk", replyToId: "spaces/AAA/threads/root" },
+        account,
+        spaceId: "spaces/AAA",
+        runtime,
+        core,
+        config,
+        typingMessage: {
+          name: "spaces/AAA/messages/typing",
+          thread: "spaces/AAA/threads/root",
+        },
+      }),
+    ).rejects.toBe(fallbackError);
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("replaces a typing message when the final reply target changed", async () => {
     const core = createCore();
     const runtime = createRuntime();


### PR DESCRIPTION
## What Problem This Solves

`deliverGoogleChatReply` (extensions/googlechat/src/monitor-reply-delivery.ts:79-109 on `main`) wrapped every chunk send in a try/catch that only logged the error and kept looping. Two silent-loss paths resulted:

1. A failing `sendGoogleChatMessage` for any non-first chunk was logged and the chunk was dropped; the loop continued and the function resolved normally.
2. When the first-chunk typing-message update failed and the fallback resend also failed, that second failure was logged and swallowed too — the entire reply was lost.

The core reply dispatcher contract treats a rejected `deliver` as a failed delivery and a resolved one as visible delivery: `src/auto-reply/reply/reply-dispatcher.ts:476-483` awaits `options.deliver(...)` and only routes to `onError` / `failed-deliver` in `.catch`. Resolving after a swallowed send error therefore reported the turn as delivered while the user saw nothing (or only part of the reply).

## Why This Change Was Made

Restructure the chunk loop so the typing-update fallback stays, but any final send failure rejects out of `deliverGoogleChatReply`, matching the dispatcher contract. The typing-update catch is kept because a stale typing placeholder is recoverable — the same chunk is immediately resent as a new message, and only that resend failing is a real delivery failure. This mirrors the LINE sibling, which documents that a lost bubble "must surface as a partial delivery, not silent success" (extensions/line/src/auto-reply-delivery.ts:217-219), and the same-channel precedent https://github.com/openclaw/openclaw/pull/96646 ("throw on non-ok instead of parsing error body as success").

Fix classification: channel delivery error-propagation fix, additive behavior change only on the failure path; no config, SDK, or core changes.

## User Impact

- Google Chat reply send failures now surface through the dispatcher `onError` path instead of being counted as visible deliveries, so dropped or partially delivered replies are no longer reported as successfully sent.
- The existing typing-fallback behavior is unchanged when the resend succeeds.

## Evidence

### Integration-backed failure-path proof (real HTTP stack, loopback stub)

New committed regression test `extensions/googlechat/src/monitor.reply-delivery-failure.test.ts` drives the production stack end to end against a local HTTP impersonator of the Google Chat API: `deliverGoogleChatReply` → `sendGoogleChatMessage` → `withGoogleChatResponse` → `fetchWithSsrFGuard` → real `google-auth-library` JWT signing and token exchange. Only global `fetch` is stubbed (rerouting `chat.googleapis.com` / `oauth2.googleapis.com` to `127.0.0.1`); the service-account key is a throwaway RSA key generated in-process, the stub issues the token, and the stub answers the second `spaces.messages` create with a real HTTP 500 error envelope. The deliver/onError wiring mirrors `extensions/googlechat/src/monitor.ts:408-429`, and the outcome labels follow the dispatcher contract in `src/auto-reply/reply/reply-dispatcher.ts:476-483`. No real credentials, endpoints, or user data anywhere.

Standalone transcript of the same flow (three-chunk reply, second create → 500), after the fix:

```
stub: POST /token (grant=jwt-bearer) -> 200 access_token=ya29.stub-token (redacted)
stub: POST /v1/spaces/AAA/messages #1 text="First chunk of the assistant reply." -> 200
stub: POST /v1/spaces/AAA/messages #2 text="Second chunk of the assistant reply." -> 500
runtime.error: [default] Google Chat text reply failed: Error: Google Chat API 500: {"error":{"code":500,"message":"stub: backend unavailable","status":"INTERNAL"}}
dispatcher: deliveryOutcome=failed-deliver
summary: tokenExchanges=1 messageCreates=2 createStatuses=[200,500] patchAttempts=0 onErrorCalls=1
```

Same stub, same input, pre-fix `monitor-reply-delivery.ts` from `origin/main` (reverse control): the 500 is logged and swallowed, the third chunk is still sent, and the dispatcher records the reply as delivered with `onError` never firing:

```
stub: POST /v1/spaces/AAA/messages #1 text="First chunk of the assistant reply." -> 200
stub: POST /v1/spaces/AAA/messages #2 text="Second chunk of the assistant reply." -> 500
runtime.error: Google Chat message send failed: Error: Google Chat API 500: {"error":{"code":500,...}}
stub: POST /v1/spaces/AAA/messages #3 text="Third chunk of the assistant reply." -> 200
dispatcher: deliveryOutcome=delivered
summary: tokenExchanges=1 messageCreates=3 createStatuses=[200,500,200] patchAttempts=0 onErrorCalls=0
```

Second after-fix scenario (typing placeholder already deleted upstream: `PATCH .../messages/typing` → 404, resend create → 500): the recoverable placeholder failure is logged, the resend failure rejects and reaches `onError`:

```
stub: PATCH /v1/spaces/AAA/messages/typing -> 404 (typing placeholder gone)
runtime.error: Google Chat message send failed: Error: Google Chat API 404: {"error":{"code":404,...}}
stub: POST /v1/spaces/AAA/messages #1 text="First chunk of the assistant reply." -> 500
runtime.error: [default] Google Chat text reply failed: Error: Google Chat API 500: {"error":{"code":500,...}}
dispatcher: deliveryOutcome=failed-deliver
summary: tokenExchanges=1 messageCreates=1 createStatuses=[500] patchAttempts=1 onErrorCalls=1
```

| | BEFORE (`origin/main` source) | AFTER (this PR) |
|---|---|---|
| Stub observed | 3 real `POST .../messages` (`[200,500,200]`) | 2 real `POST .../messages` (`[200,500]`), third chunk never attempted |
| `deliver` result | resolved — reply counted delivered, chunk 2 silently dropped | rejected with `Google Chat API 500: {...}` |
| Dispatcher outcome | `delivered`, `onError` never fires | `failed-deliver`, `onError` fires once with the API error |
| New integration test | 2 of 3 tests fail (reverse-verified) | 3/3 pass |

### Before vs after (same regression tests, same mocks)

| Scenario | `origin/main` | this PR |
|---|---|---|
| Non-first chunk send rejects | resolves; chunk dropped, loop continues | rejects with the send error |
| Typing update fails, fallback resend rejects | resolves; whole reply lost | rejects with the resend error |
| Typing update fails, fallback resend succeeds | resends, resolves (kept) | resends, resolves (unchanged) |

### Contract chain (source verified on `main`)

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Channel deliver | `extensions/googlechat/src/monitor.ts` | 408-421 | `deliver: async (payload) => { await deliverGoogleChatReply(...) }` |
| Channel onError | `extensions/googlechat/src/monitor.ts` | 425-429 | `[accountId] Google Chat <kind> reply failed: <err>` |
| Swallowed failure (pre-fix) | `extensions/googlechat/src/monitor-reply-delivery.ts` | 95-107 | catch logs, drops chunk / swallows fallback failure, loop resolves |
| Dispatcher contract | `src/auto-reply/reply/reply-dispatcher.ts` | 476-483 | `await options.deliver(...)`; only `.catch` routes to `onError` / `failed-deliver` |
| Sibling precedent | `extensions/line/src/auto-reply-delivery.ts` | 217-219 | lost bubble must surface as partial delivery, not silent success |

### Control-red (reverse verification)

Reverting only `monitor-reply-delivery.ts` to `origin/main` while keeping the new tests:

```
$ node scripts/run-vitest.mjs extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
 Tests  2 failed | 1 passed (3)
   × surfaces a failed non-first chunk send as a dispatcher-visible delivery failure
   × rejects when the resend after a typing-placeholder update failure also fails
     → Expected: "failed-deliver" / Received: "delivered" (500 logged and swallowed)
```

The mock-level suite shows the same inversion (`2 failed | 4 passed` on pre-fix source). With the fix restored, both suites are green.

### Test suite

```
$ node scripts/run-vitest.mjs extensions/googlechat/src/monitor.reply-delivery-failure.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

Full extension suite: `node scripts/run-vitest.mjs extensions/googlechat` → 211 passed / 1 failed (212 total); the single failure (`setup.test.ts:236`, service-account setup-wizard flow) also fails on a clean `origin/main` checkout without this change (pre-existing, unrelated — same failure observed in the previous proof round before this PR touched anything).

### What was not tested

- A real Google Chat workspace send (requires live service-account credentials); the loopback impersonator covers the full production HTTP/auth/guard stack instead, including the real error-envelope parsing that builds the `Google Chat API 500: ...` message.
- Full-repo `tsgo` lanes left to CI.

### Impact-surface review

| File | Change | Status |
|---|---|---|
| `extensions/googlechat/src/monitor-reply-delivery.ts` | chunk loop restructured; send failures now propagate | covered by mock-level + integration regression tests |
| `extensions/googlechat/src/monitor.reply-delivery.test.ts` | +2 rejection tests; existing fallback test unchanged and green | 6/6 pass |
| `extensions/googlechat/src/monitor.reply-delivery-failure.test.ts` | new integration suite: real HTTP stub, before/after dispatcher-visible outcomes | 3/3 pass; 2 fail on pre-fix source |

### Lint / typecheck / format

```
$ oxlint extensions/googlechat/src/monitor-reply-delivery.ts extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/monitor.reply-delivery-failure.test.ts   # exit 0
$ tsgo -p test/tsconfig/tsconfig.extensions.test.json (fresh buildinfo)                                                                                                    # 0 errors
$ oxfmt --check <all touched files>                                                                                                                                         # correct format
$ git diff --check origin/main                                                                                                                                              # clean
```

Base: 76e97ddcdb515f2af781a4b146d9e47eaacdf9e2 (`origin/main`). Head: a1cb28d8b3253761dd48e36bc51f426cd204787c.

<details>
<summary>Maintainer edits</summary>

Allow edits from maintainers is enabled on this PR.

</details>

<details>
<summary>Maintainer options</summary>

- Land-ready: single commit, 3 files, googlechat-only; no core/SDK/config surface touched.
- Branch rebased onto current `origin/main` (76e97ddcdb) during this proof round.
- Scope discipline: only the swallowed-error path in `monitor-reply-delivery.ts` plus its colocated tests; the typing-fallback success path is byte-for-byte behavior-preserved.

</details>
