### PR TITLE
fix: heartbeat tasks stay active during scheduled runs

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -1,3 +1,4 @@
+import { QUEUED_USER_MESSAGE_MARKER } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
@@ -252,5 +253,80 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     );
     expect(fixture.report.currentTurn?.kind).toBe("room_event");
     expect(fixture.report.currentTurn?.runtimeContextChars).toBeGreaterThan(0);
+  });
+
+  it("keeps a pure heartbeat task active while persisting only the poll marker", () => {
+    const taskPrompt = "Check the deployment and report any failures.";
+    const transcriptPrompt = "[OpenClaw heartbeat poll]";
+    const fixture = createInput({
+      attempt: createAttempt({ currentInboundContext: undefined }),
+      prompt: createPrompt({
+        effectivePrompt: taskPrompt,
+        promptBeforePromptBuildHooks: taskPrompt,
+        effectiveTranscriptPrompt: transcriptPrompt,
+        transcriptPromptForRuntimeSplit: transcriptPrompt,
+        promptForRuntimeContextSplit: taskPrompt,
+        promptForModelBeforeRuntimeContextSplit: taskPrompt,
+        promptForRuntimeContextBeforeAnnotation: taskPrompt,
+      }),
+    });
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.promptForSession).toBe(transcriptPrompt);
+    expect(result.promptForModel).toBe(taskPrompt);
+    expect(result.promptSubmission.runtimeContext).toBeUndefined();
+    expect(result.runtimeContextMessageForCurrentTurn).toBeUndefined();
+  });
+
+  it("keeps the live orphan-repair heartbeat task active without parsing its marker", () => {
+    const taskPrompt = "Check the deployment and report any failures.";
+    const transcriptPrompt = "[OpenClaw heartbeat poll]";
+    const mergedModelPrompt = [QUEUED_USER_MESSAGE_MARKER, transcriptPrompt, "", taskPrompt].join(
+      "\n",
+    );
+    const fixture = createInput({
+      attempt: createAttempt({ currentInboundContext: undefined }),
+      prompt: createPrompt({
+        effectivePrompt: mergedModelPrompt,
+        promptBeforePromptBuildHooks: taskPrompt,
+        effectiveTranscriptPrompt: transcriptPrompt,
+        transcriptPromptForRuntimeSplit: transcriptPrompt,
+        promptForRuntimeContextSplit: mergedModelPrompt,
+        promptForModelBeforeRuntimeContextSplit: mergedModelPrompt,
+        promptForRuntimeContextBeforeAnnotation: mergedModelPrompt,
+      }),
+    });
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.promptForSession).toBe(transcriptPrompt);
+    expect(result.promptForModel).toBe(mergedModelPrompt);
+    expect(result.promptSubmission.runtimeContext).toBeUndefined();
+    expect(result.runtimeContextMessageForCurrentTurn).toBeUndefined();
+  });
+
+  it("still separates source context on a no-hook user turn", () => {
+    const sourceContext = "Cross-session source: agent:research";
+    const visiblePrompt = "Visible request";
+    const fixture = createInput({
+      attempt: createAttempt({ currentInboundContext: undefined }),
+      prompt: createPrompt({
+        effectivePrompt: visiblePrompt,
+        promptBeforePromptBuildHooks: visiblePrompt,
+        effectiveTranscriptPrompt: visiblePrompt,
+        transcriptPromptForRuntimeSplit: visiblePrompt,
+        promptForRuntimeContextSplit: `${sourceContext}\n\n${visiblePrompt}`,
+        promptForModelBeforeRuntimeContextSplit: visiblePrompt,
+        promptForRuntimeContextBeforeAnnotation: visiblePrompt,
+      }),
+    });
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.promptForSession).toBe(visiblePrompt);
+    expect(result.promptForModel).toBe(visiblePrompt);
+    expect(result.promptSubmission.runtimeContext).toBe(sourceContext);
+    expect(result.runtimeContextMessageForCurrentTurn?.content).toContain(sourceContext);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
@@ -149,14 +149,19 @@ export function prepareEmbeddedAttemptPromptContext(input: {
     }
   }
 
+  const hasNonEmptyTranscriptPrompt = Boolean(input.prompt.effectiveTranscriptPrompt?.trim());
+  // A non-empty transcript prompt is a persistence substitution. Keep the
+  // assembled model prompt authoritative even when no hook added context.
+  const shouldUseExplicitModelPrompt =
+    input.prompt.hasPromptBuildContext || hasNonEmptyTranscriptPrompt;
   const promptSubmission = resolveRuntimeContextPromptParts({
     effectivePrompt: input.prompt.promptForRuntimeContextSplit,
     transcriptPrompt: input.prompt.transcriptPromptForRuntimeSplit,
-    modelPrompt: input.prompt.hasPromptBuildContext
+    modelPrompt: shouldUseExplicitModelPrompt
       ? input.prompt.promptForModelBeforeRuntimeContextSplit
       : undefined,
     modelPromptBuildContext:
-      input.prompt.hasPromptBuildContext && input.prompt.effectiveTranscriptPrompt !== undefined
+      shouldUseExplicitModelPrompt && input.prompt.effectiveTranscriptPrompt !== undefined
         ? {
             promptBeforeHooks: input.prompt.promptBeforePromptBuildHooks,
             transcriptPromptBeforeTransforms: input.prompt.effectiveTranscriptPrompt,


### PR DESCRIPTION
Closes #110025

AI-assisted: Yes — Codex assisted with investigation, implementation, review, and E2E validation. I reviewed the code and understand the change.

## What Problem This Solves

Fixes an issue where scheduled heartbeat tasks could reach the model as either only the `[OpenClaw heartbeat poll]` placeholder or inert runtime context while their completion timestamps still advanced.

## Why This Change Was Made

When a non-empty transcript prompt substitutes persistence text, the already-assembled model prompt now remains authoritative even when no prompt-build hook added context. This fixes the generic model/transcript split without parsing queue-marker text, changing orphan repair, or altering empty-transcript runtime events.

## User Impact

Scheduled heartbeat tasks now remain active instructions for the model on both the first tick and subsequent orphan-repair ticks. Heartbeat transcripts continue to persist only the compact poll marker, and ordinary source/runtime context remains hidden.

## Evidence

- Post-rebase focused proof: 42 assertions passed across `attempt-prompt-context`, `runtime-context-prompt`, and `transcript-repair-runtime-contract`.
- Patch-identical changed gate passed core production/test typecheck, targeted lint and formatting, Plugin SDK and architecture guards: [Testbox run](https://github.com/openclaw/openclaw/actions/runs/29614233381).
- `$autoreview` (`gpt-5.6-sol`, high reasoning) reported no accepted/actionable findings. The pre- and post-rebase commits have the same stable patch ID.
- Live two-tick Gateway scheduler E2E used an isolated workspace/state directory, the real embedded runner, and a request-recording loopback OpenAI-compatible HTTP endpoint: [Testbox run](https://github.com/openclaw/openclaw/actions/runs/29614888666).
  - Fix patch: both provider requests contained exactly one active task and no task-bearing runtime-context message.
  - Current `origin/main` baseline: neither request contained an active task; a later request carried it only as runtime context.
  - Both paths persisted only `[OpenClaw heartbeat poll]` user turns and advanced heartbeat task state, reproducing the reported silent failure on the baseline.
- All Testboxes were stopped after proof. No external provider credentials were required.
