### PR TITLE
docs: escape CI gate SHA placeholder

### DIFF
--- a/docs/start/onboarding-redesign.md
+++ b/docs/start/onboarding-redesign.md
@@ -258,7 +258,7 @@ restart` from the real environment and verify the plist. Product follow-up:
   `gh workflow run ci.yml --ref <branch> -f target_ref=<head-sha>
 -f release_gate=true -f pull_request_number=<pr>` (the run must be on the
   branch ref so `head_sha` matches, and the title becomes
-  "CI release gate <sha>", which `scripts/verify-pr-hosted-gates.mjs`
+  `CI release gate <sha>`, which `scripts/verify-pr-hosted-gates.mjs`
   accepts). Then `scripts/pr` prepare/merge as usual.
 - **Gates that CI enforces beyond focused tests**: docs map
   (`pnpm docs:map:gen` after adding any docs page), oxlint (`no-map-spread`,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the release-gate docs job fails on current `main` because Markdownlint interprets the SHA placeholder in the onboarding notes as inline HTML.

## Why This Change Was Made

Formats the documented release-gate title as inline code, matching its role as an exact command-output value and preventing MD033 from parsing the placeholder as HTML.

## User Impact

No product behavior changes. Pull requests can pass the docs gate again.

## Evidence

- Current-main release gate failure: `docs/start/onboarding-redesign.md:261:20 error MD033/no-inline-html Inline HTML [Element: sha]`
- `git diff --check` passes.
- Hosted PR gates will validate the exact head.
