### PR TITLE
fix: network error hardening, session short-id entropy, extension load caching

### DIFF
--- a/packages/agent-core/src/harness/session/memory-storage.test.ts
+++ b/packages/agent-core/src/harness/session/memory-storage.test.ts
@@ -1,5 +1,5 @@
 // Agent Core tests cover memory storage behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionTreeEntry } from "../types.js";
 import { InMemorySessionStorage } from "./memory-storage.js";
 import { Session } from "./session.js";
@@ -20,7 +20,34 @@ const childEntry: SessionTreeEntry = {
   customType: "child",
 };
 
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
 describe("InMemorySessionStorage", () => {
+  it.each([32, 128])("keeps %i rapid short entry ids unique", async (count) => {
+    let randomValue = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    vi.stubGlobal("crypto", {
+      getRandomValues(bytes: Uint8Array) {
+        bytes.fill(0);
+        new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(
+          bytes.byteLength - 4,
+          randomValue++,
+        );
+        return bytes;
+      },
+    });
+    const storage = new InMemorySessionStorage();
+
+    const ids = await Promise.all(Array.from({ length: count }, () => storage.createEntryId()));
+
+    expect(ids.every((id) => id.length === 8)).toBe(true);
+    expect(new Set(ids).size).toBe(count);
+  });
+
   it("uses shared entry indexes for labels, leaves, and paths", async () => {
     const storage = new InMemorySessionStorage({
       entries: [

--- a/packages/agent-core/src/harness/session/storage-base.ts
+++ b/packages/agent-core/src/harness/session/storage-base.ts
@@ -34,7 +34,7 @@ function isSideAppendEntry(entry: SessionTreeEntry): boolean {
 
 function generateEntryId(byId: { has(id: string): boolean }): string {
   for (let i = 0; i < 100; i++) {
-    const id = uuidv7().slice(0, 8);
+    const id = uuidv7().slice(-8);
     if (!byId.has(id)) {
       return id;
     }

--- a/src/agents/sessions/extensions/loader.bun-virtual-modules.test.ts
+++ b/src/agents/sessions/extensions/loader.bun-virtual-modules.test.ts
@@ -36,13 +36,14 @@ let virtualModulesCase: {
 };
 
 beforeAll(async () => {
-  const { loadExtensions } = await import("./loader.js");
+  const { clearExtensionCache, loadExtensionsCached } = await import("./loader.js");
+  clearExtensionCache();
   const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-sdk-"));
   tempDirs.push(dir);
   const extensionPath = join(dir, "extension.ts");
   await writeFile(extensionPath, "export default function extension() {}\n");
 
-  const result = await loadExtensions([extensionPath], dir);
+  const result = await loadExtensionsCached([extensionPath], dir);
   const virtualModules = jitiCalls.options[0]?.virtualModules as Record<string, unknown>;
   virtualModulesCase = {
     errors: result.errors,
@@ -51,11 +52,13 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  const { clearExtensionCache } = await import("./loader.js");
+  clearExtensionCache();
   jitiCalls.options.length = 0;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
 });
 
-describe("loadExtensions in Bun binary mode", () => {
+describe("loadExtensionsCached in Bun binary mode", () => {
   it("virtualizes scoped and unscoped SDK module ids", async () => {
     // Bundled Bun binaries cannot rely on Node resolution for SDK aliases, so
     // both historical and scoped module ids are registered as virtual modules.

--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -28,14 +28,19 @@ vi.mock("jiti/static", () => ({
 }));
 
 const tempDirs: string[] = [];
-let preloadedLoadExtensions: typeof import("./loader.js").loadExtensions;
+let preloadedClearExtensionCache: typeof import("./loader.js").clearExtensionCache;
+let preloadedLoadExtensionsCached: typeof import("./loader.js").loadExtensionsCached;
 
 beforeAll(async () => {
-  preloadedLoadExtensions = (await import("./loader.js")).loadExtensions;
+  ({
+    clearExtensionCache: preloadedClearExtensionCache,
+    loadExtensionsCached: preloadedLoadExtensionsCached,
+  } = await import("./loader.js"));
 });
 
 beforeEach(() => {
   vi.resetModules();
+  preloadedClearExtensionCache();
   jitiCalls.imports.length = 0;
   jitiCalls.options.length = 0;
 });
@@ -44,9 +49,9 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
 });
 
-describe("loadExtensions native JavaScript path", () => {
+describe("loadExtensionsCached native JavaScript path", () => {
   it("loads compiled JavaScript extensions without creating a jiti loader", async () => {
-    const loadExtensions = preloadedLoadExtensions;
+    const loadExtensionsCached = preloadedLoadExtensionsCached;
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.mjs");
@@ -62,7 +67,7 @@ export default async function extension(api) {
 `,
     );
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -72,9 +77,9 @@ export default async function extension(api) {
   });
 
   it("reloads native JavaScript extensions when the file changes without stat-key drift", async () => {
-    // Native dynamic imports use a content-aware cache key so same-size,
-    // same-mtime edits still reload the extension module.
-    const { loadExtensions } = await import("./loader.js");
+    // Explicit reload clears the factory cache. Native imports still need a
+    // fresh URL so same-size, same-mtime edits are observed.
+    const { clearExtensionCache, loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.cjs");
@@ -97,12 +102,13 @@ module.exports = async function(api) {
     expect(afterSource).toHaveLength(beforeSource.length);
     await writeFile(extensionPath, beforeSource);
 
-    const before = await loadExtensions([extensionPath], dir);
+    const before = await loadExtensionsCached([extensionPath], dir);
     const beforeStat = await stat(extensionPath);
 
     await writeFile(extensionPath, afterSource);
     await utimes(extensionPath, beforeStat.atime, beforeStat.mtime);
-    const after = await loadExtensions([extensionPath], dir);
+    clearExtensionCache();
+    const after = await loadExtensionsCached([extensionPath], dir);
 
     expect(before.errors).toEqual([]);
     expect(before.extensions[0]?.commands.has("native-reload-one")).toBe(true);
@@ -112,7 +118,7 @@ module.exports = async function(api) {
   });
 
   it("loads transpiled CommonJS default exports through the native path", async () => {
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.cjs");
@@ -128,7 +134,7 @@ exports.default = async function(api) {
 `,
     );
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -137,7 +143,7 @@ exports.default = async function(api) {
   });
 
   it("keeps CommonJS-shaped .js extensions on jiti", async () => {
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     await writeFile(join(dir, "package.json"), '{"type":"module"}\n');
@@ -154,7 +160,7 @@ module.exports = async function(api) {
 `,
     );
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -163,7 +169,7 @@ module.exports = async function(api) {
   });
 
   it("keeps plain ESM .js extensions on jiti", async () => {
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
@@ -179,7 +185,7 @@ export default async function extension(api) {
 `,
     );
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -190,7 +196,7 @@ export default async function extension(api) {
   it("keeps SDK-alias JavaScript extensions on one shared jiti loader", async () => {
     // SDK aliases need jiti's virtual resolution, but one shared loader keeps
     // multi-extension imports consistent and cheap.
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const firstPath = join(dir, "first.js");
@@ -207,7 +213,7 @@ module.exports = async function(api) {
     await writeFile(firstPath, source);
     await writeFile(secondPath, source);
 
-    const result = await loadExtensions([firstPath, secondPath], dir);
+    const result = await loadExtensionsCached([firstPath, secondPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(2);
@@ -216,7 +222,7 @@ module.exports = async function(api) {
   });
 
   it("keeps TypeBox-alias JavaScript extensions on jiti", async () => {
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
@@ -233,7 +239,7 @@ module.exports = async function(api) {
 `,
     );
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -244,7 +250,7 @@ module.exports = async function(api) {
   it("keeps multi-file JavaScript extensions on jiti for graph-wide aliases", async () => {
     // Alias detection walks relative helper files; a clean entrypoint can still
     // need jiti when its dependency graph imports SDK/TypeBox aliases.
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
@@ -262,7 +268,7 @@ module.exports = async function(api) {
     );
     await writeFile(join(dir, "helper.js"), 'require("typebox");\n');
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -271,7 +277,7 @@ module.exports = async function(api) {
   });
 
   it("keeps ESM re-export JavaScript extensions on jiti for graph-wide aliases", async () => {
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     await writeFile(join(dir, "package.json"), '{"type":"module"}\n');
@@ -290,7 +296,7 @@ export default async function extension(api) {
     );
     await writeFile(join(dir, "helper.js"), 'import "typebox"; export const helper = true;\n');
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
@@ -299,7 +305,7 @@ export default async function extension(api) {
   });
 
   it("keeps minified ESM relative imports on jiti for graph-wide aliases", async () => {
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.mjs");
@@ -309,7 +315,7 @@ export default async function extension(api) {
     );
     await writeFile(join(dir, "helper.mjs"), 'import "typebox"; export const helper = true;\n');
 
-    const result = await loadExtensions([extensionPath], dir);
+    const result = await loadExtensionsCached([extensionPath], dir);
 
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);

--- a/src/agents/sessions/extensions/loader.test.ts
+++ b/src/agents/sessions/extensions/loader.test.ts
@@ -4,18 +4,20 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { loadExtensions } from "./loader.js";
+import { clearExtensionCache, loadExtensionsCached } from "./loader.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  clearExtensionCache();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
 });
 
-describe("loadExtensions", () => {
-  let result: Awaited<ReturnType<typeof loadExtensions>>;
+describe("loadExtensionsCached", () => {
+  let result: Awaited<ReturnType<typeof loadExtensionsCached>>;
 
   beforeAll(async () => {
+    clearExtensionCache();
     // Extensions import both public SDK helpers and runtime helper subpaths; the
     // loader must route those aliases without package-manager involvement.
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-sdk-"));
@@ -43,7 +45,7 @@ export default async function(api) {
 `,
     );
 
-    result = await loadExtensions([extensionPath], dir);
+    result = await loadExtensionsCached([extensionPath], dir);
   });
 
   it("resolves plugin SDK subpaths in jiti-loaded extensions", () => {

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -118,8 +118,12 @@ const require = createRequire(import.meta.url);
 
 let aliases: Record<string, string> | null = null;
 let createJitiLoaderFactory: typeof createJiti | undefined;
-let extensionSourceTransformLoader: ReturnType<typeof createJiti> | undefined;
 let nativeExtensionLoadCounter = 0;
+// One cwd slot bounds the process cache. The generation keeps an in-flight
+// load from repopulating it after an explicit reload or cwd change.
+let extensionCacheCwd: string | undefined;
+let extensionCacheGeneration = 0;
+const extensionFactoryCache = new Map<string, ExtensionFactory>();
 const EXTENSION_LOADER_ALIAS_IMPORT_PATTERN =
   /(?:@openclaw\/plugin-sdk|openclaw\/plugin-sdk|@sinclair\/typebox|typebox)(?:\/[A-Za-z0-9_-]+)?/u;
 const RELATIVE_EXTENSION_IMPORT_PATTERN =
@@ -201,6 +205,39 @@ function resolvePath(extPath: string, cwd: string): string {
 }
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
+
+type ExtensionCacheScope = {
+  cwd: string;
+  generation: number;
+};
+
+type ExtensionLoadContext = {
+  cacheScope?: ExtensionCacheScope;
+  sourceTransformLoader?: ReturnType<typeof createJiti>;
+};
+
+export function clearExtensionCache(): void {
+  extensionFactoryCache.clear();
+  extensionCacheCwd = undefined;
+  extensionCacheGeneration++;
+}
+
+function useExtensionCacheCwd(cwd: string): ExtensionCacheScope {
+  const resolvedCwd = path.resolve(expandPath(cwd));
+  if (extensionCacheCwd !== undefined && extensionCacheCwd !== resolvedCwd) {
+    clearExtensionCache();
+  }
+  extensionCacheCwd = resolvedCwd;
+  return { cwd: resolvedCwd, generation: extensionCacheGeneration };
+}
+
+function isCurrentCacheScope(scope: ExtensionCacheScope | undefined): scope is ExtensionCacheScope {
+  return (
+    scope !== undefined &&
+    extensionCacheCwd === scope.cwd &&
+    extensionCacheGeneration === scope.generation
+  );
+}
 
 /**
  * Create a runtime with throwing stubs for action methods.
@@ -482,35 +519,50 @@ async function loadNativeExtensionModule(
 
 async function loadExtensionSourceTransformModule(
   extensionPath: string,
+  context: ExtensionLoadContext,
 ): Promise<ExtensionFactory | undefined> {
-  if (!extensionSourceTransformLoader) {
+  if (!context.sourceTransformLoader) {
     installOpenClawInternalCorePackageNativeResolver({ moduleUrl: import.meta.url });
     const createJitiLoader = await loadCreateJitiLoaderFactory();
-    extensionSourceTransformLoader = createJitiLoader(import.meta.url, {
+    context.sourceTransformLoader = createJitiLoader(import.meta.url, {
       ...(isBunBinary
         ? {
             ...buildPluginLoaderJitiOptions({}),
             // Bun binaries need virtual modules because extension SDK files are
             // bundled into the executable rather than present on disk.
-            tryNative: false,
             virtualModules: VIRTUAL_MODULES,
           }
         : buildPluginLoaderJitiOptions(getExtensionLoaderAliases())),
+      // Extension entry modules must bypass the native ESM cache so an explicit
+      // reload observes edited source. Product modules stay native via nativeModules.
+      tryNative: false,
       moduleCache: false,
     });
   }
 
   return resolveExtensionFactory(
-    await extensionSourceTransformLoader.import(extensionPath, { default: true }),
+    await context.sourceTransformLoader.import(extensionPath, { default: true }),
   );
 }
 
-async function loadExtensionModule(extensionPath: string) {
-  if (shouldLoadExtensionWithNativeImport(extensionPath)) {
-    return loadNativeExtensionModule(extensionPath);
+async function loadExtensionModule(
+  extensionPath: string,
+  context: ExtensionLoadContext,
+): Promise<ExtensionFactory | undefined> {
+  if (isCurrentCacheScope(context.cacheScope)) {
+    const cachedFactory = extensionFactoryCache.get(extensionPath);
+    if (cachedFactory) {
+      return cachedFactory;
+    }
   }
 
-  return loadExtensionSourceTransformModule(extensionPath);
+  const factory = shouldLoadExtensionWithNativeImport(extensionPath)
+    ? await loadNativeExtensionModule(extensionPath)
+    : await loadExtensionSourceTransformModule(extensionPath, context);
+  if (factory && isCurrentCacheScope(context.cacheScope)) {
+    extensionFactoryCache.set(extensionPath, factory);
+  }
+  return factory;
 }
 
 /**
@@ -541,11 +593,12 @@ async function loadExtension(
   cwd: string,
   eventBus: EventBus,
   runtime: ExtensionRuntime,
+  context: ExtensionLoadContext,
 ): Promise<{ extension: Extension | null; error: string | null }> {
   const resolvedPath = resolvePath(extensionPath, cwd);
 
   try {
-    const factory = await loadExtensionModule(resolvedPath);
+    const factory = await loadExtensionModule(resolvedPath, context);
     if (!factory) {
       return {
         extension: null,
@@ -583,18 +636,28 @@ export async function loadExtensionFromFactory(
 /**
  * Load extensions from paths.
  */
-export async function loadExtensions(
+async function loadExtensionsInternal(
   paths: string[],
   cwd: string,
   eventBus?: EventBus,
+  useCache = false,
 ): Promise<LoadExtensionsResult> {
   const extensions: Extension[] = [];
   const errors: Array<{ path: string; error: string }> = [];
   const resolvedEventBus = eventBus ?? createEventBus();
   const runtime = createExtensionRuntime();
+  const cacheScope = useCache ? useExtensionCacheCwd(cwd) : undefined;
+  const resolvedCwd = cacheScope?.cwd ?? cwd;
+  const context: ExtensionLoadContext = { cacheScope };
 
   for (const extPath of paths) {
-    const { extension, error } = await loadExtension(extPath, cwd, resolvedEventBus, runtime);
+    const { extension, error } = await loadExtension(
+      extPath,
+      resolvedCwd,
+      resolvedEventBus,
+      runtime,
+      context,
+    );
 
     if (error) {
       errors.push({ path: extPath, error });
@@ -611,4 +674,20 @@ export async function loadExtensions(
     errors,
     runtime,
   };
+}
+
+export async function loadExtensions(
+  paths: string[],
+  cwd: string,
+  eventBus?: EventBus,
+): Promise<LoadExtensionsResult> {
+  return loadExtensionsInternal(paths, cwd, eventBus);
+}
+
+export async function loadExtensionsCached(
+  paths: string[],
+  cwd: string,
+  eventBus?: EventBus,
+): Promise<LoadExtensionsResult> {
+  return loadExtensionsInternal(paths, cwd, eventBus, true);
 }

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -636,18 +636,17 @@ export async function loadExtensionFromFactory(
 /**
  * Load extensions from paths.
  */
-async function loadExtensionsInternal(
+export async function loadExtensionsCached(
   paths: string[],
   cwd: string,
   eventBus?: EventBus,
-  useCache = false,
 ): Promise<LoadExtensionsResult> {
   const extensions: Extension[] = [];
   const errors: Array<{ path: string; error: string }> = [];
   const resolvedEventBus = eventBus ?? createEventBus();
   const runtime = createExtensionRuntime();
-  const cacheScope = useCache ? useExtensionCacheCwd(cwd) : undefined;
-  const resolvedCwd = cacheScope?.cwd ?? cwd;
+  const cacheScope = useExtensionCacheCwd(cwd);
+  const resolvedCwd = cacheScope.cwd;
   const context: ExtensionLoadContext = { cacheScope };
 
   for (const extPath of paths) {
@@ -674,20 +673,4 @@ async function loadExtensionsInternal(
     errors,
     runtime,
   };
-}
-
-export async function loadExtensions(
-  paths: string[],
-  cwd: string,
-  eventBus?: EventBus,
-): Promise<LoadExtensionsResult> {
-  return loadExtensionsInternal(paths, cwd, eventBus);
-}
-
-export async function loadExtensionsCached(
-  paths: string[],
-  cwd: string,
-  eventBus?: EventBus,
-): Promise<LoadExtensionsResult> {
-  return loadExtensionsInternal(paths, cwd, eventBus, true);
 }

--- a/src/agents/sessions/resource-loader.test.ts
+++ b/src/agents/sessions/resource-loader.test.ts
@@ -1,11 +1,76 @@
 // Resource loader tests cover prompt loading and transforms.
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { clearExtensionCache } from "./extensions/loader.js";
 import { DefaultResourceLoader } from "./resource-loader.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+type ExtensionCacheTestState = {
+  factoryRuns: number;
+  moduleLoads: number;
+};
+
+function extensionCacheTestState(): ExtensionCacheTestState {
+  return (
+    globalThis as typeof globalThis & { openclawExtensionCacheTestState: ExtensionCacheTestState }
+  ).openclawExtensionCacheTestState;
+}
+
+function extensionSource(command: string): string {
+  return `
+const state = (globalThis.openclawExtensionCacheTestState ??= { factoryRuns: 0, moduleLoads: 0 });
+state.moduleLoads += 1;
+
+export default function extension(api) {
+  state.factoryRuns += 1;
+  api.registerCommand(${JSON.stringify(command)}, {
+    description: "cache probe",
+    handler() {},
+  });
+}
+`;
+}
+
+afterEach(() => {
+  clearExtensionCache();
+  Reflect.deleteProperty(globalThis, "openclawExtensionCacheTestState");
+});
+
 describe("DefaultResourceLoader", () => {
+  it("reuses extension modules between loaders and refreshes them on reload", async () => {
+    const root = tempDirs.make("openclaw-resource-loader-extension-");
+    const extensionPath = join(root, "extension.ts");
+    await writeFile(extensionPath, extensionSource("before-reload"));
+    const createLoader = () =>
+      new DefaultResourceLoader({
+        cwd: root,
+        agentDir: root,
+        additionalExtensionPaths: [extensionPath],
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+      });
+
+    const firstLoader = createLoader();
+    await firstLoader.reload();
+    const secondLoader = createLoader();
+    await secondLoader.reload();
+
+    expect(extensionCacheTestState()).toEqual({ factoryRuns: 2, moduleLoads: 1 });
+    expect(secondLoader.getExtensions().extensions[0]?.commands.has("before-reload")).toBe(true);
+
+    await writeFile(extensionPath, extensionSource("after-reload"));
+    await secondLoader.reload();
+
+    expect(extensionCacheTestState()).toEqual({ factoryRuns: 3, moduleLoads: 2 });
+    expect(secondLoader.getExtensions().extensions[0]?.commands.has("after-reload")).toBe(true);
+  });
+
   it("does not use unreadable prompt file paths as prompt content", async () => {
     const root = tempDirs.make("openclaw-resource-loader-");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/agents/sessions/resource-loader.ts
+++ b/src/agents/sessions/resource-loader.ts
@@ -15,9 +15,10 @@ import { canonicalizePath, isLocalPath } from "../utils/paths.js";
 import type { ResourceDiagnostic } from "./diagnostics.js";
 import { createEventBus, type EventBus } from "./event-bus.js";
 import {
+  clearExtensionCache,
   createExtensionRuntime,
   loadExtensionFromFactory,
-  loadExtensions,
+  loadExtensionsCached,
 } from "./extensions/loader.js";
 import type {
   Extension,
@@ -225,6 +226,7 @@ export class DefaultResourceLoader implements ResourceLoader {
   private extensionThemeSourceInfos: Map<string, SourceInfo>;
   private lastPromptPaths: string[];
   private lastThemePaths: string[];
+  private loaded = false;
 
   constructor(options: DefaultResourceLoaderOptions) {
     this.cwd = options.cwd;
@@ -343,6 +345,9 @@ export class DefaultResourceLoader implements ResourceLoader {
   }
 
   async reload(): Promise<void> {
+    if (this.loaded) {
+      clearExtensionCache();
+    }
     await this.settingsManager.reload();
     const resolvedPaths = await this.packageManager.resolve();
     const cliExtensionPaths = await this.packageManager.resolveExtensionSources(
@@ -422,7 +427,7 @@ export class DefaultResourceLoader implements ResourceLoader {
       ? cliEnabledExtensions
       : this.mergePaths(cliEnabledExtensions, enabledExtensions);
 
-    const extensionsResult = await loadExtensions(extensionPaths, this.cwd, this.eventBus);
+    const extensionsResult = await loadExtensionsCached(extensionPaths, this.cwd, this.eventBus);
     const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime);
     extensionsResult.extensions.push(...inlineExtensions.extensions);
     extensionsResult.errors.push(...inlineExtensions.errors);
@@ -522,6 +527,7 @@ export class DefaultResourceLoader implements ResourceLoader {
     this.appendSystemPrompt = this.appendSystemPromptTransform
       ? this.appendSystemPromptTransform(baseAppend)
       : baseAppend;
+    this.loaded = true;
   }
 
   private normalizeExtensionPaths(

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -272,6 +272,7 @@ describe("fetchWithSsrFGuard hardening", () => {
     if (params.expectEnvProxy) {
       expect(envHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
       expect(envHttpProxyAgentCtor).toHaveBeenCalledWith({
+        factory: expect.any(Function),
         connect: {
           autoSelectFamily: true,
           autoSelectFamilyAttemptTimeout: 300,
@@ -718,6 +719,7 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
 
     expect(proxyAgentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       uri: "http://proxy.example:7890",
       clientFactory: expect.any(Function),
       proxyTls: {

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -172,7 +172,7 @@ describe("makeProxyFetch", () => {
     expect(proxyAgentSpy).not.toHaveBeenCalled();
     await proxyFetch("https://api.example.com/v1/audio");
 
-    expect(proxyAgentSpy).toHaveBeenCalledWith({ uri: proxyUrl });
+    expect(proxyAgentSpy).toHaveBeenCalledWith(expect.objectContaining({ uri: proxyUrl }));
     expect(undiciFetch).toHaveBeenCalledOnce();
     const [input] = requireUndiciFetchCall();
     const init = requireUndiciFetchInit();
@@ -191,10 +191,12 @@ describe("makeProxyFetch", () => {
 
       await proxyFetch("https://api.example.com/v1/audio");
 
-      expect(proxyAgentSpy).toHaveBeenCalledWith({
-        uri: "https://proxy.test:8443",
-        proxyTls: { ca: "explicit-proxy-fetch-ca" },
-      });
+      expect(proxyAgentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uri: "https://proxy.test:8443",
+          proxyTls: expect.objectContaining({ ca: "explicit-proxy-fetch-ca" }),
+        }),
+      );
     } finally {
       stopActiveManagedProxyRegistration(registration);
     }
@@ -367,7 +369,9 @@ describe("resolveProxyFetchFromEnv", () => {
         HTTPS_PROXY: "http://proxy.test:8080",
       }),
     );
-    expect(envAgentSpy).toHaveBeenCalledWith({ httpsProxy: "http://proxy.test:8080" });
+    expect(envAgentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ httpsProxy: "http://proxy.test:8080" }),
+    );
 
     await fetchFn("https://api.example.com");
     expect(undiciFetch).toHaveBeenCalledOnce();
@@ -391,10 +395,12 @@ describe("resolveProxyFetchFromEnv", () => {
       );
 
       expect(fetchFn).toBeTypeOf("function");
-      expect(envAgentSpy).toHaveBeenCalledWith({
-        httpsProxy: "https://proxy.test:8443",
-        proxyTls: { ca: "proxy-fetch-ca" },
-      });
+      expect(envAgentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpsProxy: "https://proxy.test:8443",
+          proxyTls: expect.objectContaining({ ca: "proxy-fetch-ca" }),
+        }),
+      );
     } finally {
       stopActiveManagedProxyRegistration(registration);
     }
@@ -435,10 +441,12 @@ describe("resolveProxyFetchFromEnv", () => {
       }),
     );
     expect(fetchFn).toBeTypeOf("function");
-    expect(envAgentSpy).toHaveBeenCalledWith({
-      httpProxy: "http://fallback.test:3128",
-      httpsProxy: "http://fallback.test:3128",
-    });
+    expect(envAgentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpProxy: "http://fallback.test:3128",
+        httpsProxy: "http://fallback.test:3128",
+      }),
+    );
   });
 
   it("returns proxy fetch when lowercase https_proxy is set", () => {
@@ -451,7 +459,9 @@ describe("resolveProxyFetchFromEnv", () => {
       }),
     );
     expect(fetchFn).toBeTypeOf("function");
-    expect(envAgentSpy).toHaveBeenCalledWith({ httpsProxy: "http://lower.test:1080" });
+    expect(envAgentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ httpsProxy: "http://lower.test:1080" }),
+    );
   });
 
   it("returns proxy fetch when lowercase http_proxy is set", () => {
@@ -464,10 +474,12 @@ describe("resolveProxyFetchFromEnv", () => {
       }),
     );
     expect(fetchFn).toBeTypeOf("function");
-    expect(envAgentSpy).toHaveBeenCalledWith({
-      httpProxy: "http://lower-http.test:1080",
-      httpsProxy: "http://lower-http.test:1080",
-    });
+    expect(envAgentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpProxy: "http://lower-http.test:1080",
+        httpsProxy: "http://lower-http.test:1080",
+      }),
+    );
   });
 
   it("returns proxy fetch when ALL_PROXY is set", () => {
@@ -481,10 +493,12 @@ describe("resolveProxyFetchFromEnv", () => {
       }),
     );
     expect(fetchFn).toBeTypeOf("function");
-    expect(envAgentSpy).toHaveBeenCalledWith({
-      httpProxy: "socks5://all-proxy.test:1080",
-      httpsProxy: "socks5://all-proxy.test:1080",
-    });
+    expect(envAgentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpProxy: "socks5://all-proxy.test:1080",
+        httpsProxy: "socks5://all-proxy.test:1080",
+      }),
+    );
   });
 
   it("returns undefined when EnvHttpProxyAgent constructor throws", () => {

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -26,6 +26,8 @@ const {
   proxyAgentSpy,
   envAgentSpy,
   getLastAgent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
   loadUndiciRuntimeDeps,
 } = vi.hoisted(() => {
   const undiciFetchLocal = vi.fn();
@@ -65,6 +67,12 @@ const {
     FormData: MockUndiciFormDataLocal,
     fetch: undiciFetchLocal,
   }));
+  const createHttp1ProxyAgentLocal = vi.fn(
+    (options: { uri?: string; proxyTls?: unknown } | string) => new ProxyAgent(options),
+  );
+  const createHttp1EnvHttpProxyAgentLocal = vi.fn(
+    (options?: Record<string, unknown>) => new EnvHttpProxyAgentLocal(options),
+  );
 
   return {
     ProxyAgent,
@@ -73,6 +81,8 @@ const {
     undiciFetch: undiciFetchLocal,
     proxyAgentSpy: proxyAgentSpyLocal,
     envAgentSpy: envAgentSpyLocal,
+    createHttp1EnvHttpProxyAgent: createHttp1EnvHttpProxyAgentLocal,
+    createHttp1ProxyAgent: createHttp1ProxyAgentLocal,
     getLastAgent: () => ProxyAgent.lastCreated,
     loadUndiciRuntimeDeps: loadUndiciRuntimeDepsLocal,
   };
@@ -81,6 +91,8 @@ const {
 const mockedModuleIds = ["./undici-runtime.js"] as const;
 
 vi.mock("./undici-runtime.js", () => ({
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
   loadUndiciRuntimeDeps,
 }));
 

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -2,16 +2,14 @@
 // options and runtime FormData normalization.
 import { logWarn } from "../../logger.js";
 import { formatErrorMessage } from "../errors.js";
-import {
-  addActiveManagedProxyTlsOptions,
-  resolveManagedEnvHttpProxyAgentOptions,
-} from "./proxy/managed-proxy-undici.js";
+import { resolveManagedEnvHttpProxyAgentOptions } from "./proxy/managed-proxy-undici.js";
 import { fetchWithPreparedRuntimeDispatcher } from "./runtime-fetch.js";
 import {
-  createHttp1EnvHttpProxyAgent,
-  createHttp1ProxyAgent,
-  loadUndiciRuntimeDeps,
-} from "./undici-runtime.js";
+  buildHttp1EnvHttpProxyAgentOptions,
+  buildHttp1ProxyAgentOptions,
+} from "./undici-dispatcher-options.js";
+import { withUndiciErrorDiagnostics } from "./undici-error-diagnostics.js";
+import { loadUndiciRuntimeDeps } from "./undici-runtime.js";
 
 /** Non-enumerable marker used to recover the explicit proxy URL from proxy fetch wrappers. */
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
@@ -25,10 +23,13 @@ type ProxyFetchWithMetadata = typeof fetch & {
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const runtimeDeps = loadUndiciRuntimeDeps();
-  let agent: ReturnType<typeof createHttp1ProxyAgent> | null = null;
-  const resolveAgent = (): ReturnType<typeof createHttp1ProxyAgent> => {
+  const { ProxyAgent } = runtimeDeps;
+  let agent: InstanceType<typeof ProxyAgent> | null = null;
+  const resolveAgent = (): InstanceType<typeof ProxyAgent> => {
     if (!agent) {
-      agent = createHttp1ProxyAgent(addActiveManagedProxyTlsOptions({ uri: proxyUrl }));
+      agent = withUndiciErrorDiagnostics(
+        new ProxyAgent(buildHttp1ProxyAgentOptions({ uri: proxyUrl })),
+      );
     }
     return agent;
   };
@@ -71,7 +72,10 @@ export function resolveProxyFetchFromEnv(
   }
   try {
     const runtimeDeps = loadUndiciRuntimeDeps();
-    const agent = createHttp1EnvHttpProxyAgent(proxyOptions);
+    const { EnvHttpProxyAgent } = runtimeDeps;
+    const agent = withUndiciErrorDiagnostics(
+      new EnvHttpProxyAgent(buildHttp1EnvHttpProxyAgentOptions(proxyOptions)),
+    );
     return ((input: RequestInfo | URL, init?: RequestInit) =>
       fetchWithPreparedRuntimeDispatcher(runtimeDeps, input, {
         ...init,

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -7,7 +7,11 @@ import {
   resolveManagedEnvHttpProxyAgentOptions,
 } from "./proxy/managed-proxy-undici.js";
 import { fetchWithPreparedRuntimeDispatcher } from "./runtime-fetch.js";
-import { loadUndiciRuntimeDeps } from "./undici-runtime.js";
+import {
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+  loadUndiciRuntimeDeps,
+} from "./undici-runtime.js";
 
 /** Non-enumerable marker used to recover the explicit proxy URL from proxy fetch wrappers. */
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
@@ -21,11 +25,10 @@ type ProxyFetchWithMetadata = typeof fetch & {
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const runtimeDeps = loadUndiciRuntimeDeps();
-  const { ProxyAgent } = runtimeDeps;
-  let agent: InstanceType<typeof ProxyAgent> | null = null;
-  const resolveAgent = (): InstanceType<typeof ProxyAgent> => {
+  let agent: ReturnType<typeof createHttp1ProxyAgent> | null = null;
+  const resolveAgent = (): ReturnType<typeof createHttp1ProxyAgent> => {
     if (!agent) {
-      agent = new ProxyAgent(addActiveManagedProxyTlsOptions({ uri: proxyUrl }));
+      agent = createHttp1ProxyAgent(addActiveManagedProxyTlsOptions({ uri: proxyUrl }));
     }
     return agent;
   };
@@ -68,8 +71,7 @@ export function resolveProxyFetchFromEnv(
   }
   try {
     const runtimeDeps = loadUndiciRuntimeDeps();
-    const { EnvHttpProxyAgent } = runtimeDeps;
-    const agent = new EnvHttpProxyAgent(proxyOptions);
+    const agent = createHttp1EnvHttpProxyAgent(proxyOptions);
     return ((input: RequestInfo | URL, init?: RequestInit) =>
       fetchWithPreparedRuntimeDispatcher(runtimeDeps, input, {
         ...init,

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -116,6 +116,7 @@ describe("createPinnedDispatcher", () => {
     expect(dispatcherOptions?.connect?.autoSelectFamilyAttemptTimeout).toBe(300);
     expect(dispatcherOptions?.allowH2).toBe(false);
     expect(agentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       connect: {
         lookup,
         autoSelectFamily: true,
@@ -141,6 +142,7 @@ describe("createPinnedDispatcher", () => {
     createPinnedDispatcher(pinned);
 
     expect(agentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       connect: {
         lookup,
         autoSelectFamily: false,
@@ -169,6 +171,7 @@ describe("createPinnedDispatcher", () => {
     });
 
     expect(agentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
@@ -195,6 +198,7 @@ describe("createPinnedDispatcher", () => {
     });
 
     expect(agentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       connect: {
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 50,
@@ -215,6 +219,7 @@ describe("createPinnedDispatcher", () => {
     createPinnedDispatcher(pinned, undefined, undefined, 123_456);
 
     expect(agentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       connect: {
         lookup,
         autoSelectFamily: true,
@@ -365,6 +370,7 @@ describe("createPinnedDispatcher", () => {
     });
 
     expect(envHttpProxyAgentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
@@ -396,6 +402,7 @@ describe("createPinnedDispatcher", () => {
     });
 
     expect(proxyAgentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       uri: "http://127.0.0.1:7890",
       clientFactory: expect.any(Function),
       proxyTls: {
@@ -432,6 +439,7 @@ describe("createPinnedDispatcher", () => {
     );
 
     expect(proxyAgentCtor).toHaveBeenCalledWith({
+      factory: expect.any(Function),
       uri: "http://127.0.0.1:7890",
       clientFactory: expect.any(Function),
       requestTls: {

--- a/src/infra/net/undici-dispatcher-options.ts
+++ b/src/infra/net/undici-dispatcher-options.ts
@@ -1,0 +1,207 @@
+import { createRequire } from "node:module";
+import net from "node:net";
+import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
+import { addActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
+import { withUndiciErrorDiagnostics } from "./undici-error-diagnostics.js";
+import { resolveUndiciAutoSelectFamilyConnectOptions } from "./undici-family-policy.js";
+
+const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+const requireUndici = createRequire(import.meta.url);
+
+type UndiciAgentOptions = ConstructorParameters<typeof import("undici").Agent>[0];
+type UndiciEnvHttpProxyAgentOptions = ConstructorParameters<
+  typeof import("undici").EnvHttpProxyAgent
+>[0];
+type UndiciProxyAgentOptions = ConstructorParameters<typeof import("undici").ProxyAgent>[0];
+type UndiciProxyAgentOptionsRecord = Exclude<UndiciProxyAgentOptions, string | URL>;
+type UndiciProxyClientFactory = NonNullable<UndiciProxyAgentOptionsRecord["clientFactory"]>;
+type UnknownFunction = (...args: unknown[]) => unknown;
+
+// Guarded fetch dispatchers intentionally stay on HTTP/1.1. Undici 8 enables
+// HTTP/2 ALPN by default, but dispatcher overrides are unreliable on that path.
+const HTTP1_ONLY_DISPATCHER_OPTIONS = Object.freeze({
+  allowH2: false as const,
+});
+
+export function loadUndiciModule(
+  requiredExports: ReadonlyArray<keyof typeof import("undici")>,
+): typeof import("undici") {
+  const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
+  if (
+    isObjectRecord(override) &&
+    requiredExports.every((key) => typeof override[key] === "function")
+  ) {
+    return override as typeof import("undici");
+  }
+  return requireUndici("undici") as typeof import("undici");
+}
+
+function stripIpServernameFromConnectOptions(options: unknown): unknown {
+  if (!isObjectRecord(options) || typeof options.servername !== "string") {
+    return options;
+  }
+  const servername = options.servername.replace(/^\[|\]$/g, "");
+  if (net.isIP(servername) === 0) {
+    return options;
+  }
+  const next = { ...options };
+  delete next.servername;
+  return next;
+}
+
+function stripIpServernameFromConnect(connect: unknown): unknown {
+  if (typeof connect !== "function") {
+    return connect;
+  }
+  return (options: unknown, callback: unknown): unknown =>
+    (connect as UnknownFunction)(stripIpServernameFromConnectOptions(options), callback);
+}
+
+function createIpSafeProxyClientFactory(): UndiciProxyClientFactory {
+  return (origin, options) => {
+    // HTTPS proxies addressed by IP must not pass the IP literal as TLS SNI.
+    const clientOptions = isObjectRecord(options)
+      ? { ...options, connect: stripIpServernameFromConnect(options.connect) }
+      : options;
+    return createUndiciPool(origin, clientOptions);
+  };
+}
+
+function createUndiciClient(origin: string | URL, options: object): import("undici").Dispatcher {
+  const { Client } = loadUndiciModule(["Client"]);
+  return withUndiciErrorDiagnostics(
+    new Client(origin, options as ConstructorParameters<typeof Client>[1]),
+  );
+}
+
+function createUndiciPool(origin: string | URL, options: unknown): import("undici").Dispatcher {
+  const { Pool } = loadUndiciModule(["Pool"]);
+  const poolOptions = isObjectRecord(options) ? options : {};
+  return withUndiciErrorDiagnostics(
+    new Pool(origin, {
+      ...poolOptions,
+      factory: createUndiciClient,
+    }),
+  );
+}
+
+function createUndiciOriginDispatcher(
+  origin: string | URL,
+  options: object,
+): import("undici").Dispatcher {
+  return isObjectRecord(options) && options.connections === 1
+    ? createUndiciClient(origin, options)
+    : createUndiciPool(origin, options);
+}
+
+function addUndiciAgentFactory<TOptions extends object>(options: TOptions): TOptions {
+  if ("factory" in options) {
+    return options;
+  }
+  return {
+    ...options,
+    factory: createUndiciOriginDispatcher,
+  };
+}
+
+function addIpSafeProxyClientFactory<TOptions extends object>(options: TOptions): TOptions {
+  if ("clientFactory" in options) {
+    return options;
+  }
+  // Caller factories own their connection policy and must not be replaced.
+  return {
+    ...options,
+    clientFactory: createIpSafeProxyClientFactory(),
+  };
+}
+
+function applyMissingConnectOptions(
+  connect: Record<string, unknown>,
+  defaults: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(defaults)) {
+    if (!(key in connect)) {
+      connect[key] = value;
+    }
+  }
+}
+
+function withHttp1OnlyDispatcherOptions<T extends object | undefined>(
+  options?: T,
+  timeoutMs?: number,
+  applyTo?: { connect?: boolean; proxyTls?: boolean },
+): (T extends object ? T : Record<never, never>) & { allowH2: false } {
+  const base = {} as (T extends object ? T : Record<never, never>) & { allowH2: false };
+  if (options) {
+    Object.assign(base, options);
+  }
+  Object.assign(base, HTTP1_ONLY_DISPATCHER_OPTIONS);
+  const baseRecord = base as Record<string, unknown>;
+  const targets = applyTo ?? { connect: true };
+  const autoSelectConnect = resolveUndiciAutoSelectFamilyConnectOptions();
+  if (autoSelectConnect && targets.connect && typeof baseRecord.connect !== "function") {
+    const connect = isObjectRecord(baseRecord.connect) ? baseRecord.connect : {};
+    applyMissingConnectOptions(connect, autoSelectConnect);
+    baseRecord.connect = connect;
+  }
+  if (autoSelectConnect && targets.proxyTls) {
+    const proxyTls = isObjectRecord(baseRecord.proxyTls) ? baseRecord.proxyTls : {};
+    applyMissingConnectOptions(proxyTls, autoSelectConnect);
+    baseRecord.proxyTls = proxyTls;
+  }
+  if (timeoutMs !== undefined && Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    const normalizedTimeoutMs = Math.floor(timeoutMs);
+    baseRecord.bodyTimeout = normalizedTimeoutMs;
+    baseRecord.headersTimeout = normalizedTimeoutMs;
+    if (targets.connect && typeof baseRecord.connect !== "function") {
+      baseRecord.connect = {
+        ...(isObjectRecord(baseRecord.connect) ? baseRecord.connect : {}),
+        timeout: normalizedTimeoutMs,
+      };
+    }
+    if (targets.proxyTls) {
+      baseRecord.proxyTls = {
+        ...(isObjectRecord(baseRecord.proxyTls) ? baseRecord.proxyTls : {}),
+        timeout: normalizedTimeoutMs,
+      };
+    }
+  }
+  return base;
+}
+
+export function buildHttp1AgentOptions(
+  options?: UndiciAgentOptions,
+  timeoutMs?: number,
+): NonNullable<UndiciAgentOptions> {
+  return addUndiciAgentFactory(withHttp1OnlyDispatcherOptions(options, timeoutMs));
+}
+
+export function buildHttp1EnvHttpProxyAgentOptions(
+  options?: UndiciEnvHttpProxyAgentOptions,
+  timeoutMs?: number,
+): NonNullable<UndiciEnvHttpProxyAgentOptions> {
+  return withHttp1OnlyDispatcherOptions(
+    addIpSafeProxyClientFactory(
+      addUndiciAgentFactory(addActiveManagedProxyTlsOptions(options) ?? {}),
+    ),
+    timeoutMs,
+    { connect: true, proxyTls: true },
+  );
+}
+
+export function buildHttp1ProxyAgentOptions(
+  options: UndiciProxyAgentOptions,
+  timeoutMs?: number,
+): Exclude<UndiciProxyAgentOptions, string> {
+  const normalized =
+    typeof options === "string" || options instanceof URL
+      ? { uri: options.toString() }
+      : { ...options };
+  return withHttp1OnlyDispatcherOptions(
+    addIpSafeProxyClientFactory(
+      addUndiciAgentFactory(addActiveManagedProxyTlsOptions(normalized as object)),
+    ),
+    timeoutMs,
+    { proxyTls: true },
+  ) as Exclude<UndiciProxyAgentOptions, string>;
+}

--- a/src/infra/net/undici-error-diagnostics.ts
+++ b/src/infra/net/undici-error-diagnostics.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from "node:events";
+import { logDebug } from "../../logger.js";
+import { formatErrorMessage } from "../errors.js";
+
+const observedDispatcherValues = new WeakSet<object>();
+
+function logUndiciDispatcherError(error: unknown): void {
+  logDebug(`undici: internal dispatcher error: ${formatErrorMessage(error)}`);
+}
+
+function observeDispatcherValue(value: unknown): void {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+    return;
+  }
+  if (observedDispatcherValues.has(value)) {
+    return;
+  }
+  observedDispatcherValues.add(value);
+
+  if (value instanceof EventEmitter) {
+    // Undici nests clients behind agents and proxy dispatchers. Observe both
+    // existing children and future connect targets without replacing factories.
+    EventEmitter.prototype.on.call(value, "error", logUndiciDispatcherError);
+    EventEmitter.prototype.on.call(value, "connect", (_origin: unknown, targets: unknown) => {
+      observeDispatcherValue(targets);
+    });
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor && "value" in descriptor) {
+        observeDispatcherValue(descriptor.value);
+      }
+    }
+    return;
+  }
+
+  if (Array.isArray(value) || value instanceof Set) {
+    for (const entry of value) {
+      observeDispatcherValue(entry);
+    }
+    return;
+  }
+  if (value instanceof Map) {
+    for (const entry of value.values()) {
+      observeDispatcherValue(entry);
+    }
+  }
+}
+
+export function withUndiciErrorDiagnostics<T extends import("undici").Dispatcher>(
+  dispatcher: T,
+): T {
+  observeDispatcherValue(dispatcher);
+  return dispatcher;
+}

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -21,6 +21,7 @@ const poolCtor = vi.fn();
 const proxyAgentCtor = vi.fn();
 const proxyConnect = vi.fn();
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+const DESTINATION_AGENT = Symbol("destination agent");
 
 afterEach(() => {
   Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
@@ -47,14 +48,18 @@ class MockAgent extends EventEmitter {
     super();
   }
 
-  createOriginDispatcher(options: Record<string, unknown>): EventEmitter {
+  createOriginDispatcher(options: Record<string, unknown>, emitConnect = true): EventEmitter {
     const factory = this.options?.factory;
-    if (typeof factory === "function") {
-      return factory(new URL("https://service.test"), options) as EventEmitter;
+    const dispatcher =
+      typeof factory === "function"
+        ? (factory(new URL("https://service.test"), options) as EventEmitter)
+        : options.connections === 1
+          ? new MockClient(new URL("https://service.test"), options)
+          : new MockPool(new URL("https://service.test"), options);
+    if (emitConnect) {
+      this.emit("connect", new URL("https://service.test"), [this, dispatcher]);
     }
-    return options.connections === 1
-      ? new MockClient(new URL("https://service.test"), options)
-      : new MockPool(new URL("https://service.test"), options);
+    return dispatcher;
   }
 }
 
@@ -80,18 +85,26 @@ class MockPool extends EventEmitter {
 
 class MockEnvHttpProxyAgent extends EventEmitter {
   readonly __testStub = true;
+  readonly [DESTINATION_AGENT]: MockAgent;
 
   constructor(public readonly options: unknown) {
     super();
+    this[DESTINATION_AGENT] = new MockAgent(
+      expectOptionsRecord(options, "expected EnvHttpProxyAgent options"),
+    );
     envHttpProxyAgentCtor(options);
   }
 }
 
 class MockProxyAgent extends EventEmitter {
   readonly __testStub = true;
+  readonly [DESTINATION_AGENT]: MockAgent;
 
   constructor(public readonly options: unknown) {
     super();
+    this[DESTINATION_AGENT] = new MockAgent(
+      expectOptionsRecord(options, "expected ProxyAgent options"),
+    );
     proxyAgentCtor(options);
   }
 }
@@ -105,17 +118,6 @@ function installUndiciRuntimeDeps(): void {
     ProxyAgent: MockProxyAgent,
     fetch: vi.fn(),
   };
-}
-
-function createProxyClientFromOptions(options: Record<string, unknown>): EventEmitter {
-  const clientFactory = options.clientFactory;
-  if (typeof clientFactory !== "function") {
-    throw new Error("expected ProxyAgent clientFactory");
-  }
-  const pool = clientFactory(new URL("https://service.test"), {
-    connect: proxyConnect,
-  }) as MockPool;
-  return pool.createClient();
 }
 
 function expectOptionsRecord(options: unknown, message: string): Record<string, unknown> {
@@ -163,24 +165,28 @@ describe("undici dispatcher errors", () => {
       name: "direct agent client",
       createClient: () => {
         const agent = createHttp1Agent() as unknown as MockAgent;
-        return agent.createOriginDispatcher({ connections: 1 });
+        return agent.createOriginDispatcher({ connections: 1 }, false);
       },
     },
     {
       name: "explicit proxy client",
       createClient: () => {
-        createHttp1ProxyAgent({ uri: "http://proxy.test:8080" });
-        return createProxyClientFromOptions(requireProxyAgentOptions());
+        const agent = createHttp1ProxyAgent({
+          uri: "http://proxy.test:8080",
+        }) as unknown as MockProxyAgent;
+        return agent[DESTINATION_AGENT].createOriginDispatcher({ connections: 1 }, false);
       },
     },
     {
       name: "environment proxy client",
       createClient: () => {
-        createHttp1EnvHttpProxyAgent({ httpsProxy: "http://proxy.test:8080" });
-        return createProxyClientFromOptions(requireEnvHttpProxyAgentOptions());
+        const agent = createHttp1EnvHttpProxyAgent({
+          httpsProxy: "http://proxy.test:8080",
+        }) as unknown as MockEnvHttpProxyAgent;
+        return agent[DESTINATION_AGENT].createOriginDispatcher({ connections: 1 }, false);
       },
     },
-  ])("handles an internal error from $name", ({ createClient }) => {
+  ])("handles an internal error from $name before connect", ({ createClient }) => {
     installUndiciRuntimeDeps();
     const client = createClient();
     const error = new Error("stream handler aborted");

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -1,11 +1,20 @@
 // Undici runtime tests cover managed proxy TLS, IP-SNI stripping, and proxy
 // client factory installation.
+import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   registerActiveManagedProxyUrl,
   stopActiveManagedProxyRegistration,
 } from "./proxy/active-proxy-state.js";
-import { createHttp1EnvHttpProxyAgent, createHttp1ProxyAgent } from "./undici-runtime.js";
+import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+} from "./undici-runtime.js";
+
+const logDebug = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logger.js", () => ({ logDebug }));
 
 const envHttpProxyAgentCtor = vi.fn();
 const poolCtor = vi.fn();
@@ -19,35 +28,70 @@ afterEach(() => {
   poolCtor.mockReset();
   proxyAgentCtor.mockReset();
   proxyConnect.mockReset();
+  logDebug.mockReset();
 });
 
-class MockAgent {
-  readonly __testStub = true;
+class MockClient extends EventEmitter {
+  constructor(
+    public readonly origin: unknown,
+    public readonly options: unknown,
+  ) {
+    super();
+  }
 }
 
-class MockPool {
+class MockAgent extends EventEmitter {
+  readonly __testStub = true;
+
+  constructor(public readonly options?: Record<string, unknown>) {
+    super();
+  }
+
+  createOriginDispatcher(options: Record<string, unknown>): EventEmitter {
+    const factory = this.options?.factory;
+    if (typeof factory === "function") {
+      return factory(new URL("https://service.test"), options) as EventEmitter;
+    }
+    return options.connections === 1
+      ? new MockClient(new URL("https://service.test"), options)
+      : new MockPool(new URL("https://service.test"), options);
+  }
+}
+
+class MockPool extends EventEmitter {
   readonly __testStub = true;
 
   constructor(
     public readonly origin: unknown,
     public readonly options: unknown,
   ) {
+    super();
     poolCtor(origin, options);
+  }
+
+  createClient(): EventEmitter {
+    const options = expectOptionsRecord(this.options, "expected Pool options object");
+    const factory = options.factory;
+    return typeof factory === "function"
+      ? (factory(this.origin, options) as EventEmitter)
+      : new MockClient(this.origin, options);
   }
 }
 
-class MockEnvHttpProxyAgent {
+class MockEnvHttpProxyAgent extends EventEmitter {
   readonly __testStub = true;
 
   constructor(public readonly options: unknown) {
+    super();
     envHttpProxyAgentCtor(options);
   }
 }
 
-class MockProxyAgent {
+class MockProxyAgent extends EventEmitter {
   readonly __testStub = true;
 
   constructor(public readonly options: unknown) {
+    super();
     proxyAgentCtor(options);
   }
 }
@@ -55,11 +99,23 @@ class MockProxyAgent {
 function installUndiciRuntimeDeps(): void {
   (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
     Agent: MockAgent,
+    Client: MockClient,
     EnvHttpProxyAgent: MockEnvHttpProxyAgent,
     Pool: MockPool,
     ProxyAgent: MockProxyAgent,
     fetch: vi.fn(),
   };
+}
+
+function createProxyClientFromOptions(options: Record<string, unknown>): EventEmitter {
+  const clientFactory = options.clientFactory;
+  if (typeof clientFactory !== "function") {
+    throw new Error("expected ProxyAgent clientFactory");
+  }
+  const pool = clientFactory(new URL("https://service.test"), {
+    connect: proxyConnect,
+  }) as MockPool;
+  return pool.createClient();
 }
 
 function expectOptionsRecord(options: unknown, message: string): Record<string, unknown> {
@@ -100,6 +156,39 @@ function invokeProxyClientFactory(options: Record<string, unknown>): void {
   }
   clientFactory(new URL("https://127.0.0.1:8443"), { connect: proxyConnect });
 }
+
+describe("undici dispatcher errors", () => {
+  it.each([
+    {
+      name: "direct agent client",
+      createClient: () => {
+        const agent = createHttp1Agent() as unknown as MockAgent;
+        return agent.createOriginDispatcher({ connections: 1 });
+      },
+    },
+    {
+      name: "explicit proxy client",
+      createClient: () => {
+        createHttp1ProxyAgent({ uri: "http://proxy.test:8080" });
+        return createProxyClientFromOptions(requireProxyAgentOptions());
+      },
+    },
+    {
+      name: "environment proxy client",
+      createClient: () => {
+        createHttp1EnvHttpProxyAgent({ httpsProxy: "http://proxy.test:8080" });
+        return createProxyClientFromOptions(requireEnvHttpProxyAgentOptions());
+      },
+    },
+  ])("handles an internal error from $name", ({ createClient }) => {
+    installUndiciRuntimeDeps();
+    const client = createClient();
+    const error = new Error("stream handler aborted");
+
+    expect(() => client.emit("error", error)).not.toThrow();
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining(error.message));
+  });
+});
 
 function invokeClientConnect(options: Record<string, unknown>, servername: string): void {
   const connect = options.connect;

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -1,24 +1,18 @@
 // Undici runtime helpers lazily load dispatcher constructors and enforce
 // OpenClaw HTTP/1, timeout, proxy TLS, and IP-safe proxy policies.
-import { EventEmitter } from "node:events";
-import { createRequire } from "node:module";
-import net from "node:net";
-import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
-import { logDebug } from "../../logger.js";
-import { formatErrorMessage } from "../errors.js";
-import { addActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
-import { resolveUndiciAutoSelectFamilyConnectOptions } from "./undici-family-policy.js";
-
-const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
-const requireUndici = createRequire(import.meta.url);
+import {
+  buildHttp1AgentOptions,
+  buildHttp1EnvHttpProxyAgentOptions,
+  buildHttp1ProxyAgentOptions,
+  loadUndiciModule,
+} from "./undici-dispatcher-options.js";
+import { withUndiciErrorDiagnostics } from "./undici-error-diagnostics.js";
 
 /** Runtime-loaded undici constructors/functions used where static imports would affect globals. */
 export type UndiciRuntimeDeps = {
   Agent: typeof import("undici").Agent;
-  Client: typeof import("undici").Client;
   EnvHttpProxyAgent: typeof import("undici").EnvHttpProxyAgent;
   FormData?: typeof import("undici").FormData;
-  Pool: typeof import("undici").Pool;
   ProxyAgent: typeof import("undici").ProxyAgent;
   fetch: typeof import("undici").fetch;
 };
@@ -30,137 +24,10 @@ export type UndiciGlobalDispatcherDeps = Pick<UndiciRuntimeDeps, "Agent" | "EnvH
 };
 
 type UndiciAgentOptions = ConstructorParameters<UndiciRuntimeDeps["Agent"]>[0];
-type UndiciClientOptions = ConstructorParameters<UndiciRuntimeDeps["Client"]>[1];
 type UndiciEnvHttpProxyAgentOptions = ConstructorParameters<
   UndiciRuntimeDeps["EnvHttpProxyAgent"]
 >[0];
 type UndiciProxyAgentOptions = ConstructorParameters<UndiciRuntimeDeps["ProxyAgent"]>[0];
-type UndiciProxyAgentOptionsRecord = Exclude<UndiciProxyAgentOptions, string | URL>;
-type UndiciProxyClientFactory = NonNullable<UndiciProxyAgentOptionsRecord["clientFactory"]>;
-type UndiciDispatcher = import("undici").Dispatcher;
-type UnknownFunction = (...args: unknown[]) => unknown;
-
-// Guarded fetch dispatchers intentionally stay on HTTP/1.1. Undici 8 enables
-// HTTP/2 ALPN by default, but our guarded paths rely on dispatcher overrides
-// that have not been reliable on the HTTP/2 path yet.
-const HTTP1_ONLY_DISPATCHER_OPTIONS = Object.freeze({
-  allowH2: false as const,
-});
-
-function logUndiciDispatcherError(error: unknown): void {
-  logDebug(`undici: internal dispatcher error: ${formatErrorMessage(error)}`);
-}
-
-function withUndiciErrorDiagnostics<T extends UndiciDispatcher>(dispatcher: T): T {
-  // Body consumers already receive the failure. This listener prevents the
-  // EventEmitter error channel from turning that same failure into a crash.
-  if (dispatcher instanceof EventEmitter) {
-    EventEmitter.prototype.on.call(dispatcher, "error", logUndiciDispatcherError);
-  }
-  return dispatcher;
-}
-
-function applyMissingConnectOptions(
-  connect: Record<string, unknown>,
-  defaults: Record<string, unknown>,
-): void {
-  for (const [key, value] of Object.entries(defaults)) {
-    if (!(key in connect)) {
-      connect[key] = value;
-    }
-  }
-}
-
-function loadUndiciModule(
-  requiredExports: ReadonlyArray<keyof typeof import("undici")>,
-): typeof import("undici") {
-  const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
-  if (
-    isObjectRecord(override) &&
-    requiredExports.every((key) => typeof override[key] === "function")
-  ) {
-    return override as typeof import("undici");
-  }
-  return requireUndici("undici") as typeof import("undici");
-}
-
-function stripIpServernameFromConnectOptions(options: unknown): unknown {
-  // OpenSSL rejects IP literals as SNI values; strip only IP servernames while
-  // preserving hostname SNI for HTTPS proxies.
-  if (!isObjectRecord(options) || typeof options.servername !== "string") {
-    return options;
-  }
-  const servername = options.servername.replace(/^\[|\]$/g, "");
-  if (net.isIP(servername) === 0) {
-    return options;
-  }
-  const next = { ...options };
-  delete next.servername;
-  return next;
-}
-
-function stripIpServernameFromConnect(connect: unknown): unknown {
-  if (typeof connect !== "function") {
-    return connect;
-  }
-  return (options: unknown, callback: unknown): unknown =>
-    (connect as UnknownFunction)(stripIpServernameFromConnectOptions(options), callback);
-}
-
-function createIpSafeProxyClientFactory(): UndiciProxyClientFactory {
-  return (origin, options) => {
-    // HTTPS proxies addressed by IP can arrive with an IP servername. Strip it
-    // before TLS connect because OpenSSL rejects IP literals as SNI values.
-    const clientOptions = isObjectRecord(options)
-      ? { ...options, connect: stripIpServernameFromConnect(options.connect) }
-      : options;
-    return createUndiciPool(origin, clientOptions);
-  };
-}
-
-function createUndiciClient(origin: string | URL, options: object): UndiciDispatcher {
-  const { Client } = loadUndiciModule(["Client"]);
-  return withUndiciErrorDiagnostics(new Client(origin, options as UndiciClientOptions));
-}
-
-function createUndiciPool(origin: string | URL, options: unknown): UndiciDispatcher {
-  const { Pool } = loadUndiciModule(["Pool"]);
-  const poolOptions = isObjectRecord(options) ? options : {};
-  return withUndiciErrorDiagnostics(
-    new Pool(origin, {
-      ...poolOptions,
-      factory: createUndiciClient,
-    }),
-  );
-}
-
-function createUndiciOriginDispatcher(origin: string | URL, options: object): UndiciDispatcher {
-  return isObjectRecord(options) && options.connections === 1
-    ? createUndiciClient(origin, options)
-    : createUndiciPool(origin, options);
-}
-
-function addUndiciAgentFactory<TOptions extends object>(options: TOptions): TOptions {
-  if ("factory" in options) {
-    return options;
-  }
-  return {
-    ...options,
-    factory: createUndiciOriginDispatcher,
-  };
-}
-
-function addIpSafeProxyClientFactory<TOptions extends object>(options: TOptions): TOptions {
-  if ("clientFactory" in options) {
-    return options;
-  }
-  // Only install our factory when the caller did not provide one, otherwise
-  // custom proxy pools would lose their own connection policy.
-  return {
-    ...options,
-    clientFactory: createIpSafeProxyClientFactory(),
-  };
-}
 
 /** Loads undici lazily, allowing tests to inject constructors without global side effects. */
 export function loadUndiciRuntimeDeps(): UndiciRuntimeDeps {
@@ -177,59 +44,13 @@ export function loadUndiciGlobalDispatcherDeps(): UndiciGlobalDispatcherDeps {
   ]);
 }
 
-function withHttp1OnlyDispatcherOptions<T extends object | undefined>(
-  options?: T,
-  timeoutMs?: number,
-  applyTo?: { connect?: boolean; proxyTls?: boolean },
-): (T extends object ? T : Record<never, never>) & { allowH2: false } {
-  const base = {} as (T extends object ? T : Record<never, never>) & { allowH2: false };
-  if (options) {
-    Object.assign(base, options);
-  }
-  // Enforce HTTP/1.1-only — must come after options to prevent accidental override
-  Object.assign(base, HTTP1_ONLY_DISPATCHER_OPTIONS);
-  const baseRecord = base as Record<string, unknown>;
-  const targets = applyTo ?? { connect: true };
-  const autoSelectConnect = resolveUndiciAutoSelectFamilyConnectOptions();
-  if (autoSelectConnect && targets.connect && typeof baseRecord.connect !== "function") {
-    const connect = isObjectRecord(baseRecord.connect) ? baseRecord.connect : {};
-    applyMissingConnectOptions(connect, autoSelectConnect);
-    baseRecord.connect = connect;
-  }
-  if (autoSelectConnect && targets.proxyTls) {
-    const proxyTls = isObjectRecord(baseRecord.proxyTls) ? baseRecord.proxyTls : {};
-    applyMissingConnectOptions(proxyTls, autoSelectConnect);
-    baseRecord.proxyTls = proxyTls;
-  }
-  if (timeoutMs !== undefined && Number.isFinite(timeoutMs) && timeoutMs > 0) {
-    const normalizedTimeoutMs = Math.floor(timeoutMs);
-    baseRecord.bodyTimeout = normalizedTimeoutMs;
-    baseRecord.headersTimeout = normalizedTimeoutMs;
-    if (targets.connect && typeof baseRecord.connect !== "function") {
-      baseRecord.connect = {
-        ...(isObjectRecord(baseRecord.connect) ? baseRecord.connect : {}),
-        timeout: normalizedTimeoutMs,
-      };
-    }
-    if (targets.proxyTls) {
-      baseRecord.proxyTls = {
-        ...(isObjectRecord(baseRecord.proxyTls) ? baseRecord.proxyTls : {}),
-        timeout: normalizedTimeoutMs,
-      };
-    }
-  }
-  return base;
-}
-
 /** Creates a direct undici Agent with OpenClaw's HTTP/1-only dispatcher policy. */
 export function createHttp1Agent(
   options?: UndiciAgentOptions,
   timeoutMs?: number,
 ): import("undici").Agent {
   const { Agent } = loadUndiciRuntimeDeps();
-  return withUndiciErrorDiagnostics(
-    new Agent(addUndiciAgentFactory(withHttp1OnlyDispatcherOptions(options, timeoutMs))),
-  );
+  return withUndiciErrorDiagnostics(new Agent(buildHttp1AgentOptions(options, timeoutMs)));
 }
 
 /**
@@ -242,18 +63,7 @@ export function createHttp1EnvHttpProxyAgent(
 ): import("undici").EnvHttpProxyAgent {
   const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
   return withUndiciErrorDiagnostics(
-    new EnvHttpProxyAgent(
-      withHttp1OnlyDispatcherOptions(
-        addIpSafeProxyClientFactory(
-          addUndiciAgentFactory(addActiveManagedProxyTlsOptions(options) ?? {}),
-        ),
-        timeoutMs,
-        {
-          connect: true,
-          proxyTls: true,
-        },
-      ),
-    ),
+    new EnvHttpProxyAgent(buildHttp1EnvHttpProxyAgentOptions(options, timeoutMs)),
   );
 }
 
@@ -266,21 +76,7 @@ export function createHttp1ProxyAgent(
   timeoutMs?: number,
 ): import("undici").ProxyAgent {
   const { ProxyAgent } = loadUndiciRuntimeDeps();
-  const normalized =
-    typeof options === "string" || options instanceof URL
-      ? { uri: options.toString() }
-      : { ...options };
   return withUndiciErrorDiagnostics(
-    new ProxyAgent(
-      withHttp1OnlyDispatcherOptions(
-        addIpSafeProxyClientFactory(
-          addUndiciAgentFactory(addActiveManagedProxyTlsOptions(normalized as object)),
-        ),
-        timeoutMs,
-        {
-          proxyTls: true,
-        },
-      ) as UndiciProxyAgentOptions,
-    ),
+    new ProxyAgent(buildHttp1ProxyAgentOptions(options, timeoutMs)),
   );
 }

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -1,8 +1,11 @@
 // Undici runtime helpers lazily load dispatcher constructors and enforce
 // OpenClaw HTTP/1, timeout, proxy TLS, and IP-safe proxy policies.
+import { EventEmitter } from "node:events";
 import { createRequire } from "node:module";
 import net from "node:net";
 import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
+import { logDebug } from "../../logger.js";
+import { formatErrorMessage } from "../errors.js";
 import { addActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
 import { resolveUndiciAutoSelectFamilyConnectOptions } from "./undici-family-policy.js";
 
@@ -12,8 +15,10 @@ const requireUndici = createRequire(import.meta.url);
 /** Runtime-loaded undici constructors/functions used where static imports would affect globals. */
 export type UndiciRuntimeDeps = {
   Agent: typeof import("undici").Agent;
+  Client: typeof import("undici").Client;
   EnvHttpProxyAgent: typeof import("undici").EnvHttpProxyAgent;
   FormData?: typeof import("undici").FormData;
+  Pool: typeof import("undici").Pool;
   ProxyAgent: typeof import("undici").ProxyAgent;
   fetch: typeof import("undici").fetch;
 };
@@ -25,12 +30,14 @@ export type UndiciGlobalDispatcherDeps = Pick<UndiciRuntimeDeps, "Agent" | "EnvH
 };
 
 type UndiciAgentOptions = ConstructorParameters<UndiciRuntimeDeps["Agent"]>[0];
+type UndiciClientOptions = ConstructorParameters<UndiciRuntimeDeps["Client"]>[1];
 type UndiciEnvHttpProxyAgentOptions = ConstructorParameters<
   UndiciRuntimeDeps["EnvHttpProxyAgent"]
 >[0];
 type UndiciProxyAgentOptions = ConstructorParameters<UndiciRuntimeDeps["ProxyAgent"]>[0];
 type UndiciProxyAgentOptionsRecord = Exclude<UndiciProxyAgentOptions, string | URL>;
 type UndiciProxyClientFactory = NonNullable<UndiciProxyAgentOptionsRecord["clientFactory"]>;
+type UndiciDispatcher = import("undici").Dispatcher;
 type UnknownFunction = (...args: unknown[]) => unknown;
 
 // Guarded fetch dispatchers intentionally stay on HTTP/1.1. Undici 8 enables
@@ -39,6 +46,19 @@ type UnknownFunction = (...args: unknown[]) => unknown;
 const HTTP1_ONLY_DISPATCHER_OPTIONS = Object.freeze({
   allowH2: false as const,
 });
+
+function logUndiciDispatcherError(error: unknown): void {
+  logDebug(`undici: internal dispatcher error: ${formatErrorMessage(error)}`);
+}
+
+function withUndiciErrorDiagnostics<T extends UndiciDispatcher>(dispatcher: T): T {
+  // Body consumers already receive the failure. This listener prevents the
+  // EventEmitter error channel from turning that same failure into a crash.
+  if (dispatcher instanceof EventEmitter) {
+    EventEmitter.prototype.on.call(dispatcher, "error", logUndiciDispatcherError);
+  }
+  return dispatcher;
+}
 
 function applyMissingConnectOptions(
   connect: Record<string, unknown>,
@@ -89,16 +109,44 @@ function stripIpServernameFromConnect(connect: unknown): unknown {
 
 function createIpSafeProxyClientFactory(): UndiciProxyClientFactory {
   return (origin, options) => {
-    const { Pool } = loadUndiciModule(["Pool"]);
     // HTTPS proxies addressed by IP can arrive with an IP servername. Strip it
     // before TLS connect because OpenSSL rejects IP literals as SNI values.
     const clientOptions = isObjectRecord(options)
       ? { ...options, connect: stripIpServernameFromConnect(options.connect) }
       : options;
-    return new Pool(
-      origin,
-      clientOptions as ConstructorParameters<typeof import("undici").Pool>[1],
-    );
+    return createUndiciPool(origin, clientOptions);
+  };
+}
+
+function createUndiciClient(origin: string | URL, options: object): UndiciDispatcher {
+  const { Client } = loadUndiciModule(["Client"]);
+  return withUndiciErrorDiagnostics(new Client(origin, options as UndiciClientOptions));
+}
+
+function createUndiciPool(origin: string | URL, options: unknown): UndiciDispatcher {
+  const { Pool } = loadUndiciModule(["Pool"]);
+  const poolOptions = isObjectRecord(options) ? options : {};
+  return withUndiciErrorDiagnostics(
+    new Pool(origin, {
+      ...poolOptions,
+      factory: createUndiciClient,
+    }),
+  );
+}
+
+function createUndiciOriginDispatcher(origin: string | URL, options: object): UndiciDispatcher {
+  return isObjectRecord(options) && options.connections === 1
+    ? createUndiciClient(origin, options)
+    : createUndiciPool(origin, options);
+}
+
+function addUndiciAgentFactory<TOptions extends object>(options: TOptions): TOptions {
+  if ("factory" in options) {
+    return options;
+  }
+  return {
+    ...options,
+    factory: createUndiciOriginDispatcher,
   };
 }
 
@@ -179,7 +227,9 @@ export function createHttp1Agent(
   timeoutMs?: number,
 ): import("undici").Agent {
   const { Agent } = loadUndiciRuntimeDeps();
-  return new Agent(withHttp1OnlyDispatcherOptions(options, timeoutMs));
+  return withUndiciErrorDiagnostics(
+    new Agent(addUndiciAgentFactory(withHttp1OnlyDispatcherOptions(options, timeoutMs))),
+  );
 }
 
 /**
@@ -191,14 +241,18 @@ export function createHttp1EnvHttpProxyAgent(
   timeoutMs?: number,
 ): import("undici").EnvHttpProxyAgent {
   const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
-  return new EnvHttpProxyAgent(
-    withHttp1OnlyDispatcherOptions(
-      addIpSafeProxyClientFactory(addActiveManagedProxyTlsOptions(options) ?? {}),
-      timeoutMs,
-      {
-        connect: true,
-        proxyTls: true,
-      },
+  return withUndiciErrorDiagnostics(
+    new EnvHttpProxyAgent(
+      withHttp1OnlyDispatcherOptions(
+        addIpSafeProxyClientFactory(
+          addUndiciAgentFactory(addActiveManagedProxyTlsOptions(options) ?? {}),
+        ),
+        timeoutMs,
+        {
+          connect: true,
+          proxyTls: true,
+        },
+      ),
     ),
   );
 }
@@ -216,13 +270,17 @@ export function createHttp1ProxyAgent(
     typeof options === "string" || options instanceof URL
       ? { uri: options.toString() }
       : { ...options };
-  return new ProxyAgent(
-    withHttp1OnlyDispatcherOptions(
-      addIpSafeProxyClientFactory(addActiveManagedProxyTlsOptions(normalized as object)),
-      timeoutMs,
-      {
-        proxyTls: true,
-      },
-    ) as UndiciProxyAgentOptions,
+  return withUndiciErrorDiagnostics(
+    new ProxyAgent(
+      withHttp1OnlyDispatcherOptions(
+        addIpSafeProxyClientFactory(
+          addUndiciAgentFactory(addActiveManagedProxyTlsOptions(normalized as object)),
+        ),
+        timeoutMs,
+        {
+          proxyTls: true,
+        },
+      ) as UndiciProxyAgentOptions,
+    ),
   );
 }

--- a/src/infra/provider-usage.load.plugin.test.ts
+++ b/src/infra/provider-usage.load.plugin.test.ts
@@ -220,7 +220,10 @@ describe("provider-usage.load plugin boundary", () => {
       ],
     });
 
-    expect(envAgentSpy).toHaveBeenCalledWith({ httpsProxy: "http://proxy.test:8080" });
+    expect(envAgentSpy).toHaveBeenCalledOnce();
+    expect(envAgentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ httpsProxy: "http://proxy.test:8080" }),
+    );
     expect(undiciFetch).toHaveBeenCalledOnce();
     const [input] = undiciFetch.mock.calls[0] ?? [];
     expect(input).toBe("https://chatgpt.com/backend-api/wham/usage");


### PR DESCRIPTION
## What Problem This Solves

Three runtime hardening gaps:

- A mid-stream client error on the shared HTTP dispatcher (direct, proxy, or environment-proxy paths) could surface as an unhandled EventEmitter error and crash the process; errors are now absorbed into redacted debug diagnostics on every client construction path.
- Session-entry short ids were derived from the timestamp-dominated head of time-ordered UUIDs, so ids minted within the same ~65-second window collided until the uniqueness retry loop exhausted and fell back to full-length ids; they now come from the random tail.
- Every extension (re)load re-transformed all extension modules from scratch (module caching disabled), a known startup stall; loads now use a bounded, single-cwd factory cache with a generation guard. An explicit reload clears the cache first, so edited extension source is always re-evaluated — proven by a test that edits a temp extension and reloads.

## Why This Change Was Made

All three are defensive/performance issues users experience as rare crashes, noisy fallback ids, and slow startups. The cache follows the repo's process-local, lifecycle-owned, bounded single-slot cache rule; the generation counter prevents an in-flight load from repopulating a cleared cache.

## User Impact

No API changes. Fewer hard crashes under flaky networks/proxies; deterministic short session ids under burst writes; faster repeat extension loads with unchanged `/reload` semantics.

## Evidence

- 93 focused tests passing across undici-runtime, proxy-fetch, resource-loader (including the edit-then-reload regression), and session storage suites (hosted run 29615007614; re-verified locally).
- Full changed-file gate green on hosted runner (run 29613040329); full build green on Testbox (run 29614241006).
- Autoreview clean; no lint/format findings.
