### PR TITLE
test(media): scope download watchdog budgets to the phase under test

### DIFF
--- a/src/media/store.download-timeout.test.ts
+++ b/src/media/store.download-timeout.test.ts
@@ -111,6 +111,23 @@ function useInjectedRequest(
   });
 }
 
+// Tight budgets go only on the phase a test asserts times out. Phases expected
+// to make progress keep production-default budgets: a 40ms real-timer watchdog
+// on a progressing phase fires spuriously under CI worker contention.
+function usePinnedResolver(timeouts?: {
+  responseHeaderTimeoutMs?: number;
+  readIdleTimeoutMs?: number;
+}): void {
+  setMediaStoreDownloadDepsForTest({
+    resolvePinnedHostname: async (hostname) => ({
+      hostname,
+      addresses: ["127.0.0.1"],
+      lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+    }),
+    ...timeouts,
+  });
+}
+
 describe("media store download timeouts", () => {
   let testState: OpenClawTestState;
   let mediaRoot: string;
@@ -175,15 +192,7 @@ describe("media store download timeouts", () => {
   beforeEach(() => {
     mode = "ok";
     stalledSocketClosed = undefined;
-    setMediaStoreDownloadDepsForTest({
-      resolvePinnedHostname: async (hostname) => ({
-        hostname,
-        addresses: ["127.0.0.1"],
-        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
-      }),
-      responseHeaderTimeoutMs: HEADER_TIMEOUT_MS,
-      readIdleTimeoutMs: IDLE_TIMEOUT_MS,
-    });
+    usePinnedResolver();
   });
 
   afterEach(async () => {
@@ -207,6 +216,7 @@ describe("media store download timeouts", () => {
 
   it("times out when the server accepts a connection but never sends headers", async () => {
     mode = "hang-headers";
+    usePinnedResolver({ responseHeaderTimeoutMs: HEADER_TIMEOUT_MS });
     await expect(saveMediaSource(baseUrl)).rejects.toThrow(
       /timed out waiting for response headers after 40ms/i,
     );
@@ -223,7 +233,6 @@ describe("media store download timeouts", () => {
       }) as unknown as typeof http.request,
       resolvePinnedHostname: async () => await new Promise<never>(() => {}),
       responseHeaderTimeoutMs: HEADER_TIMEOUT_MS,
-      readIdleTimeoutMs: IDLE_TIMEOUT_MS,
     });
 
     await expect(saveMediaSource(baseUrl)).rejects.toThrow(
@@ -235,6 +244,7 @@ describe("media store download timeouts", () => {
 
   it("times out when the response body stalls after partial data", async () => {
     mode = "stall-body";
+    usePinnedResolver({ readIdleTimeoutMs: IDLE_TIMEOUT_MS });
     await expect(saveMediaSource(baseUrl)).rejects.toThrow(/stalled: no data received for 40ms/i);
     await expectSocketClosed(stalledSocketClosed);
     expect(await listMediaFiles(mediaRoot)).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

`src/media/store.download-timeout.test.ts > "closes a stalled redirect body before following the next hop"` flaked in CI (run 29570400984): "Media download stalled: no data received for 40ms" fired from the prod idle watchdog during a phase the test expected to succeed.

## Why This Change Was Made

The suite's `beforeEach` armed **both** 40ms watchdogs (header + idle) for every test, including tests asserting success over real sockets. The redirect recursion's second hop resets the idle timer when 200 headers arrive — before any data event — so under isolate:false worker contention, >40ms between headers and first byte fires the idle watchdog on a legitimately progressing phase. The header budget carried the same hazard for the other tests.

Fix (test-only; the injection seam already existed): each test sets only the tight budget for the phase it proves times out; success-expecting phases keep production-default budgets (30s), which cannot fire mid-progress. No assertion weakened — the timeout tests still assert the same 40ms messages on the same phases; the target test's assertions (socket closed + second-hop content) are timing-independent and unchanged.

## User Impact

None — test-only.

## Evidence

- Deterministic repro both directions: a temporary second-hop `flushHeaders()` + 80ms-delayed body byte reproduced the exact CI failure under the blanket-40ms config and passed under the scoped config (repro deleted after proof). Sub-finding: without flushHeaders the same delay trips the header watchdog — both budgets were live hazards, both now scoped.
- Stress: 10/10 green runs of the file (8 tests each) at OPENCLAW_VITEST_MAX_WORKERS=6.
- `node scripts/check-changed.mjs -- src/media/store.download-timeout.test.ts` delegated to Blacksmith Testbox, exit 0 (oxfmt, tsgo core-test, lint, guards; Actions run 29612556181).
- Autoreview (codex/gpt-5.6-sol): clean, 0 findings, "patch is correct (0.98)".
