### PR TITLE
fix(browser): time out download saves

### DIFF
--- a/extensions/browser/src/browser/pw-download-capture.test.ts
+++ b/extensions/browser/src/browser/pw-download-capture.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDownloadCaptureForPage } from "./pw-download-capture.js";
+
+const outputMocks = vi.hoisted(() => ({
+  writeExternalFileWithinOutputRoot: vi.fn(),
+}));
+
+vi.mock("./output-files.js", () => outputMocks);
+
+describe("createDownloadCaptureForPage", () => {
+  beforeEach(() => {
+    outputMocks.writeExternalFileWithinOutputRoot.mockReset();
+  });
+
+  it("hands off the deadline before atomic output finalization", async () => {
+    let releaseFinalize = () => {};
+    const finalizeReleased = new Promise<void>((resolve) => {
+      releaseFinalize = resolve;
+    });
+    let markFinalizeStarted = () => {};
+    const finalizeStarted = new Promise<void>((resolve) => {
+      markFinalizeStarted = resolve;
+    });
+    outputMocks.writeExternalFileWithinOutputRoot.mockImplementation(
+      async (params: {
+        path: string;
+        write: (tempPath: string) => Promise<void>;
+      }): Promise<string> => {
+        await params.write(`${params.path}.part`);
+        markFinalizeStarted();
+        await finalizeReleased;
+        return params.path;
+      },
+    );
+
+    const handlers = new Set<(download: unknown) => void>();
+    const page = {
+      on: (_event: string, handler: (download: unknown) => void) => handlers.add(handler),
+      off: (_event: string, handler: (download: unknown) => void) => handlers.delete(handler),
+    };
+    const state = { downloadWaiterDepth: 0 };
+    const cancel = vi.fn(async () => {});
+    const capture = createDownloadCaptureForPage(page as never, state, 50, {
+      outputPath: "/tmp/download.bin",
+    });
+
+    for (const handler of handlers) {
+      handler({
+        cancel,
+        saveAs: vi.fn(async () => {}),
+        suggestedFilename: () => "download.bin",
+      });
+    }
+    await finalizeStarted;
+
+    const outcome = await Promise.race([
+      capture.promise.then(
+        () => "settled",
+        () => "settled",
+      ),
+      new Promise<"pending">((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    expect(outcome).toBe("pending");
+    expect(cancel).not.toHaveBeenCalled();
+
+    releaseFinalize();
+    await expect(capture.promise).resolves.toMatchObject({ path: "/tmp/download.bin" });
+    expect(state.downloadWaiterDepth).toBe(0);
+    expect(handlers.size).toBe(0);
+  });
+
+  it("preserves an already-captured save when its passive owner stops waiting", async () => {
+    let releaseSave = () => {};
+    const saveReleased = new Promise<void>((resolve) => {
+      releaseSave = resolve;
+    });
+    let markSaveStarted = () => {};
+    const saveStarted = new Promise<void>((resolve) => {
+      markSaveStarted = resolve;
+    });
+    outputMocks.writeExternalFileWithinOutputRoot.mockImplementation(
+      async (params: {
+        path: string;
+        write: (tempPath: string) => Promise<void>;
+      }): Promise<string> => {
+        await params.write(`${params.path}.part`);
+        return params.path;
+      },
+    );
+
+    const handlers = new Set<(download: unknown) => void>();
+    const page = {
+      on: (_event: string, handler: (download: unknown) => void) => handlers.add(handler),
+      off: (_event: string, handler: (download: unknown) => void) => handlers.delete(handler),
+    };
+    const state = { downloadWaiterDepth: 0 };
+    const cancel = vi.fn(async () => {});
+    const capture = createDownloadCaptureForPage(page as never, state, 50);
+
+    for (const handler of handlers) {
+      handler({
+        cancel,
+        saveAs: vi.fn(async () => {
+          markSaveStarted();
+          await saveReleased;
+        }),
+        suggestedFilename: () => "download.bin",
+      });
+    }
+    await saveStarted;
+    capture.cancel();
+
+    const outcome = await Promise.race([
+      capture.promise.then(
+        () => "settled",
+        () => "settled",
+      ),
+      new Promise<"pending">((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    expect(outcome).toBe("pending");
+    expect(cancel).not.toHaveBeenCalled();
+
+    releaseSave();
+    await expect(capture.promise).resolves.toMatchObject({
+      suggestedFilename: "download.bin",
+    });
+  });
+});

--- a/extensions/browser/src/browser/pw-download-capture.ts
+++ b/extensions/browser/src/browser/pw-download-capture.ts
@@ -20,6 +20,7 @@ export type BrowserDownloadCaptureOptions = {
 };
 
 export type PlaywrightDownload = {
+  cancel?: () => Promise<void>;
   url?: () => string;
   suggestedFilename?: () => string;
   saveAs?: (outPath: string) => Promise<void>;
@@ -35,6 +36,8 @@ function buildManagedDownloadPath(rootDir: string, fileName: string): string {
 export async function saveBrowserDownload(
   download: PlaywrightDownload,
   opts: BrowserDownloadCaptureOptions = {},
+  signal?: AbortSignal,
+  onSaveReady?: () => void,
 ): Promise<BrowserDownloadResult> {
   const suggestedFilename = download.suggestedFilename?.() || "download.bin";
   const candidate: BrowserDownloadCandidate = {
@@ -42,6 +45,7 @@ export async function saveBrowserDownload(
     suggestedFilename,
   };
   await opts.beforeSave?.(candidate);
+  signal?.throwIfAborted();
   const saveAs = download.saveAs?.bind(download);
   if (!saveAs) {
     throw new Error("Download cannot be saved");
@@ -53,7 +57,12 @@ export async function saveBrowserDownload(
     rootDir: requestedPath ? opts.outputRoot : implicitRoot,
     path: managedPath,
     write: async (tempPath) => {
+      signal?.throwIfAborted();
       await saveAs(tempPath);
+      // Timeout and saveAs race here: timeout leaves the temp unpublished,
+      // while a completed save claims the deadline before finalization.
+      signal?.throwIfAborted();
+      onSaveReady?.();
     },
   });
   return { ...candidate, path: savedPath };
@@ -81,19 +90,17 @@ export function createDownloadCaptureForPage(
   }
 
   state.downloadWaiterDepth += 1;
-  let done = false;
+  let phase: "waiting" | "saving" | "settled" = "waiting";
   let depthReleased = false;
   let timer: NodeJS.Timeout | undefined;
   let handler: ((download: unknown) => void) | undefined;
+  let activeDownload: PlaywrightDownload | undefined;
+  const saveAbortController = new AbortController();
 
-  const cleanup = () => {
+  const releaseWaiter = () => {
     if (!depthReleased) {
       depthReleased = true;
       state.downloadWaiterDepth = Math.max(0, state.downloadWaiterDepth - 1);
-    }
-    if (timer) {
-      clearTimeout(timer);
-      timer = undefined;
     }
     if (handler) {
       page.off("download", handler as never);
@@ -101,24 +108,65 @@ export function createDownloadCaptureForPage(
     }
   };
 
+  const clearDeadline = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const settle = () => {
+    if (phase === "settled") {
+      return false;
+    }
+    phase = "settled";
+    releaseWaiter();
+    clearDeadline();
+    return true;
+  };
+
+  const claimSaveDeadline = () => {
+    saveAbortController.signal.throwIfAborted();
+    clearDeadline();
+  };
+
   const promise = new Promise<BrowserDownloadResult>((resolve, reject) => {
     handler = (download: unknown) => {
-      if (done) {
+      if (phase !== "waiting") {
         return;
       }
-      done = true;
-      cleanup();
-      void saveBrowserDownload(download as PlaywrightDownload, opts).then(resolve, reject);
+      phase = "saving";
+      activeDownload = download as PlaywrightDownload;
+      releaseWaiter();
+      void saveBrowserDownload(
+        activeDownload,
+        opts,
+        saveAbortController.signal,
+        claimSaveDeadline,
+      ).then(
+        (result) => {
+          if (settle()) {
+            resolve(result);
+          }
+        },
+        (error: unknown) => {
+          if (settle()) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        },
+      );
     };
     page.on("download", handler as never);
     timer = setTimeout(
       () => {
-        if (done) {
+        const timeoutError = new Error(opts.timeoutMessage ?? "Timeout waiting for download");
+        if (!settle()) {
           return;
         }
-        done = true;
-        cleanup();
-        reject(new Error(opts.timeoutMessage ?? "Timeout waiting for download"));
+        saveAbortController.abort(timeoutError);
+        // Playwright cleanup is best-effort and must not delay or replace the timeout.
+        void activeDownload?.cancel?.().catch(() => {});
+        reject(timeoutError);
       },
       Math.max(1, timeoutMs),
     );
@@ -129,11 +177,18 @@ export function createDownloadCaptureForPage(
     armed: true,
     promise,
     cancel: () => {
-      if (done) {
+      if (phase === "settled") {
         return;
       }
-      done = true;
-      cleanup();
+      if (phase === "saving") {
+        // Passive action capture no longer owns the wait once a download starts.
+        // Let the owned save finish, but remove its action-scoped deadline.
+        clearDeadline();
+        return;
+      }
+      phase = "settled";
+      releaseWaiter();
+      clearDeadline();
     },
   };
 }

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -205,6 +205,71 @@ describe("pw-tools-core", () => {
     });
   });
 
+  it("times out an in-flight save and prevents late output publication", async () => {
+    await withTempDir(async (tempDir) => {
+      const harness = createDownloadEventHarness();
+      const targetPath = path.join(tempDir, "file.bin");
+      let releaseSave!: () => void;
+      const saveReleased = new Promise<void>((resolve) => {
+        releaseSave = resolve;
+      });
+      let finishSave!: () => void;
+      const saveFinished = new Promise<void>((resolve) => {
+        finishSave = resolve;
+      });
+      const cancel = vi.fn(async () => {
+        throw new Error("cancel failed");
+      });
+      const saveAs = vi.fn(async (outPath: string) => {
+        await saveReleased;
+        await fs.writeFile(outPath, "late-content", "utf8");
+        finishSave();
+      });
+
+      const promise = mod.waitForDownloadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        path: targetPath,
+        timeoutMs: 500,
+      });
+
+      await Promise.resolve();
+      harness.expectArmed();
+      harness.trigger({
+        url: () => "https://example.com/file.bin",
+        suggestedFilename: () => "file.bin",
+        saveAs,
+        cancel,
+      });
+
+      await vi.waitFor(() => expect(saveAs).toHaveBeenCalledOnce());
+      const outcome = await Promise.race([
+        promise.then(
+          () => ({ kind: "resolved" as const }),
+          (error: unknown) => ({ kind: "rejected" as const, error }),
+        ),
+        new Promise<{ kind: "hung" }>((resolve) => {
+          setTimeout(() => resolve({ kind: "hung" }), 750);
+        }),
+      ]);
+
+      releaseSave();
+      await saveFinished;
+      await promise.catch(() => {});
+
+      expect(outcome.kind).toBe("rejected");
+      if (outcome.kind === "rejected") {
+        expect(outcome.error).toEqual(new Error("Timeout waiting for download"));
+      }
+      expect(cancel).toHaveBeenCalledOnce();
+      await vi.waitFor(async () => {
+        await expectPathMissing(requireSaveAsPath(saveAs));
+      });
+      await expectPathMissing(targetPath);
+      expect(harness.activeHandlerCount()).toBe(0);
+    });
+  });
+
   it("creates missing explicit download output parents through the safe output directory path", async () => {
     await withTempDir(async (tempDir) => {
       const harness = createDownloadEventHarness();

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -165,7 +165,7 @@ export function registerBrowserFilesAndDownloadsCommands(
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .option(
       "--timeout-ms <ms>",
-      "How long to wait for the download to start (default: 120000)",
+      "How long to wait for the download to start and save (default: 120000)",
       (v: string) => parseBrowserPositiveIntegerOption(v, "--timeout-ms"),
     )
     .action(async (ref: string, outPath: string, opts, cmd) => {


### PR DESCRIPTION
## What Problem This Solves

Browser download waits applied the configured timeout only until Playwright emitted the `download` event. The timer was then cleared before `download.saveAs()` and atomic output publication completed.

Playwright 1.62 runs `saveAs()` with `kNoTimeout`, so a stalled body could leave the browser tool call pending indefinitely. A late save could also race a timeout and publish the requested output after the tool had already reported failure.

## Why This Change Was Made

The download capture now owns one explicit lifecycle:

1. wait for the Playwright download event;
2. keep the deadline active while `saveAs()` writes the fs-safe sibling temp;
3. atomically hand off the deadline only after the save is complete and immediately before fs-safe finalization;
4. on timeout, reject immediately, abort publication, and best-effort cancel the Playwright download without letting cancellation delay or replace the timeout.

Passive action cleanup intentionally releases its action-scoped deadline after a download has started while allowing the already-owned save to finish.

## Evidence Map

| Layer | Evidence |
| --- | --- |
| Entry point | Explicit browser download wait and passive action download capture |
| Owner boundary | `extensions/browser/src/browser/pw-download-capture.ts` |
| Dependency contract | Playwright 1.62 `Artifact.saveAs()` uses `kNoTimeout`; `Artifact.cancel()` is the supported cancellation surface |
| Publication contract | `@openclaw/fs-safe` publishes only after the write callback returns and removes an unpublished sibling temp on failure |
| Focused + sibling tests | 74/74 passed |
| Exact-head spot check | Direct lifecycle and tool integration tests passed 16/16 |
| Repeated timing proof | Direct/integration pair passed three bounded repeats |
| Real behavior | Real Chromium with a genuinely stalled HTTP body rejected 5/5 at 201-202 ms, canceled the download, and left no final or staging file |
| Static proof | Formatting and `git diff --check` passed |
| Autoreview | Clean; no P0/P1 findings, correctness 0.91 |
| Changed gate | Scoped guards and plugin boundaries passed; the remaining type failure is the unchanged shared-install `packages/terminal-core/src/ansi.ts:194` baseline |

Upstream dependency source:

- https://github.com/microsoft/playwright/blob/e3950d9c140d007bd52853b45813c6274b24e36f/packages/playwright-core/src/client/artifact.ts#L38-L52
- https://github.com/microsoft/playwright/blob/e3950d9c140d007bd52853b45813c6274b24e36f/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts#L53-L68

## Repair Shape

- Root cause: the download deadline was released at event delivery instead of completed save ownership.
- Architectural owner: the shared Playwright download capture state machine.
- Canonical fix: carry timeout state through save and atomically hand it to fs-safe finalization.
- Removed paths: the event-only `done`/cleanup flow; no fallback or parallel save path was added.
- Production delta: +72/-17, net +55.
- Test delta: +197.
- Positive production delta: the capture now represents the three real lifecycle phases, the exact save/finalize handoff, the abort fence, and dependency cancellation.
- Sibling coverage: explicit waits, passive captures, direct save handling, and CLI timeout help are aligned.

## User Impact

The configured browser download timeout now covers both starting and saving the download. A timed-out download cannot later publish the requested output path.
