### PR TITLE
fix(zalo): propagate reply text send failures to the reply dispatcher

### DIFF
--- a/extensions/zalo/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/zalo/src/monitor.reply-delivery-failure.test.ts
@@ -1,0 +1,156 @@
+// Zalo reply delivery failure propagation covered against a real Bot API HTTP stub.
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createEmptyPluginRegistry,
+  createRuntimeEnv,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { monitorZaloProvider } from "./monitor.js";
+import type { PluginRuntime } from "./runtime-api.js";
+import { setZaloRuntime } from "./runtime.js";
+import {
+  createLifecycleMonitorSetup,
+  createTextUpdate,
+  postWebhookReplay,
+  settleAsyncWork,
+} from "./test-support/lifecycle-test-support.js";
+
+describe("Zalo reply delivery failure propagation", () => {
+  const finalizeInboundContextMock = vi.fn((ctx: Record<string, unknown>) => ctx);
+  const recordInboundSessionMock = vi.fn(async () => undefined);
+  const dispatchReplyWithBufferedBlockDispatcherMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    setZaloRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          reply: {
+            finalizeInboundContext:
+              finalizeInboundContextMock as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
+            dispatchReplyWithBufferedBlockDispatcher:
+              dispatchReplyWithBufferedBlockDispatcherMock as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"],
+          },
+          session: {
+            recordInboundSession:
+              recordInboundSessionMock as unknown as PluginRuntime["channel"]["session"]["recordInboundSession"],
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("propagates Bot API send failures from deliver instead of reporting the reply as delivered", async () => {
+    const sendAttempts: Array<{ chat_id?: string; text?: string }> = [];
+    let deliverError: unknown;
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementation(
+      async ({ dispatcherOptions }) => {
+        try {
+          await dispatcherOptions.deliver({ text: "zalo delivery failure probe" });
+        } catch (err) {
+          deliverError = err;
+          dispatcherOptions.onError?.(err, { kind: "final" });
+        }
+      },
+    );
+
+    await withServer(
+      (req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => {
+          const url = req.url ?? "";
+          if (url.endsWith("/sendMessage")) {
+            sendAttempts.push(
+              JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+                chat_id?: string;
+                text?: string;
+              },
+            );
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json");
+            res.end(
+              JSON.stringify({ ok: false, error_code: 500, description: "stub: send disabled" }),
+            );
+            return;
+          }
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ ok: true, result: { url: "" } }));
+        });
+      },
+      async (zaloApiUrl) => {
+        vi.stubEnv("ZALO_API_URL", zaloApiUrl);
+        const registry = createEmptyPluginRegistry();
+        setActivePluginRegistry(registry);
+        const abort = new AbortController();
+        const setup = createLifecycleMonitorSetup({
+          accountId: "acct-zalo-delivery-failure",
+          dmPolicy: "open",
+        });
+        const run = monitorZaloProvider({
+          token: "zalo-token",
+          account: setup.account,
+          config: setup.config,
+          runtime: createRuntimeEnv(),
+          abortSignal: abort.signal,
+          useWebhook: true,
+          webhookUrl: "https://example.com/hooks/zalo",
+          webhookSecret: "supersecret",
+        });
+
+        try {
+          await vi.waitFor(
+            () => {
+              if (!registry.httpRoutes.some((route) => route.source === "zalo-webhook")) {
+                throw new Error("waiting for webhook registration");
+              }
+            },
+            { timeout: 15000 },
+          );
+          const route = registry.httpRoutes.find((entry) => entry.source === "zalo-webhook");
+          if (!route) {
+            throw new Error("missing plugin HTTP route");
+          }
+
+          await withServer(
+            (req, res) => {
+              void route.handler(req, res);
+            },
+            async (baseUrl) => {
+              const { first } = await postWebhookReplay({
+                baseUrl,
+                path: "/hooks/zalo",
+                secret: "supersecret",
+                payload: createTextUpdate({
+                  messageId: `zalo-delivery-failure-${Date.now()}`,
+                  userId: "user-1",
+                  userName: "User One",
+                  chatId: "dm-chat-1",
+                }),
+              });
+              expect(first.status).toBe(200);
+              await settleAsyncWork();
+            },
+          );
+        } finally {
+          abort.abort();
+          await run;
+        }
+      },
+    );
+
+    expect(sendAttempts).toHaveLength(1);
+    expect(sendAttempts[0]?.chat_id).toBe("dm-chat-1");
+    expect(sendAttempts[0]?.text).toBe("zalo delivery failure probe");
+    expect(deliverError).toBeInstanceOf(Error);
+    expect((deliverError as Error).message).toContain("stub: send disabled");
+  });
+});

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -771,12 +771,10 @@ async function deliverZaloReply(params: {
     chunkText: (value) =>
       core.channel.text.chunkMarkdownTextWithMode(value, ZALO_TEXT_LIMIT, chunkMode),
     sendText: async (chunk) => {
-      try {
-        await sendMessage(token, { chat_id: chatId, text: chunk }, fetcher);
-        statusSink?.({ lastOutboundAt: Date.now() });
-      } catch (err) {
-        runtime.error?.(`Zalo message send failed: ${String(err)}`);
-      }
+      // Failures must throw so the core dispatcher records the reply as failed
+      // instead of delivered; sendMedia below already propagates the same way.
+      await sendMessage(token, { chat_id: chatId, text: chunk }, fetcher);
+      statusSink?.({ lastOutboundAt: Date.now() });
     },
     sendMedia: async ({ mediaUrl, caption }) => {
       const sendableMediaUrl =


### PR DESCRIPTION
## What Problem This Solves

`deliverZaloReply` in the Zalo plugin swallowed every text-send failure. Its `sendText` callback wrapped `sendMessage` in `try/catch` and only logged the error (`extensions/zalo/src/monitor.ts:773-780`), while the `sendMedia` callback in the same function let failures throw.

The core delivery contract only observes thrown errors:

- `src/plugin-sdk/reply-payload.ts:575-578` — `deliverTextOrMediaReply` awaits `sendText(chunk)` and reports the reply as `"text"` (delivered) when it resolves.
- `src/auto-reply/reply/reply-dispatcher.ts:476-482` — a resolving `deliver` is recorded as `deliveryOutcome = "delivered"`; only a throw produces `"failed-deliver"` and fires the plugin's `onError`.

So when the Zalo Bot API rejected a text send (HTTP error, `ok:false`, network failure), the reply was counted as delivered, `onError` never ran, and the user silently never received the message while logs/status showed success.

## Why This Change Was Made

Drop the local `try/catch` so `sendText` propagates failures, exactly like the `sendMedia` callback in the same function already does. The asymmetry inside one function is direct evidence the swallow was an oversight, not a policy. Sibling plugins using the same `deliverTextOrMediaReply` contract (`extensions/signal/src/monitor.ts:404`, `extensions/mattermost/src/mattermost/reply-delivery.ts:119`) also let `sendText` throw. No error context is lost: the plugin's `onError` (`extensions/zalo/src/monitor.ts:714-716`) already logs `[accountId] Zalo <kind> reply failed: <err>` once the failure reaches the dispatcher.

Fix classification: bug fix, plugin-local, no config/env/SDK surface change, no behavior change on the success path.

Sibling PR (same defect in the zalouser sister plugin): https://github.com/openclaw/openclaw/pull/110156

## User Impact

Failed Zalo text replies are now reported as delivery failures: the core dispatcher records `failed-deliver`, invokes the plugin's `onError` handler, and failure accounting/status reflect reality instead of a false "delivered". Operators see the send error with account context instead of silence.

## Evidence

Real HTTP behavior proof, committed as a regression test (`extensions/zalo/src/monitor.reply-delivery-failure.test.ts`): the test boots the real `monitorZaloProvider` in webhook mode with the production `api.js` HTTP client pointed at a local stub Bot API server via the existing `ZALO_API_URL` seam, delivers an inbound webhook event, and lets the reply dispatcher invoke the plugin's real `deliver` callback. The stub answers `sendMessage` with `{"ok": false, "error_code": 500, "description": "stub: send disabled"}`.

| | BEFORE (base `48863e1b83`) | AFTER (head `56d7e703cf`) |
|---|---|---|
| Stub observed | 1 real `POST /bot<token>/sendMessage` (`chat_id=dm-chat-1`) | same |
| `deliver` result | resolved — reply counted delivered | rejected with `stub: send disabled` |
| Regression test | fails: `expected undefined to be an instance of Error` | passes |

Validation on head `56d7e703cf4b30f73cf27b60650843d5b493dc0e` (base `48863e1b8309b27e344150a3769a08a7b1424c8a`), Node 24.15.0:

- `node scripts/run-vitest.mjs extensions/zalo/src/monitor.reply-delivery-failure.test.ts` — 1/1 pass; same test fails on the pre-fix `monitor.ts` (reverse-verified via `git stash`).
- `node scripts/run-vitest.mjs extensions/zalo` — 122/123 pass; the single failure is `setup-surface.test.ts` "configures a polling token flow", a locale-dependent setup-wizard prompt assertion that also fails on the pristine base SHA with no changes applied (unrelated, pre-existing).
- `oxfmt --check` and `oxlint` clean on both touched files; `git diff --check` clean.
- Full-repo `tsgo` lanes left to CI: this worktree cannot resolve `openclaw/plugin-sdk/*` types without a dist build, and the failure reproduces identically on untouched files.

Impact-surface review:

| Surface | Status |
|---|---|
| `extensions/zalo/src/monitor.ts:773-778` (`sendText`) | changed — failures now throw |
| `extensions/zalo/src/monitor.ts:781-794` (`sendMedia`) | unchanged — already propagated |
| `extensions/zalo/src/monitor.ts:714-716` (`onError` logging) | unchanged — now actually fires for text sends |
| Core dispatcher / SDK contract | untouched — plugin now honors the existing throw contract |
| Config / env / SDK API surface | untouched |

<details>
<summary>Maintainer edits</summary>

"Allow edits by maintainers" is enabled on this PR; feel free to push directly to the branch.

</details>

<details>
<summary>Maintainer options</summary>

- Land-ready as-is: single-commit, plugin-local, one commit on top of `48863e1b83`.
- No rebase needed unless `extensions/zalo/src/monitor.ts` changes on `main`.
- Scope discipline: only `extensions/zalo/src/monitor.ts` plus its new regression test; the zalouser sibling fix ships in its own PR (https://github.com/openclaw/openclaw/pull/110156) so each plugin stays an independent review/rollback unit.

</details>
