### PR TITLE
fix(reef): accepted receipts no longer stall inbox delivery

### DIFF
--- a/extensions/reef/protocol/audit-receipts.test.ts
+++ b/extensions/reef/protocol/audit-receipts.test.ts
@@ -140,6 +140,8 @@ describe("receipts", () => {
       "accepted",
       "rejected",
     ]);
+    expect(entries[0]!.event.payload).not.toHaveProperty("category");
+    expect(entries[1]!.event.payload).toHaveProperty("category", "guard_deny");
     await expect(
       confirmDelivery({ ...accepted, bodyHash: "e".repeat(64) }, identity.signing.publicKey, audit),
     ).rejects.toThrow("invalid delivery receipt");

--- a/extensions/reef/protocol/receipts.ts
+++ b/extensions/reef/protocol/receipts.ts
@@ -61,7 +61,7 @@ export async function confirmDelivery(
   return appendAudit(audit, "confirm_delivery", {
     receipt,
     status: receipt.status,
-    category: receipt.category,
+    ...(receipt.category ? { category: receipt.category } : {}),
   });
 }
 


### PR DESCRIPTION
Closes #110150

## What Problem This Solves

Fixes an issue where Reef peers would enter an inbox reconnect loop after processing a valid accepted delivery receipt.

## Why This Change Was Made

Accepted receipts have no rejection category. The audit projection now omits that optional field instead of handing strict plugin-state persistence an `undefined` value; categorized rejected receipts remain unchanged. No schema, migration, config, or protocol change.

## User Impact

Reef peers can process accepted receipts, advance their durable inbox cursor, and continue receiving messages instead of repeatedly disconnecting.

## Evidence

- Blacksmith Testbox: `pnpm test extensions/reef/protocol/audit-receipts.test.ts` — 6/6 passed.
- Run: https://github.com/openclaw/openclaw/actions/runs/29608645404
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Regression assertions cover both accepted receipts without a category and rejected receipts with `guard_deny`.
