### PR TITLE
fix(reef): accepted receipts no longer stall inbox delivery

### DIFF
--- a/extensions/reef/protocol/audit-receipts.test.ts
+++ b/extensions/reef/protocol/audit-receipts.test.ts
@@ -140,6 +140,8 @@ describe("receipts", () => {
       "accepted",
       "rejected",
     ]);
+    expect(entries[0]!.event.payload).not.toHaveProperty("category");
+    expect(entries[1]!.event.payload).toHaveProperty("category", "guard_deny");
     await expect(
       confirmDelivery({ ...accepted, bodyHash: "e".repeat(64) }, identity.signing.publicKey, audit),
     ).rejects.toThrow("invalid delivery receipt");

--- a/extensions/reef/protocol/receipts.ts
+++ b/extensions/reef/protocol/receipts.ts
@@ -61,7 +61,7 @@ export async function confirmDelivery(
   return appendAudit(audit, "confirm_delivery", {
     receipt,
     status: receipt.status,
-    category: receipt.category,
+    ...(receipt.category ? { category: receipt.category } : {}),
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Reef accepted receipts omit a rejection category, but the audit payload builder persisted `category: undefined`. The strict plugin-state JSON validator rejects that value, which can stall inbox delivery and force reconnects after an otherwise accepted message.

Closes #110150.

## Why This Change Was Made

Conditionally include `category` only when the receipt defines it. This fixes the value at its producer, preserves the shared JSON validator, and keeps rejection categories intact.

## User Impact

Accepted Reef messages can persist their audit receipt and continue inbox processing. Rejected messages still retain their guard category for diagnostics.

## Evidence

- Exact head `d63c67250990eb33586fe5052684d39d8c29bb14`
- Blacksmith Testbox: focused audit-receipts suite, 6/6 passed: https://github.com/openclaw/openclaw/actions/runs/29613322113
- Blacksmith Testbox: full Reef suite, 258 passed and 2 skipped: https://github.com/openclaw/openclaw/actions/runs/29613502032
- Fresh Codex autoreview: no actionable findings; correctness 0.98
- No schema, migration, config, or protocol change

The same-repository PR was superseded because Blacksmith PR CI was capacity-stalled; this fork PR runs the normal narrow matrix on GitHub-hosted runners without changing the patch.
