### PR TITLE
fix(baseten): reject malformed model metadata numbers

### DIFF
--- a/extensions/baseten/models.test.ts
+++ b/extensions/baseten/models.test.ts
@@ -121,26 +121,43 @@ describe("Baseten model catalog", () => {
     });
   });
 
-  it("rejects malformed live numeric strings before applying model metadata", () => {
-    const model = projectBasetenLiveModels([
+  it("rejects malformed live numeric strings without dropping compatible forms", () => {
+    const models = projectBasetenLiveModels([
       {
         id: "thinkingmachines/inkling",
         object: "model",
         context_length: "0x100000",
-        max_completion_tokens: "3.2e4",
+        max_completion_tokens: "0x8000",
         pricing: {
-          prompt: "0x1",
-          completion: "4.2e-6",
-          input_cache_read: " 0.00000018 ",
+          prompt: "1e308",
+          completion: "NaN",
+          input_cache_read: "0x1",
         },
       },
-    ])[0];
+      {
+        id: "future/model",
+        object: "model",
+        context_length: "3.2e4",
+        max_completion_tokens: " 4e3 ",
+        pricing: {
+          prompt: " 0.0000002 ",
+          completion: "4.2e-6",
+          input_cache_read: ".00000004",
+        },
+      },
+    ]);
 
-    expect(model).toMatchObject({
+    expect(models[0]).toMatchObject({
       id: "thinkingmachines/inkling",
       contextWindow: 1_048_000,
       maxTokens: 32_000,
       cost: { input: 1, output: 4.05, cacheRead: 0.17, cacheWrite: 0 },
+    });
+    expect(models[1]).toMatchObject({
+      id: "future/model",
+      contextWindow: 32_000,
+      maxTokens: 4_000,
+      cost: { input: 0.2, output: 4.2, cacheRead: 0.04, cacheWrite: 0 },
     });
   });
 

--- a/extensions/baseten/models.test.ts
+++ b/extensions/baseten/models.test.ts
@@ -121,6 +121,29 @@ describe("Baseten model catalog", () => {
     });
   });
 
+  it("rejects malformed live numeric strings before applying model metadata", () => {
+    const model = projectBasetenLiveModels([
+      {
+        id: "thinkingmachines/inkling",
+        object: "model",
+        context_length: "0x100000",
+        max_completion_tokens: "3.2e4",
+        pricing: {
+          prompt: "0x1",
+          completion: "4.2e-6",
+          input_cache_read: " 0.00000018 ",
+        },
+      },
+    ])[0];
+
+    expect(model).toMatchObject({
+      id: "thinkingmachines/inkling",
+      contextWindow: 1_048_000,
+      maxTokens: 32_000,
+      cost: { input: 1, output: 4.05, cacheRead: 0.17, cacheWrite: 0 },
+    });
+  });
+
   it("keeps discovery offline without resolved auth", async () => {
     await expect(discoverBasetenModels()).resolves.toHaveLength(12);
   });

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -147,12 +147,20 @@ type BasetenLiveModelRow = {
 };
 
 function readPositiveInteger(value: unknown): number | undefined {
-  const number = typeof value === "number" ? value : Number(value);
+  const number =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value)
+        ? Number(value)
+        : undefined;
   return Number.isSafeInteger(number) && number > 0 ? number : undefined;
 }
 
 function readPerTokenPrice(value: unknown): number | undefined {
-  if (typeof value !== "number" && (typeof value !== "string" || !value.trim())) {
+  if (
+    typeof value !== "number" &&
+    (typeof value !== "string" || !/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value))
+  ) {
     return undefined;
   }
   const number = typeof value === "number" ? value : Number(value);

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -153,6 +153,9 @@ function readPositiveInteger(value: unknown): number | undefined {
       : typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value)
         ? Number(value)
         : undefined;
+  if (number === undefined) {
+    return undefined;
+  }
   return Number.isSafeInteger(number) && number > 0 ? number : undefined;
 }
 

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -146,29 +146,31 @@ type BasetenLiveModelRow = {
   supported_features?: unknown;
 };
 
-function readPositiveInteger(value: unknown): number | undefined {
+const DECIMAL_NUMBER_STRING_RE = /^[+-]?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/;
+
+function readFiniteDecimalNumber(value: unknown): number | undefined {
   const number =
     typeof value === "number"
       ? value
-      : typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value)
+      : typeof value === "string" && DECIMAL_NUMBER_STRING_RE.test(value.trim())
         ? Number(value)
         : undefined;
-  if (number === undefined) {
-    return undefined;
-  }
-  return Number.isSafeInteger(number) && number > 0 ? number : undefined;
+  return number !== undefined && Number.isFinite(number) ? number : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  const number = readFiniteDecimalNumber(value);
+  return number !== undefined && Number.isSafeInteger(number) && number > 0 ? number : undefined;
 }
 
 function readPerTokenPrice(value: unknown): number | undefined {
-  if (
-    typeof value !== "number" &&
-    (typeof value !== "string" || !/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value))
-  ) {
+  const number = readFiniteDecimalNumber(value);
+  if (number === undefined || number < 0) {
     return undefined;
   }
-  const number = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(number) && number >= 0
-    ? Number((number * 1_000_000).toFixed(9))
+  const costPerMillionTokens = number * 1_000_000;
+  return Number.isFinite(costPerMillionTokens)
+    ? Number(costPerMillionTokens.toFixed(9))
     : undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Baseten live model discovery trusted JavaScript-only numeric string forms from `/models` metadata. Malformed strings such as hexadecimal limits, `NaN`, or prices that overflow after per-million scaling could override curated context-window, max-token, or pricing metadata instead of falling back to the bundled catalog values.

## Why This Change Was Made

Live metadata still accepts JSON numbers and compatible decimal string forms, including exponent notation and trimmed decimal strings, but rejects non-decimal, non-finite, and scaled-overflow numeric values before applying live metadata. Invalid live values are ignored so bundled fallback metadata remains authoritative for malformed rows.

## User Impact

Baseten model catalogs no longer surface inflated or malformed live context windows, token limits, or per-token prices, while valid decimal/exponent live metadata can continue to update bundled catalog values.

## Evidence

- Current head: `c85dad85ff5f3d0902a729f74ddb34217f518ecf`.
- Provider-boundary transcript at the Baseten projection seam passed for the current head: `projectBasetenLiveModels` projected one malformed fallback row and one compatible decimal-string row.
- The malformed `thinkingmachines/inkling` row used `context_length: "0x100000"`, `max_completion_tokens: "0x8000"`, and price strings `"1e308"`, `"NaN"`, and `"0x1"`; the projected model kept bundled fallback values `contextWindow: 1048000`, `maxTokens: 32000`, and cost `{ input: 1, output: 4.05, cacheRead: 0.17, cacheWrite: 0 }`.
- The compatible `future/model` row used `context_length: "3.2e4"`, `max_completion_tokens: " 4e3 "`, and prices `" 0.0000002 "`, `"4.2e-6"`, and `".00000004"`; the projected model applied live values `contextWindow: 32000`, `maxTokens: 4000`, and cost `{ input: 0.2, output: 4.2, cacheRead: 0.04, cacheWrite: 0 }`.
- Transcript assertions passed: `malformedFallsBack: true`, `compatibleStringsApply: true`, and `scaledOverflowFallsBack: true`.
- `node scripts/run-vitest.mjs extensions/baseten/models.test.ts` passed: 1 test file, 7 tests.
- `git diff --check -- extensions/baseten/models.ts extensions/baseten/models.test.ts` passed.