### PR TITLE
fix(ui): lock channel wizard controls while busy

### DIFF
--- a/ui/src/pages/channels/wizard-view.busy.test.ts
+++ b/ui/src/pages/channels/wizard-view.busy.test.ts
@@ -1,0 +1,144 @@
+/* @vitest-environment jsdom */
+
+import { nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../../i18n/index.ts";
+import type { ChannelWizardStep } from "./wizard-controller.ts";
+import { renderChannelWizard } from "./wizard-view.ts";
+
+function renderStep(step: ChannelWizardStep, busy = true) {
+  const container = document.createElement("div");
+  const onAnswer = vi.fn();
+  const onToggleMultiselect = vi.fn();
+  document.body.append(container);
+  render(
+    renderChannelWizard({
+      wizard: {
+        phase: "step",
+        channel: null,
+        step,
+        stepIndex: 1,
+        busy,
+        validationError: null,
+      },
+      channelLabel: (channelId) => channelId,
+      multiselectValues: ["alpha"],
+      onToggleMultiselect,
+      onAnswer,
+      onClose: vi.fn(),
+      whatsappQrDataUrl: null,
+      whatsappMessage: null,
+      whatsappConnected: null,
+      whatsappBusy: false,
+      onWhatsAppStart: vi.fn(),
+      onWhatsAppWait: vi.fn(),
+    }),
+    container,
+  );
+  return { container, onAnswer, onToggleMultiselect };
+}
+
+describe("renderChannelWizard busy controls", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  afterEach(() => {
+    for (const container of document.body.querySelectorAll("div")) {
+      render(nothing, container);
+    }
+    document.body.replaceChildren();
+  });
+
+  it("disables note and confirm answers while a step is running", () => {
+    const note = renderStep({ id: "note", type: "note", message: "Do this" });
+    const noteContinue = note.container.querySelector<HTMLButtonElement>(
+      ".channels-wizard__footer .primary",
+    );
+    expect(noteContinue?.disabled).toBe(true);
+    noteContinue?.click();
+    expect(note.onAnswer).not.toHaveBeenCalled();
+
+    const confirm = renderStep({ id: "confirm", type: "confirm", message: "Continue?" });
+    const confirmButtons = Array.from(
+      confirm.container.querySelectorAll<HTMLButtonElement>(".channels-wizard__footer button"),
+    );
+    expect(confirmButtons).toHaveLength(2);
+    expect(confirmButtons.every((button) => button.disabled)).toBe(true);
+    confirmButtons.forEach((button) => button.click());
+    expect(confirm.onAnswer).not.toHaveBeenCalled();
+  });
+
+  it("disables select choices while a step is running", () => {
+    const select = renderStep({
+      id: "select",
+      type: "select",
+      message: "Pick one",
+      options: [
+        { label: "Alpha", value: "alpha" },
+        { label: "Beta", value: "beta" },
+      ],
+    });
+    const group = select.container.querySelector<HTMLElement & { disabled: boolean }>(
+      "wa-radio-group",
+    );
+    expect(group?.disabled).toBe(true);
+    expect(group?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("disables multiselect choices and submission while a step is running", () => {
+    const multiselect = renderStep({
+      id: "multi",
+      type: "multiselect",
+      message: "Pick several",
+      options: [
+        { label: "Alpha", value: "alpha" },
+        { label: "Beta", value: "beta" },
+      ],
+    });
+    const buttons = Array.from(multiselect.container.querySelectorAll<HTMLButtonElement>("button"));
+    expect(buttons).toHaveLength(3);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    buttons.forEach((button) => button.click());
+    expect(multiselect.onToggleMultiselect).not.toHaveBeenCalled();
+    expect(multiselect.onAnswer).not.toHaveBeenCalled();
+  });
+
+  it("disables text editing and submission while a step is running", () => {
+    const text = renderStep({
+      id: "text",
+      type: "text",
+      message: "Enter a value",
+      initialValue: "original",
+    });
+    const input = text.container.querySelector<HTMLInputElement>('input[name="wizard-text"]');
+    const submit = text.container.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(input?.disabled).toBe(true);
+    expect(input?.value).toBe("original");
+    expect(submit?.disabled).toBe(true);
+    submit?.click();
+    expect(text.onAnswer).not.toHaveBeenCalled();
+  });
+
+  it("keeps controls enabled when no step request is running", () => {
+    const text = renderStep(
+      { id: "text", type: "text", message: "Enter a value", initialValue: "original" },
+      false,
+    );
+    expect(text.container.querySelector<HTMLInputElement>("input")?.disabled).toBe(false);
+    expect(text.container.querySelector<HTMLButtonElement>("button")?.disabled).toBe(false);
+
+    const select = renderStep(
+      {
+        id: "select",
+        type: "select",
+        options: [{ label: "Alpha", value: "alpha" }],
+      },
+      false,
+    );
+    expect(
+      select.container.querySelector<HTMLElement & { disabled: boolean }>("wa-radio-group")
+        ?.disabled,
+    ).toBe(false);
+  });
+});

--- a/ui/src/pages/channels/wizard-view.ts
+++ b/ui/src/pages/channels/wizard-view.ts
@@ -33,6 +33,10 @@ function stepKeyboardValue(step: ChannelWizardStep): string {
   return typeof step.initialValue === "string" ? step.initialValue : "";
 }
 
+function stepIsBusy(props: ChannelWizardViewProps): boolean {
+  return props.wizard.phase === "step" && props.wizard.busy;
+}
+
 function renderNoteStep(step: ChannelWizardStep, props: ChannelWizardViewProps) {
   const message = step.message?.trim() ?? "";
   const looksLikeCode = message.includes("{") || message.includes("  ");
@@ -59,7 +63,12 @@ function renderNoteStep(step: ChannelWizardStep, props: ChannelWizardViewProps) 
         `
       : nothing}
     <div class="channels-wizard__footer">
-      <button type="button" class="btn primary" @click=${() => props.onAnswer(null)}>
+      <button
+        type="button"
+        class="btn primary"
+        ?disabled=${stepIsBusy(props)}
+        @click=${() => props.onAnswer(null)}
+      >
         ${t("channels.setup.continue")}
       </button>
     </div>
@@ -75,6 +84,7 @@ function renderSelectStep(step: ChannelWizardStep, props: ChannelWizardViewProps
       label=${step.message ?? ""}
       orientation="vertical"
       .value=${selectedIndex >= 0 ? String(selectedIndex) : null}
+      ?disabled=${stepIsBusy(props)}
       @change=${(event: Event) => {
         const rawIndex = (event.currentTarget as HTMLElement & { value?: string | number | null })
           .value;
@@ -115,6 +125,7 @@ function renderMultiselectStep(step: ChannelWizardStep, props: ChannelWizardView
             type="button"
             class="channels-wizard__option"
             aria-pressed=${selected.has(option.value) ? "true" : "false"}
+            ?disabled=${stepIsBusy(props)}
             @click=${() => props.onToggleMultiselect(option.value)}
           >
             <span class="channels-wizard__option-label">
@@ -131,6 +142,7 @@ function renderMultiselectStep(step: ChannelWizardStep, props: ChannelWizardView
       <button
         type="button"
         class="btn primary"
+        ?disabled=${stepIsBusy(props)}
         @click=${() => props.onAnswer([...props.multiselectValues])}
       >
         ${t("channels.setup.continue")}
@@ -157,9 +169,12 @@ function renderTextStep(step: ChannelWizardStep, props: ChannelWizardViewProps) 
         autocomplete=${step.sensitive ? "off" : "on"}
         placeholder=${step.placeholder ?? ""}
         .value=${stepKeyboardValue(step)}
+        ?disabled=${stepIsBusy(props)}
       />
       <div class="channels-wizard__footer" style="margin-top: 12px;">
-        <button type="submit" class="btn primary">${t("channels.setup.continue")}</button>
+        <button type="submit" class="btn primary" ?disabled=${stepIsBusy(props)}>
+          ${t("channels.setup.continue")}
+        </button>
       </div>
     </form>
   `;
@@ -169,10 +184,20 @@ function renderConfirmStep(step: ChannelWizardStep, props: ChannelWizardViewProp
   return html`
     <div class="channels-wizard__message">${step.message ?? ""}</div>
     <div class="channels-wizard__footer">
-      <button type="button" class="btn" @click=${() => props.onAnswer(false)}>
+      <button
+        type="button"
+        class="btn"
+        ?disabled=${stepIsBusy(props)}
+        @click=${() => props.onAnswer(false)}
+      >
         ${t("common.no")}
       </button>
-      <button type="button" class="btn primary" @click=${() => props.onAnswer(true)}>
+      <button
+        type="button"
+        class="btn primary"
+        ?disabled=${stepIsBusy(props)}
+        @click=${() => props.onAnswer(true)}
+      >
         ${t("common.yes")}
       </button>
     </div>


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

While the Channel Wizard waits for `wizard.next`, its controller ignores additional answers, but the rendered controls remain interactive. Users can therefore change a selection or text value on screen even though that second input is silently discarded.

## Why This Change Was Made

Disable every answer-producing control while the current wizard step is busy: note continuation, select, multiselect, text, and confirmation controls. Closing the modal and non-answer helper actions remain available. Add focused component coverage across every step type.

## User Impact

The Channel Wizard now visibly locks the current step while work is in progress, so the displayed value cannot drift away from the answer actually sent to the Gateway.

## Evidence

- `node node_modules/vitest/vitest.mjs run --root ui --config vitest.config.ts src/pages/channels/wizard-view.busy.test.ts --reporter=verbose` — 1 file passed, 5 tests passed across note, select, multiselect, text, and confirm steps.
- Fresh exact-head browser proof at `f523d11d62d9fde495b685e8649eaa011d9b95a9` with Playwright Chromium 149: the 5-option select group became disabled while a real `wizard.next` request was held pending; a forced second choice kept the request count at `1 → 1` and the original Slack selection unchanged; the Documentation helper link remained usable; resolving the request completed the flow.
- [Inspectable browser transcript and artifact hashes](https://github.com/IWhatsskill/openclaw/blob/e4827a27b8c7095ed9aed57c59464769aaada730/proof-assets/pr-110163/proof.md)
- Operator-attested browser media for this exact-head run:

<img width="1440" height="900" alt="busy-state" src="https://github.com/user-attachments/assets/d381d076-5156-4341-9eba-aa0970416fdf" />

**Busy-state video**

[busy-state.webm](https://github.com/user-attachments/assets/badce35f-058e-4348-9a85-2f0b1b9fc9c0)

- `pnpm exec oxlint ui/src/pages/channels/wizard-view.ts ui/src/pages/channels/wizard-view.busy.test.ts` — 0 warnings and 0 errors.
- `pnpm exec oxfmt --check ui/src/pages/channels/wizard-view.ts ui/src/pages/channels/wizard-view.busy.test.ts` — passed.
- `git diff --check` — passed.
