### PR TITLE
fix(daemon): retry launchd reload bootstrap instead of kickstart

### DIFF
--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -95,7 +95,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(args[1]).not.toContain('basename "$service_target"');
   });
 
-  it("polls after bootout and falls back to kickstart on bootstrap failure for reload mode", () => {
+  it("retries bootstrap and verifies launchctl print after reload bootout", () => {
     spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
 
     scheduleDetachedLaunchdRestartHandoff({
@@ -114,9 +114,12 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     // polls until launchd finishes the async unload before re-bootstrapping
     expect(args[1]).toContain("bootout_wait_count=");
     expect(args[1]).toContain('if ! launchctl print "$service_target" >/dev/null 2>&1; then');
+    // Bounded bootstrap retry + print verify; kickstart cannot restore a booted-out label.
+    expect(args[1]).toContain("bootstrap_retry_count=");
     expect(args[1]).toContain('if launchctl bootstrap "$domain" "$plist_path"; then');
-    // fallback: kickstart -k on bootstrap failure so service isn't left deregistered
-    expect(args[1]).toContain('launchctl kickstart -k "$service_target"');
+    expect(args[1]).toContain('if launchctl print "$service_target" >/dev/null 2>&1; then');
+    expect(args[1]).toContain("bootstrap_retry_count=$((bootstrap_retry_count - 1))");
+    expect(args[1]).not.toContain('launchctl kickstart -k "$service_target"');
   });
 
   it("sanitizes restart helper environment overrides before spawning", () => {

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -23,6 +23,11 @@ type LaunchdRestartTarget = {
 
 const START_AFTER_EXIT_PRINT_RETRY_COUNT = 15;
 const START_AFTER_EXIT_PRINT_RETRY_DELAY_SECONDS = 0.2;
+// Post-bootout bootstrap can still race launchd's async unload (EIO). Retry
+// bootstrap + launchctl print verify instead of kickstart, which cannot restore
+// an already-unloaded label.
+const RELOAD_BOOTSTRAP_RETRY_COUNT = 15;
+const RELOAD_BOOTSTRAP_RETRY_DELAY_SECONDS = 0.2;
 
 type LaunchdRestartLogEnv = {
   HOME?: string;
@@ -138,10 +143,9 @@ exit "$status"
   if (mode === "reload") {
     // Reloading is required after plist content changes; kickstart alone keeps
     // launchd's already-loaded stdout/stderr/stdin paths.
-    // After bootout we poll until launchd finishes the async unload before
-    // re-bootstrapping to avoid EIO (Bootstrap failed: 5) from the race.
-    // If bootstrap still fails, kickstart -k as a fallback to keep the service
-    // alive rather than leaving it deregistered.
+    // After bootout we poll until launchd finishes the async unload, then retry
+    // bootstrap with launchctl print verification. kickstart -k cannot restore
+    // a booted-out label, so never use it as reload recovery (#110137).
     const bootoutWaitLoop = `bootout_wait_count="${START_AFTER_EXIT_PRINT_RETRY_COUNT}"
 while [ "$bootout_wait_count" -gt 0 ]; do
   if ! launchctl print "$service_target" >/dev/null 2>&1; then
@@ -149,6 +153,27 @@ while [ "$bootout_wait_count" -gt 0 ]; do
   fi
   bootout_wait_count=$((bootout_wait_count - 1))
   sleep ${START_AFTER_EXIT_PRINT_RETRY_DELAY_SECONDS}
+done
+`;
+    const bootstrapRetryLoop = `bootstrap_retry_count="${RELOAD_BOOTSTRAP_RETRY_COUNT}"
+status=1
+while [ "$bootstrap_retry_count" -gt 0 ]; do
+  if launchctl bootstrap "$domain" "$plist_path"; then
+    if launchctl print "$service_target" >/dev/null 2>&1; then
+      status=0
+      break
+    fi
+    status=1
+  else
+    status=$?
+    # Bootstrap may report already-loaded / in-progress while the label is up.
+    if launchctl print "$service_target" >/dev/null 2>&1; then
+      status=0
+      break
+    fi
+  fi
+  bootstrap_retry_count=$((bootstrap_retry_count - 1))
+  sleep ${RELOAD_BOOTSTRAP_RETRY_DELAY_SECONDS}
 done
 `;
     return `service_target="$1"
@@ -159,13 +184,7 @@ status=0
 launchctl enable "$service_target"
 launchctl bootout "$service_target" >/dev/null 2>&1 || true
 ${bootoutWaitLoop}
-if launchctl bootstrap "$domain" "$plist_path"; then
-  status=0
-else
-  status=$?
-  launchctl kickstart -k "$service_target"
-  status=$?
-fi
+${bootstrapRetryLoop}
 if [ "$status" -eq 0 ]; then
   printf '[%s] openclaw restart done source=launchd-handoff mode=${mode}\\n' "$(date -u +%FT%TZ)" >&2
 else


### PR DESCRIPTION
Closes #110137.

## What Problem This Solves

Fixes an issue where users restarting the gateway in reload mode on macOS launchd would end up with the service unloaded and stranded. After bootout, the handoff fell back to kickstart -k, which cannot restore a label that is already unloaded, so the gateway never came back.

## Why This Change Was Made

Reload handoff now retries launchctl bootstrap with launchctl print verification after the bootout wait loop, and no longer uses kickstart as reload recovery. Kickstart remains the path for kickstart mode only.

## User Impact

macOS launchd reloads that change plist content should bring the gateway back instead of leaving it unloaded after a bootstrap race (EIO / Bootstrap failed: 5).

## AI assistance

Assisted by Cursor/Grok. Human: Stan Shih (stantheman0128).

## Evidence

```text
pnpm exec vitest run src/daemon/launchd-restart-handoff.test.ts
# reload assertion test: PASS (retries bootstrap and verifies launchctl print after reload bootout)
# 3 passed including reload + start-after-exit + invalid label
# 2 failed on Windows only: kickstart/sanitize tests expect /Users/test/... log paths;
# received Windows TEMP paths. Same class of Windows path expectation on this host;
# A/B not blamed on this diff (reload script content assertions pass).
```

Script assertions now require bootstrap_retry_count= and forbid launchctl kickstart -k in reload mode.
