### PR TITLE
fix(imessage): cap staged attachment reads

### DIFF
--- a/extensions/imessage/src/monitor/media-staging.test-utils.ts
+++ b/extensions/imessage/src/monitor/media-staging.test-utils.ts
@@ -102,7 +102,7 @@ describe("stageIMessageAttachments", () => {
     expect(convertHeicToJpeg).toHaveBeenCalledOnce();
     const [convertedPath, convertedMaxBytes] = convertHeicToJpeg.mock.calls[0]!;
     expect(convertedPath).not.toBe(sourcePath);
-    expect(path.basename(String(convertedPath))).toBe("IMG_0001.HEIC");
+    expect(path.basename(convertedPath)).toBe("IMG_0001.HEIC");
     expect(convertedMaxBytes).toBe(1024);
     expect(saveMediaBuffer).toHaveBeenCalledWith(
       Buffer.from("jpeg-bytes"),

--- a/extensions/imessage/src/monitor/media-staging.test-utils.ts
+++ b/extensions/imessage/src/monitor/media-staging.test-utils.ts
@@ -90,7 +90,9 @@ describe("stageIMessageAttachments", () => {
       size: 10,
       contentType: "image/jpeg",
     }));
-    const convertHeicToJpeg = vi.fn(async () => Buffer.from("jpeg-bytes"));
+    const convertHeicToJpeg = vi.fn<(sourcePath: string, maxBytes: number) => Promise<Buffer>>(
+      async () => Buffer.from("jpeg-bytes"),
+    );
 
     await stageIMessageAttachments(
       [{ original_path: sourcePath, mime_type: "image/heic", missing: false }],
@@ -98,7 +100,7 @@ describe("stageIMessageAttachments", () => {
     );
 
     expect(convertHeicToJpeg).toHaveBeenCalledOnce();
-    const [convertedPath, convertedMaxBytes] = convertHeicToJpeg.mock.calls[0] ?? [];
+    const [convertedPath, convertedMaxBytes] = convertHeicToJpeg.mock.calls[0]!;
     expect(convertedPath).not.toBe(sourcePath);
     expect(path.basename(String(convertedPath))).toBe("IMG_0001.HEIC");
     expect(convertedMaxBytes).toBe(1024);
@@ -166,7 +168,9 @@ describe("stageIMessageAttachments", () => {
     });
 
     const saveMediaBuffer = vi.fn();
-    const convertHeicToJpeg = vi.fn(async () => Buffer.from("jpeg-bytes"));
+    const convertHeicToJpeg = vi.fn<(sourcePath: string, maxBytes: number) => Promise<Buffer>>(
+      async () => Buffer.from("jpeg-bytes"),
+    );
     const logVerbose = vi.fn();
 
     await expect(

--- a/extensions/imessage/src/monitor/media-staging.test-utils.ts
+++ b/extensions/imessage/src/monitor/media-staging.test-utils.ts
@@ -19,6 +19,7 @@ describe("stageIMessageAttachments", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -96,7 +97,11 @@ describe("stageIMessageAttachments", () => {
       { maxBytes: 1024, deps: { saveMediaBuffer, convertHeicToJpeg } },
     );
 
-    expect(convertHeicToJpeg).toHaveBeenCalledWith(sourcePath, 1024);
+    expect(convertHeicToJpeg).toHaveBeenCalledOnce();
+    const [convertedPath, convertedMaxBytes] = convertHeicToJpeg.mock.calls[0] ?? [];
+    expect(convertedPath).not.toBe(sourcePath);
+    expect(path.basename(String(convertedPath))).toBe("IMG_0001.HEIC");
+    expect(convertedMaxBytes).toBe(1024);
     expect(saveMediaBuffer).toHaveBeenCalledWith(
       Buffer.from("jpeg-bytes"),
       "image/jpeg",
@@ -120,6 +125,92 @@ describe("stageIMessageAttachments", () => {
 
     expect(saveMediaBuffer).not.toHaveBeenCalled();
     expect(logVerbose).toHaveBeenCalledWith(expect.stringContaining("failed to stage"));
+  });
+
+  it("drops allowed attachments that grow after stat before read", async () => {
+    const sourcePath = await writeTempFile("growing.png", Buffer.from("1234"));
+    const realOpen = fs.open.bind(fs);
+    let grewBeforeRead = false;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (!grewBeforeRead && path.resolve(String(args[0])) === path.resolve(sourcePath)) {
+        grewBeforeRead = true;
+        await fs.appendFile(sourcePath, Buffer.from("56789"));
+      }
+      return await realOpen(...args);
+    });
+
+    const saveMediaBuffer = vi.fn();
+    const logVerbose = vi.fn();
+
+    await expect(
+      stageIMessageAttachments(
+        [{ original_path: sourcePath, mime_type: "image/png", missing: false }],
+        { maxBytes: 4, allowedRoots: [tempDir], deps: { saveMediaBuffer, logVerbose } },
+      ),
+    ).resolves.toEqual({ attachments: [], unavailableCount: 1 });
+
+    expect(saveMediaBuffer).not.toHaveBeenCalled();
+    expect(logVerbose).toHaveBeenCalledWith(expect.stringContaining("attachment exceeds"));
+  });
+
+  it("drops HEIC attachments that grow after stat before conversion", async () => {
+    const sourcePath = await writeTempFile("growing.HEIC", Buffer.from("1234"));
+    const realOpen = fs.open.bind(fs);
+    let grewBeforeRead = false;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (!grewBeforeRead && path.resolve(String(args[0])) === path.resolve(sourcePath)) {
+        grewBeforeRead = true;
+        await fs.appendFile(sourcePath, Buffer.from("56789"));
+      }
+      return await realOpen(...args);
+    });
+
+    const saveMediaBuffer = vi.fn();
+    const convertHeicToJpeg = vi.fn(async () => Buffer.from("jpeg-bytes"));
+    const logVerbose = vi.fn();
+
+    await expect(
+      stageIMessageAttachments(
+        [{ original_path: sourcePath, mime_type: "image/heic", missing: false }],
+        {
+          maxBytes: 4,
+          allowedRoots: [tempDir],
+          deps: { saveMediaBuffer, convertHeicToJpeg, logVerbose },
+        },
+      ),
+    ).resolves.toEqual({ attachments: [], unavailableCount: 1 });
+
+    expect(convertHeicToJpeg).not.toHaveBeenCalled();
+    expect(saveMediaBuffer).not.toHaveBeenCalled();
+    expect(logVerbose).toHaveBeenCalledWith(expect.stringContaining("attachment exceeds"));
+  });
+
+  it("stages allowed attachments exactly at the inbound media limit", async () => {
+    const sourcePath = await writeTempFile("boundary.png", Buffer.from("1234"));
+    const saveMediaBuffer = vi.fn(async () => ({
+      id: "boundary.png",
+      path: "/state/media/inbound/boundary.png",
+      size: 4,
+      contentType: "image/png",
+    }));
+
+    await expect(
+      stageIMessageAttachments(
+        [{ original_path: sourcePath, mime_type: "image/png", missing: false }],
+        { maxBytes: 4, allowedRoots: [tempDir], deps: { saveMediaBuffer } },
+      ),
+    ).resolves.toEqual({
+      attachments: [{ path: "/state/media/inbound/boundary.png", contentType: "image/png" }],
+      unavailableCount: 0,
+    });
+
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      Buffer.from("1234"),
+      "image/png",
+      "inbound",
+      4,
+      "boundary.png",
+    );
   });
 
   it("counts attachments already marked missing", async () => {

--- a/extensions/imessage/src/monitor/media-staging.ts
+++ b/extensions/imessage/src/monitor/media-staging.ts
@@ -1,5 +1,6 @@
 // Imessage plugin module implements media staging behavior.
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { isInboundPathAllowed } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
@@ -36,6 +37,52 @@ function isHeicAttachment(attachmentPath: string, mimeType?: string | null): boo
 function jpegFilenameForAttachment(attachmentPath: string): string {
   const parsed = path.parse(attachmentPath);
   return `${parsed.name || "imessage-attachment"}.jpg`;
+}
+
+function attachmentLimitMessage(maxBytes: number): string {
+  return `attachment exceeds ${Math.round(maxBytes / (1024 * 1024))}MB limit`;
+}
+
+async function readFileWithinLimit(filePath: string, maxBytes: number): Promise<Buffer> {
+  const handle = await fs.open(filePath, "r");
+  try {
+    const readLimit = Math.max(0, Math.floor(maxBytes)) + 1;
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let position = 0;
+    while (totalBytes <= maxBytes) {
+      const chunkSize = Math.min(64 * 1024, Math.max(1, readLimit - totalBytes));
+      const chunk = Buffer.allocUnsafe(chunkSize);
+      const { bytesRead } = await handle.read(chunk, 0, chunkSize, position);
+      if (bytesRead === 0) {
+        break;
+      }
+      totalBytes += bytesRead;
+      if (totalBytes > maxBytes) {
+        throw new Error(attachmentLimitMessage(maxBytes));
+      }
+      chunks.push(chunk.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+    return Buffer.concat(chunks, totalBytes);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function withHeicSnapshot<T>(
+  sourcePath: string,
+  buffer: Buffer,
+  fn: (snapshotPath: string, snapshotDir: string) => Promise<T>,
+): Promise<T> {
+  const snapshotDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-heic-"));
+  try {
+    const snapshotPath = path.join(snapshotDir, path.basename(sourcePath));
+    await fs.writeFile(snapshotPath, buffer, { flag: "wx" });
+    return await fn(snapshotPath, snapshotDir);
+  } finally {
+    await fs.rm(snapshotDir, { recursive: true, force: true });
+  }
 }
 
 function hasWildcardSegment(root: string): boolean {
@@ -87,7 +134,7 @@ async function readAttachmentBuffer(params: {
     throw new Error("attachment path is not a file");
   }
   if (stat.size > params.maxBytes) {
-    throw new Error(`attachment exceeds ${Math.round(params.maxBytes / (1024 * 1024))}MB limit`);
+    throw new Error(attachmentLimitMessage(params.maxBytes));
   }
 
   const canonicalPath = await resolveAllowedCanonicalAttachmentPath({
@@ -99,21 +146,24 @@ async function readAttachmentBuffer(params: {
     throw new Error("attachment path is not a file");
   }
   if (canonicalStat.size > params.maxBytes) {
-    throw new Error(`attachment exceeds ${Math.round(params.maxBytes / (1024 * 1024))}MB limit`);
+    throw new Error(attachmentLimitMessage(params.maxBytes));
   }
 
   if (isHeicAttachment(params.attachmentPath, params.mimeType)) {
     try {
+      const sourceBuffer = await readFileWithinLimit(canonicalPath, params.maxBytes);
       const convert = params.deps.convertHeicToJpeg;
-      const converted = convert
-        ? {
-            buffer: await convert(canonicalPath, params.maxBytes),
-            fileName: jpegFilenameForAttachment(params.attachmentPath),
-          }
-        : await loadWebMedia(canonicalPath, {
-            maxBytes: params.maxBytes,
-            localRoots: [path.dirname(canonicalPath)],
-          });
+      const converted = await withHeicSnapshot(canonicalPath, sourceBuffer, async (snapshotPath, snapshotDir) =>
+        convert
+          ? {
+              buffer: await convert(snapshotPath, params.maxBytes),
+              fileName: jpegFilenameForAttachment(params.attachmentPath),
+            }
+          : await loadWebMedia(snapshotPath, {
+              maxBytes: params.maxBytes,
+              localRoots: [snapshotDir],
+            }),
+      );
       return {
         buffer: converted.buffer,
         contentType: "image/jpeg",
@@ -127,7 +177,7 @@ async function readAttachmentBuffer(params: {
   }
 
   return {
-    buffer: await fs.readFile(canonicalPath),
+    buffer: await readFileWithinLimit(canonicalPath, params.maxBytes),
     contentType: params.mimeType ?? undefined,
     originalFilename: path.basename(params.attachmentPath),
   };

--- a/extensions/imessage/src/monitor/media-staging.ts
+++ b/extensions/imessage/src/monitor/media-staging.ts
@@ -1,9 +1,9 @@
 // Imessage plugin module implements media staging behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { isInboundPathAllowed } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import type { IMessageAttachment } from "./types.js";
 
@@ -75,7 +75,9 @@ async function withHeicSnapshot<T>(
   buffer: Buffer,
   fn: (snapshotPath: string, snapshotDir: string) => Promise<T>,
 ): Promise<T> {
-  const snapshotDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-heic-"));
+  const snapshotDir = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-imessage-heic-"),
+  );
   try {
     const snapshotPath = path.join(snapshotDir, path.basename(sourcePath));
     await fs.writeFile(snapshotPath, buffer, { flag: "wx" });
@@ -153,16 +155,19 @@ async function readAttachmentBuffer(params: {
     try {
       const sourceBuffer = await readFileWithinLimit(canonicalPath, params.maxBytes);
       const convert = params.deps.convertHeicToJpeg;
-      const converted = await withHeicSnapshot(canonicalPath, sourceBuffer, async (snapshotPath, snapshotDir) =>
-        convert
-          ? {
-              buffer: await convert(snapshotPath, params.maxBytes),
-              fileName: jpegFilenameForAttachment(params.attachmentPath),
-            }
-          : await loadWebMedia(snapshotPath, {
-              maxBytes: params.maxBytes,
-              localRoots: [snapshotDir],
-            }),
+      const converted = await withHeicSnapshot(
+        canonicalPath,
+        sourceBuffer,
+        async (snapshotPath, snapshotDir) =>
+          convert
+            ? {
+                buffer: await convert(snapshotPath, params.maxBytes),
+                fileName: jpegFilenameForAttachment(params.attachmentPath),
+              }
+            : await loadWebMedia(snapshotPath, {
+                maxBytes: params.maxBytes,
+                localRoots: [snapshotDir],
+              }),
       );
       return {
         buffer: converted.buffer,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving iMessage image attachments could have attachment staging process a file larger than the configured inbound media limit when the source file grew after the initial filesystem size checks.

## Why This Change Was Made

The iMessage media staging path now reads regular attachments through a bounded file reader that stops at `maxBytes + 1` and rejects oversized growth before calling the media store. HEIC conversion now snapshots the already bounded input into a temporary file before conversion, so the converter cannot consume a later-enlarged source file.

## User Impact

Inbound iMessage attachments remain available when they are within the configured size limit, including files exactly at the boundary, while attachments that grow past the limit during staging are treated as unavailable instead of being saved or converted.

## Evidence

- Current head: `c1c4554b2fb408880a611a12f089020fbe8b9287`.
- GitHub Actions `Real behavior proof` passed for the current head.
- GitHub Actions `openclaw/ci-gate`, `check-lint`, `check-prod-types`, `check-test-types`, and `checks-node-changed` passed for the current head.
- Focused behavior proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/imessage/src/monitor.behavior.test.ts -- -t "converts HEIC|grow after stat|exactly at"` passed: 1 file, 4 tests passed, 184 skipped.