### PR TITLE
fix(cron): queued jobs are lost after Gateway restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron queued-run restart recovery:** distinguish jobs waiting for shared run admission from actively executing jobs so a Gateway restart no longer records false interrupted failures or disables one-shot jobs before their payload starts.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron queued-run restart recovery:** distinguish jobs waiting for shared run admission from actively executing jobs so a Gateway restart no longer records false interrupted failures or disables one-shot jobs before their payload starts.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/extensions/qa-channel/src/channel.test.ts
+++ b/extensions/qa-channel/src/channel.test.ts
@@ -64,6 +64,7 @@ function expectDispatchedContext(ctx: Record<string, unknown> | null): Record<st
 
 function createMockQaRuntime(params?: {
   onDispatch?: (ctx: Record<string, unknown>) => void;
+  onTurn?: (turn: QaDispatchTurn) => void;
   toolStarts?: Array<{ name?: string; phase?: string; args?: Record<string, unknown> }>;
 }): PluginRuntime {
   return createPluginRuntimeMock({
@@ -78,6 +79,7 @@ function createMockQaRuntime(params?: {
       },
       inbound: {
         async dispatch(turn: QaDispatchTurn) {
+          params?.onTurn?.(turn);
           for (const toolStart of params?.toolStarts ?? []) {
             await turn.replyOptions?.onToolStart?.(toolStart);
           }
@@ -390,6 +392,38 @@ describe("qa-channel plugin", () => {
       }
     },
   );
+
+  it("captures tool starts when channel progress is hidden", { timeout: 20_000 }, async () => {
+    let allowHiddenToolLifecycle = false;
+    const harness = await startQaChannelTestHarness({
+      allowFrom: ["*"],
+      runtime: createMockQaRuntime({
+        onTurn: (turn) => {
+          allowHiddenToolLifecycle =
+            turn.replyOptions?.allowToolLifecycleWhenProgressHidden === true;
+        },
+      }),
+    });
+
+    try {
+      harness.state.addInboundMessage({
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        senderName: "Alice",
+        text: "hello",
+      });
+      await harness.state.waitFor({
+        kind: "message-text",
+        textIncludes: "qa-echo: hello",
+        direction: "outbound",
+        timeoutMs: 15_000,
+      });
+
+      expect(allowHiddenToolLifecycle).toBe(true);
+    } finally {
+      await harness.stop();
+    }
+  });
 
   it(
     "surfaces shared group traffic with the room target as From",

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -384,6 +384,7 @@ export async function handleQaInbound(params: {
       },
     },
     replyOptions: {
+      allowToolLifecycleWhenProgressHidden: true,
       onPartialReply: async (payload) => {
         await preview.update(payload.text ?? "");
       },

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -131,7 +131,7 @@ function createQaChannelReportNotes(params: QaTransportReportParams) {
     params.isolatedWorkers === true
       ? `Scenarios run in isolated gateway workers with concurrency ${params.concurrency}.`
       : "Scenarios run serially in one gateway worker.",
-    "Cron uses a one-minute schedule assertion plus forced execution for fast verification.",
+    "Scheduling scenarios verify stored schedules and execution behavior through the Gateway.",
   ];
 }
 

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -197,6 +197,7 @@ describe("qa scenario catalog", () => {
       );
 
     expect(scenarios.map((scenario) => scenario.id).toSorted()).toEqual([
+      "cron-model-created-one-shot-recurring",
       "kitchen-sink-live-openai",
       "matrix-post-restart-room-continue",
       "matrix-restart-resume",

--- a/qa/scenarios/scheduling/cron-model-created-one-shot-recurring.yaml
+++ b/qa/scenarios/scheduling/cron-model-created-one-shot-recurring.yaml
@@ -1,0 +1,230 @@
+title: Model-created one-shot and recurring cron jobs
+
+scenario:
+  id: cron-model-created-one-shot-recurring
+  surface: cron
+  runtimeParityTier: live-only
+  coverage:
+    primary:
+      - scheduling.cron
+      - agents.tool-use
+    secondary:
+      - scheduling.dedup
+      - scheduling.persistence
+  gatewayConfigPatch:
+    commands:
+      ownerAllowFrom:
+        - qa-cron-operator
+  objective: Verify a live model can author one-off and recurring cron jobs whose natural scheduler behavior matches their requested semantics.
+  successCriteria:
+    - The model creates exactly one `at` job and one `every` job through the cron tool.
+    - The one-off job fires naturally once and is deleted after success.
+    - The recurring job fires naturally at least twice, remains enabled, and advances its next run.
+    - Stored jobs use isolated agent turns with no delivery side effects.
+  docsRefs:
+    - docs/automation/cron-jobs.md
+  codeRefs:
+    - src/agents/tools/cron-tool.ts
+    - src/cron/service/timer.ts
+    - extensions/qa-lab/src/cron-run-wait.ts
+  execution:
+    kind: flow
+    suiteIsolation: isolated
+    summary: Ask the live model to create one-off and recurring jobs, then verify stored shape and natural scheduler outcomes over the isolated Gateway.
+    channel: qa-channel
+    transportPolicy:
+      senderAllowlist:
+        - qa-cron-operator
+    config:
+      conversationPrefix: cron-model-author
+      authorDoneMarker: CRON-MODEL-AUTHOR-OK
+      oneShotDelayMs: 240000
+      recurringEveryMs: 20000
+
+flow:
+  steps:
+    - name: model authors exact one-off and recurring jobs
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: suffix
+          value:
+            expr: randomUUID().slice(0, 8)
+        - set: conversationId
+          value:
+            expr: "`${config.conversationPrefix}-${suffix}`"
+        - set: oneShotName
+          value:
+            expr: "`qa-model-at-${suffix}`"
+        - set: recurringName
+          value:
+            expr: "`qa-model-every-${suffix}`"
+        - set: oneShotPayloadMarker
+          value:
+            expr: "`QA-MODEL-AT-PAYLOAD-${suffix}`"
+        - set: recurringPayloadMarker
+          value:
+            expr: "`QA-MODEL-EVERY-PAYLOAD-${suffix}`"
+        - set: authorStartedAt
+          value:
+            expr: Date.now()
+        - set: oneShotAt
+          value:
+            expr: "new Date(authorStartedAt + config.oneShotDelayMs).toISOString()"
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId: qa-cron-operator
+            senderName: QA Cron Operator
+            text:
+              expr: "`Use the cron tool now. Create exactly two jobs and do not run either manually. Job 1: name '${oneShotName}', one-off absolute at '${oneShotAt}', isolated agent turn, payload message 'Reply exactly ${oneShotPayloadMarker}', delivery none. Job 2: name '${recurringName}', recurring every ${config.recurringEveryMs / 1000} seconds using an every schedule, isolated agent turn, payload message 'Reply exactly ${recurringPayloadMarker}', delivery none. After both tool calls succeed, reply exactly ${config.authorDoneMarker}.`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: outboundStartIndex
+            textIncludes:
+              ref: config.authorDoneMarker
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 180000)
+          saveAs: authorReply
+        - set: cronToolCalls
+          value:
+            expr: "(authorReply.toolCalls ?? []).filter((toolCall) => toolCall.name === 'cron')"
+        - assert:
+            expr: "(authorReply.toolCalls ?? []).length === 2 && cronToolCalls.length === 2 && cronToolCalls.every((toolCall) => toolCall.arguments?.job && typeof toolCall.arguments.job === 'object')"
+            message:
+              expr: "`expected exactly two native cron add calls, saw ${JSON.stringify(authorReply.toolCalls ?? [])}`"
+        - call: waitForCondition
+          saveAs: jobs
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('cron.list', { includeDisabled: true }, { timeoutMs: 30000 }).then((page) => { const matches = page.jobs.filter((job) => job.name === oneShotName || job.name === recurringName); return matches.length === 2 ? matches : undefined; })"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        - set: oneShotJob
+          value:
+            expr: "jobs.find((job) => job.name === oneShotName)"
+        - set: recurringJob
+          value:
+            expr: "jobs.find((job) => job.name === recurringName)"
+        - assert:
+            expr: "oneShotJob.schedule.kind === 'at' && oneShotJob.schedule.at === oneShotAt"
+            message:
+              expr: "`model created wrong one-off schedule: ${JSON.stringify(oneShotJob?.schedule)}`"
+        - assert:
+            expr: "oneShotJob.deleteAfterRun === true"
+            message: model-created one-off did not receive delete-after-success semantics
+        - assert:
+            expr: "recurringJob.schedule.kind === 'every' && recurringJob.schedule.everyMs === config.recurringEveryMs"
+            message:
+              expr: "`model created wrong recurring schedule: ${JSON.stringify(recurringJob?.schedule)}`"
+        - assert:
+            expr: "jobs.every((job) => job.sessionTarget === 'isolated' && job.payload.kind === 'agentTurn' && job.delivery?.mode === 'none')"
+            message:
+              expr: "`model created unsafe job shape: ${JSON.stringify(jobs)}`"
+      detailsExpr: "`author=${authorReply.text}; cron-tool-calls=${cronToolCalls.length}; at=${oneShotJob.id}; every=${recurringJob.id}`"
+
+    - name: scheduler fires one-off once and recurring repeatedly
+      actions:
+        - call: waitForCronRunCompletion
+          saveAs: oneShotRun
+          args:
+            - callGateway:
+                expr: "env.gateway.call.bind(env.gateway)"
+              jobId:
+                expr: oneShotJob.id
+              afterTs:
+                ref: authorStartedAt
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, config.oneShotDelayMs + 120000)
+        - assert:
+            expr: "oneShotRun.status === 'ok'"
+            message:
+              expr: "`model-created one-off failed: ${JSON.stringify(oneShotRun)}`"
+        - call: waitForCondition
+          saveAs: recurringRuns
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('cron.runs', { id: recurringJob.id, limit: 20, sortDir: 'desc' }, { timeoutMs: 30000 }).then((page) => { const runs = page.entries.filter((entry) => entry.ts >= authorStartedAt && entry.status === 'ok'); return runs.length >= 2 ? runs : undefined; })"
+            - expr: liveTurnTimeoutMs(env, 180000)
+            - 1000
+        - set: preRestartRecurringTs
+          value:
+            expr: "Math.max(...recurringRuns.map((entry) => entry.ts))"
+        - assert:
+            expr: "typeof env.gateway.restartAfterStateMutation === 'function'"
+            message: qa gateway child does not expose restartAfterStateMutation
+        - call: env.gateway.restartAfterStateMutation
+          args:
+            - lambda:
+                async: true
+                params: [ctx]
+                expr: "Promise.resolve(ctx)"
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForCondition
+          saveAs: postRestartRecurringRun
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('cron.runs', { id: recurringJob.id, limit: 20, sortDir: 'desc' }, { timeoutMs: 30000 }).then((page) => page.entries.find((entry) => entry.ts > preRestartRecurringTs && entry.status === 'ok'))"
+            - expr: liveTurnTimeoutMs(env, 120000)
+            - 1000
+        - call: env.gateway.call
+          saveAs: finalList
+          args:
+            - cron.list
+            - includeDisabled: true
+            - timeoutMs: 30000
+        - set: finalRecurring
+          value:
+            expr: "finalList.jobs.find((job) => job.id === recurringJob.id)"
+        - assert:
+            expr: "!finalList.jobs.some((job) => job.id === oneShotJob.id)"
+            message: successful model-created one-off was not deleted
+        - assert:
+            expr: "Boolean(finalRecurring?.enabled) && finalRecurring.state.nextRunAtMs > Date.now()"
+            message:
+              expr: "`recurring job did not remain scheduled: ${JSON.stringify(finalRecurring)}`"
+        - call: env.gateway.call
+          saveAs: oneShotRunsPage
+          args:
+            - cron.runs
+            - id:
+                expr: oneShotJob.id
+              limit: 20
+              sortDir: desc
+            - timeoutMs: 30000
+        - set: oneShotRuns
+          value:
+            expr: "oneShotRunsPage.entries.filter((entry) => entry.ts >= authorStartedAt && ['ok', 'error', 'skipped'].includes(entry.status))"
+        - assert:
+            expr: "oneShotRuns.length === 1"
+            message:
+              expr: "`expected exactly one one-off run, got ${JSON.stringify(oneShotRuns)}`"
+        - call: env.gateway.call
+          args:
+            - cron.remove
+            - id:
+                expr: recurringJob.id
+            - timeoutMs: 30000
+      detailsExpr: "`one-shot=${oneShotRun.status}; recurring-runs=${recurringRuns.length}; post-restart=${postRestartRecurringRun.status}; next=${finalRecurring.state.nextRunAtMs}`"

--- a/src/cron/public-job.ts
+++ b/src/cron/public-job.ts
@@ -1,0 +1,8 @@
+import type { CronJob } from "./types.js";
+
+/** Remove scheduler-only state before a cron job crosses a public API boundary. */
+export function toPublicCronJob(job: CronJob): CronJob {
+  const state = { ...job.state };
+  delete state.queuedAtMs;
+  return { ...job, state };
+}

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -320,6 +320,48 @@ describe("CronService restart catch-up", () => {
       },
     );
   });
+
+  it("releases queued reservations and runs due jobs after restart", async () => {
+    const dueAt = Date.parse("2025-12-13T16:30:00.000Z");
+    const queuedAt = Date.parse("2025-12-13T16:45:00.000Z");
+    const recurring = createOverdueEveryJob("restart-queued-recurring", dueAt);
+    recurring.state.queuedAtMs = queuedAt;
+    const oneShot: CronJob = {
+      id: "restart-queued-one-shot",
+      name: "queued one shot",
+      enabled: true,
+      deleteAfterRun: true,
+      createdAtMs: dueAt - 60_000,
+      updatedAtMs: queuedAt,
+      schedule: { kind: "at", at: new Date(dueAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "queued-one-shot" },
+      state: { nextRunAtMs: dueAt, queuedAtMs: queuedAt },
+    };
+
+    await withRestartedCron([recurring, oneShot], async ({ cron, enqueueSystemEvent, onEvent }) => {
+      expect(enqueueSystemEvent).toHaveBeenCalledTimes(2);
+      expect(enqueueSystemEvent.mock.calls.map(([text]) => text)).toEqual(
+        expect.arrayContaining(["tick-restart-queued-recurring", "queued-one-shot"]),
+      );
+
+      const listedJobs = await cron.list({ includeDisabled: true });
+      const updatedRecurring = listedJobs.find((job) => job.id === recurring.id);
+      expect(updatedRecurring?.state.queuedAtMs).toBeUndefined();
+      expect(updatedRecurring?.state.lastRunStatus).toBe("ok");
+      expect(updatedRecurring?.enabled).toBe(true);
+      expect(listedJobs.some((job) => job.id === oneShot.id)).toBe(false);
+      expect(
+        onEvent.mock.calls.some(
+          ([evt]) =>
+            (evt as CronEvent).action === "finished" &&
+            (evt as CronEvent).error === "cron: job interrupted by gateway restart",
+        ),
+      ).toBe(false);
+    });
+  });
+
   it("replays the most recent missed cron slot after restart when nextRunAtMs already advanced", async () => {
     vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
     await withRestartedCron(

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -220,6 +220,7 @@ function shouldRepairFutureCronNextRunAtMs(params: {
     job.schedule.kind !== "cron" ||
     !hasScheduledNextRunAtMs(nextRun) ||
     nowMs >= nextRun ||
+    typeof job.state.queuedAtMs === "number" ||
     typeof job.state.runningAtMs === "number"
   ) {
     return false;
@@ -597,6 +598,13 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
       changed = true;
     }
     if (
+      job.state.queuedAtMs !== undefined &&
+      !isQueuedForceCronRun(state, job.id, job.state.queuedAtMs)
+    ) {
+      job.state.queuedAtMs = undefined;
+      changed = true;
+    }
+    if (
       job.state.runningAtMs !== undefined &&
       !isQueuedForceCronRun(state, job.id, job.state.runningAtMs)
     ) {
@@ -608,6 +616,20 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
 
   if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs) && job.state.nextRunAtMs !== undefined) {
     job.state.nextRunAtMs = undefined;
+    changed = true;
+  }
+
+  const queuedAt = job.state.queuedAtMs;
+  if (
+    typeof queuedAt === "number" &&
+    nowMs - queuedAt > STUCK_RUN_MS &&
+    !isQueuedCronRun(state, job.id, queuedAt)
+  ) {
+    state.deps.log.warn(
+      { jobId: job.id, queuedAtMs: queuedAt },
+      "cron: clearing stuck queued marker",
+    );
+    job.state.queuedAtMs = undefined;
     changed = true;
   }
 
@@ -789,6 +811,7 @@ export function recomputeNextRunsForMaintenance(
       } else if (
         recomputeExpired &&
         now >= job.state.nextRunAtMs &&
+        typeof job.state.queuedAtMs !== "number" &&
         typeof job.state.runningAtMs !== "number"
       ) {
         // Only advance when the expired slot was already executed, or when
@@ -1313,7 +1336,7 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
   if (!job.state) {
     job.state = {};
   }
-  if (typeof job.state.runningAtMs === "number") {
+  if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
     return false;
   }
   if (opts.forced) {

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -536,6 +536,35 @@ describe("cron service ops regressions", () => {
     expect(options?.agentId).toBeUndefined();
   });
 
+  it("clears an orphaned queued reservation and executes the due job", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:01.000Z");
+    const job = createDueIsolatedJob({
+      id: "stale-queued",
+      nowMs: now,
+      nextRunAtMs: now - 60_000,
+    });
+    job.state.queuedAtMs = now - 2 * 60 * 60 * 1000 - 1;
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "ok" });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await expect(run(state, job.id, "due")).resolves.toEqual({ ok: true, ran: true });
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    expect(
+      state.store?.jobs.find((entry) => entry.id === job.id)?.state.queuedAtMs,
+    ).toBeUndefined();
+  });
+
   it("queues manual cron.run requests behind the cron execution lane", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);

--- a/src/cron/service/ops.run-admission-cleanup.test.ts
+++ b/src/cron/service/ops.run-admission-cleanup.test.ts
@@ -46,10 +46,11 @@ describe("cron service run admission cleanup", () => {
       const saveSpy = vi
         .spyOn(cronStoreModule, "saveCronJobsStore")
         .mockImplementation(async (storePath, nextStore, opts) => {
-          const runningAtMs = nextStore.jobs.find((entry) => entry.id === job.id)?.state
-            .runningAtMs;
+          const nextState = nextStore.jobs.find((entry) => entry.id === job.id)?.state;
+          const queuedAtMs = nextState?.queuedAtMs;
+          const runningAtMs = nextState?.runningAtMs;
           await realSave(storePath, nextStore, opts);
-          if (!reservationPersisted && runningAtMs === dueAt) {
+          if (!reservationPersisted && queuedAtMs === dueAt) {
             reservationPersisted = true;
             now = dueAt + 1;
           } else if (reservationPersisted && runningAtMs === dueAt + 1) {
@@ -110,14 +111,14 @@ describe("cron service run admission cleanup", () => {
       const saveSpy = vi
         .spyOn(cronStoreModule, "saveCronJobsStore")
         .mockImplementation(async (storePath, nextStore, opts) => {
-          const runningAtMs = nextStore.jobs.find((entry) => entry.id === job.id)?.state
-            .runningAtMs;
-          if (reservationPersisted && !cleanupFailed && runningAtMs === undefined) {
+          const nextState = nextStore.jobs.find((entry) => entry.id === job.id)?.state;
+          const queuedAtMs = nextState?.queuedAtMs;
+          if (reservationPersisted && !cleanupFailed && queuedAtMs === undefined) {
             cleanupFailed = true;
             throw new Error("reservation cleanup persist failed");
           }
           await realSave(storePath, nextStore, opts);
-          if (!reservationPersisted && runningAtMs === dueAt) {
+          if (!reservationPersisted && queuedAtMs === dueAt) {
             reservationPersisted = true;
             stop(state);
           }
@@ -177,14 +178,15 @@ describe("cron service run admission cleanup", () => {
       const saveSpy = vi
         .spyOn(cronStoreModule, "saveCronJobsStore")
         .mockImplementation(async (storePath, nextStore, opts) => {
-          const runningAtMs = nextStore.jobs.find((entry) => entry.id === job.id)?.state
-            .runningAtMs;
+          const nextState = nextStore.jobs.find((entry) => entry.id === job.id)?.state;
+          const queuedAtMs = nextState?.queuedAtMs;
+          const runningAtMs = nextState?.runningAtMs;
           if (reservationPersisted && !activationFailed && runningAtMs === dueAt + 1) {
             activationFailed = true;
             throw new Error("activation persist failed");
           }
           await realSave(storePath, nextStore, opts);
-          if (!reservationPersisted && runningAtMs === dueAt) {
+          if (!reservationPersisted && queuedAtMs === dueAt) {
             reservationPersisted = true;
             now = dueAt + 1;
           }
@@ -243,14 +245,20 @@ describe("cron service run admission cleanup", () => {
       const saveSpy = vi
         .spyOn(cronStoreModule, "saveCronJobsStore")
         .mockImplementation(async (storePath, nextStore, opts) => {
-          const runningAtMs = nextStore.jobs.find((entry) => entry.id === job.id)?.state
-            .runningAtMs;
-          if (activationPersisted && !cleanupFailed && runningAtMs === undefined) {
+          const nextState = nextStore.jobs.find((entry) => entry.id === job.id)?.state;
+          const queuedAtMs = nextState?.queuedAtMs;
+          const runningAtMs = nextState?.runningAtMs;
+          if (
+            activationPersisted &&
+            !cleanupFailed &&
+            queuedAtMs === undefined &&
+            runningAtMs === undefined
+          ) {
             cleanupFailed = true;
             throw new Error("cleanup persist failed");
           }
           await realSave(storePath, nextStore, opts);
-          if (!reservationPersisted && runningAtMs === dueAt) {
+          if (!reservationPersisted && queuedAtMs === dueAt) {
             reservationPersisted = true;
             now = dueAt + 1;
           } else if (reservationPersisted && runningAtMs === dueAt + 1) {
@@ -309,13 +317,14 @@ describe("cron service run admission cleanup", () => {
       const saveSpy = vi
         .spyOn(cronStoreModule, "saveCronJobsStore")
         .mockImplementation(async (storePath, nextStore, opts) => {
-          const runningAtMs = nextStore.jobs.find((entry) => entry.id === job.id)?.state
-            .runningAtMs;
-          if (activationPersisted && runningAtMs === undefined) {
+          const nextState = nextStore.jobs.find((entry) => entry.id === job.id)?.state;
+          const queuedAtMs = nextState?.queuedAtMs;
+          const runningAtMs = nextState?.runningAtMs;
+          if (activationPersisted && queuedAtMs === undefined && runningAtMs === undefined) {
             throw new Error("terminal cleanup persist failed");
           }
           await realSave(storePath, nextStore, opts);
-          if (!reservationPersisted && runningAtMs === dueAt) {
+          if (!reservationPersisted && queuedAtMs === dueAt) {
             reservationPersisted = true;
             now = dueAt + 1;
           } else if (reservationPersisted && runningAtMs === dueAt + 1) {

--- a/src/cron/service/ops.run-admission.test.ts
+++ b/src/cron/service/ops.run-admission.test.ts
@@ -125,6 +125,54 @@ describe("cron service run admission", () => {
     await Promise.all([manualRun, timerRun]);
   });
 
+  it("drains a burst of scheduled jobs without exceeding shared admission", async () => {
+    vi.useRealTimers();
+    const store = opsRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:05.250Z");
+    const jobs = Array.from({ length: 40 }, (_, index) =>
+      createDueIsolatedJob({
+        id: `scheduled-admission-burst-${index}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      }),
+    );
+    await saveCronStore(store.storePath, { version: 1, jobs });
+
+    let active = 0;
+    let peakActive = 0;
+    const completed = new Set<string>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      cronConfig: { maxConcurrentRuns: 4 },
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async ({ job }: { job: { id: string } }) => {
+        active += 1;
+        peakActive = Math.max(peakActive, active);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 2);
+        });
+        active -= 1;
+        completed.add(job.id);
+        return { status: "ok" as const, summary: job.id };
+      }),
+    });
+
+    await onTimer(state);
+
+    expect(completed).toEqual(new Set(jobs.map((job) => job.id)));
+    expect(peakActive).toBe(4);
+    const persisted = await loadCronStore(store.storePath);
+    expect(
+      persisted.jobs.every(
+        (job) => job.state.queuedAtMs === undefined && job.state.runningAtMs === undefined,
+      ),
+    ).toBe(true);
+  });
+
   it("finalizes an admitted scheduled sibling before surfacing an activation failure", async () => {
     const store = opsRegressionFixtures.makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:05.500Z");
@@ -178,7 +226,7 @@ describe("cron service run admission", () => {
         await realSave(storePath, nextStore, opts);
         if (
           !reservationsPersisted &&
-          nextStore.jobs.every((job) => job.state.runningAtMs === dueAt)
+          nextStore.jobs.every((job) => job.state.queuedAtMs === dueAt)
         ) {
           reservationsPersisted = true;
           now = dueAt + 1;
@@ -253,7 +301,7 @@ describe("cron service run admission", () => {
     await activeStarted.promise;
     const waitingRun = run(state, waitingJob.id, "force");
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
@@ -390,7 +438,7 @@ describe("cron service run admission", () => {
       expect(state.queuedRunReservationsByJobId.get(waitingJob.id)?.identity).not.toBe(
         staleIdentity,
       );
-      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
@@ -471,17 +519,22 @@ describe("cron service run admission", () => {
     await activeStarted.promise;
     const waitingRun = run(state, waitingJob.id, "force");
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
     recomputeNextRunsForMaintenance(state);
-    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
-      dueAt,
-    );
+    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(dueAt);
 
     releaseActive.resolve({ status: "ok", summary: "active" });
     await waitingStarted.promise;
+    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      dueAt,
+    );
+    recomputeNextRunsForMaintenance(state);
+    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      dueAt,
+    );
     releaseWaiting.resolve({ status: "ok", summary: "waiting" });
     await Promise.all([activeRun, waitingRun]);
 
@@ -530,29 +583,37 @@ describe("cron service run admission", () => {
     await activeStarted.promise;
     const waitingRun = run(state, waitingJob.id, "force");
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
     now += 2 * 60 * 60 * 1000 + 1;
     recomputeNextRunsForMaintenance(state);
-    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
-      dueAt,
-    );
+    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(dueAt);
     releaseActive.resolve({ status: "ok", summary: "active" });
     await waitingStarted.promise;
-    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(now);
+    const waitingStartedAt = now;
+    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      waitingStartedAt,
+    );
     expect(
       (await loadCronStore(store.storePath))?.jobs.find((job) => job.id === waitingJob.id)?.state
         .runningAtMs,
-    ).toBe(now);
+    ).toBe(waitingStartedAt);
+    expect(state.queuedRunReservationsByJobId.has(waitingJob.id)).toBe(true);
+    now += 2 * 60 * 60 * 1000 + 1;
+    recomputeNextRunsForMaintenance(state);
+    expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      waitingStartedAt,
+    );
     now += 100;
     releaseWaiting.resolve({ status: "ok", summary: "queued" });
 
     await Promise.all([activeRun, waitingRun]);
     const completedWaitingJob = state.store?.jobs.find((job) => job.id === waitingJob.id);
-    expect(completedWaitingJob?.state.lastRunAtMs).toBe(dueAt + 2 * 60 * 60 * 1000 + 1);
-    expect(completedWaitingJob?.state.lastDurationMs).toBe(100);
+    expect(completedWaitingJob?.state.lastRunAtMs).toBe(waitingStartedAt);
+    expect(completedWaitingJob?.state.lastDurationMs).toBe(2 * 60 * 60 * 1000 + 101);
+    expect(state.queuedRunReservationsByJobId.has(waitingJob.id)).toBe(false);
   });
 
   it("releases a manual reservation when activation reload fails", async () => {
@@ -626,7 +687,7 @@ describe("cron service run admission", () => {
       .spyOn(cronStoreModule, "saveCronJobsStore")
       .mockImplementation(async (storePath, nextStore, opts) => {
         await realSave(storePath, nextStore, opts);
-        if (nextStore.jobs.find((entry) => entry.id === job.id)?.state.runningAtMs === dueAt) {
+        if (nextStore.jobs.find((entry) => entry.id === job.id)?.state.queuedAtMs === dueAt) {
           stop(state);
         }
       });
@@ -744,7 +805,7 @@ describe("cron service run admission", () => {
     await activeStarted.promise;
     const waitingRun = run(state, waitingJob.id, "force");
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === waitingJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
@@ -797,7 +858,7 @@ describe("cron service run admission", () => {
     await activeStarted.promise;
     const timerRun = onTimer(state);
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === scheduledJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === scheduledJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -47,11 +47,11 @@ import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import {
   cancelCronRunAdmissionWaiters,
+  clearQueuedCronRunReservationMarker,
   isQueuedCronRunReservationCurrent,
   isQueuedCronRunReservationMarkerCurrent,
   releaseQueuedCronRun,
   reserveQueuedCronRun,
-  restoreQueuedCronRunReservationLastError,
   runWithCronAdmission,
   updateQueuedCronRunReservationMarker,
 } from "./run-admission.js";
@@ -171,7 +171,17 @@ export async function start(state: CronServiceState) {
     const jobs = state.store?.jobs ?? [];
     for (const job of jobs) {
       job.state ??= {};
+      if (typeof job.state.queuedAtMs === "number") {
+        state.deps.log.info(
+          { jobId: job.id, queuedAtMs: job.state.queuedAtMs },
+          "cron: releasing queued job reservation on startup",
+        );
+        job.state.queuedAtMs = undefined;
+        repairedAnyStartupRun = true;
+      }
       if (typeof job.state.runningAtMs === "number") {
+        // Older releases used runningAtMs for both queued and active work. Those
+        // rows are intentionally recovered conservatively to avoid replaying side effects.
         const runningAtMs = job.state.runningAtMs;
         const taskRunId = tryFindCronTaskRunIdForRecovery(state, job.id, runningAtMs);
         const finalized = tryFindFinalizedCronTaskRun(state, job.id, runningAtMs);
@@ -494,6 +504,7 @@ function finalizeUpdatedJob(params: {
       nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
     } else {
       nextJob.state.nextRunAtMs = undefined;
+      nextJob.state.queuedAtMs = undefined;
       nextJob.state.runningAtMs = undefined;
     }
   } else if (isJobEnabled(nextJob) && !hasScheduledNextRunAtMs(nextJob.state.nextRunAtMs)) {
@@ -862,7 +873,7 @@ async function inspectManualRunPreflight(
       await skipInvalidPersistedManualRun({ state, job, mode, runId, terminalTracker, error });
       return { ok: true, ran: false, reason: "invalid-spec" as const };
     }
-    if (typeof job.state.runningAtMs === "number") {
+    if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
       return { ok: true, ran: false, reason: "already-running" as const };
     }
     const now = state.deps.nowMs();
@@ -941,7 +952,7 @@ async function prepareManualRun(
       });
       return { ok: true, ran: false, reason: "invalid-spec" as const };
     }
-    if (typeof job.state.runningAtMs === "number") {
+    if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
       return { ok: true, ran: false, reason: "already-running" as const };
     }
     const reservationAt = state.deps.nowMs();
@@ -949,8 +960,8 @@ async function prepareManualRun(
       return { ok: true, ran: false, reason: "not-due" as const };
     }
     const reservationRollbackSnapshot = snapshotStoreForRollback(state);
-    job.state.runningAtMs = reservationAt;
-    // Persist the running marker before releasing lock so timer ticks that
+    job.state.queuedAtMs = reservationAt;
+    // Persist the queued marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.
     await persistOrRestore(state, reservationRollbackSnapshot);
     const reservationIdentity = reserveQueuedCronRun(state, job.id, reservationAt, {
@@ -961,19 +972,19 @@ async function prepareManualRun(
         await ensureLoaded(state, { forceReload: true, skipRecompute: true });
         const persistedJob = state.store?.jobs.find((entry) => entry.id === id);
         if (
-          typeof persistedJob?.state.runningAtMs !== "number" ||
+          typeof persistedJob?.state.queuedAtMs !== "number" ||
           !isQueuedCronRunReservationMarkerCurrent(
             state,
             job.id,
             reservationIdentity,
-            persistedJob.state.runningAtMs,
+            persistedJob.state.queuedAtMs,
           )
         ) {
           releaseQueuedCronRun(state, job.id, reservationIdentity);
           return;
         }
         const rollbackSnapshot = snapshotStoreForRollback(state);
-        delete persistedJob.state.runningAtMs;
+        delete persistedJob.state.queuedAtMs;
         await persistOrRestore(state, rollbackSnapshot);
         releaseQueuedCronRun(state, job.id, reservationIdentity);
       };
@@ -1026,13 +1037,13 @@ async function activatePreparedManualRun(
     if (
       !job ||
       !isQueuedCronRunReservationCurrent(state, prepared.jobId, prepared.reservationIdentity) ||
-      job.state.runningAtMs !== prepared.reservationAt
+      job.state.queuedAtMs !== prepared.reservationAt
     ) {
       await releasePreparedManualReservationWithRetry(state, prepared);
       return { ok: true, ran: false, reason: "not-due" } as const;
     }
     const dueProbe = structuredClone(job);
-    delete dueProbe.state.runningAtMs;
+    delete dueProbe.state.queuedAtMs;
     if (
       (prepared.wasEnabled && !isJobEnabled(job)) ||
       !isJobDue(dueProbe, state.deps.nowMs(), { forced: mode === "force" })
@@ -1058,6 +1069,7 @@ async function activatePreparedManualRun(
     const startedAt = state.deps.nowMs();
     const previousLastError = job.state.lastError;
     const activationRollbackSnapshot = snapshotStoreForRollback(state);
+    delete job.state.queuedAtMs;
     job.state.runningAtMs = startedAt;
     job.state.lastError = undefined;
     // A failed write restores the durable reservation; run() owns releasing
@@ -1087,7 +1099,6 @@ async function activatePreparedManualRun(
         reason: state.stopped ? "stopped" : "restart-recovery-pending",
       } as const;
     }
-    releaseQueuedCronRun(state, prepared.jobId, prepared.reservationIdentity);
     emit(state, { jobId: job.id, action: "started", job, runAtMs: startedAt });
     const taskRunId = tryCreateCronTaskRun({
       state,
@@ -1126,26 +1137,19 @@ async function releasePreparedManualReservation(
     return;
   }
   const job = state.store?.jobs.find((entry) => entry.id === prepared.jobId);
+  const rollbackSnapshot = snapshotStoreForRollback(state);
   if (
-    typeof job?.state.runningAtMs !== "number" ||
-    !isQueuedCronRunReservationMarkerCurrent(
+    !job ||
+    !clearQueuedCronRunReservationMarker(
       state,
       prepared.jobId,
       prepared.reservationIdentity,
-      job.state.runningAtMs,
+      job.state,
     )
   ) {
     releaseQueuedCronRun(state, prepared.jobId, prepared.reservationIdentity);
     return;
   }
-  restoreQueuedCronRunReservationLastError(
-    state,
-    prepared.jobId,
-    prepared.reservationIdentity,
-    job.state,
-  );
-  const rollbackSnapshot = snapshotStoreForRollback(state);
-  delete job.state.runningAtMs;
   await persistOrRestore(state, rollbackSnapshot);
   releaseQueuedCronRun(state, prepared.jobId, prepared.reservationIdentity);
 }
@@ -1394,6 +1398,7 @@ async function finishPreparedManualRun(
     }
     emitMissingQueuedTerminal();
   } finally {
+    releaseQueuedCronRun(state, prepared.jobId, prepared.reservationIdentity);
     clearManualCronJobActive(state, jobId, prepared.activeJobMarker);
   }
 }
@@ -1414,9 +1419,8 @@ export async function run(
     try {
       activeRun = await activatePreparedManualRun(state, prepared, mode);
     } catch (error) {
-      // Only activation failures still own the original durable reservation.
-      // Once activation succeeds, a same-millisecond started marker is valid
-      // recovery state and must survive any later execution/finalization error.
+      // Activation failures still own the original durable reservation. Once
+      // activation succeeds, finishPreparedManualRun releases it after execution.
       try {
         await locked(state, async () => {
           await releasePreparedManualReservationWithRetry(state, prepared);

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -61,7 +61,7 @@ export function cancelCronRunAdmissionWaiters(state: CronServiceState): void {
   }
 }
 
-/** Track a persisted marker only while it is waiting for shared admission. */
+/** Track a persisted marker through shared admission and payload execution. */
 export function reserveQueuedCronRun(
   state: CronServiceState,
   jobId: string,
@@ -126,6 +126,32 @@ export function restoreQueuedCronRunReservationLastError(
   }
 }
 
+/** Clear a locally owned reservation, including a persisted-but-unstarted activation. */
+export function clearQueuedCronRunReservationMarker(
+  state: CronServiceState,
+  jobId: string,
+  identity: object,
+  jobState: { queuedAtMs?: number; runningAtMs?: number; lastError?: string },
+): boolean {
+  const reservation = state.queuedRunReservationsByJobId.get(jobId);
+  if (reservation?.identity !== identity) {
+    return false;
+  }
+  const queuedMatches = reservation.markerAtMs === jobState.queuedAtMs;
+  const runningMatches = reservation.markerAtMs === jobState.runningAtMs;
+  if (!queuedMatches && !runningMatches) {
+    return false;
+  }
+  restoreQueuedCronRunReservationLastError(state, jobId, identity, jobState);
+  if (queuedMatches) {
+    delete jobState.queuedAtMs;
+  }
+  if (runningMatches) {
+    delete jobState.runningAtMs;
+  }
+  return true;
+}
+
 export function isQueuedCronRunReservationMarkerCurrent(
   state: CronServiceState,
   jobId: string,
@@ -136,23 +162,23 @@ export function isQueuedCronRunReservationMarkerCurrent(
   return reservation?.identity === identity && reservation.markerAtMs === runningAtMs;
 }
 
-/** A matching process-local record means this durable marker is queued, not stuck. */
+/** A matching process-local record means this durable queued or running marker is still owned. */
 export function isQueuedCronRun(
   state: CronServiceState,
   jobId: string,
-  runningAtMs: number,
+  queuedAtMs: number,
 ): boolean {
-  return state.queuedRunReservationsByJobId.get(jobId)?.markerAtMs === runningAtMs;
+  return state.queuedRunReservationsByJobId.get(jobId)?.markerAtMs === queuedAtMs;
 }
 
 /** A disabled job can retain only a force reservation that predated the disabled state. */
 export function isQueuedForceCronRun(
   state: CronServiceState,
   jobId: string,
-  runningAtMs: number,
+  markerAtMs: number,
 ): boolean {
   const reservation = state.queuedRunReservationsByJobId.get(jobId);
-  return reservation?.markerAtMs === runningAtMs && reservation.preserveWhenDisabled;
+  return reservation?.markerAtMs === markerAtMs && reservation.preserveWhenDisabled;
 }
 
 /**

--- a/src/cron/service/timer-outcome-finalization.ts
+++ b/src/cron/service/timer-outcome-finalization.ts
@@ -1,11 +1,7 @@
 /** Finalizes cron task rows and active markers after timer outcome persistence. */
 import { clearCronJobActive, isCronActiveJobMarkerCurrent } from "../active-jobs.js";
 import type { CronActiveJobMarker } from "../active-jobs.js";
-import {
-  isQueuedCronRunReservationMarkerCurrent,
-  releaseQueuedCronRun,
-  restoreQueuedCronRunReservationLastError,
-} from "./run-admission.js";
+import { clearQueuedCronRunReservationMarker, releaseQueuedCronRun } from "./run-admission.js";
 import type { CronServiceState } from "./state.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
 
@@ -76,21 +72,14 @@ export function clearUnstartedStartupCatchupReservationMarkers(
     }
     const job = state.store?.jobs.find((entry) => entry.id === candidate.jobId);
     if (
-      typeof job?.state.runningAtMs === "number" &&
-      isQueuedCronRunReservationMarkerCurrent(
-        state,
-        candidate.jobId,
-        candidate.reservationIdentity,
-        job.state.runningAtMs,
-      )
-    ) {
-      restoreQueuedCronRunReservationLastError(
+      job &&
+      clearQueuedCronRunReservationMarker(
         state,
         candidate.jobId,
         candidate.reservationIdentity,
         job.state,
-      );
-      delete job.state.runningAtMs;
+      )
+    ) {
       pendingReleases.push(candidate);
     } else {
       releaseQueuedCronRun(state, candidate.jobId, candidate.reservationIdentity);

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2166,26 +2166,36 @@ describe("cron service timer regressions", () => {
     const timerRun = onTimer(state);
     await firstStarted.promise;
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(dueAt);
+      expect(state.store?.jobs.find((job) => job.id === second.id)?.state.queuedAtMs).toBe(dueAt);
     });
     now += 2 * 60 * 60 * 1000 + 1;
     recomputeNextRunsForMaintenance(state);
-    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(dueAt);
+    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.queuedAtMs).toBe(dueAt);
 
     releaseFirst.resolve({ status: "ok", summary: "first" });
     await secondStarted.promise;
-    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(now);
+    const secondStartedAt = now;
+    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(
+      secondStartedAt,
+    );
     expect(
       (await loadCronStore(store.storePath))?.jobs.find((job) => job.id === second.id)?.state
         .runningAtMs,
-    ).toBe(now);
+    ).toBe(secondStartedAt);
+    expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(true);
+    now += 2 * 60 * 60 * 1000 + 1;
+    recomputeNextRunsForMaintenance(state);
+    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(
+      secondStartedAt,
+    );
     now += 100;
     releaseSecond.resolve({ status: "ok", summary: "second" });
 
     await timerRun;
     const completedSecond = state.store?.jobs.find((job) => job.id === second.id);
-    expect(completedSecond?.state.lastRunAtMs).toBe(dueAt + 2 * 60 * 60 * 1000 + 1);
-    expect(completedSecond?.state.lastDurationMs).toBe(100);
+    expect(completedSecond?.state.lastRunAtMs).toBe(secondStartedAt);
+    expect(completedSecond?.state.lastDurationMs).toBe(2 * 60 * 60 * 1000 + 101);
+    expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(false);
   });
 
   it("shares maxConcurrentRuns with startup catch-up", async () => {
@@ -2227,7 +2237,7 @@ describe("cron service timer regressions", () => {
     await activeStarted.promise;
     const catchupRun = runMissedJobs(state);
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
@@ -2277,7 +2287,7 @@ describe("cron service timer regressions", () => {
     await activeStarted.promise;
     const catchupRun = runMissedJobs(state);
     await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.runningAtMs).toBe(
+      expect(state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.queuedAtMs).toBe(
         dueAt,
       );
     });
@@ -2819,7 +2829,7 @@ describe("cron service timer regressions", () => {
     if (!replacementPersistedJob) {
       throw new Error("expected replacement-claimed startup job");
     }
-    replacementPersistedJob.state.runningAtMs = replacementReservationMs;
+    replacementPersistedJob.state.queuedAtMs = replacementReservationMs;
     await saveCronStore(store.storePath, replacementStore);
 
     releaseRun.resolve({ status: "ok", summary: "old service result" });
@@ -2835,7 +2845,7 @@ describe("cron service timer regressions", () => {
     expect(persistedJob?.state.lastStatus).toBeUndefined();
     expect(persistedUnstartedJob?.state.runningAtMs).toBeUndefined();
     expect(persistedUnstartedJob?.state.lastStatus).toBeUndefined();
-    expect(persistedReplacementClaimedJob?.state.runningAtMs).toBe(replacementReservationMs);
+    expect(persistedReplacementClaimedJob?.state.queuedAtMs).toBe(replacementReservationMs);
     expect(persistedReplacementClaimedJob?.state.lastStatus).toBeUndefined();
     expect(
       listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id)
@@ -2889,7 +2899,7 @@ describe("cron service timer regressions", () => {
     if (!replacementPersistedJob) {
       throw new Error("expected replacement-claimed timer job");
     }
-    replacementPersistedJob.state.runningAtMs = replacementReservationMs;
+    replacementPersistedJob.state.queuedAtMs = replacementReservationMs;
     await saveCronStore(store.storePath, replacementStore);
 
     releaseRun.resolve({ status: "ok", summary: "old service result" });
@@ -2897,7 +2907,7 @@ describe("cron service timer regressions", () => {
 
     const persisted = await loadCronStore(store.storePath);
     expect(
-      persisted.jobs.find((entry) => entry.id === replacementClaimedJob.id)?.state.runningAtMs,
+      persisted.jobs.find((entry) => entry.id === replacementClaimedJob.id)?.state.queuedAtMs,
     ).toBe(replacementReservationMs);
   });
 

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -247,7 +247,7 @@ describe("cron service timer seam coverage", () => {
     const saveSpy = vi
       .spyOn(cronStoreModule, "saveCronJobsStore")
       .mockImplementation(async (...args) => {
-        const marker = args[1].jobs[0]?.state.runningAtMs;
+        const marker = args[1].jobs[0]?.state.queuedAtMs;
         if (reservedAt === undefined && typeof marker === "number") {
           reservedAt = marker;
         }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -83,6 +83,7 @@ import {
 } from "./jobs.js";
 import { locked } from "./locked.js";
 import {
+  clearQueuedCronRunReservationMarker,
   isQueuedCronRunReservationMarkerCurrent,
   isQueuedCronRunReservationCurrent,
   releaseQueuedCronRun,
@@ -136,6 +137,7 @@ type TimedCronRunOutcome = CronRunOutcome &
     delivery?: CronDeliveryTrace;
     isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
     activeJobMarker?: CronActiveJobMarker;
+    reservationIdentity?: object;
     startedAt: number;
     endedAt: number;
     triggerEval?: CronTriggerEvalOutcome;
@@ -745,6 +747,7 @@ export function applyJobResult(
       job.state.lastRunAtMs = saved;
     }
   };
+  job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
   job.state.lastRunAtMs = result.startedAt;
   job.state.lastRunStatus = result.status;
@@ -1103,6 +1106,7 @@ export function applyTriggerNoFireResult(
   job: CronJob,
   result: { startedAt: number; endedAt: number; triggerEval: CronTriggerEvalOutcome },
 ): void {
+  job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
   job.updatedAtMs = result.endedAt;
   if (!result.triggerEval.busy) {
@@ -1348,7 +1352,7 @@ async function onAdmittedTimer(state: CronServiceState) {
       const now = state.deps.nowMs();
       const reservationRollbackSnapshot = snapshotStoreForRollback(state);
       for (const job of due) {
-        job.state.runningAtMs = now;
+        job.state.queuedAtMs = now;
       }
       await persistOrRestore(state, reservationRollbackSnapshot);
       const reservedDue = due.map((job) => ({
@@ -1369,12 +1373,12 @@ async function onAdmittedTimer(state: CronServiceState) {
             }
             const persistedJob = state.store?.jobs.find((entry) => entry.id === candidate.id);
             if (
-              typeof persistedJob?.state.runningAtMs === "number" &&
+              typeof persistedJob?.state.queuedAtMs === "number" &&
               isQueuedCronRunReservationMarkerCurrent(
                 state,
                 candidate.id,
                 candidate.reservationIdentity,
-                persistedJob.state.runningAtMs,
+                persistedJob.state.queuedAtMs,
               )
             ) {
               restoreQueuedCronRunReservationLastError(
@@ -1383,7 +1387,7 @@ async function onAdmittedTimer(state: CronServiceState) {
                 candidate.reservationIdentity,
                 persistedJob.state,
               );
-              delete persistedJob.state.runningAtMs;
+              delete persistedJob.state.queuedAtMs;
               pendingReleases.push(candidate);
             } else {
               releaseQueuedCronRun(state, candidate.id, candidate.reservationIdentity);
@@ -1452,6 +1456,7 @@ async function onAdmittedTimer(state: CronServiceState) {
           job: executionJob,
           taskRunId,
           activeJobMarker,
+          reservationIdentity: params.reservationIdentity,
           ...result,
           startedAt,
           endedAt: state.deps.nowMs(),
@@ -1467,6 +1472,7 @@ async function onAdmittedTimer(state: CronServiceState) {
           job: executionJob,
           taskRunId,
           activeJobMarker,
+          reservationIdentity: params.reservationIdentity,
           status: "error",
           error: errorText,
           diagnostics: createCronRunDiagnosticsFromError("cron-setup", errorText, {
@@ -1524,6 +1530,11 @@ async function onAdmittedTimer(state: CronServiceState) {
         finalizationSucceeded = finalizedResults.length > 0;
         return finalizedResults;
       } finally {
+        for (const result of completedResults) {
+          if (result.reservationIdentity) {
+            releaseQueuedCronRun(state, result.jobId, result.reservationIdentity);
+          }
+        }
         if (opts?.clearOnFailure !== false || finalizationSucceeded) {
           clearActiveMarkersForOutcomes(completedResults);
         }
@@ -1550,21 +1561,9 @@ async function onAdmittedTimer(state: CronServiceState) {
           }
           const job = state.store?.jobs.find((entry) => entry.id === due.id);
           if (
-            typeof job?.state.runningAtMs === "number" &&
-            isQueuedCronRunReservationMarkerCurrent(
-              state,
-              due.id,
-              due.reservationIdentity,
-              job.state.runningAtMs,
-            )
+            job &&
+            clearQueuedCronRunReservationMarker(state, due.id, due.reservationIdentity, job.state)
           ) {
-            restoreQueuedCronRunReservationLastError(
-              state,
-              due.id,
-              due.reservationIdentity,
-              job.state,
-            );
-            delete job.state.runningAtMs;
             pendingReleases.push(due);
           } else {
             releaseQueuedCronRun(state, due.id, due.reservationIdentity);
@@ -1623,19 +1622,19 @@ async function onAdmittedTimer(state: CronServiceState) {
                 if (
                   !job ||
                   !isQueuedCronRunReservationCurrent(state, due.id, due.reservationIdentity) ||
-                  job.state.runningAtMs !== due.reservedAtMs
+                  job.state.queuedAtMs !== due.reservedAtMs
                 ) {
                   releaseQueuedCronRun(state, due.id, due.reservationIdentity);
                   return undefined;
                 }
                 const dueProbe = structuredClone(job);
-                delete dueProbe.state.runningAtMs;
+                delete dueProbe.state.queuedAtMs;
                 if (
                   !isJobEnabled(job) ||
                   !isRunnableJob({ state, job: dueProbe, nowMs: state.deps.nowMs() })
                 ) {
                   const rollbackSnapshot = snapshotStoreForRollback(state);
-                  delete job.state.runningAtMs;
+                  delete job.state.queuedAtMs;
                   await persistOrRestore(state, rollbackSnapshot);
                   releaseQueuedCronRun(state, due.id, due.reservationIdentity);
                   return undefined;
@@ -1643,6 +1642,7 @@ async function onAdmittedTimer(state: CronServiceState) {
                 const startedAt = state.deps.nowMs();
                 const previousLastError = job.state.lastError;
                 const activationRollbackSnapshot = snapshotStoreForRollback(state);
+                delete job.state.queuedAtMs;
                 job.state.runningAtMs = startedAt;
                 job.state.lastError = undefined;
                 await persistOrRestore(state, activationRollbackSnapshot);
@@ -1662,14 +1662,19 @@ async function onAdmittedTimer(state: CronServiceState) {
                   releaseQueuedCronRun(state, due.id, due.reservationIdentity);
                   return undefined;
                 }
-                releaseQueuedCronRun(state, due.id, due.reservationIdentity);
                 return { ...due, job, startedAt };
               });
               if (!currentDueJob) {
                 return pMapSkip;
               }
               claimedIndexes.add(index);
-              const result = await runDueJob(currentDueJob);
+              let result: TimedCronRunOutcome;
+              try {
+                result = await runDueJob(currentDueJob);
+              } catch (error) {
+                releaseQueuedCronRun(state, due.id, due.reservationIdentity);
+                throw error;
+              }
               if (!result.isolatedAgentSetupTimeout) {
                 return result;
               }
@@ -1807,7 +1812,7 @@ function isRunnableJob(params: {
   if (params.skipJobIds?.has(job.id)) {
     return false;
   }
-  if (typeof job.state.runningAtMs === "number") {
+  if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
     return false;
   }
   const lastRunStatus = resolveJobLastRunStatus(job);
@@ -1899,6 +1904,7 @@ function deferPendingBackoffMissedCronSlots(
       !isJobEnabled(job) ||
       job.schedule.kind !== "cron" ||
       opts?.skipJobIds?.has(job.id) ||
+      typeof job.state.queuedAtMs === "number" ||
       typeof job.state.runningAtMs === "number"
     ) {
       continue;
@@ -2096,7 +2102,7 @@ async function planStartupCatchup(
     }
     const reservationRollbackSnapshot = snapshotStoreForRollback(state);
     for (const job of startupCandidates) {
-      job.state.runningAtMs = now;
+      job.state.queuedAtMs = now;
     }
     await persistOrRestore(state, reservationRollbackSnapshot);
 
@@ -2136,13 +2142,13 @@ async function executeStartupCatchupPlan(
               candidate.jobId,
               candidate.reservationIdentity,
             ) ||
-            job.state.runningAtMs !== candidate.reservedAtMs
+            job.state.queuedAtMs !== candidate.reservedAtMs
           ) {
             releaseQueuedCronRun(state, candidate.jobId, candidate.reservationIdentity);
             return undefined;
           }
           const dueProbe = structuredClone(job);
-          delete dueProbe.state.runningAtMs;
+          delete dueProbe.state.queuedAtMs;
           if (
             !isRunnableJob({
               state,
@@ -2153,7 +2159,7 @@ async function executeStartupCatchupPlan(
             })
           ) {
             const rollbackSnapshot = snapshotStoreForRollback(state);
-            delete job.state.runningAtMs;
+            delete job.state.queuedAtMs;
             recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
             await persistOrRestore(state, rollbackSnapshot);
             releaseQueuedCronRun(state, candidate.jobId, candidate.reservationIdentity);
@@ -2162,6 +2168,7 @@ async function executeStartupCatchupPlan(
           const startedAt = state.deps.nowMs();
           const previousLastError = job.state.lastError;
           const activationRollbackSnapshot = snapshotStoreForRollback(state);
+          delete job.state.queuedAtMs;
           job.state.runningAtMs = startedAt;
           job.state.lastError = undefined;
           await persistOrRestore(state, activationRollbackSnapshot);
@@ -2180,12 +2187,17 @@ async function executeStartupCatchupPlan(
             releaseQueuedCronRun(state, candidate.jobId, candidate.reservationIdentity);
             return undefined;
           }
-          releaseQueuedCronRun(state, candidate.jobId, candidate.reservationIdentity);
           return { ...candidate, job, startedAt };
         });
-        return startedCandidate
-          ? await runStartupCatchupCandidate(state, startedCandidate)
-          : undefined;
+        if (!startedCandidate) {
+          return undefined;
+        }
+        try {
+          return await runStartupCatchupCandidate(state, startedCandidate);
+        } catch (error) {
+          releaseQueuedCronRun(state, candidate.jobId, candidate.reservationIdentity);
+          throw error;
+        }
       });
       if (admission.kind === "stopped") {
         break;
@@ -2232,6 +2244,7 @@ async function runStartupCatchupCandidate(
       job: executionJob,
       taskRunId,
       activeJobMarker,
+      reservationIdentity: candidate.reservationIdentity,
       status: result.status,
       error: result.error,
       executionStarted: result.executionStarted,
@@ -2257,6 +2270,7 @@ async function runStartupCatchupCandidate(
       job: executionJob,
       taskRunId,
       activeJobMarker,
+      reservationIdentity: candidate.reservationIdentity,
       status: "error",
       error: normalizeCronRunErrorText(err),
       diagnostics: createCronRunDiagnosticsFromError("cron-setup", normalizeCronRunErrorText(err), {
@@ -2362,6 +2376,11 @@ async function applyStartupCatchupOutcomes(
     });
     return finalizedOutcomes;
   } finally {
+    for (const outcome of outcomes) {
+      if (outcome.reservationIdentity) {
+        releaseQueuedCronRun(state, outcome.jobId, outcome.reservationIdentity);
+      }
+    }
     clearActiveMarkersForOutcomes(outcomes);
   }
 }

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -497,6 +497,32 @@ describe("cron store", () => {
     await expectPathMissing(`${store.storePath}.bak`);
   });
 
+  it("stores queued reservations separately from active run markers", async () => {
+    const store = await makeStorePath();
+    const payload = makeStore("job-queued-phase", true);
+    const job = expectDefined(payload.jobs[0], "payload.jobs[0] test invariant");
+    job.state = { nextRunAtMs: job.createdAtMs, queuedAtMs: job.createdAtMs + 1 };
+
+    await saveCronStore(store.storePath, payload);
+
+    const queuedRow = openOpenClawStateDatabase()
+      .db.prepare("SELECT running_at_ms, state_json FROM cron_jobs WHERE job_id = ?")
+      .get(job.id) as { running_at_ms: number | null; state_json: string };
+    expect(queuedRow.running_at_ms).toBeNull();
+    expect(JSON.parse(queuedRow.state_json)).toMatchObject({ queuedAtMs: job.createdAtMs + 1 });
+    expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+      queuedAtMs: job.createdAtMs + 1,
+    });
+
+    job.state.queuedAtMs = undefined;
+    job.state.runningAtMs = job.createdAtMs + 2;
+    await saveCronStore(store.storePath, payload, { stateOnly: true });
+
+    const activated = (await loadCronStore(store.storePath)).jobs[0]?.state;
+    expect(activated?.queuedAtMs).toBeUndefined();
+    expect(activated?.runningAtMs).toBe(job.createdAtMs + 2);
+  });
+
   it("updates runtime state without replacing concurrent cron config", async () => {
     const store = await makeStorePath();
     const stale = makeStore("job-state-only", true);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -313,6 +313,8 @@ type CronCommandPayloadPatch = {
 /** Mutable runtime state persisted beside the immutable cron job spec. */
 export type CronJobState = {
   nextRunAtMs?: number;
+  /** Durable pre-admission reservation. Cleared on restart without recording a run. */
+  queuedAtMs?: number;
   runningAtMs?: number;
   lastRunAtMs?: number;
   /** Preferred execution outcome field. */

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -24,6 +24,7 @@ import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
+import { toPublicCronJob } from "../cron/public-job.js";
 import { CronService, type CronEvent } from "../cron/service.js";
 import {
   resolveCronDeliverySessionKey,
@@ -727,7 +728,9 @@ export function buildGatewayCronService(params: {
       // Any job/store change can alter session automation bindings, including
       // in-place enable flips during runs; run/schedule events bump too (cheap).
       bumpSessionAutomationVersion();
-      params.broadcast("cron", evt, { dropIfSlow: true });
+      params.broadcast("cron", evt.job ? { ...evt, job: toPublicCronJob(evt.job) } : evt, {
+        dropIfSlow: true,
+      });
       // Build hook event from CronEvent. The job snapshot is carried on the
       // internal event so it's available even for "removed" actions where
       // getJob() would return undefined. `delivery` and `usage` are

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -23,6 +23,7 @@ import {
 import { resolveCronDeliveryPreviews } from "../../cron/delivery-preview.js";
 import { assertCronDeliveryInputNonBlankFields } from "../../cron/delivery-target-validation.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
+import { toPublicCronJob } from "../../cron/public-job.js";
 import { applyJobPatch } from "../../cron/service/jobs.js";
 import {
   isInvalidCronSessionTargetIdError,
@@ -86,8 +87,9 @@ class CronJobConfigRevisionConflictError extends Error {
 }
 
 function cronJobReadView(job: CronJob) {
+  const publicJob = toPublicCronJob(job);
   return {
-    ...job,
+    ...publicJob,
     configRevision: resolveCronJobConfigRevision(job),
     nextRunAtMs: job.state.nextRunAtMs,
     lastRunAtMs: job.state.lastRunAtMs,

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -477,6 +477,26 @@ describe("gateway server cron", () => {
       const dailyJobId = (addRes.payload as { id?: unknown } | null)?.id;
       expect(typeof dailyJobId).toBe("string");
 
+      const internalJob = cronState.cron.getJob(String(dailyJobId));
+      expect(internalJob).toBeDefined();
+      if (internalJob) {
+        internalJob.state.queuedAtMs = Date.now();
+      }
+      const updateRes = await directCronReq(cronState, "cron.update", {
+        id: String(dailyJobId),
+        patch: { description: "public projection check" },
+      });
+      expect(updateRes.ok).toBe(true);
+      expect(
+        (updateRes.payload as { state?: Record<string, unknown> } | null)?.state,
+      ).not.toHaveProperty("queuedAtMs");
+      const updateEvent = await cronEvents.wait(
+        (payload) => payload.jobId === dailyJobId && payload.action === "updated",
+      );
+      expect(
+        (updateEvent.job as { state?: Record<string, unknown> } | undefined)?.state,
+      ).not.toHaveProperty("queuedAtMs");
+
       const listRes = await directCronReq(cronState, "cron.list", {
         includeDisabled: true,
       });
@@ -484,6 +504,9 @@ describe("gateway server cron", () => {
       const jobs = (listRes.payload as { jobs?: unknown } | null)?.jobs;
       expect(Array.isArray(jobs)).toBe(true);
       expect((jobs as unknown[]).length).toBe(1);
+      expect((jobs as Array<{ state?: Record<string, unknown> }>)[0]?.state).not.toHaveProperty(
+        "queuedAtMs",
+      );
       expect(((jobs as Array<{ name?: unknown }>)[0]?.name as string) ?? "").toBe("daily");
       expect(
         ((jobs as Array<{ delivery?: { mode?: unknown } }>)[0]?.delivery?.mode as string) ?? "",
@@ -535,6 +558,9 @@ describe("gateway server cron", () => {
       expect(getRes.ok).toBe(true);
       expect((getRes.payload as { id?: unknown } | null)?.id).toBe(dailyJobId);
       expect((getRes.payload as { name?: unknown } | null)?.name).toBe("daily");
+      expect(
+        (getRes.payload as { state?: Record<string, unknown> } | null)?.state,
+      ).not.toHaveProperty("queuedAtMs");
 
       const missingGetRes = await directCronReq(cronState, "cron.get", { id: "missing-job-id" });
       expect(missingGetRes.ok).toBe(false);


### PR DESCRIPTION
Related: #101988
Related: #102236

## What Problem This Solves

Fixes an issue where scheduled cron runs that were waiting for the shared concurrency slot could be treated as interrupted after a Gateway restart, even though they had never started. For one-shot jobs, that could delete or disable the job without executing it.

## Why This Change Was Made

Cron now persists queued and running as separate internal phases. A job receives its running marker only after admission, queued markers are cleared and rescheduled during startup, and active in-process reservations remain protected for the complete run. The private queued marker is projected out of Gateway responses, so the public protocol and SQLite schema remain unchanged. Legacy running markers remain conservatively interrupted because old releases did not preserve enough information to replay them without risking duplicate side effects.

Adds a live QA scenario where an OpenAI model creates exactly one one-shot job and one recurring job through native cron tools, then verifies schedules, natural execution, one-shot deletion, recurring continuity, and post-restart execution.

## User Impact

Queued cron jobs survive Gateway restarts without false failures or silent one-shot loss. Recurring jobs resume normally. One-shot jobs still execute exactly once and are removed afterward.

## Evidence

- Isolated live Gateway on custom port 60688 with `openai/gpt-5.6-luna`: model made exactly two native cron-add calls; one-shot ran once and was deleted; recurring job ran 10 times, remained enabled, and ran again after Gateway restart.
- Full remote cron suite: 130 files, 1,439 tests passed.
- Focused local cron/Gateway/QA suites: 178 + 22 + 61 tests passed; restart/admission regression group: 104 tests passed.
- Remote `pnpm build`: passed.
- Remote `check:changed`: typecheck, formatting, lint, boundaries, cycle checks, and all changed-surface gates passed.
- Fresh autoreview: no accepted or actionable findings.
