### PR TITLE
fix(browser): time out response body reads

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.responses.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.e2e.test.ts
@@ -81,7 +81,9 @@ describeBrowserE2e("pw-tools-core response bodies e2e", () => {
       }
       await page.close().catch(() => {});
       await browser.close().catch(() => {});
-      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.responses.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.e2e.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import { chromium, type Browser, type Page } from "playwright-core";
+import { describe, expect, it, vi } from "vitest";
+
+const chromiumExecutablePath = chromium.executablePath();
+const describeBrowserE2e = fs.existsSync(chromiumExecutablePath) ? describe : describe.skip;
+
+describeBrowserE2e("pw-tools-core response bodies e2e", () => {
+  it("times out a matched body read in a real Chromium session", async () => {
+    vi.useRealTimers();
+
+    const openSockets = new Set<net.Socket>();
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/page") {
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end(`<!doctype html>
+<html>
+  <body>ready</body>
+</html>`);
+        return;
+      }
+      if (url.pathname === "/hang") {
+        res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        res.write("partial");
+        return;
+      }
+      res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      res.end("not found");
+    });
+
+    server.on("connection", (socket) => {
+      openSockets.add(socket);
+      socket.on("close", () => openSockets.delete(socket));
+      socket.on("error", () => {});
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected an IPv4 server address");
+    }
+    const pageUrl = `http://127.0.0.1:${address.port}/page`;
+
+    const browser: Browser = await chromium.launch({
+      executablePath: chromiumExecutablePath,
+      headless: true,
+    });
+    const page: Page = await browser.newPage();
+
+    try {
+      vi.resetModules();
+      vi.doMock("./pw-session.js", () => ({
+        ensurePageState: vi.fn(() => {}),
+        getPageForTargetId: vi.fn(async () => page),
+      }));
+
+      const { responseBodyViaPlaywright } = await import("./pw-tools-core.responses.js");
+
+      const result = responseBodyViaPlaywright({
+        cdpUrl: "http://127.0.0.1:1",
+        targetId: "T1",
+        url: "**/hang",
+        timeoutMs: 3_000,
+      });
+
+      await Promise.resolve();
+      await page.goto(pageUrl, { waitUntil: "domcontentloaded" });
+      await page.evaluate(() => {
+        void fetch("/hang").catch(() => {});
+      });
+
+      await expect(result).rejects.toThrow(/Response body read timed out after 3000ms/);
+    } finally {
+      for (const socket of openSockets) {
+        socket.destroy();
+      }
+      await page.close().catch(() => {});
+      await browser.close().catch(() => {});
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.responses.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  getPwToolsCoreSessionMocks,
+  installPwToolsCoreTestHooks,
+  setPwToolsCoreCurrentPage,
+} from "./pw-tools-core.test-harness.js";
+
+const sessionMocks = getPwToolsCoreSessionMocks();
+
+let mod: typeof import("./pw-tools-core.responses.js");
+
+describe("pw-tools-core response bodies", () => {
+  installPwToolsCoreTestHooks();
+
+  beforeAll(async () => {
+    vi.doMock("./pw-session.js", () => sessionMocks);
+    mod = await import("./pw-tools-core.responses.js");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function installResponsePage() {
+    let responseHandler: ((resp: unknown) => void) | undefined;
+    const on = vi.fn((event: string, handler: (resp: unknown) => void) => {
+      if (event === "response") {
+        responseHandler = handler;
+      }
+    });
+    const off = vi.fn();
+    setPwToolsCoreCurrentPage({ on, off });
+    return {
+      off,
+      requireResponseHandler: () => {
+        if (!responseHandler) {
+          throw new Error("expected Playwright response handler");
+        }
+        return responseHandler;
+      },
+    };
+  }
+
+  it("rejects when a matched response body misses the same deadline", async () => {
+    vi.useFakeTimers();
+    const page = installResponsePage();
+
+    const result = mod.responseBodyViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      url: "**/api/hangs",
+      timeoutMs: 500,
+    });
+
+    await Promise.resolve();
+    const responseHandler = page.requireResponseHandler();
+    responseHandler({
+      url: () => "https://example.com/api/hangs",
+      status: () => 200,
+      headers: () => ({ "content-type": "application/json" }),
+      body: () => new Promise<Buffer>(() => {}),
+    });
+
+    const deadlineExpectation = expect(result).rejects.toThrow(
+      /Failed to read response body.*Response body read timed out after 500ms/,
+    );
+    await vi.advanceTimersByTimeAsync(500);
+
+    await deadlineExpectation;
+    expect(page.off).toHaveBeenCalledWith("response", responseHandler);
+  });
+
+  it("still returns a normal matched response body", async () => {
+    const page = installResponsePage();
+    const result = mod.responseBodyViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      url: "**/api/ok",
+      timeoutMs: 500,
+    });
+
+    await Promise.resolve();
+    page.requireResponseHandler()({
+      url: () => "https://example.com/api/ok",
+      status: () => 200,
+      headers: () => ({ "content-type": "application/json" }),
+      body: async () => Buffer.from('{"ok":true}'),
+    });
+
+    await expect(result).resolves.toMatchObject({
+      url: "https://example.com/api/ok",
+      status: 200,
+      body: '{"ok":true}',
+    });
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.responses.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.ts
@@ -7,6 +7,34 @@ import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 import { normalizeTimeoutMs } from "./pw-tools-core.shared.js";
 import { matchBrowserUrlPattern } from "./url-pattern.js";
 
+async function withResponseBodyDeadline<T>(
+  work: Promise<T>,
+  deadlineMs: number,
+  timeoutMs: number,
+  url: string,
+): Promise<T> {
+  const remainingMs = Math.max(0, deadlineMs - Date.now());
+  if (remainingMs === 0) {
+    throw new Error(`Response body read timed out after ${timeoutMs}ms for "${url}".`);
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Response body read timed out after ${timeoutMs}ms for "${url}".`));
+    }, remainingMs);
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 /** Waits for a response URL pattern and returns a bounded text body. */
 export async function responseBodyViaPlaywright(opts: {
   cdpUrl: string;
@@ -34,6 +62,7 @@ export async function responseBodyViaPlaywright(opts: {
 
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
+  const deadlineMs = Date.now() + timeout;
 
   const promise = new Promise<unknown>((resolve, reject) => {
     let done = false;
@@ -94,7 +123,7 @@ export async function responseBodyViaPlaywright(opts: {
   let bodyByteLength = 0;
   try {
     if (typeof resp.body === "function") {
-      const buf = await resp.body();
+      const buf = await withResponseBodyDeadline(resp.body(), deadlineMs, timeout, url);
       bodyByteLength = buf.byteLength;
       // Playwright exposes only a full-body Buffer. Bound the second allocation
       // while preserving the existing response-prefix contract.


### PR DESCRIPTION
## What Problem This Solves  Fixes an issue where Browser response body capture could hang past its timeout when Playwright matched the response headers but the response body read never completed.  ## Why This Change Was Made  The response-body path now carries the existing response deadline through the Playwright `response.body()` read instead of clearing the timer after the matching response event. This keeps the existing URL matching and body truncation behavior while preventing a stalled body read from holding the tool call indefinitely.  ## User Impact  Users and automation that wait for a Browser response body now get a bounded timeout failure instead of a stuck command when the response body never resolves.  ## Evidence  Current head: `7936aa3384279516dff9454f9c34a13dfefc7501`.  - `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.responses.e2e.test.ts` passed: 1 real Chromium e2e test proving the bounded response-body timeout. - `node_modules\.bin\oxlint extensions/browser/src/browser/pw-tools-core.responses.e2e.test.ts` passed: the file no longer reports the Promise executor return issue. - `git diff --check` passed. 