### PR TITLE
fix(sessions): Windows SQLite archive fsync no longer loops on EPERM

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-archive.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.test.ts
@@ -1,0 +1,76 @@
+// Windows archive fsync must use a writable descriptor (#110152).
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
+import { materializeSqliteSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-archive-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("sqlite transcript archive durability", () => {
+  it.runIf(process.platform === "win32")(
+    "fsync on a read-only descriptor fails with EPERM on Windows",
+    () => {
+      const dir = makeTempDir();
+      const filePath = path.join(dir, "readonly-fsync.tmp");
+      fs.writeFileSync(filePath, Buffer.from("payload"), { flag: "wx", mode: 0o600 });
+
+      const readOnlyFd = fs.openSync(filePath, "r");
+      try {
+        let thrown: unknown;
+        try {
+          fs.fsyncSync(readOnlyFd);
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown).toMatchObject({
+          code: "EPERM",
+          errno: -4048,
+          syscall: "fsync",
+        });
+      } finally {
+        fs.closeSync(readOnlyFd);
+      }
+
+      const writableFd = fs.openSync(filePath, "r+");
+      try {
+        fs.fsyncSync(writableFd);
+      } finally {
+        fs.closeSync(writableFd);
+      }
+    },
+  );
+
+  it("materializes SQLite transcript archives through a writable fsync path", () => {
+    const dir = makeTempDir();
+    const content = `${JSON.stringify({ type: "message", body: "archive-fsync" })}\n`;
+    const [plan] = materializeSqliteSessionStateDeletePlans([
+      {
+        archiveDirectory: dir,
+        archiveTranscript: true,
+        content,
+        hadTranscriptState: true,
+        reason: "deleted",
+        sessionId: "archive-fsync-session",
+      },
+    ]);
+
+    expect(plan.archivedTranscript?.archivedPath).toBeTruthy();
+    const archivePath = plan.archivedTranscript!.archivedPath;
+    expect(fs.existsSync(archivePath)).toBe(true);
+    expect(readSessionArchiveContentSync(archivePath)).toBe(content);
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -102,8 +102,17 @@ function writeSqliteTranscriptArchive(params: {
     }
     const tempPath = `${archivePath}.${randomUUID()}.tmp`;
     try {
-      fs.writeFileSync(tempPath, encoded.bytes, { flag: "wx", mode: 0o600 });
-      fsyncRegularFile(tempPath);
+      // Keep one exclusive writable descriptor through write+fsync. Reopening
+      // the temp file read-only for fsync fails with EPERM on Windows (Node
+      // fsync on an "r" handle), which aborts archive materialization before
+      // the row-delete transaction and retries forever on the event loop.
+      const fd = fs.openSync(tempPath, "wx", 0o600);
+      try {
+        fs.writeSync(fd, encoded.bytes);
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
       fs.renameSync(tempPath, archivePath);
       fsyncDirectory(params.archiveDirectory);
       return archivePath;
@@ -116,15 +125,6 @@ function writeSqliteTranscriptArchive(params: {
     }
   }
   throw new Error(`Could not create SQLite transcript archive for ${params.sessionId}`);
-}
-
-function fsyncRegularFile(filePath: string): void {
-  const fd = fs.openSync(filePath, "r");
-  try {
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
 }
 
 function fsyncDirectory(dirPath: string): void {

--- a/src/config/sessions/store.session-lifecycle-mutation.test.ts
+++ b/src/config/sessions/store.session-lifecycle-mutation.test.ts
@@ -333,17 +333,17 @@ describe("session store lifecycle mutations", () => {
       [createTranscriptEvent("durable-delete-session", "durable archive first")],
     );
 
-    const originalWriteFileSync = fs.writeFileSync;
+    const originalOpenSync = fs.openSync;
     const entryObservedDuringArchiveWrite: boolean[] = [];
-    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation((...args) => {
+    const openSpy = vi.spyOn(fs, "openSync").mockImplementation((...args) => {
       const filePath = String(args[0]);
-      if (filePath.includes("durable-delete-session.jsonl.deleted.")) {
+      if (filePath.includes("durable-delete-session.jsonl.deleted.") && filePath.endsWith(".tmp")) {
         entryObservedDuringArchiveWrite.push(
           loadSessionEntry({ sessionKey: "agent:main:durable-delete", storePath })?.sessionId ===
             "durable-delete-session",
         );
       }
-      return originalWriteFileSync(...args);
+      return originalOpenSync(...args);
     });
 
     try {
@@ -360,7 +360,7 @@ describe("session store lifecycle mutations", () => {
       expect(result.archivedTranscripts).toHaveLength(1);
       expect(entryObservedDuringArchiveWrite).toEqual([true]);
     } finally {
-      writeSpy.mockRestore();
+      openSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
Closes #110152

AI-assisted: implemented with Cursor/Grok under human direction and review. Workflow: issue-driven fix; reproduced the Windows fsync EPERM on this machine, then kept one writable exclusive-create descriptor through write+fsync.

## What Problem This Solves

Fixes an issue where Windows users running SQLite-backed sessions would see repeated "SQLite session maintenance cleanup failed" warnings with EPERM from fsync, while the gateway stalled for tens of seconds and never finished cleaning the same stale session IDs.

## Why This Change Was Made

Archive materialization used to write the temp file, reopen it read-only, then fsync. On Windows that read-only fsync fails with EPERM, so the archive path aborts before the row-delete transaction and the same stale rows keep getting re-planned. The fix keeps the original exclusive writable descriptor through write and fsync, then renames into place. Directory fsync stays best-effort. Off-main-thread compression/IO for large archives is left as a follow-up.

## User Impact

Windows gateways can finish SQLite transcript archival and stop looping on the same cleanup set. Non-Windows behavior stays on the same durable archive-before-delete path.

## Evidence

Live Windows runtime repro (Node v24.15.0, Windows 11) of the descriptor-mode failure described in #110152:

```text
{"mode":"r","ok":false,"code":"EPERM","errno":-4048,"syscall":"fsync","node":"v24.15.0"}
{"mode":"r+","ok":true,"node":"v24.15.0"}
{"pattern":"writable-fd","ok":true,"node":"v24.15.0"}
```

Focused tests on this worktree after the fix:

```text
pnpm test src/config/sessions/session-accessor.sqlite-archive.test.ts src/config/sessions/store.session-lifecycle-mutation.test.ts

Test Files  2 passed (2)
     Tests  14 passed (14)
```

Includes a Windows-only regression that asserts fsync on an "r" handle throws EPERM -4048, plus a materializeSqliteSessionStateDeletePlans archive write that exercises the real writable-descriptor path.
