### PR TITLE
fix(qa-lab): bound credential payload reads

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -2791,21 +2791,22 @@ describe("qa cli runtime", () => {
     await fs.writeFile(payloadPath, payloadText, "utf8");
     vi.stubEnv("OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES", "32");
     vi.stubEnv("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER", "maint-secret");
-    const fetchImpl = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          status: "ok",
-          credential: {
-            credentialId: "cred-boundary",
-            kind: "telegram",
-            status: "active",
-            createdAtMs: 100,
-            updatedAtMs: 100,
-            lastLeasedAtMs: 0,
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: "ok",
+            credential: {
+              credentialId: "cred-boundary",
+              kind: "telegram",
+              status: "active",
+              createdAtMs: 100,
+              updatedAtMs: 100,
+              lastLeasedAtMs: 0,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchImpl);
 
@@ -2828,21 +2829,22 @@ describe("qa cli runtime", () => {
     await fs.writeFile(payloadPath, boundaryPayloadText, "utf8");
     vi.stubEnv("OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES", "32");
     vi.stubEnv("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER", "maint-secret");
-    const fetchImpl = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          status: "ok",
-          credential: {
-            credentialId: "cred-growing",
-            kind: "telegram",
-            status: "active",
-            createdAtMs: 100,
-            updatedAtMs: 100,
-            lastLeasedAtMs: 0,
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: "ok",
+            credential: {
+              credentialId: "cred-growing",
+              kind: "telegram",
+              status: "active",
+              createdAtMs: 100,
+              updatedAtMs: 100,
+              lastLeasedAtMs: 0,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchImpl);
     const originalOpen = fs.open.bind(fs);

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -2784,6 +2784,102 @@ describe("qa cli runtime", () => {
     }
   });
 
+  it("accepts credential payload files at the configured byte boundary", async () => {
+    const payloadText = JSON.stringify({ a: "x".repeat(24) });
+    expect(Buffer.byteLength(payloadText, "utf8")).toBe(32);
+    const payloadPath = path.join(suiteArtifactsDir, "boundary-credential.json");
+    await fs.writeFile(payloadPath, payloadText, "utf8");
+    vi.stubEnv("OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES", "32");
+    vi.stubEnv("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER", "maint-secret");
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          credential: {
+            credentialId: "cred-boundary",
+            kind: "telegram",
+            status: "active",
+            createdAtMs: 100,
+            updatedAtMs: 100,
+            lastLeasedAtMs: 0,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+
+    await runQaCredentialsAddCommand({
+      kind: "telegram",
+      payloadFile: payloadPath,
+      siteUrl: "https://qa-cred.example.convex.site",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expectWriteContains(stdoutWrite, "QA credential added: cred-boundary");
+  });
+
+  it("rejects credential payload files that grow after the initial stat", async () => {
+    const boundaryPayloadText = JSON.stringify({ a: "x".repeat(24) });
+    const oversizedPayloadText = JSON.stringify({ a: "x".repeat(25) });
+    expect(Buffer.byteLength(boundaryPayloadText, "utf8")).toBe(32);
+    expect(Buffer.byteLength(oversizedPayloadText, "utf8")).toBe(33);
+    const payloadPath = path.join(suiteArtifactsDir, "growing-credential.json");
+    await fs.writeFile(payloadPath, boundaryPayloadText, "utf8");
+    vi.stubEnv("OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES", "32");
+    vi.stubEnv("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER", "maint-secret");
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          credential: {
+            credentialId: "cred-growing",
+            kind: "telegram",
+            status: "active",
+            createdAtMs: 100,
+            updatedAtMs: 100,
+            lastLeasedAtMs: 0,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+    const originalOpen = fs.open.bind(fs);
+    let replacedPayload = false;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await originalOpen(...args);
+      const [target] = args;
+      if (path.resolve(String(target)) === payloadPath) {
+        const originalHandleStat = handle.stat.bind(handle);
+        vi.spyOn(handle, "stat").mockImplementation(async (...statArgs) => {
+          const result = await originalHandleStat(...statArgs);
+          if (!replacedPayload) {
+            replacedPayload = true;
+            await fs.writeFile(payloadPath, oversizedPayloadText, "utf8");
+          }
+          return result;
+        });
+      }
+      return handle;
+    });
+
+    try {
+      await expect(
+        runQaCredentialsAddCommand({
+          kind: "telegram",
+          payloadFile: payloadPath,
+          siteUrl: "https://qa-cred.example.convex.site",
+        }),
+      ).rejects.toThrow(
+        "Payload file exceeds OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES (32 bytes).",
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
   it("resolves docker scaffold paths relative to the explicit repo root", async () => {
     await runQaDockerScaffoldCommand({
       repoRoot: "/tmp/openclaw-repo",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1,7 +1,9 @@
 // Qa Lab tests cover cli plugin behavior.
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { QaScenarioPack } from "./scenario-catalog.js";
 
@@ -107,6 +109,7 @@ import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-
 import type { QaProviderModeInput } from "./run-config.js";
 
 const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
+const execFileAsync = promisify(execFile);
 
 function mockFirstObjectArg(mock: unknown): Record<string, unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
@@ -2881,6 +2884,36 @@ describe("qa cli runtime", () => {
       openSpy.mockRestore();
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects credential payload FIFOs without waiting for a writer",
+    async () => {
+      const previousMaxBytes = process.env.OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES;
+      const payloadPath = path.join(suiteArtifactsDir, "fifo-credential.json");
+      await execFileAsync("mkfifo", [payloadPath]);
+      process.env.OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES = "32";
+      vi.stubEnv("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER", "maint-secret");
+      const fetchImpl = vi.fn(async () => new Response("", { status: 200 }));
+      vi.stubGlobal("fetch", fetchImpl);
+
+      try {
+        await expect(
+          runQaCredentialsAddCommand({
+            kind: "telegram",
+            payloadFile: payloadPath,
+            siteUrl: "https://qa-cred.example.convex.site",
+          }),
+        ).rejects.toThrow("Payload file must be a regular JSON file.");
+        expect(fetchImpl).not.toHaveBeenCalled();
+      } finally {
+        if (previousMaxBytes === undefined) {
+          delete process.env.OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES;
+        } else {
+          process.env.OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES = previousMaxBytes;
+        }
+      }
+    },
+  );
 
   it("resolves docker scaffold paths relative to the explicit repo root", async () => {
     await runQaDockerScaffoldCommand({

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -639,16 +639,29 @@ function resolveQaCredentialPayloadFileMaxBytes(env: NodeJS.ProcessEnv = process
 
 async function readQaCredentialPayloadFile(filePath: string) {
   const maxBytes = resolveQaCredentialPayloadFileMaxBytes();
-  const stat = await fs.stat(filePath);
-  if (!stat.isFile()) {
-    throw new Error("Payload file must be a regular JSON file.");
+  const handle = await fs.open(filePath, "r");
+  let text: string;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error("Payload file must be a regular JSON file.");
+    }
+    if (stat.size > maxBytes) {
+      throw new Error(
+        `Payload file exceeds ${QA_CREDENTIAL_PAYLOAD_MAX_BYTES_ENV} (${maxBytes} bytes).`,
+      );
+    }
+    const bytes = Buffer.allocUnsafe(maxBytes + 1);
+    const result = await handle.read(bytes, 0, maxBytes + 1, 0);
+    if (result.bytesRead > maxBytes) {
+      throw new Error(
+        `Payload file exceeds ${QA_CREDENTIAL_PAYLOAD_MAX_BYTES_ENV} (${maxBytes} bytes).`,
+      );
+    }
+    text = bytes.subarray(0, result.bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
   }
-  if (stat.size > maxBytes) {
-    throw new Error(
-      `Payload file exceeds ${QA_CREDENTIAL_PAYLOAD_MAX_BYTES_ENV} (${maxBytes} bytes).`,
-    );
-  }
-  const text = await fs.readFile(filePath, "utf8");
   let payload: unknown;
   try {
     payload = JSON.parse(text) as unknown;

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1,5 +1,6 @@
 // Qa Lab plugin module implements cli behavior.
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import path from "node:path";
 import {
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
@@ -102,6 +103,11 @@ import {
 const QA_SUITE_INFRA_RETRY_LIMIT = 1;
 const QA_CREDENTIAL_PAYLOAD_MAX_BYTES_ENV = "OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES";
 const DEFAULT_QA_CREDENTIAL_PAYLOAD_MAX_BYTES = 64 * 1024 * 1024;
+const FS_CONSTANTS_WITH_OPTIONAL_NONBLOCK = fsConstants as typeof fsConstants & {
+  O_NONBLOCK?: number;
+};
+const QA_CREDENTIAL_PAYLOAD_OPEN_FLAGS =
+  fsConstants.O_RDONLY | (FS_CONSTANTS_WITH_OPTIONAL_NONBLOCK.O_NONBLOCK ?? 0);
 const QA_SUITE_INFRA_RETRY_NETWORK_ERROR_CODES = new Set([
   "ECONNRESET",
   "ECONNREFUSED",
@@ -639,7 +645,8 @@ function resolveQaCredentialPayloadFileMaxBytes(env: NodeJS.ProcessEnv = process
 
 async function readQaCredentialPayloadFile(filePath: string) {
   const maxBytes = resolveQaCredentialPayloadFileMaxBytes();
-  const handle = await fs.open(filePath, "r");
+  // Open non-blocking so FIFO payload paths fail fast before regular-file validation.
+  const handle = await fs.open(filePath, QA_CREDENTIAL_PAYLOAD_OPEN_FLAGS);
   let text: string;
   try {
     const stat = await handle.stat();

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1,6 +1,6 @@
+import { constants as fsConstants } from "node:fs";
 // Qa Lab plugin module implements cli behavior.
 import fs from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
 import path from "node:path";
 import {
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,


### PR DESCRIPTION
## What Problem This Solves

QA Lab credential add commands enforced `OPENCLAW_QA_CREDENTIAL_PAYLOAD_MAX_BYTES` with a file stat before reading the payload. A payload file could grow after that stat and before the read, which let the command read and parse data beyond the configured cap.

## Why This Change Was Made

The credential payload reader now opens the file, verifies the opened handle is a regular file, and reads at most `maxBytes + 1` bytes from that handle. That keeps boundary-sized payload JSON accepted while rejecting files that are oversized at stat time or grow past the cap before the read, without reading the whole grown file into memory.

## User Impact

Operators using QA Lab credential pools get the configured payload byte limit applied to the actual bytes consumed by the CLI. Oversized or racing payload files fail before any credential broker request is sent.

## Evidence

- Current head: `36c45dbc46e05dd87fb89a21e204d59b27e6850e`.
- Focused formatter proof: `oxfmt --check extensions/qa-lab/src/cli.runtime.ts` passed.
- `git diff --check -- extensions/qa-lab/src/cli.runtime.ts` passed.

## Related independent bug-family PRs

This is an independent bounded-file-read fix for QA Lab credential payloads. It is not stacked on any sibling PR and has no merge dependency.