### PR TITLE
fix: prevent exec output capture test timeout flake

### DIFF
--- a/src/process/exec.no-output-timer.test.ts
+++ b/src/process/exec.no-output-timer.test.ts
@@ -34,7 +34,8 @@ describe("runCommandWithTimeout no-output timer", () => {
       ";",
     );
     const result = await runCommandWithTimeout([process.execPath, "-e", script], {
-      timeoutMs: 2_000,
+      // Output capture is independent from watchdog timing; Vitest owns the
+      // test deadline so a loaded worker cannot race the child's exit event.
       maxOutputBytes: 5,
     });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a Linux Node 24 CI flake where the exec output-capture test could report `termination: "timeout"` instead of `"exit"` when the shared Vitest worker was heavily loaded.

## Why This Change Was Made

The failing case tests bounded tail capture, not timeout behavior. It now leaves command lifetime to Vitest's test deadline instead of racing an unrelated 2-second command watchdog against the delayed child `exit` event. The dedicated global-timeout and no-output-timeout assertions remain unchanged.

No runtime change is needed: the failed run captured the expected stdout and stderr before the overdue global watchdog won the event-loop ordering race, and Execa 9.6.1 waits for the observed child `exit` event after cancellation.

## User Impact

No user-visible runtime change. Maintainers get deterministic CI coverage for bounded exec output capture under loaded Linux runners.

## Evidence

- Failure: [CI run 29606946090, `checks-node-compact-large-5`](https://github.com/openclaw/openclaw/actions/runs/29606946090/job/87972477490), Linux Node 24. The case took 6077 ms and received `"timeout"`; the dedicated timer cases passed.
- Bounded repetition on Blacksmith Testbox: [run 29610232989](https://github.com/openclaw/openclaw/actions/runs/29610232989), `for i in $(seq 1 20); do node scripts/run-vitest.mjs src/process/exec.no-output-timer.test.ts; done` — 20/20 files and 80/80 tests passed.
- `./node_modules/.bin/oxfmt --check src/process/exec.no-output-timer.test.ts`
- `git diff origin/main...HEAD --check`
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; implementation and evidence reviewed by the author.
