### PR TITLE
fix(zalouser): propagate reply text send failures to the reply dispatcher

### DIFF
--- a/extensions/zalouser/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/zalouser/src/monitor.reply-delivery-failure.test.ts
@@ -1,0 +1,245 @@
+// Zalouser tests cover monitor reply delivery failure propagation.
+import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+import "./monitor.send.test-mocks.js";
+import "./zalo-js.test-mocks.js";
+import { monitorZalouserProvider } from "./monitor.js";
+import { sendMessageZalouserMock } from "./monitor.send.test-mocks.js";
+import { setZalouserRuntime } from "./runtime.js";
+import { createZalouserRuntimeEnv } from "./test-helpers.js";
+import type { ResolvedZalouserAccount, ZaloInboundMessage } from "./types.js";
+import { startZaloListenerMock } from "./zalo-js.test-mocks.js";
+
+function createAccount(): ResolvedZalouserAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    profile: "default",
+    authenticated: true,
+    config: {
+      dmPolicy: "open",
+      allowFrom: ["*"],
+    },
+  };
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      zalouser: {
+        enabled: true,
+        dmPolicy: "open",
+        allowFrom: ["*"],
+      },
+    },
+  };
+}
+
+function createDmMessage(overrides: Partial<ZaloInboundMessage> = {}): ZaloInboundMessage {
+  return {
+    threadId: "u-1",
+    isGroup: false,
+    senderId: "123",
+    senderName: "Alice",
+    content: "hello",
+    timestampMs: Date.now(),
+    msgId: "m-1",
+    raw: { source: "test" },
+    ...overrides,
+  };
+}
+
+function installRuntime(params: { replyPayload: { text?: string } }) {
+  const deliveryFailure: { error?: unknown } = {};
+  const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async ({ dispatcherOptions, ctx }) => {
+    try {
+      await dispatcherOptions.deliver(params.replyPayload);
+    } catch (err) {
+      // Mirror the core dispatcher contract: a throwing deliver marks the reply
+      // failed and routes the error to the plugin's onError handler.
+      deliveryFailure.error = err;
+      dispatcherOptions.onError?.(err, { kind: "final" });
+    }
+    return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 }, ctx };
+  });
+  const recordInboundSession = vi.fn(async (_params: unknown) => {});
+  type TurnPlan = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
+  const dispatch = vi.fn(async (plan: TurnPlan) => {
+    const turn = {
+      ...plan,
+      agentId: plan.route.agentId,
+      routeSessionKey: plan.route.sessionKey,
+      storePath: "/tmp",
+      recordInboundSession,
+      dispatchReplyWithBufferedBlockDispatcher,
+    };
+    await turn.recordInboundSession({
+      storePath: turn.storePath,
+      sessionKey: turn.ctxPayload.SessionKey ?? turn.routeSessionKey,
+      ctx: turn.ctxPayload,
+      groupResolution: turn.record?.groupResolution,
+      createIfMissing: turn.record?.createIfMissing,
+      updateLastRoute: turn.record?.updateLastRoute,
+      onRecordError: turn.record?.onRecordError ?? (() => undefined),
+    });
+    const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
+      cfg: turn.cfg,
+      agentId: turn.agentId,
+      channel: "zalouser",
+      accountId: turn.accountId,
+      ...turn.replyPipeline,
+    });
+    const dispatchResult = await turn.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: turn.ctxPayload,
+      cfg: turn.cfg,
+      dispatcherOptions: {
+        ...replyPipeline,
+        ...turn.dispatcherOptions,
+        deliver: async (...args: Parameters<typeof turn.delivery.deliver>) => {
+          await turn.delivery.deliver(...args);
+        },
+        onError: turn.delivery.onError,
+      },
+      replyOptions: {
+        onModelSelected,
+        ...turn.replyOptions,
+      },
+      replyResolver: turn.replyResolver,
+    });
+    return {
+      admission: { kind: "dispatch" as const },
+      dispatched: true,
+      ctxPayload: turn.ctxPayload,
+      routeSessionKey: turn.routeSessionKey,
+      dispatchResult,
+    };
+  });
+  const buildContext = vi.fn(
+    (paramsLocal: Parameters<PluginRuntime["channel"]["inbound"]["buildContext"]>[0]) =>
+      ({
+        Body: paramsLocal.message.body ?? paramsLocal.message.rawBody,
+        BodyForAgent: paramsLocal.message.bodyForAgent ?? paramsLocal.message.rawBody,
+        RawBody: paramsLocal.message.rawBody,
+        CommandBody: paramsLocal.message.commandBody ?? paramsLocal.message.rawBody,
+        BodyForCommands: paramsLocal.message.commandBody ?? paramsLocal.message.rawBody,
+        From: paramsLocal.from,
+        To: paramsLocal.reply.to,
+        SessionKey: paramsLocal.route.dispatchSessionKey ?? paramsLocal.route.routeSessionKey,
+        AccountId: paramsLocal.route.accountId ?? paramsLocal.accountId,
+        ChatType: paramsLocal.conversation.kind,
+        SenderName: paramsLocal.sender.name,
+        SenderId: paramsLocal.sender.id,
+        Provider: paramsLocal.provider ?? paramsLocal.channel,
+        Surface: paramsLocal.surface ?? paramsLocal.provider ?? paramsLocal.channel,
+        MessageSid: paramsLocal.messageId,
+        OriginatingChannel: paramsLocal.channel,
+        OriginatingTo: paramsLocal.reply.originatingTo,
+        ...paramsLocal.extra,
+      }) as Awaited<ReturnType<PluginRuntime["channel"]["inbound"]["buildContext"]>>,
+  );
+  setZalouserRuntime({
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+    channel: {
+      pairing: {
+        readAllowFromStore: vi.fn(async () => []),
+        upsertPairingRequest: vi.fn(async () => ({ code: "PAIR", created: true })),
+        buildPairingReply: vi.fn(() => "pair"),
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn((body: string) => body.trim().startsWith("/")),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+        isControlCommandMessage: vi.fn((body: string) => body.trim().startsWith("/")),
+        shouldHandleTextCommands: vi.fn(() => true),
+      },
+      mentions: {
+        buildMentionRegexes: vi.fn(() => []),
+        matchesMentionWithExplicit: vi.fn(
+          (input) => input.explicit?.isExplicitlyMentioned === true,
+        ),
+      },
+      routing: {
+        resolveAgentRoute: vi.fn(() => ({
+          agentId: "main",
+          sessionKey: "agent:main:zalouser:direct:123",
+          accountId: "default",
+          mainSessionKey: "agent:main:main",
+        })),
+      },
+      session: {
+        resolveStorePath: vi.fn(() => "/tmp"),
+        recordInboundSession,
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn(() => undefined),
+        formatAgentEnvelope: vi.fn(({ body }) => body),
+        finalizeInboundContext: vi.fn((ctx) => ctx),
+        dispatchReplyWithBufferedBlockDispatcher,
+      },
+      inbound: {
+        dispatch,
+        buildContext:
+          buildContext as unknown as PluginRuntime["channel"]["inbound"]["buildContext"],
+      },
+      text: {
+        resolveMarkdownTableMode: vi.fn(() => "code"),
+        convertMarkdownTables: vi.fn((text: string) => text),
+        resolveChunkMode: vi.fn(() => "length"),
+        resolveTextChunkLimit: vi.fn(() => 1200),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+      },
+    },
+  } as unknown as PluginRuntime);
+  return { deliveryFailure };
+}
+
+describe("zalouser monitor reply delivery failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates send failures from deliver instead of reporting the reply as delivered", async () => {
+    const { deliveryFailure } = installRuntime({
+      replyPayload: { text: "zalouser delivery failure probe" },
+    });
+    sendMessageZalouserMock.mockRejectedValueOnce(new Error("zalouser send boom"));
+
+    const enqueueSpy = vi.spyOn(KeyedAsyncQueue.prototype, "enqueue");
+    const abortController = new AbortController();
+    let resolveProcessed: (() => void) | undefined;
+    const processed = new Promise<void>((resolve) => {
+      resolveProcessed = resolve;
+    });
+    startZaloListenerMock.mockImplementationOnce(async (listenerParams) => {
+      const resultIndex = enqueueSpy.mock.results.length;
+      listenerParams.onMessage(createDmMessage());
+      const queued = enqueueSpy.mock.results[resultIndex]?.value;
+      if (!(queued instanceof Promise)) {
+        throw new Error("Zalouser monitor did not enqueue the inbound message");
+      }
+      await queued;
+      resolveProcessed?.();
+      return { stop: vi.fn() };
+    });
+    try {
+      const run = monitorZalouserProvider({
+        account: createAccount(),
+        config: createConfig(),
+        runtime: createZalouserRuntimeEnv(),
+        abortSignal: abortController.signal,
+      });
+      await processed;
+      abortController.abort();
+      await run;
+    } finally {
+      enqueueSpy.mockRestore();
+    }
+
+    expect(sendMessageZalouserMock).toHaveBeenCalledOnce();
+    expect(deliveryFailure.error).toBeInstanceOf(Error);
+    expect((deliveryFailure.error as Error).message).toContain("zalouser send boom");
+  });
+});

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -710,18 +710,16 @@ async function deliverZalouserReply(params: {
     payload,
     text: reply.text,
     sendText: async (chunk) => {
-      try {
-        await sendMessageZalouser(chatId, chunk, {
-          profile,
-          isGroup,
-          textMode: "markdown",
-          textChunkMode: chunkMode,
-          textChunkLimit,
-        });
-        visibleReplySent = true;
-      } catch (err) {
-        runtime.error(`Zalouser message send failed: ${String(err)}`);
-      }
+      // Failures must throw so the core dispatcher records the reply as failed
+      // instead of delivered; sendMedia below already propagates the same way.
+      await sendMessageZalouser(chatId, chunk, {
+        profile,
+        isGroup,
+        textMode: "markdown",
+        textChunkMode: chunkMode,
+        textChunkLimit,
+      });
+      visibleReplySent = true;
     },
     sendMedia: async ({ mediaUrl, caption }) => {
       logVerbose(core, runtime, `Sending media to ${chatId}`);


### PR DESCRIPTION
## What Problem This Solves

`deliverZalouserReply` in the Zalouser plugin swallowed every text-send failure. Its `sendText` callback wrapped `sendMessageZalouser` in `try/catch` and only logged the error (`extensions/zalouser/src/monitor.ts:712-724`), while the `sendMedia` callback in the same function let failures throw. `sendMessageZalouser` does throw on failure (`extensions/zalouser/src/send.ts:60-62`), so the catch was discarding a real, actionable error.

The core delivery contract only observes thrown errors:

- `src/plugin-sdk/reply-payload.ts:575-578` — `deliverTextOrMediaReply` awaits `sendText(chunk)` and reports the reply as `"text"` (delivered) when it resolves.
- `src/auto-reply/reply/reply-dispatcher.ts:476-482` — a resolving `deliver` is recorded as `deliveryOutcome = "delivered"`; only a throw produces `"failed-deliver"` and fires the plugin's `onError`.

So when a Zalouser text send failed, the reply was counted as delivered, `onError` never ran, and the user silently never received the message. The `visibleReplySent` flag only gated the `lastOutboundAt` status patch — it did not stop core from recording the reply as delivered.

This is the same defect class as the sibling Zalo plugin PR: https://github.com/openclaw/openclaw/pull/110155

## Why This Change Was Made

Drop the local `try/catch` so `sendText` propagates failures, exactly like the `sendMedia` callback in the same function already does. The asymmetry inside one function is direct evidence the swallow was an oversight, not a policy. Sibling plugins using the same `deliverTextOrMediaReply` contract (`extensions/signal/src/monitor.ts:404`, `extensions/mattermost/src/mattermost/reply-delivery.ts:119`) also let `sendText` throw. `visibleReplySent` semantics are preserved: it is still set only after a successful send, and on failure the throw now propagates instead of returning `{ visibleReplySent: false }` that core counted as delivered anyway. No error context is lost: the plugin's `onError` (`extensions/zalouser/src/monitor.ts:664-666`) already logs `[accountId] Zalouser <kind> reply failed: <err>` once the failure reaches the dispatcher.

Fix classification: bug fix, plugin-local, no config/env/SDK surface change, no behavior change on the success path.

## User Impact

Failed Zalouser text replies are now reported as delivery failures: the core dispatcher records `failed-deliver`, invokes the plugin's `onError` handler, and failure accounting/status reflect reality instead of a false "delivered". Operators see the send error with account context instead of silence.

## Evidence

Regression test committed as `extensions/zalouser/src/monitor.reply-delivery-failure.test.ts`: it boots the real `monitorZalouserProvider` with the production dispatch wiring (mirroring the existing `monitor.group-gating.test.ts` harness), feeds an inbound DM, and has the reply dispatcher invoke the plugin's real `deliver` callback while the transport mock rejects with `zalouser send boom`.

| | BEFORE (base `48863e1b83`) | AFTER (head `1f4a0e2764`) |
|---|---|---|
| Transport | `sendMessageZalouser` called once, rejects | same |
| `deliver` result | resolved — reply counted delivered, `onError` never fired | rejected with `zalouser send boom`, routed to plugin `onError` |
| Regression test | fails: `expected undefined to be an instance of Error` | passes |

Validation on head `1f4a0e27646c463c4054bdff373d6cbe7fdc0739` (base `48863e1b8309b27e344150a3769a08a7b1424c8a`), Node 24.15.0:

- `node scripts/run-vitest.mjs extensions/zalouser/src/monitor.reply-delivery-failure.test.ts` — 1/1 pass; same test fails on the pre-fix `monitor.ts` (reverse-verified via `git stash`).
- `node scripts/run-vitest.mjs extensions/zalouser/src/monitor.reply-delivery-failure.test.ts extensions/zalouser/src/monitor.group-gating.test.ts extensions/zalouser/src/monitor.account-scope.test.ts` — 24/24 pass.
- `node scripts/run-vitest.mjs extensions/zalouser` — 181/188 pass; all 7 failures are in `setup-surface.test.ts` (locale-dependent setup-wizard prompt assertions) and reproduce identically on the pristine base SHA with no changes applied (unrelated, pre-existing).
- `oxfmt --check` and `oxlint` clean on both touched files; `git diff --check` clean.
- Note: the Zalouser transport is WebSocket-based (`zca-js`), so there is no `ZALO_API_URL`-style HTTP loopback seam; the sibling Zalo PR linked above carries the real-HTTP stub proof for the same contract.
- Full-repo `tsgo` lanes left to CI: this worktree cannot resolve `openclaw/plugin-sdk/*` types without a dist build, and the failure reproduces identically on untouched files.

Impact-surface review:

| Surface | Status |
|---|---|
| `extensions/zalouser/src/monitor.ts:712-721` (`sendText`) | changed — failures now throw |
| `extensions/zalouser/src/monitor.ts:726-737` (`sendMedia`) | unchanged — already propagated |
| `extensions/zalouser/src/monitor.ts:664-666` (`onError` logging) | unchanged — now actually fires for text sends |
| `visibleReplySent` semantics | preserved — still set only after a successful send |
| Core dispatcher / SDK contract | untouched — plugin now honors the existing throw contract |
| Config / env / SDK API surface | untouched |

<details>
<summary>Maintainer edits</summary>

"Allow edits by maintainers" is enabled on this PR; feel free to push directly to the branch.

</details>

<details>
<summary>Maintainer options</summary>

- Land-ready as-is: single-commit, plugin-local, one commit on top of `48863e1b83`.
- No rebase needed unless `extensions/zalouser/src/monitor.ts` changes on `main`.
- Scope discipline: only `extensions/zalouser/src/monitor.ts` plus its new regression test; the zalo sibling fix ships in its own PR (https://github.com/openclaw/openclaw/pull/110155) so each plugin stays an independent review/rollback unit.

</details>
