### PR TITLE
fix(matrix): surface sustained E2EE decryption failures

### DIFF
--- a/extensions/matrix/src/approval-auth.test.ts
+++ b/extensions/matrix/src/approval-auth.test.ts
@@ -1,6 +1,11 @@
 // Matrix tests cover approval auth plugin behavior.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { matrixApprovalAuth } from "./approval-auth.js";
+import { installMatrixTestRuntime } from "./test-runtime.js";
+
+beforeEach(() => {
+  installMatrixTestRuntime();
+});
 
 describe("matrixApprovalAuth", () => {
   it("normalizes Matrix user ids before authorizing", () => {

--- a/extensions/matrix/src/approval-native.test.ts
+++ b/extensions/matrix/src/approval-native.test.ts
@@ -1,7 +1,12 @@
 // Matrix tests cover approval native plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { matrixApprovalCapability } from "./approval-native.js";
+import { installMatrixTestRuntime } from "./test-runtime.js";
+
+beforeEach(() => {
+  installMatrixTestRuntime();
+});
 
 function buildConfig(
   overrides?: Partial<NonNullable<NonNullable<OpenClawConfig["channels"]>["matrix"]>>,

--- a/extensions/matrix/src/matrix/monitor/e2ee-health.test.ts
+++ b/extensions/matrix/src/matrix/monitor/e2ee-health.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMatrixE2eeHealthTracker } from "./e2ee-health.js";
+import type { MatrixRawEvent } from "./types.js";
+import { EventType } from "./types.js";
+
+type EventOptions = {
+  ts?: number;
+  sender?: string;
+  deviceId?: string;
+  senderKey?: string;
+};
+
+function encryptedEvent(id: string, options: EventOptions = {}): MatrixRawEvent {
+  return {
+    event_id: id,
+    sender: options.sender ?? "@alice:example.org",
+    type: EventType.RoomMessageEncrypted,
+    origin_server_ts: options.ts ?? Date.now(),
+    content: {
+      ...(options.deviceId ? { device_id: options.deviceId } : {}),
+      ...(options.senderKey ? { sender_key: options.senderKey } : {}),
+    },
+  };
+}
+
+function recordFailure(
+  tracker: ReturnType<typeof createMatrixE2eeHealthTracker>,
+  roomId: string,
+  event: MatrixRawEvent,
+  isInbound = true,
+) {
+  tracker.recordEncryptedEvent(roomId, event);
+  return tracker.recordFailure(roomId, event, new Error("missing key"), isInbound);
+}
+
+function recordSuccess(
+  tracker: ReturnType<typeof createMatrixE2eeHealthTracker>,
+  roomId: string,
+  event: MatrixRawEvent,
+  isInbound = true,
+) {
+  tracker.recordEncryptedEvent(roomId, event);
+  return tracker.recordSuccess(
+    roomId,
+    { ...event, type: EventType.RoomMessage, content: { body: "decrypted" } },
+    isInbound,
+  );
+}
+
+function createHealthyTracker(baseMs = Date.now()) {
+  return createMatrixE2eeHealthTracker({ getHealthySyncSinceMs: () => baseMs - 60_000 });
+}
+
+function degradeDefaultCohort(
+  tracker: ReturnType<typeof createMatrixE2eeHealthTracker>,
+  baseMs = Date.now(),
+) {
+  for (const index of [1, 2, 3]) {
+    recordFailure(
+      tracker,
+      "!room:example.org",
+      encryptedEvent(`$failed-${index}`, { ts: baseMs + index }),
+    );
+  }
+}
+
+describe("Matrix E2EE health tracker", () => {
+  it("degrades after three fresh failures and re-arms after recovery", () => {
+    const baseMs = Date.now();
+    const tracker = createHealthyTracker(baseMs);
+    expect(
+      recordFailure(tracker, "!room:example.org", encryptedEvent("$f1", { ts: baseMs + 1 })),
+    ).not.toHaveProperty("warning");
+    expect(
+      recordFailure(tracker, "!room:example.org", encryptedEvent("$f2", { ts: baseMs + 2 })),
+    ).not.toHaveProperty("warning");
+    expect(
+      recordFailure(tracker, "!room:example.org", encryptedEvent("$f3", { ts: baseMs + 3 })),
+    ).toHaveProperty("warning");
+    expect(
+      recordSuccess(tracker, "!room:example.org", encryptedEvent("$recovered", { ts: baseMs + 4 })),
+    ).toBe(true);
+
+    expect(
+      recordFailure(tracker, "!room:example.org", encryptedEvent("$f4", { ts: baseMs + 5 })),
+    ).not.toHaveProperty("warning");
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$f5", { ts: baseMs + 6 }));
+    expect(
+      recordFailure(tracker, "!room:example.org", encryptedEvent("$f6", { ts: baseMs + 7 })),
+    ).toHaveProperty("warning");
+  });
+
+  it("keeps pre-healthy, stale-window, and arrival-less failures generic", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-10T16:21:00.000Z"));
+    try {
+      const noHealthy = createMatrixE2eeHealthTracker({});
+      expect(
+        recordFailure(noHealthy, "!room:example.org", encryptedEvent("$pre-healthy")),
+      ).toMatchObject({ freshAfterHealthySync: false, failureCount: 0 });
+
+      const tracker = createHealthyTracker();
+      recordFailure(tracker, "!room:example.org", encryptedEvent("$old-1"));
+      vi.advanceTimersByTime(2 * 60_000 + 1);
+      expect(recordFailure(tracker, "!room:example.org", encryptedEvent("$new-1"))).toMatchObject({
+        freshAfterHealthySync: true,
+        failureCount: 1,
+      });
+      expect(
+        tracker.recordFailure(
+          "!room:example.org",
+          encryptedEvent("$arrival-less"),
+          new Error("missing"),
+          true,
+        ),
+      ).toMatchObject({ freshAfterHealthySync: false, failureCount: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores self failures and self successes for health", () => {
+    const tracker = createHealthyTracker();
+    for (const index of [1, 2, 3]) {
+      expect(
+        recordFailure(tracker, "!room:example.org", encryptedEvent(`$self-${index}`), false),
+      ).toMatchObject({ freshAfterHealthySync: false, failureCount: 0 });
+    }
+    degradeDefaultCohort(tracker);
+    expect(recordSuccess(tracker, "!room:example.org", encryptedEvent("$self-echo"), false)).toBe(
+      false,
+    );
+  });
+
+  it("requires all room and sender cohorts to recover", () => {
+    const baseMs = Date.now();
+    const tracker = createHealthyTracker(baseMs);
+    recordFailure(
+      tracker,
+      "!home:example.org",
+      encryptedEvent("$hermes-failed", { ts: baseMs + 1, sender: "@hermes:example.org" }),
+    );
+    for (const index of [1, 2]) {
+      recordFailure(
+        tracker,
+        "!kit:example.org",
+        encryptedEvent(`$element-failed-${index}`, {
+          ts: baseMs + index,
+          sender: "@alex:example.org",
+        }),
+      );
+    }
+    expect(
+      recordSuccess(
+        tracker,
+        "!home:example.org",
+        encryptedEvent("$hermes-success", {
+          ts: baseMs + 3,
+          sender: "@hermes:example.org",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      recordSuccess(
+        tracker,
+        "!kit:example.org",
+        encryptedEvent("$element-success", {
+          ts: baseMs + 4,
+          sender: "@alex:example.org",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires the failed sender device cohort to recover", () => {
+    const baseMs = Date.now();
+    const tracker = createHealthyTracker(baseMs);
+    for (const index of [1, 2, 3]) {
+      recordFailure(
+        tracker,
+        "!kit:example.org",
+        encryptedEvent(`$device-a-failed-${index}`, {
+          ts: baseMs + index,
+          sender: "@alex:example.org",
+          deviceId: "ELEMENT_A",
+          senderKey: "curve-a",
+        }),
+      );
+    }
+    expect(
+      recordSuccess(
+        tracker,
+        "!kit:example.org",
+        encryptedEvent("$device-b-success", {
+          ts: baseMs + 4,
+          sender: "@alex:example.org",
+          deviceId: "ELEMENT_B",
+          senderKey: "curve-b",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      recordSuccess(
+        tracker,
+        "!kit:example.org",
+        encryptedEvent("$device-a-success", {
+          ts: baseMs + 5,
+          sender: "@alex:example.org",
+          deviceId: "ELEMENT_A",
+          senderKey: "curve-a",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores an older delayed failure after a newer success", () => {
+    const baseMs = Date.now();
+    const tracker = createHealthyTracker(baseMs);
+    recordFailure(tracker, "!kit:example.org", encryptedEvent("$a-failed", { ts: baseMs + 1 }));
+    recordFailure(
+      tracker,
+      "!home:example.org",
+      encryptedEvent("$b-failed-1", { ts: baseMs + 1, sender: "@hermes:example.org" }),
+    );
+    recordFailure(
+      tracker,
+      "!home:example.org",
+      encryptedEvent("$b-failed-2", { ts: baseMs + 2, sender: "@hermes:example.org" }),
+    );
+    const delayed = encryptedEvent("$a-old-delayed", { ts: baseMs + 3 });
+    tracker.recordEncryptedEvent("!kit:example.org", delayed);
+    expect(
+      recordSuccess(tracker, "!kit:example.org", encryptedEvent("$a-new", { ts: baseMs + 4 })),
+    ).toBe(false);
+    expect(
+      tracker.recordFailure("!kit:example.org", delayed, new Error("late"), true),
+    ).toMatchObject({ freshAfterHealthySync: false });
+    expect(
+      recordSuccess(
+        tracker,
+        "!home:example.org",
+        encryptedEvent("$b-success", { ts: baseMs + 5, sender: "@hermes:example.org" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not let an older-timestamp success suppress a newer-timestamp failure", () => {
+    const baseMs = Date.now() - 1_000;
+    const tracker = createHealthyTracker(baseMs);
+    recordFailure(tracker, "!kit:example.org", encryptedEvent("$a-failed", { ts: baseMs + 50 }));
+    recordFailure(
+      tracker,
+      "!home:example.org",
+      encryptedEvent("$b-failed-1", { ts: baseMs + 50, sender: "@hermes:example.org" }),
+    );
+    recordFailure(
+      tracker,
+      "!home:example.org",
+      encryptedEvent("$b-failed-2", { ts: baseMs + 50, sender: "@hermes:example.org" }),
+    );
+    const delayed = encryptedEvent("$a-newer-ts", { ts: baseMs + 200 });
+    tracker.recordEncryptedEvent("!kit:example.org", delayed);
+    recordSuccess(tracker, "!kit:example.org", encryptedEvent("$a-older-ts", { ts: baseMs + 100 }));
+    expect(
+      tracker.recordFailure("!kit:example.org", delayed, new Error("late"), true),
+    ).toMatchObject({ freshAfterHealthySync: true });
+    expect(
+      recordSuccess(
+        tracker,
+        "!home:example.org",
+        encryptedEvent("$b-success", { ts: baseMs + 300, sender: "@hermes:example.org" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not watermark a non-finite success timestamp", () => {
+    const baseMs = Date.now() - 1_000;
+    const tracker = createHealthyTracker(baseMs);
+    const delayed = encryptedEvent("$delayed", { ts: baseMs + 100 });
+    tracker.recordEncryptedEvent("!kit:example.org", delayed);
+    recordSuccess(tracker, "!kit:example.org", encryptedEvent("$nan", { ts: Number.NaN }));
+    recordFailure(tracker, "!home:example.org", encryptedEvent("$b1", { ts: baseMs + 200 }));
+    recordFailure(tracker, "!home:example.org", encryptedEvent("$b2", { ts: baseMs + 200 }));
+    expect(
+      tracker.recordFailure("!kit:example.org", delayed, new Error("late"), true),
+    ).toHaveProperty("warning");
+  });
+
+  it("requires retained original arrival metadata for failures", () => {
+    const tracker = createHealthyTracker();
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$f1"));
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$f2"));
+
+    const contradictory = encryptedEvent("$same-event");
+    tracker.recordEncryptedEvent("!room:example.org", contradictory);
+    tracker.recordSuccess("!room:example.org", contradictory, true);
+    expect(
+      tracker.recordFailure("!room:example.org", contradictory, new Error("late"), true),
+    ).toMatchObject({ freshAfterHealthySync: false, failureCount: 0 });
+  });
+
+  it("keeps an evicted failure generic even after a newer success", () => {
+    const tracker = createHealthyTracker();
+    const evicted = encryptedEvent("$evicted", {
+      sender: "@alex:example.org",
+      deviceId: "ELEMENT_A",
+    });
+    tracker.recordEncryptedEvent("!kit:example.org", evicted);
+    for (let index = 0; index < 512; index += 1) {
+      tracker.recordEncryptedEvent(
+        `!pending-${index}:example.org`,
+        encryptedEvent(`$pending-${index}`, { sender: `@sender-${index}:example.org` }),
+      );
+    }
+    recordSuccess(
+      tracker,
+      "!kit:example.org",
+      encryptedEvent("$newer", { sender: "@alex:example.org", deviceId: "ELEMENT_A" }),
+    );
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$other-1"));
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$other-2"));
+    expect(
+      tracker.recordFailure("!kit:example.org", evicted, new Error("late"), true),
+    ).toMatchObject({ freshAfterHealthySync: false, failureCount: 0 });
+  });
+
+  it("keeps degradation across a new healthy-sync epoch", () => {
+    const baseMs = Date.now();
+    let healthySyncSinceMs = baseMs - 60_000;
+    const tracker = createMatrixE2eeHealthTracker({
+      getHealthySyncSinceMs: () => healthySyncSinceMs,
+    });
+    degradeDefaultCohort(tracker, baseMs);
+    healthySyncSinceMs = baseMs;
+    recordFailure(
+      tracker,
+      "!room:example.org",
+      encryptedEvent("$after-reconnect", { ts: baseMs + 10 }),
+    );
+    expect(
+      recordSuccess(
+        tracker,
+        "!room:example.org",
+        encryptedEvent("$recovered", { ts: baseMs + 11 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires recovery to be newer than failures after degradation", () => {
+    const baseMs = Date.now();
+    const tracker = createHealthyTracker(baseMs);
+    degradeDefaultCohort(tracker, baseMs);
+    recordFailure(
+      tracker,
+      "!room:example.org",
+      encryptedEvent("$later-failure", { ts: baseMs + 20 }),
+    );
+    expect(
+      recordSuccess(
+        tracker,
+        "!room:example.org",
+        encryptedEvent("$stale-success", { ts: baseMs + 10 }),
+      ),
+    ).toBe(false);
+    expect(
+      recordSuccess(
+        tracker,
+        "!room:example.org",
+        encryptedEvent("$current-success", { ts: baseMs + 21 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("latches conservative degradation when cohort capacity overflows", () => {
+    const tracker = createHealthyTracker();
+    let overflowCount = 0;
+    for (let index = 0; index < 520; index += 1) {
+      const state = recordFailure(
+        tracker,
+        `!room-${index}:example.org`,
+        encryptedEvent(`$failed-${index}`, { sender: `@sender-${index}:example.org` }),
+      );
+      overflowCount += state.cohortOverflowed ? 1 : 0;
+    }
+    expect(overflowCount).toBe(1);
+    for (let index = 0; index < 520; index += 1) {
+      expect(
+        recordSuccess(
+          tracker,
+          `!room-${index}:example.org`,
+          encryptedEvent(`$success-${index}`, { sender: `@sender-${index}:example.org` }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it.each([
+    { fillerCount: 511, shouldRecover: true },
+    { fillerCount: 512, shouldRecover: false },
+  ])("bounds encrypted arrivals with $fillerCount fillers", ({ fillerCount, shouldRecover }) => {
+    const tracker = createHealthyTracker();
+    degradeDefaultCohort(tracker);
+    const candidate = encryptedEvent("$candidate", { ts: Date.now() + 10 });
+    tracker.recordEncryptedEvent("!room:example.org", candidate);
+    for (let index = 0; index < fillerCount; index += 1) {
+      tracker.recordEncryptedEvent(
+        `!pending-${index}:example.org`,
+        encryptedEvent(`$pending-${index}`, { sender: `@sender-${index}:example.org` }),
+      );
+    }
+    expect(tracker.recordSuccess("!room:example.org", candidate, true)).toBe(shouldRecover);
+  });
+
+  it.each([
+    { fillerCount: 511, shouldDegrade: false },
+    { fillerCount: 512, shouldDegrade: true },
+  ])("bounds success watermarks with $fillerCount fillers", ({ fillerCount, shouldDegrade }) => {
+    const baseMs = Date.now() - 1_000;
+    const tracker = createHealthyTracker(baseMs);
+    const delayed = encryptedEvent("$delayed", { ts: baseMs + 100 });
+    tracker.recordEncryptedEvent("!kit:example.org", delayed);
+    recordSuccess(tracker, "!kit:example.org", encryptedEvent("$watermark", { ts: baseMs + 100 }));
+    for (let index = 0; index < fillerCount; index += 1) {
+      recordSuccess(
+        tracker,
+        `!success-${index}:example.org`,
+        encryptedEvent(`$success-${index}`, {
+          ts: baseMs + 100,
+          sender: `@sender-${index}:example.org`,
+        }),
+      );
+    }
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$other-1", { ts: baseMs + 200 }));
+    recordFailure(tracker, "!room:example.org", encryptedEvent("$other-2", { ts: baseMs + 200 }));
+    const state = tracker.recordFailure("!kit:example.org", delayed, new Error("late"), true);
+    expect("warning" in state).toBe(shouldDegrade);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/e2ee-health.ts
+++ b/extensions/matrix/src/matrix/monitor/e2ee-health.ts
@@ -1,0 +1,279 @@
+import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MatrixRawEvent } from "./types.js";
+
+const FAILURE_WINDOW_MS = 2 * 60_000;
+const FAILURE_THRESHOLD = 3;
+const FAILURE_SAMPLE_LIMIT = 3;
+const ENCRYPTED_EVENT_TRACK_LIMIT = 512;
+const COHORT_SUCCESS_TRACK_LIMIT = 512;
+export const MATRIX_E2EE_DEGRADED_COHORT_LIMIT = 512;
+
+type FailureObservation = {
+  key: string;
+  cohortKey: string;
+  roomId: string;
+  eventId: string;
+  sender: string | null;
+  eventTs: number;
+  arrivalSequence: number;
+  error: string;
+};
+
+type FailureCohort = {
+  latestEventTs: number;
+  latestArrivalSequence: number;
+};
+
+type EncryptedEventArrival = {
+  sequence: number;
+  cohortKey: string;
+};
+
+type CohortSuccess = {
+  arrivalSequence: number;
+  eventTs: number;
+};
+
+export function formatMatrixE2eeDegradationHint(accountId: string): string {
+  return (
+    "matrix: repeated fresh encrypted messages are still failing to decrypt after Matrix resumed healthy sync. " +
+    "This device may still be missing new room keys. " +
+    `Check 'openclaw matrix verify status --verbose --account ${accountId}' and 'openclaw matrix devices list --account ${accountId}'.`
+  );
+}
+
+export function formatMatrixE2eeCohortOverflowHint(): string {
+  return (
+    "matrix: E2EE degradation exceeded the tracked encrypted sender cohort limit; " +
+    "automatic recovery is disabled until the Matrix monitor restarts."
+  );
+}
+
+function isFreshPostHealthySyncFailure(params: {
+  event: MatrixRawEvent;
+  healthySyncSinceMs?: number;
+  graceMs?: number;
+  nowMs: number;
+}): boolean {
+  const { event, healthySyncSinceMs, graceMs = 0, nowMs } = params;
+  if (typeof healthySyncSinceMs !== "number" || !Number.isFinite(healthySyncSinceMs)) {
+    return false;
+  }
+  const eventTs = event.origin_server_ts;
+  if (!Number.isFinite(eventTs) || eventTs <= 0) {
+    return false;
+  }
+  if (eventTs < healthySyncSinceMs + graceMs) {
+    return false;
+  }
+  if (eventTs > nowMs + 60_000) {
+    return false;
+  }
+  return true;
+}
+
+export function createMatrixE2eeHealthTracker(params: {
+  getHealthySyncSinceMs?: () => number | undefined;
+  startupGraceMs?: number;
+}) {
+  let observations: FailureObservation[] = [];
+  let warningEmitted = false;
+  const degradedCohorts = new Map<string, FailureCohort>();
+  let degradedCohortOverflow = false;
+  let encryptedEventSequence = 0;
+  const encryptedEventArrivals = new Map<string, EncryptedEventArrival>();
+  const latestSuccessByCohort = new Map<string, CohortSuccess>();
+  let trackedHealthySyncSinceMs: number | undefined;
+
+  const eventKey = (roomId: string, event: MatrixRawEvent) => `${roomId}|${event.event_id}`;
+  const cohortKey = (roomId: string, event: MatrixRawEvent) => {
+    const deviceId = normalizeOptionalString(event.content?.device_id);
+    const senderKey = normalizeOptionalString(event.content?.sender_key);
+    return JSON.stringify([roomId, event.sender, deviceId || null, senderKey || null]);
+  };
+
+  const takeEncryptedEventArrival = (roomId: string, event: MatrixRawEvent) => {
+    const key = eventKey(roomId, event);
+    const arrival = encryptedEventArrivals.get(key);
+    encryptedEventArrivals.delete(key);
+    return arrival;
+  };
+
+  const resetFailureWave = () => {
+    observations = [];
+    warningEmitted = false;
+  };
+
+  const clearDegradation = () => {
+    resetFailureWave();
+    degradedCohorts.clear();
+    degradedCohortOverflow = false;
+  };
+
+  const recordCohortFailure = (observation: FailureObservation) => {
+    const current = degradedCohorts.get(observation.cohortKey);
+    if (!current && degradedCohorts.size >= MATRIX_E2EE_DEGRADED_COHORT_LIMIT) {
+      const overflowTriggered = !degradedCohortOverflow;
+      degradedCohortOverflow = true;
+      return overflowTriggered;
+    }
+    degradedCohorts.set(observation.cohortKey, {
+      latestEventTs: Math.max(current?.latestEventTs ?? 0, observation.eventTs),
+      latestArrivalSequence: Math.max(
+        current?.latestArrivalSequence ?? 0,
+        observation.arrivalSequence,
+      ),
+    });
+    return false;
+  };
+
+  const recordCohortSuccess = (cohort: string, success: CohortSuccess) => {
+    const current = latestSuccessByCohort.get(cohort);
+    if (current !== undefined && current.arrivalSequence >= success.arrivalSequence) {
+      return;
+    }
+    latestSuccessByCohort.delete(cohort);
+    latestSuccessByCohort.set(cohort, success);
+    if (latestSuccessByCohort.size > COHORT_SUCCESS_TRACK_LIMIT) {
+      const oldestCohort = latestSuccessByCohort.keys().next().value!;
+      latestSuccessByCohort.delete(oldestCohort);
+    }
+  };
+
+  const pruneObservations = (nowMs: number) => {
+    observations = observations.filter((entry) => nowMs - entry.eventTs <= FAILURE_WINDOW_MS);
+    if (observations.length === 0) {
+      warningEmitted = false;
+    }
+  };
+
+  return {
+    recordEncryptedEvent(roomId: string, event: MatrixRawEvent) {
+      encryptedEventSequence += 1;
+      const key = eventKey(roomId, event);
+      encryptedEventArrivals.delete(key);
+      encryptedEventArrivals.set(key, {
+        sequence: encryptedEventSequence,
+        cohortKey: cohortKey(roomId, event),
+      });
+      if (encryptedEventArrivals.size > ENCRYPTED_EVENT_TRACK_LIMIT) {
+        const oldestKey = encryptedEventArrivals.keys().next().value!;
+        encryptedEventArrivals.delete(oldestKey);
+      }
+    },
+    recordSuccess(roomId: string, event: MatrixRawEvent, isInbound: boolean) {
+      const arrival = takeEncryptedEventArrival(roomId, event);
+      if (!isInbound || !arrival) {
+        return false;
+      }
+      const eventTs = event.origin_server_ts;
+      if (!Number.isFinite(eventTs)) {
+        return false;
+      }
+      recordCohortSuccess(arrival.cohortKey, {
+        arrivalSequence: arrival.sequence,
+        eventTs,
+      });
+      if (degradedCohorts.size === 0 && !degradedCohortOverflow) {
+        return false;
+      }
+      const cohort = degradedCohorts.get(arrival.cohortKey);
+      if (!cohort) {
+        return false;
+      }
+      if (arrival.sequence <= cohort.latestArrivalSequence || eventTs < cohort.latestEventTs) {
+        return false;
+      }
+      degradedCohorts.delete(arrival.cohortKey);
+      if (degradedCohorts.size > 0 || degradedCohortOverflow) {
+        return false;
+      }
+      clearDegradation();
+      return true;
+    },
+    recordFailure(roomId: string, event: MatrixRawEvent, error: Error, isInbound: boolean) {
+      const nowMs = Date.now();
+      const arrival = takeEncryptedEventArrival(roomId, event);
+      if (!isInbound || !arrival) {
+        return { freshAfterHealthySync: false, failureCount: 0 } as const;
+      }
+      const latestSuccess = latestSuccessByCohort.get(arrival.cohortKey);
+      if (
+        latestSuccess !== undefined &&
+        latestSuccess.arrivalSequence > arrival.sequence &&
+        latestSuccess.eventTs >= event.origin_server_ts
+      ) {
+        return { freshAfterHealthySync: false, failureCount: 0 } as const;
+      }
+      const healthySyncSinceMs = params.getHealthySyncSinceMs?.();
+      if (healthySyncSinceMs !== trackedHealthySyncSinceMs) {
+        trackedHealthySyncSinceMs = healthySyncSinceMs;
+        resetFailureWave();
+      }
+      if (
+        !isFreshPostHealthySyncFailure({
+          event,
+          healthySyncSinceMs,
+          graceMs: params.startupGraceMs,
+          nowMs,
+        })
+      ) {
+        return { freshAfterHealthySync: false, failureCount: 0 } as const;
+      }
+
+      pruneObservations(nowMs);
+      const key = eventKey(roomId, event);
+      const isNewObservation = !observations.some((entry) => entry.key === key);
+      let cohortOverflowed = false;
+      if (isNewObservation) {
+        observations.push({
+          key,
+          cohortKey: arrival.cohortKey,
+          roomId,
+          eventId: event.event_id,
+          sender: typeof event.sender === "string" ? event.sender : null,
+          eventTs: event.origin_server_ts,
+          arrivalSequence: arrival.sequence,
+          error: error.message,
+        });
+        if (degradedCohorts.size > 0 || degradedCohortOverflow) {
+          cohortOverflowed = recordCohortFailure(observations.at(-1)!);
+        }
+      }
+
+      const failureCount = observations.length;
+      if (warningEmitted || failureCount < FAILURE_THRESHOLD) {
+        return { freshAfterHealthySync: true, failureCount, cohortOverflowed } as const;
+      }
+
+      warningEmitted = true;
+      for (const observation of observations) {
+        cohortOverflowed = recordCohortFailure(observation) || cohortOverflowed;
+      }
+      const rooms = uniqueStrings(observations.map((entry) => entry.roomId)).slice(
+        0,
+        FAILURE_SAMPLE_LIMIT,
+      );
+      const senders = uniqueStrings(
+        observations
+          .map((entry) => entry.sender)
+          .filter((sender): sender is string => Boolean(sender)),
+      ).slice(0, FAILURE_SAMPLE_LIMIT);
+      const eventIds = observations.slice(-FAILURE_SAMPLE_LIMIT).map((entry) => entry.eventId);
+      return {
+        freshAfterHealthySync: true,
+        failureCount,
+        cohortOverflowed,
+        warning: {
+          rooms,
+          roomCount: new Set(observations.map((entry) => entry.roomId)).size,
+          senders,
+          senderCount: new Set(observations.map((entry) => entry.sender).filter(Boolean)).size,
+          eventIds,
+          latestError: observations.at(-1)?.error ?? error.message,
+          windowMs: FAILURE_WINDOW_MS,
+        },
+      } as const;
+    },
+  };
+}

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -69,6 +69,8 @@ function createHarness(params?: {
   startupMs?: number;
   startupGraceMs?: number;
   getHealthySyncSinceMs?: () => number | undefined;
+  onE2eeDegraded?: (error: string) => void;
+  onE2eeRecovered?: () => void;
   allowFrom?: string[];
   dmEnabled?: boolean;
   dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
@@ -191,6 +193,7 @@ function createHarness(params?: {
     auth: {
       accountId: params?.accountId ?? "default",
       encryption: params?.authEncryption ?? true,
+      userId: params?.selfUserId ?? "@bot:example.org",
     } as MatrixAuth,
     allowFrom,
     dmEnabled: params?.dmEnabled ?? true,
@@ -208,6 +211,8 @@ function createHarness(params?: {
     getHealthySyncSinceMs:
       params?.getHealthySyncSinceMs ??
       (typeof params?.startupMs === "number" ? () => params.startupMs : undefined),
+    onE2eeDegraded: params?.onE2eeDegraded,
+    onE2eeRecovered: params?.onE2eeRecovered,
     formatNativeDependencyHint,
     onRoomMessage,
     runDetachedTask,
@@ -233,6 +238,9 @@ function createHarness(params?: {
     flushTasks,
     runDetachedTask,
     roomMessageListener: listeners.get("room.message") as RoomEventListener | undefined,
+    roomEncryptedEventListener: listeners.get("room.encrypted_event") as
+      | RoomEventListener
+      | undefined,
     roomDecryptedEventListener: listeners.get("room.decrypted_event") as
       | RoomEventListener
       | undefined,
@@ -245,6 +253,58 @@ function createHarness(params?: {
     roomInviteListener: listeners.get("room.invite") as RoomEventListener | undefined,
     roomJoinListener: listeners.get("room.join") as RoomEventListener | undefined,
   };
+}
+
+function createEncryptedTestEvent(
+  eventId: string,
+  originServerTs = Date.now(),
+  sender = "@alice:matrix.example.org",
+  content: Record<string, unknown> = {},
+): MatrixRawEvent {
+  return {
+    event_id: eventId,
+    sender,
+    type: EventType.RoomMessageEncrypted,
+    origin_server_ts: originServerTs,
+    content,
+  };
+}
+
+async function emitFailedDecryption(
+  harness: Pick<
+    ReturnType<typeof createHarness>,
+    "failedDecryptListener" | "flushTasks" | "roomEncryptedEventListener"
+  >,
+  eventId: string,
+  originServerTs = Date.now(),
+) {
+  if (!harness.failedDecryptListener || !harness.roomEncryptedEventListener) {
+    throw new Error("expected Matrix encryption listeners to be registered");
+  }
+  const event = createEncryptedTestEvent(eventId, originServerTs);
+  harness.roomEncryptedEventListener("!room:example.org", event);
+  harness.failedDecryptListener("!room:example.org", event, new Error("missing key"));
+  await harness.flushTasks();
+}
+
+function emitSuccessfulDecryption(
+  harness: Pick<
+    ReturnType<typeof createHarness>,
+    "roomEncryptedEventListener" | "roomDecryptedEventListener"
+  >,
+  eventId: string,
+  originServerTs = Date.now(),
+) {
+  if (!harness.roomEncryptedEventListener || !harness.roomDecryptedEventListener) {
+    throw new Error("expected Matrix encryption listeners to be registered");
+  }
+  const event = createEncryptedTestEvent(eventId, originServerTs);
+  harness.roomEncryptedEventListener("!room:example.org", event);
+  harness.roomDecryptedEventListener("!room:example.org", {
+    ...event,
+    type: EventType.RoomMessage,
+    content: { body: "decrypted" },
+  });
 }
 
 describe("registerMatrixMonitorEvents verification routing", () => {
@@ -1566,12 +1626,15 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     vi.setSystemTime(new Date("2026-04-10T16:21:00.000Z"));
     try {
       const healthySyncSinceMs = Date.now() - 60_000;
-      const { logger, failedDecryptListener, flushTasks } = createHarness({
-        accountId: "ops",
-        getHealthySyncSinceMs: () => healthySyncSinceMs,
-      });
-      if (!failedDecryptListener) {
-        throw new Error("room.failed_decryption listener was not registered");
+      const onE2eeDegraded = vi.fn();
+      const { logger, failedDecryptListener, flushTasks, roomEncryptedEventListener } =
+        createHarness({
+          accountId: "ops",
+          getHealthySyncSinceMs: () => healthySyncSinceMs,
+          onE2eeDegraded,
+        });
+      if (!failedDecryptListener || !roomEncryptedEventListener) {
+        throw new Error("Matrix encryption listeners were not registered");
       }
 
       for (const [index, roomId] of [
@@ -1579,19 +1642,31 @@ describe("registerMatrixMonitorEvents verification routing", () => {
         "!room-b:example.org",
         "!room-c:example.org",
       ].entries()) {
+        const event = createEncryptedTestEvent(
+          `$enc-fresh-${index + 1}`,
+          Date.now() - 1_000 * (index + 1),
+          `@alice${index + 1}:matrix.example.org`,
+        );
+        roomEncryptedEventListener(roomId, event);
         failedDecryptListener(
           roomId,
-          {
-            event_id: `$enc-fresh-${index + 1}`,
-            sender: `@alice${index + 1}:matrix.example.org`,
-            type: EventType.RoomMessageEncrypted,
-            origin_server_ts: Date.now() - 1_000 * (index + 1),
-            content: {},
-          },
+          event,
           new Error("The sender's device has not sent us the keys for this message."),
         );
         await flushTasks();
       }
+      failedDecryptListener(
+        "!room-c:example.org",
+        {
+          event_id: "$enc-fresh-3",
+          sender: "@alice3:matrix.example.org",
+          type: EventType.RoomMessageEncrypted,
+          origin_server_ts: Date.now() - 3_000,
+          content: {},
+        },
+        new Error("missing key"),
+      );
+      await flushTasks();
 
       expectWarnContextFields(logger, 1, "Failed to decrypt fresh post-healthy-sync message", {
         eventId: "$enc-fresh-1",
@@ -1620,9 +1695,217 @@ describe("registerMatrixMonitorEvents verification routing", () => {
           sampleEventIds: ["$enc-fresh-1", "$enc-fresh-2", "$enc-fresh-3"],
         },
       );
+      expect(onE2eeDegraded).toHaveBeenCalledTimes(1);
+      expect(onE2eeDegraded).toHaveBeenCalledWith(
+        expect.stringContaining("openclaw matrix verify status --verbose --account ops"),
+      );
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("ignores self-sent decrypt failures for E2EE health while retaining diagnostics", async () => {
+    const onE2eeDegraded = vi.fn();
+    const harness = createHarness({
+      selfUserId: "@bot:example.org",
+      getHealthySyncSinceMs: () => Date.now() - 60_000,
+      onE2eeDegraded,
+    });
+    if (!harness.failedDecryptListener || !harness.roomEncryptedEventListener) {
+      throw new Error("expected Matrix encryption listeners to be registered");
+    }
+
+    for (const eventId of ["$enc-self-1", "$enc-self-2", "$enc-self-3"]) {
+      const failedSelfEvent = createEncryptedTestEvent(eventId, Date.now(), "@bot:example.org");
+      harness.roomEncryptedEventListener("!room:example.org", failedSelfEvent);
+      harness.failedDecryptListener("!room:example.org", failedSelfEvent, new Error("missing key"));
+    }
+    await harness.flushTasks();
+
+    expect(onE2eeDegraded).not.toHaveBeenCalled();
+    expect(
+      harness.logger.warn.mock.calls.filter(([message]) => message === "Failed to decrypt message"),
+    ).toHaveLength(3);
+    expect(
+      harness.logger.warn.mock.calls.filter(([message]) =>
+        String(message).startsWith(
+          "matrix: failed to decrypt a message from this same Matrix user",
+        ),
+      ),
+    ).toHaveLength(3);
+  });
+
+  it("does not clear E2EE degradation after decrypting a self-sent encrypted echo", async () => {
+    const onE2eeDegraded = vi.fn();
+    const onE2eeRecovered = vi.fn();
+    const healthySyncSinceMs = Date.now() - 60_000;
+    const harness = createHarness({
+      selfUserId: "@bot:example.org",
+      getHealthySyncSinceMs: () => healthySyncSinceMs,
+      onE2eeDegraded,
+      onE2eeRecovered,
+    });
+
+    for (const eventId of ["$enc-1", "$enc-2", "$enc-3"]) {
+      await emitFailedDecryption(harness, eventId);
+    }
+    expect(onE2eeDegraded).toHaveBeenCalledTimes(1);
+
+    const selfEcho = createEncryptedTestEvent("$enc-self-echo", Date.now() + 1, "@bot:example.org");
+    harness.roomEncryptedEventListener?.("!room:example.org", selfEcho);
+    harness.roomDecryptedEventListener?.("!room:example.org", {
+      ...selfEcho,
+      type: EventType.RoomMessage,
+      content: { body: "outbound echo" },
+    });
+
+    expect(onE2eeRecovered).not.toHaveBeenCalled();
+  });
+
+  it("keeps a failure callback generic after success consumed the same encrypted arrival", async () => {
+    const onE2eeDegraded = vi.fn();
+    const healthySyncSinceMs = Date.now() - 60_000;
+    const harness = createHarness({
+      getHealthySyncSinceMs: () => healthySyncSinceMs,
+      onE2eeDegraded,
+    });
+    if (
+      !harness.failedDecryptListener ||
+      !harness.roomEncryptedEventListener ||
+      !harness.roomDecryptedEventListener
+    ) {
+      throw new Error("expected Matrix decryption listeners to be registered");
+    }
+
+    await emitFailedDecryption(harness, "$valid-failure-1");
+    await emitFailedDecryption(harness, "$valid-failure-2");
+    const contradictoryEvent = createEncryptedTestEvent("$success-then-failure");
+    harness.roomEncryptedEventListener("!room:example.org", contradictoryEvent);
+    harness.roomDecryptedEventListener("!room:example.org", {
+      ...contradictoryEvent,
+      type: EventType.RoomMessage,
+      content: { body: "success" },
+    });
+    harness.failedDecryptListener(
+      "!room:example.org",
+      contradictoryEvent,
+      new Error("late contradictory failure"),
+    );
+    await harness.flushTasks();
+
+    expect(onE2eeDegraded).not.toHaveBeenCalled();
+    expectWarnContextFields(harness.logger, 3, "Failed to decrypt message", {
+      eventId: "$success-then-failure",
+      freshAfterHealthySync: false,
+    });
+  });
+
+  it("keeps an arrival-less failure on the generic diagnostic path", async () => {
+    const onE2eeDegraded = vi.fn();
+    const healthySyncSinceMs = Date.now() - 60_000;
+    const harness = createHarness({
+      getHealthySyncSinceMs: () => healthySyncSinceMs,
+      onE2eeDegraded,
+    });
+    if (!harness.failedDecryptListener) {
+      throw new Error("expected Matrix failed-decryption listener to be registered");
+    }
+
+    await emitFailedDecryption(harness, "$valid-failure-1");
+    await emitFailedDecryption(harness, "$valid-failure-2");
+    harness.failedDecryptListener(
+      "!room:example.org",
+      createEncryptedTestEvent("$arrival-less"),
+      new Error("missing arrival"),
+    );
+    await harness.flushTasks();
+
+    expect(onE2eeDegraded).not.toHaveBeenCalled();
+    expectWarnContextFields(harness.logger, 3, "Failed to decrypt message", {
+      eventId: "$arrival-less",
+      freshAfterHealthySync: false,
+    });
+  });
+
+  it("orders synchronous decrypt failures before a later encrypted recovery", async () => {
+    const transitions: string[] = [];
+    const healthySyncSinceMs = Date.now() - 60_000;
+    const harness = createHarness({
+      getHealthySyncSinceMs: () => healthySyncSinceMs,
+      onE2eeDegraded: () => transitions.push("degraded"),
+      onE2eeRecovered: () => transitions.push("recovered"),
+    });
+    if (
+      !harness.failedDecryptListener ||
+      !harness.roomEncryptedEventListener ||
+      !harness.roomDecryptedEventListener
+    ) {
+      throw new Error("expected Matrix decryption listeners to be registered");
+    }
+
+    for (const eventId of ["$enc-1", "$enc-2", "$enc-3"]) {
+      const failedEvent = createEncryptedTestEvent(eventId);
+      harness.roomEncryptedEventListener("!room:example.org", failedEvent);
+      harness.failedDecryptListener("!room:example.org", failedEvent, new Error("missing key"));
+    }
+    emitSuccessfulDecryption(harness, "$enc-recovered");
+    await harness.flushTasks();
+
+    expect(transitions).toEqual(["degraded", "recovered"]);
+  });
+
+  it("stays degraded when unresolved room and sender cohorts exceed bounded capacity", async () => {
+    const onE2eeDegraded = vi.fn();
+    const onE2eeRecovered = vi.fn();
+    const healthySyncSinceMs = Date.now() - 60_000;
+    const harness = createHarness({
+      getHealthySyncSinceMs: () => healthySyncSinceMs,
+      onE2eeDegraded,
+      onE2eeRecovered,
+    });
+    if (
+      !harness.failedDecryptListener ||
+      !harness.roomEncryptedEventListener ||
+      !harness.roomDecryptedEventListener
+    ) {
+      throw new Error("expected Matrix decryption listeners to be registered");
+    }
+
+    const cohortCount = 520;
+    for (let index = 0; index < cohortCount; index += 1) {
+      const failedEvent = createEncryptedTestEvent(
+        `$enc-failed-${index}`,
+        Date.now(),
+        `@sender-${index}:example.org`,
+      );
+      harness.roomEncryptedEventListener(`!room-${index}:example.org`, failedEvent);
+      harness.failedDecryptListener(
+        `!room-${index}:example.org`,
+        failedEvent,
+        new Error("missing key"),
+      );
+    }
+    await harness.flushTasks();
+    expect(onE2eeDegraded).toHaveBeenCalledTimes(2);
+    expect(onE2eeDegraded).toHaveBeenLastCalledWith(
+      expect.stringContaining("automatic recovery is disabled until the Matrix monitor restarts"),
+    );
+
+    for (let index = 0; index < cohortCount; index += 1) {
+      const recoveredEvent = createEncryptedTestEvent(
+        `$enc-recovered-${index}`,
+        Date.now() + 1,
+        `@sender-${index}:example.org`,
+      );
+      harness.roomEncryptedEventListener(`!room-${index}:example.org`, recoveredEvent);
+      harness.roomDecryptedEventListener(`!room-${index}:example.org`, {
+        ...recoveredEvent,
+        type: EventType.RoomMessage,
+        content: { body: "decrypted" },
+      });
+    }
+
+    expect(onE2eeRecovered).not.toHaveBeenCalled();
   });
 
   it("keeps decrypt failures before healthy sync on the generic warning path", async () => {
@@ -1630,23 +1913,24 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     vi.setSystemTime(new Date("2026-04-10T16:21:00.000Z"));
     try {
       const healthySync = { sinceMs: undefined as number | undefined };
-      const { logger, failedDecryptListener, flushTasks } = createHarness({
-        accountId: "ops",
-        getHealthySyncSinceMs: () => healthySync.sinceMs,
-      });
-      if (!failedDecryptListener) {
-        throw new Error("room.failed_decryption listener was not registered");
+      const { logger, failedDecryptListener, flushTasks, roomEncryptedEventListener } =
+        createHarness({
+          accountId: "ops",
+          getHealthySyncSinceMs: () => healthySync.sinceMs,
+        });
+      if (!failedDecryptListener || !roomEncryptedEventListener) {
+        throw new Error("Matrix encryption listeners were not registered");
       }
 
+      const oldEvent = createEncryptedTestEvent(
+        "$enc-old",
+        Date.now() - 5 * 60_000,
+        "@alice:matrix.example.org",
+      );
+      roomEncryptedEventListener("!room:example.org", oldEvent);
       failedDecryptListener(
         "!room:example.org",
-        {
-          event_id: "$enc-old",
-          sender: "@alice:matrix.example.org",
-          type: EventType.RoomMessageEncrypted,
-          origin_server_ts: Date.now() - 5 * 60_000,
-          content: {},
-        },
+        oldEvent,
         new Error("The sender's device has not sent us the keys for this message."),
       );
       await flushTasks();
@@ -1659,15 +1943,15 @@ describe("registerMatrixMonitorEvents verification routing", () => {
 
       healthySync.sinceMs = Date.now();
 
+      const freshEvent = createEncryptedTestEvent(
+        "$enc-fresh-after-ready",
+        Date.now() + 1,
+        "@alice:matrix.example.org",
+      );
+      roomEncryptedEventListener("!room:example.org", freshEvent);
       failedDecryptListener(
         "!room:example.org",
-        {
-          event_id: "$enc-fresh-after-ready",
-          sender: "@alice:matrix.example.org",
-          type: EventType.RoomMessageEncrypted,
-          origin_server_ts: Date.now() + 1,
-          content: {},
-        },
+        freshEvent,
         new Error("The sender's device has not sent us the keys for this message."),
       );
       await flushTasks();
@@ -1687,25 +1971,27 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     vi.setSystemTime(new Date("2026-04-10T16:21:00.000Z"));
     try {
       const healthySyncSinceMs = Date.now() - 60_000;
-      const { logger, failedDecryptListener, flushTasks } = createHarness({
-        accountId: "ops",
-        getHealthySyncSinceMs: () => healthySyncSinceMs,
-      });
-      if (!failedDecryptListener) {
-        throw new Error("room.failed_decryption listener was not registered");
+      const { logger, failedDecryptListener, flushTasks, roomEncryptedEventListener } =
+        createHarness({
+          accountId: "ops",
+          getHealthySyncSinceMs: () => healthySyncSinceMs,
+        });
+      if (!failedDecryptListener || !roomEncryptedEventListener) {
+        throw new Error("Matrix encryption listeners were not registered");
       }
 
       for (const wave of [1, 2]) {
         for (const index of [1, 2, 3]) {
+          const roomId = `!room-${wave}-${index}:example.org`;
+          const event = createEncryptedTestEvent(
+            `$enc-wave-${wave}-${index}`,
+            Date.now() - index * 1_000,
+            `@alice${wave}${index}:matrix.example.org`,
+          );
+          roomEncryptedEventListener(roomId, event);
           failedDecryptListener(
-            `!room-${wave}-${index}:example.org`,
-            {
-              event_id: `$enc-wave-${wave}-${index}`,
-              sender: `@alice${wave}${index}:matrix.example.org`,
-              type: EventType.RoomMessageEncrypted,
-              origin_server_ts: Date.now() - index * 1_000,
-              content: {},
-            },
+            roomId,
+            event,
             new Error("The sender's device has not sent us the keys for this message."),
           );
           await flushTasks();
@@ -1742,24 +2028,26 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     vi.setSystemTime(new Date("2026-04-10T16:21:00.000Z"));
     try {
       let healthySyncSinceMs = Date.now() - 60_000;
-      const { logger, failedDecryptListener, flushTasks } = createHarness({
-        accountId: "ops",
-        getHealthySyncSinceMs: () => healthySyncSinceMs,
-      });
-      if (!failedDecryptListener) {
-        throw new Error("room.failed_decryption listener was not registered");
+      const { logger, failedDecryptListener, flushTasks, roomEncryptedEventListener } =
+        createHarness({
+          accountId: "ops",
+          getHealthySyncSinceMs: () => healthySyncSinceMs,
+        });
+      if (!failedDecryptListener || !roomEncryptedEventListener) {
+        throw new Error("Matrix encryption listeners were not registered");
       }
 
       for (const index of [1, 2, 3]) {
+        const roomId = `!room-first-${index}:example.org`;
+        const event = createEncryptedTestEvent(
+          `$enc-first-${index}`,
+          Date.now() - index * 1_000,
+          `@alice-first-${index}:matrix.example.org`,
+        );
+        roomEncryptedEventListener(roomId, event);
         failedDecryptListener(
-          `!room-first-${index}:example.org`,
-          {
-            event_id: `$enc-first-${index}`,
-            sender: `@alice-first-${index}:matrix.example.org`,
-            type: EventType.RoomMessageEncrypted,
-            origin_server_ts: Date.now() - index * 1_000,
-            content: {},
-          },
+          roomId,
+          event,
           new Error("The sender's device has not sent us the keys for this message."),
         );
         await flushTasks();
@@ -1768,15 +2056,16 @@ describe("registerMatrixMonitorEvents verification routing", () => {
       healthySyncSinceMs = Date.now();
 
       for (const index of [1, 2, 3]) {
+        const roomId = `!room-second-${index}:example.org`;
+        const event = createEncryptedTestEvent(
+          `$enc-second-${index}`,
+          Date.now() + index,
+          `@alice-second-${index}:matrix.example.org`,
+        );
+        roomEncryptedEventListener(roomId, event);
         failedDecryptListener(
-          `!room-second-${index}:example.org`,
-          {
-            event_id: `$enc-second-${index}`,
-            sender: `@alice-second-${index}:matrix.example.org`,
-            type: EventType.RoomMessageEncrypted,
-            origin_server_ts: Date.now() + index,
-            content: {},
-          },
+          roomId,
+          event,
           new Error("The sender's device has not sent us the keys for this message."),
         );
         await flushTasks();

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -1,148 +1,19 @@
 // Matrix plugin module implements events behavior.
-import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PluginRuntime, RuntimeLogger } from "../../runtime-api.js";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixAuth } from "../client.js";
 import { formatMatrixEncryptedEventDisabledWarning } from "../encryption-guidance.js";
 import type { MatrixClient } from "../sdk.js";
+import {
+  createMatrixE2eeHealthTracker,
+  formatMatrixE2eeCohortOverflowHint,
+  formatMatrixE2eeDegradationHint,
+  MATRIX_E2EE_DEGRADED_COHORT_LIMIT,
+} from "./e2ee-health.js";
 import type { MatrixRawEvent } from "./types.js";
 import { EventType } from "./types.js";
 import { createMatrixVerificationEventRouter } from "./verification-events.js";
-
-const MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_WINDOW_MS = 2 * 60_000;
-const MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_THRESHOLD = 3;
-const MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_SAMPLE_LIMIT = 3;
-
-type MatrixPostHealthySyncDecryptFailureObservation = {
-  key: string;
-  roomId: string;
-  eventId: string;
-  sender: string | null;
-  eventTs: number;
-  error: string;
-};
-
-function formatMatrixPostHealthySyncDecryptionHint(accountId: string): string {
-  return (
-    "matrix: repeated fresh encrypted messages are still failing to decrypt after Matrix resumed healthy sync. " +
-    "This device may still be missing new room keys. " +
-    `Check 'openclaw matrix verify status --verbose --account ${accountId}' and 'openclaw matrix devices list --account ${accountId}'.`
-  );
-}
-
-function isFreshPostHealthySyncDecryptFailure(params: {
-  event: MatrixRawEvent;
-  healthySyncSinceMs?: number;
-  graceMs?: number;
-  nowMs: number;
-}): boolean {
-  const { event, healthySyncSinceMs, graceMs = 0, nowMs } = params;
-  if (typeof healthySyncSinceMs !== "number" || !Number.isFinite(healthySyncSinceMs)) {
-    return false;
-  }
-  const eventTs = event.origin_server_ts;
-  if (!Number.isFinite(eventTs) || eventTs <= 0) {
-    return false;
-  }
-  if (eventTs < healthySyncSinceMs + graceMs) {
-    return false;
-  }
-  if (eventTs > nowMs + 60_000) {
-    return false;
-  }
-  return true;
-}
-
-function createMatrixPostHealthySyncDecryptFailureTracker(params: {
-  getHealthySyncSinceMs?: () => number | undefined;
-  startupGraceMs?: number;
-}) {
-  let observations: MatrixPostHealthySyncDecryptFailureObservation[] = [];
-  let warningEmitted = false;
-  let trackedHealthySyncSinceMs: number | undefined;
-
-  const resetObservations = () => {
-    observations = [];
-    warningEmitted = false;
-  };
-
-  const pruneObservations = (nowMs: number) => {
-    observations = observations.filter(
-      (entry) => nowMs - entry.eventTs <= MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_WINDOW_MS,
-    );
-    if (observations.length === 0) {
-      warningEmitted = false;
-    }
-  };
-
-  return {
-    recordFailure(roomId: string, event: MatrixRawEvent, error: Error) {
-      const nowMs = Date.now();
-      const healthySyncSinceMs = params.getHealthySyncSinceMs?.();
-      if (healthySyncSinceMs !== trackedHealthySyncSinceMs) {
-        trackedHealthySyncSinceMs = healthySyncSinceMs;
-        resetObservations();
-      }
-      if (
-        !isFreshPostHealthySyncDecryptFailure({
-          event,
-          healthySyncSinceMs,
-          graceMs: params.startupGraceMs,
-          nowMs,
-        })
-      ) {
-        return { freshAfterHealthySync: false, failureCount: 0 } as const;
-      }
-
-      pruneObservations(nowMs);
-
-      const key = `${roomId}|${event.event_id}`;
-      if (!observations.some((entry) => entry.key === key)) {
-        observations.push({
-          key,
-          roomId,
-          eventId: event.event_id,
-          sender: typeof event.sender === "string" ? event.sender : null,
-          eventTs: event.origin_server_ts,
-          error: error.message,
-        });
-      }
-
-      const failureCount = observations.length;
-      if (warningEmitted || failureCount < MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_THRESHOLD) {
-        return { freshAfterHealthySync: true, failureCount } as const;
-      }
-
-      warningEmitted = true;
-      const rooms = uniqueStrings(observations.map((entry) => entry.roomId)).slice(
-        0,
-        MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_SAMPLE_LIMIT,
-      );
-      const senders = uniqueStrings(
-        observations
-          .map((entry) => entry.sender)
-          .filter((sender): sender is string => Boolean(sender)),
-      ).slice(0, MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_SAMPLE_LIMIT);
-      const eventIds = observations
-        .slice(-MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_SAMPLE_LIMIT)
-        .map((entry) => entry.eventId);
-      const latestError = observations.at(-1)?.error ?? error.message;
-      return {
-        freshAfterHealthySync: true,
-        failureCount,
-        warning: {
-          rooms,
-          roomCount: new Set(observations.map((entry) => entry.roomId)).size,
-          senders,
-          senderCount: new Set(observations.map((entry) => entry.sender).filter(Boolean)).size,
-          eventIds,
-          latestError,
-          windowMs: MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_WINDOW_MS,
-        },
-      } as const;
-    },
-  };
-}
 
 function formatMatrixSelfDecryptionHint(accountId: string): string {
   return (
@@ -185,6 +56,8 @@ export function registerMatrixMonitorEvents(params: {
   logger: RuntimeLogger;
   startupGraceMs?: number;
   getHealthySyncSinceMs?: () => number | undefined;
+  onE2eeDegraded?: (error: string) => void;
+  onE2eeRecovered?: () => void;
   formatNativeDependencyHint: PluginRuntime["system"]["formatNativeDependencyHint"];
   onRoomMessage: (roomId: string, event: MatrixRawEvent) => void | Promise<void>;
   runDetachedTask?: (label: string, task: () => Promise<void>) => Promise<void>;
@@ -205,12 +78,14 @@ export function registerMatrixMonitorEvents(params: {
     logger,
     startupGraceMs,
     getHealthySyncSinceMs,
+    onE2eeDegraded,
+    onE2eeRecovered,
     formatNativeDependencyHint,
     onRoomMessage,
     runDetachedTask,
     sasNoticeRetryDelayMs,
   } = params;
-  const postHealthySyncDecryptFailureTracker = createMatrixPostHealthySyncDecryptFailureTracker({
+  const postHealthySyncDecryptFailureTracker = createMatrixE2eeHealthTracker({
     getHealthySyncSinceMs,
     startupGraceMs,
   });
@@ -251,6 +126,7 @@ export function registerMatrixMonitorEvents(params: {
   client.on("room.encrypted_event", (roomId: string, event: MatrixRawEvent) => {
     const eventId = event?.event_id ?? "unknown";
     const eventType = event?.type ?? "unknown";
+    postHealthySyncDecryptFailureTracker.recordEncryptedEvent(roomId, event);
     logVerboseMessage(`matrix: encrypted event room=${roomId} type=${eventType} id=${eventId}`);
   });
 
@@ -258,6 +134,15 @@ export function registerMatrixMonitorEvents(params: {
     const eventId = event?.event_id ?? "unknown";
     const eventType = event?.type ?? "unknown";
     logVerboseMessage(`matrix: decrypted event room=${roomId} type=${eventType} id=${eventId}`);
+    if (
+      postHealthySyncDecryptFailureTracker.recordSuccess(
+        roomId,
+        event,
+        event.sender !== auth.userId,
+      )
+    ) {
+      onE2eeRecovered?.();
+    }
     if (routeVerificationEvent(roomId, event)) {
       return;
     }
@@ -273,14 +158,23 @@ export function registerMatrixMonitorEvents(params: {
   });
 
   client.on("room.failed_decryption", (roomId: string, event: MatrixRawEvent, error: Error) => {
+    const failureState = postHealthySyncDecryptFailureTracker.recordFailure(
+      roomId,
+      event,
+      error,
+      event.sender !== auth.userId,
+    );
+    const degradationError = failureState.cohortOverflowed
+      ? formatMatrixE2eeCohortOverflowHint()
+      : failureState.warning
+        ? formatMatrixE2eeDegradationHint(auth.accountId)
+        : null;
+    if (degradationError) {
+      onE2eeDegraded?.(degradationError);
+    }
     void runMonitorTask(
       `failed decryption handler room=${roomId} id=${event.event_id ?? "unknown"}`,
       async () => {
-        const failureState = postHealthySyncDecryptFailureTracker.recordFailure(
-          roomId,
-          event,
-          error,
-        );
         const selfUserId = await resolveMatrixSelfUserId(client, logVerboseMessage);
         const sender = typeof event.sender === "string" ? event.sender : null;
         const senderMatchesOwnUser = Boolean(selfUserId && sender && selfUserId === sender);
@@ -302,8 +196,8 @@ export function registerMatrixMonitorEvents(params: {
               : {}),
           },
         );
-        if (failureState.warning) {
-          logger.warn(formatMatrixPostHealthySyncDecryptionHint(auth.accountId), {
+        if (failureState.warning && degradationError) {
+          logger.warn(formatMatrixE2eeDegradationHint(auth.accountId), {
             roomId,
             eventId: event.event_id,
             failureCount: failureState.failureCount,
@@ -314,6 +208,13 @@ export function registerMatrixMonitorEvents(params: {
             sampleEventIds: failureState.warning.eventIds,
             latestError: failureState.warning.latestError,
             windowMs: failureState.warning.windowMs,
+          });
+        }
+        if (failureState.cohortOverflowed) {
+          logger.warn(formatMatrixE2eeCohortOverflowHint(), {
+            roomId,
+            eventId: event.event_id,
+            cohortLimit: MATRIX_E2EE_DEGRADED_COHORT_LIMIT,
           });
         }
         if (senderMatchesOwnUser) {

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -129,6 +129,8 @@ const hoisted = vi.hoisted(() => {
     resolveTextChunkLimit,
     runMatrixStartupMaintenance,
     registeredHealthySyncGetter: undefined as undefined | (() => number | undefined),
+    registeredE2eeDegraded: undefined as undefined | ((error: string) => void),
+    registeredE2eeRecovered: undefined as undefined | (() => void),
     setActiveMatrixClient,
     setMatrixRuntime,
     setStatus,
@@ -325,11 +327,15 @@ vi.mock("./events.js", () => ({
   registerMatrixMonitorEvents: vi.fn(
     (params: {
       getHealthySyncSinceMs?: () => number | undefined;
+      onE2eeDegraded?: (error: string) => void;
+      onE2eeRecovered?: () => void;
       onRoomMessage: (roomId: string, event: unknown) => Promise<void>;
       runDetachedTask?: (label: string, task: () => Promise<void>) => Promise<void>;
     }) => {
       hoisted.callOrder.push("register-events");
       hoisted.registeredHealthySyncGetter = params.getHealthySyncSinceMs;
+      hoisted.registeredE2eeDegraded = params.onE2eeDegraded;
+      hoisted.registeredE2eeRecovered = params.onE2eeRecovered;
       hoisted.registeredOnRoomMessage = (roomId: string, event: unknown) =>
         params.runDetachedTask
           ? params.runDetachedTask("test room message", async () => {
@@ -562,6 +568,44 @@ describe("monitorMatrixProvider", () => {
 
     hoisted.client.emit("sync.state", "SYNCING", "RECONNECTING", undefined);
 
+    expectStatusCallFields({
+      accountId: "default",
+      connected: true,
+      healthState: "healthy",
+      lastError: null,
+    });
+
+    abortController.abort();
+    await expect(monitorPromise).resolves.toBeUndefined();
+  });
+
+  it("keeps E2EE degradation across sync and clears it only after encrypted recovery", async () => {
+    const abortController = new AbortController();
+    const monitorPromise = monitorMatrixProvider({
+      abortSignal: abortController.signal,
+      setStatus: hoisted.setStatus,
+    });
+
+    await waitForCallOrderEntry("start-client");
+    hoisted.client.emit("sync.state", "SYNCING", "RECONNECTING", undefined);
+
+    hoisted.registeredE2eeDegraded?.("Matrix E2EE could not decrypt fresh messages");
+    expectStatusCallFields({
+      accountId: "default",
+      connected: true,
+      healthState: "degraded",
+      lastError: "Matrix E2EE could not decrypt fresh messages",
+    });
+
+    hoisted.client.emit("sync.state", "SYNCING", "SYNCING", undefined);
+    expectStatusCallFields({
+      accountId: "default",
+      connected: true,
+      healthState: "degraded",
+      lastError: "Matrix E2EE could not decrypt fresh messages",
+    });
+
+    hoisted.registeredE2eeRecovered?.();
     expectStatusCallFields({
       accountId: "default",
       connected: true,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -471,6 +471,8 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       logger,
       startupGraceMs,
       getHealthySyncSinceMs: () => healthySyncSinceMs,
+      onE2eeDegraded: (error) => statusController.noteE2eeDegraded(error),
+      onE2eeRecovered: () => statusController.noteE2eeRecovered(),
       formatNativeDependencyHint: core.system.formatNativeDependencyHint,
       onRoomMessage: handleRoomMessage,
       runDetachedTask: monitorTaskRunner.runDetachedTask,

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -5,6 +5,7 @@ import {
   resolveMatrixApprovalReactionTargetWithPersistence as resolveMatrixApprovalReactionTargetWithPersistenceRaw,
   unregisterMatrixApprovalReactionTarget,
 } from "../../approval-reactions.js";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
 import type { CoreConfig } from "../../types.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
 
@@ -54,6 +55,7 @@ vi.mock("../send.js", () => ({
 }));
 
 beforeEach(() => {
+  installMatrixTestRuntime();
   resolveMatrixApproval.mockReset().mockResolvedValue({
     applied: true,
     approval: { id: "req-123", status: "allowed", decision: "allow-once" },

--- a/extensions/matrix/src/matrix/monitor/status.ts
+++ b/extensions/matrix/src/matrix/monitor/status.ts
@@ -48,6 +48,7 @@ export function createMatrixMonitorStatusController(params: {
     lastError: null,
     healthState: "starting",
   };
+  let e2eeDegradationError: string | null = null;
 
   const emit = () => {
     params.statusSink?.({
@@ -65,9 +66,9 @@ export function createMatrixMonitorStatusController(params: {
     if (options?.transportActivity) {
       Object.assign(status, createTransportActivityStatusPatch(at));
     }
-    status.lastError = null;
+    status.lastError = e2eeDegradationError;
     status.lastDisconnect = null;
-    status.healthState = "healthy";
+    status.healthState = e2eeDegradationError ? "degraded" : "healthy";
     emit();
   };
 
@@ -112,6 +113,28 @@ export function createMatrixMonitorStatusController(params: {
     },
     noteUnexpectedError(error: unknown, at = Date.now()) {
       noteDisconnected({ state: "ERROR", at, error });
+    },
+    noteE2eeDegraded(error: string, at = Date.now()) {
+      e2eeDegradationError = error;
+      if (!status.connected) {
+        return;
+      }
+      status.lastEventAt = at;
+      status.lastError = error;
+      status.healthState = "degraded";
+      emit();
+    },
+    noteE2eeRecovered(at = Date.now()) {
+      if (!e2eeDegradationError) {
+        return;
+      }
+      e2eeDegradationError = null;
+      status.lastEventAt = at;
+      if (status.connected) {
+        status.lastError = null;
+        status.healthState = "healthy";
+      }
+      emit();
     },
     markStopped(at = Date.now()) {
       status.connected = false;

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -60,6 +60,69 @@ function expectLastStatusFields(
 }
 
 describe("createMatrixMonitorSyncLifecycle", () => {
+  it("does not clear a transport error when E2EE later recovers", () => {
+    const { setStatus, statusController } = createSyncLifecycleHarness();
+
+    statusController.noteSyncState("SYNCING");
+    statusController.noteE2eeDegraded("Matrix E2EE could not decrypt fresh messages");
+    statusController.noteUnexpectedError(new Error("sync exploded"));
+    statusController.noteE2eeRecovered();
+
+    expectLastStatusFields(setStatus, {
+      connected: false,
+      healthState: "error",
+      lastError: "sync exploded",
+    });
+  });
+
+  it("does not clear a stopped state when E2EE later recovers", () => {
+    const { setStatus, statusController } = createSyncLifecycleHarness();
+
+    statusController.noteSyncState("SYNCING");
+    statusController.noteE2eeDegraded("Matrix E2EE could not decrypt fresh messages");
+    statusController.markStopped();
+    statusController.noteE2eeRecovered();
+
+    expectLastStatusFields(setStatus, {
+      connected: false,
+      healthState: "stopped",
+    });
+  });
+
+  it("does not let delayed E2EE degradation overwrite a transport error", () => {
+    const { setStatus, statusController } = createSyncLifecycleHarness();
+
+    statusController.noteSyncState("SYNCING");
+    statusController.noteUnexpectedError(new Error("sync exploded"));
+    statusController.noteE2eeDegraded("Matrix E2EE could not decrypt fresh messages");
+
+    expectLastStatusFields(setStatus, {
+      connected: false,
+      healthState: "error",
+      lastError: "sync exploded",
+    });
+
+    statusController.noteSyncState("SYNCING");
+    expectLastStatusFields(setStatus, {
+      connected: true,
+      healthState: "degraded",
+      lastError: "Matrix E2EE could not decrypt fresh messages",
+    });
+  });
+
+  it("does not let delayed E2EE degradation overwrite a stopped state", () => {
+    const { setStatus, statusController } = createSyncLifecycleHarness();
+
+    statusController.noteSyncState("SYNCING");
+    statusController.markStopped();
+    statusController.noteE2eeDegraded("Matrix E2EE could not decrypt fresh messages");
+
+    expectLastStatusFields(setStatus, {
+      connected: false,
+      healthState: "stopped",
+    });
+  });
+
   it("rejects the channel wait on unexpected sync errors", async () => {
     const { client, lifecycle, setStatus } = createSyncLifecycleHarness();
 


### PR DESCRIPTION
## What Problem This Solves
OpenClaw could report a healthy Matrix channel while fresh inbound encrypted messages were failing decryption before agent dispatch. The existing `whoami` probe and successful `/sync` lifecycle did not represent inbound E2EE health, so a user could send messages that the agent silently never received.

## Summary
- mark Matrix channel health degraded after a sustained wave of fresh inbound E2EE decryption failures
- keep degradation across healthy syncs and recover only after newer inbound successes for every affected device-aware cohort
- bound ordering and cohort state, fail closed on overflow, and make Matrix test runtime setup order-independent

## Evidence
- reproduced the false-green state from sustained inbound decryption failures while sync remained healthy
- targeted Matrix E2EE health suite: 4 files, 121 tests passed
- full Matrix extension suite: 119 files, 1,495 tests passed
- exact CI lint shard `node scripts/run-oxlint-shards.mjs --threads=8` passed
- `pnpm tsgo:test:extensions`, formatting, and diff checks passed
- two independent Codex reviewers approved the state-machine ordering, cohort, recovery, overflow, and self-event behavior

## Test plan
- `pnpm test:extension matrix`
- targeted Matrix E2EE health suite
- `pnpm tsgo:test:extensions`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- formatter and `git diff --check`