### PR TITLE
fix: keep newline-mode reply paragraphs as separate channel bubbles

### DIFF
--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -74,7 +74,18 @@ describe("EmbeddedBlockChunker", () => {
     chunker.append("First paragraph.\n \nSecond paragraph.");
 
     expect(drainChunks(chunker)).toStrictEqual([]);
-    expect(drainChunks(chunker, true)).toEqual(["First paragraph.\n \nSecond paragraph."]);
+    // Force + flushOnParagraph preserves blank-line boundaries instead of
+    // collapsing the accumulated buffer into one delivery unit.
+    expect(drainChunks(chunker, true)).toEqual(["First paragraph.", "Second paragraph."]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("force flushes multi-paragraph Codex-style finals as separate units", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 4000 });
+
+    chunker.append("Short reply part one.\n\nShort reply part two.");
+
+    expect(drainChunks(chunker, true)).toEqual(["Short reply part one.", "Short reply part two."]);
     expect(chunker.bufferedText).toBe("");
   });
 

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -156,7 +156,11 @@ export class EmbeddedBlockChunker {
       return;
     }
 
-    if (force && this.#buffer.length <= maxChars) {
+    // Without paragraph flushing, a force drain of an under-max buffer is one
+    // final payload. With flushOnParagraph, keep blank-line boundaries even on
+    // the terminal force flush so accumulated final replies (e.g. Codex) do not
+    // collapse into a single delivery unit.
+    if (force && this.#buffer.length <= maxChars && !this.#chunking.flushOnParagraph) {
       if (this.#buffer.trim().length > 0) {
         emit(this.#buffer);
       }
@@ -177,8 +181,9 @@ export class EmbeddedBlockChunker {
         break;
       }
 
-      if (this.#chunking.flushOnParagraph && !force) {
-        const paragraphBreak = findNextParagraphBreak(source, fenceSpans, start, minChars);
+      if (this.#chunking.flushOnParagraph) {
+        const paragraphMinChars = force ? 1 : minChars;
+        const paragraphBreak = findNextParagraphBreak(source, fenceSpans, start, paragraphMinChars);
         const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
         if (paragraphBreak && paragraphBreak.index - start <= paragraphLimit) {
           const chunk = `${reopenPrefix}${source.slice(start, paragraphBreak.index)}`;
@@ -189,7 +194,16 @@ export class EmbeddedBlockChunker {
           reopenFence = undefined;
           continue;
         }
-        if (remainingLength < maxChars) {
+        if (force && !paragraphBreak) {
+          const chunk = `${reopenPrefix}${source.slice(start)}`;
+          if (chunk.trim().length > 0) {
+            emit(chunk);
+          }
+          start = source.length;
+          reopenFence = undefined;
+          break;
+        }
+        if (!force && remainingLength < maxChars) {
           break;
         }
       }

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -644,6 +644,21 @@ describe("chunkMarkdownTextWithMode", () => {
     ]);
   });
 
+  it("keeps top-level paragraphs separate when packAdjacent is false", () => {
+    expect(
+      chunkMarkdownTextWithMode("Alpha\n\nBeta\n\nGamma", 4000, "newline", {
+        packAdjacent: false,
+      }),
+    ).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+
+  it("keeps fenced blanks intact when packAdjacent is false", () => {
+    const fence = "```js\nconst a = 1;\n\nconst b = 2;\n```";
+    expect(
+      chunkMarkdownTextWithMode(`${fence}\n\nAfter`, 4000, "newline", { packAdjacent: false }),
+    ).toEqual([fence, "After"]);
+  });
+
   it("does not split surrogate pairs at hard length boundaries", () => {
     const text = `a${"😀".repeat(20_000)}`;
     const chunks = chunkMarkdownTextWithMode(text, 32_768, "length");

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -6,7 +6,6 @@ import * as fences from "../../packages/markdown-core/src/fences.js";
 import { hasBalancedFences } from "../test-utils/chunk-test-helpers.js";
 import {
   chunkByNewline,
-  chunkByParagraph,
   chunkMarkdownText,
   chunkMarkdownTextWithMode,
   chunkText,
@@ -232,7 +231,7 @@ describe("chunkText", () => {
   ]);
 });
 
-describe("chunkByParagraph Unicode line/paragraph separators", () => {
+describe("newline mode Unicode line/paragraph separators", () => {
   it.each([
     {
       name: "treats lone U+2029 as a standalone paragraph boundary",
@@ -256,10 +255,13 @@ describe("chunkByParagraph Unicode line/paragraph separators", () => {
       expected: ["paragraph one line", "paragraph two starts here"],
     },
   ] as const)("$name", ({ text, normalized, limit, expected }) => {
-    const chunks = chunkByParagraph(text, limit);
+    // Exercise via the public newline-mode API; chunkByParagraph stays internal
+    // so knip deadcode:exports stays green after outbound planning moved to
+    // splitOutboundNewlineDeliveryUnits.
+    const chunks = chunkTextWithMode(text, limit, "newline");
 
     expect(chunks).toEqual(expected);
-    expect(chunks).toEqual(chunkByParagraph(normalized, limit));
+    expect(chunks).toEqual(chunkTextWithMode(normalized, limit, "newline"));
   });
 });
 

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -13,6 +13,7 @@ import {
   chunkTextWithMode,
   resolveChunkMode,
   resolveTextChunkLimit,
+  splitOutboundNewlineDeliveryUnits,
 } from "./chunk.js";
 
 function expectFencesBalanced(chunks: string[]) {
@@ -644,19 +645,20 @@ describe("chunkMarkdownTextWithMode", () => {
     ]);
   });
 
-  it("keeps top-level paragraphs separate when packAdjacent is false", () => {
-    expect(
-      chunkMarkdownTextWithMode("Alpha\n\nBeta\n\nGamma", 4000, "newline", {
-        packAdjacent: false,
-      }),
-    ).toEqual(["Alpha", "Beta", "Gamma"]);
+  it("keeps top-level paragraphs separate for outbound newline delivery units", () => {
+    expect(splitOutboundNewlineDeliveryUnits("Alpha\n\nBeta\n\nGamma", 4000, "markdown")).toEqual([
+      "Alpha",
+      "Beta",
+      "Gamma",
+    ]);
   });
 
-  it("keeps fenced blanks intact when packAdjacent is false", () => {
+  it("keeps fenced blanks intact for outbound markdown newline delivery units", () => {
     const fence = "```js\nconst a = 1;\n\nconst b = 2;\n```";
-    expect(
-      chunkMarkdownTextWithMode(`${fence}\n\nAfter`, 4000, "newline", { packAdjacent: false }),
-    ).toEqual([fence, "After"]);
+    expect(splitOutboundNewlineDeliveryUnits(`${fence}\n\nAfter`, 4000, "markdown")).toEqual([
+      fence,
+      "After",
+    ]);
   });
 
   it("does not split surrogate pairs at hard length boundaries", () => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -197,7 +197,7 @@ export function chunkByNewline(
 export function chunkByParagraph(
   text: string,
   limit: number,
-  opts?: { splitLongParagraphs?: boolean },
+  opts?: { splitLongParagraphs?: boolean; packAdjacent?: boolean },
 ): string[] {
   if (!text) {
     return [];
@@ -206,6 +206,10 @@ export function chunkByParagraph(
     return [text];
   }
   const splitLongParagraphs = opts?.splitLongParagraphs !== false;
+  // When false, each blank-line paragraph is its own chunk and `limit` only
+  // splits oversized paragraphs. Outbound newline planning uses this so a
+  // transport ceiling cannot re-join logical reply blocks before delivery.
+  const packAdjacent = opts?.packAdjacent !== false;
 
   // U+2029 PARAGRAPH SEPARATOR maps to a blank-line boundary; U+2028 LINE
   // SEPARATOR and CR/CRLF map to a single newline.
@@ -250,6 +254,15 @@ export function chunkByParagraph(
   let currentChunk = "";
 
   const pushParagraph = (paragraph: string, separatorBefore?: string) => {
+    if (!packAdjacent) {
+      if (paragraph.length <= limit || !splitLongParagraphs) {
+        chunks.push(paragraph);
+        return;
+      }
+      chunks.push(...chunkText(paragraph, limit));
+      return;
+    }
+
     if (!currentChunk) {
       if (paragraph.length <= limit) {
         currentChunk = paragraph;

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -194,7 +194,7 @@ export function chunkByNewline(
  * - Falls back to length-based splitting when a single paragraph exceeds `limit`
  *   (unless `splitLongParagraphs` is disabled)
  */
-export function chunkByParagraph(
+function chunkByParagraph(
   text: string,
   limit: number,
   opts?: { splitLongParagraphs?: boolean },

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -312,11 +312,21 @@ export function chunkTextWithMode(text: string, limit: number, mode: ChunkMode):
   return chunkText(text, limit);
 }
 
-export function chunkMarkdownTextWithMode(text: string, limit: number, mode: ChunkMode): string[] {
+export function chunkMarkdownTextWithMode(
+  text: string,
+  limit: number,
+  mode: ChunkMode,
+  opts?: { packAdjacent?: boolean },
+): string[] {
   if (mode === "newline") {
     // Paragraph chunking is fence-safe because we never split at arbitrary indices.
     // If a paragraph must be split by length, defer to the markdown-aware chunker.
-    const paragraphChunks = chunkByParagraph(text, limit, { splitLongParagraphs: false });
+    // Outbound newline planning passes packAdjacent:false so top-level blank-line
+    // paragraphs stay separate delivery units while fenced blanks stay intact.
+    const paragraphChunks = chunkByParagraph(text, limit, {
+      splitLongParagraphs: false,
+      packAdjacent: opts?.packAdjacent,
+    });
     const out: string[] = [];
     for (const chunk of paragraphChunks.flatMap((paragraphChunk) =>
       paragraphChunk.length > limit

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -194,7 +194,7 @@ export function chunkByNewline(
  * - Falls back to length-based splitting when a single paragraph exceeds `limit`
  *   (unless `splitLongParagraphs` is disabled)
  */
-function chunkByParagraph(
+export function chunkByParagraph(
   text: string,
   limit: number,
   opts?: { splitLongParagraphs?: boolean },

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -197,6 +197,44 @@ export function chunkByNewline(
 export function chunkByParagraph(
   text: string,
   limit: number,
+  opts?: { splitLongParagraphs?: boolean },
+): string[] {
+  return chunkByParagraphInternal(text, limit, opts);
+}
+
+/**
+ * Core outbound planning helper: keep each top-level blank-line paragraph as its
+ * own delivery unit. Packing short adjacent paragraphs up to `limit` is a public
+ * reply-chunking concern; outbound newline mode must not rejoin logical reply
+ * blocks before channel delivery. Not part of the plugin SDK reply-chunking API.
+ */
+export function splitOutboundNewlineDeliveryUnits(
+  text: string,
+  limit: number,
+  style: "text" | "markdown",
+): string[] {
+  if (style === "markdown") {
+    // Fence-aware paragraph split without packing, then markdown length chunking.
+    const paragraphChunks = chunkByParagraphInternal(text, limit, {
+      splitLongParagraphs: false,
+      packAdjacent: false,
+    });
+    const out: string[] = [];
+    for (const chunk of paragraphChunks.flatMap((paragraphChunk) =>
+      paragraphChunk.length > limit
+        ? splitPackedFenceParagraphChunk(paragraphChunk)
+        : paragraphChunk,
+    )) {
+      out.push(...chunkMarkdownText(chunk, limit));
+    }
+    return out;
+  }
+  return chunkByParagraphInternal(text, limit, { packAdjacent: false });
+}
+
+function chunkByParagraphInternal(
+  text: string,
+  limit: number,
   opts?: { splitLongParagraphs?: boolean; packAdjacent?: boolean },
 ): string[] {
   if (!text) {
@@ -312,21 +350,11 @@ export function chunkTextWithMode(text: string, limit: number, mode: ChunkMode):
   return chunkText(text, limit);
 }
 
-export function chunkMarkdownTextWithMode(
-  text: string,
-  limit: number,
-  mode: ChunkMode,
-  opts?: { packAdjacent?: boolean },
-): string[] {
+export function chunkMarkdownTextWithMode(text: string, limit: number, mode: ChunkMode): string[] {
   if (mode === "newline") {
     // Paragraph chunking is fence-safe because we never split at arbitrary indices.
     // If a paragraph must be split by length, defer to the markdown-aware chunker.
-    // Outbound newline planning passes packAdjacent:false so top-level blank-line
-    // paragraphs stay separate delivery units while fenced blanks stay intact.
-    const paragraphChunks = chunkByParagraph(text, limit, {
-      splitLongParagraphs: false,
-      packAdjacent: opts?.packAdjacent,
-    });
+    const paragraphChunks = chunkByParagraph(text, limit, { splitLongParagraphs: false });
     const out: string[] = [];
     for (const chunk of paragraphChunks.flatMap((paragraphChunk) =>
       paragraphChunk.length > limit

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4164,8 +4164,11 @@ describe("deliverOutboundPayloads", () => {
     expect(results.map((r) => r.messageId)).toEqual(["m1", "m2"]);
   });
 
-  it("respects newline chunk mode for plugin text without splitting short messages", async () => {
-    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+  it("respects newline chunk mode by keeping blank-line paragraphs as separate sends", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
     const cfg: OpenClawConfig = {
       channels: {
         matrix: { textChunkLimit: 4000, chunkMode: "newline" },
@@ -4180,18 +4183,23 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
-    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(sendMatrix).toHaveBeenCalledTimes(2);
     const firstChunkCall = requireMatrixSendCall(sendMatrix);
     expect(firstChunkCall?.[0]).toBe("!room:example");
-    expect(firstChunkCall?.[1]).toBe("Line one\n\nLine two");
+    expect(firstChunkCall?.[1]).toBe("Line one");
     expect((firstChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
+    const secondChunkCall = sendMatrix.mock.calls[1];
+    expect(secondChunkCall?.[0]).toBe("!room:example");
+    expect(secondChunkCall?.[1]).toBe("Line two");
+    expect((secondChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
   });
 
-  it("splits long plugin text on packed paragraph boundaries in newline mode", async () => {
+  it("splits newline-mode plugin text on each blank-line paragraph boundary", async () => {
     const sendMatrix = vi
       .fn()
       .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
-      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m3", roomId: "!room:example" });
     const cfg: OpenClawConfig = {
       channels: {
         matrix: { textChunkLimit: 14, chunkMode: "newline" },
@@ -4206,15 +4214,19 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
-    expect(sendMatrix).toHaveBeenCalledTimes(2);
+    expect(sendMatrix).toHaveBeenCalledTimes(3);
     const firstChunkCall = requireMatrixSendCall(sendMatrix);
     expect(firstChunkCall?.[0]).toBe("!room:example");
-    expect(firstChunkCall?.[1]).toBe("Alpha\n\nBeta");
+    expect(firstChunkCall?.[1]).toBe("Alpha");
     expect((firstChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
     const secondChunkCall = sendMatrix.mock.calls[1];
     expect(secondChunkCall?.[0]).toBe("!room:example");
-    expect(secondChunkCall?.[1]).toBe("Gamma");
+    expect(secondChunkCall?.[1]).toBe("Beta");
     expect((secondChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
+    const thirdChunkCall = sendMatrix.mock.calls[2];
+    expect(thirdChunkCall?.[0]).toBe("!room:example");
+    expect(thirdChunkCall?.[1]).toBe("Gamma");
+    expect((thirdChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
   });
 
   it("lets explicit formatting options override configured chunking", async () => {

--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -130,4 +130,39 @@ describe("outbound message planning", () => {
       ["text", "Second bubble."],
     ]);
   });
+
+  it("keeps fenced code blanks intact while splitting top-level markdown paragraphs", () => {
+    const fence = "```js\nconst a = 1;\n\nconst b = 2;\n```";
+    const units = planOutboundTextMessageUnits({
+      text: `${fence}\n\nAfter fence.`,
+      textLimit: 4000,
+      chunkMode: "newline",
+      chunkerMode: "markdown",
+      chunker: (text) => [text],
+      overrides: {},
+    });
+
+    expect(
+      units.map((unit) => (unit.kind === "text" ? [unit.kind, unit.text] : [unit.kind])),
+    ).toEqual([
+      ["text", fence],
+      ["text", "After fence."],
+    ]);
+  });
+
+  it("does not split a lone fenced block that contains blank lines", () => {
+    const fence = "```python\ndef my_function():\n    x = 1\n\n    y = 2\n    return x + y\n```";
+    const units = planOutboundTextMessageUnits({
+      text: fence,
+      textLimit: 4000,
+      chunkMode: "newline",
+      chunkerMode: "markdown",
+      chunker: (text) => [text],
+      overrides: {},
+    });
+
+    expect(
+      units.map((unit) => (unit.kind === "text" ? [unit.kind, unit.text] : [unit.kind])),
+    ).toEqual([["text", fence]]);
+  });
 });

--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -111,4 +111,23 @@ describe("outbound message planning", () => {
       },
     ]);
   });
+
+  it("keeps newline-mode paragraphs as separate units under a large transport limit", () => {
+    // Codex finals arrive as one accumulated payload; packing to textLimit would
+    // collapse intended WhatsApp bubbles before coalescing can separate them.
+    const units = planOutboundTextMessageUnits({
+      text: "First bubble.\n\nSecond bubble.",
+      textLimit: 4000,
+      chunkMode: "newline",
+      chunker: (text) => [text],
+      overrides: {},
+    });
+
+    expect(
+      units.map((unit) => (unit.kind === "text" ? [unit.kind, unit.text] : [unit.kind])),
+    ).toEqual([
+      ["text", "First bubble."],
+      ["text", "Second bubble."],
+    ]);
+  });
 });

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -1,10 +1,6 @@
 // Message planning expands normalized payloads into ordered text/media send
 // units while preserving reply-to consumption rules.
-import {
-  chunkByParagraph,
-  chunkMarkdownTextWithMode,
-  type ChunkMode,
-} from "../../auto-reply/chunk.js";
+import { splitOutboundNewlineDeliveryUnits, type ChunkMode } from "../../auto-reply/chunk.js";
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { ReplyToOverride } from "./reply-policy.js";
 
@@ -141,12 +137,13 @@ export function planOutboundTextMessageUnits(params: {
     // logical blocks first (Codex final replies arrive as one accumulated text).
     // Markdown uses the fence-aware newline splitter so blanks inside code
     // fences are not treated as outbound boundaries.
-    const blockChunks =
-      (params.chunkerMode ?? "text") === "markdown"
-        ? chunkMarkdownTextWithMode(params.text, params.textLimit, "newline", {
-            packAdjacent: false,
-          })
-        : chunkByParagraph(params.text, params.textLimit, { packAdjacent: false });
+    // Non-packing stays on this outbound-planning boundary; it is not a public
+    // reply-chunking / plugin SDK option.
+    const blockChunks = splitOutboundNewlineDeliveryUnits(
+      params.text,
+      params.textLimit,
+      (params.chunkerMode ?? "text") === "markdown" ? "markdown" : "text",
+    );
 
     if (!blockChunks.length && params.text) {
       blockChunks.push(params.text);

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -1,10 +1,6 @@
 // Message planning expands normalized payloads into ordered text/media send
 // units while preserving reply-to consumption rules.
-import {
-  chunkByParagraph,
-  chunkMarkdownTextWithMode,
-  type ChunkMode,
-} from "../../auto-reply/chunk.js";
+import { chunkByParagraph, chunkMarkdownText, type ChunkMode } from "../../auto-reply/chunk.js";
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { ReplyToOverride } from "./reply-policy.js";
 
@@ -136,10 +132,16 @@ export function planOutboundTextMessageUnits(params: {
   }
 
   if (params.chunkMode === "newline") {
+    // Keep blank-line paragraphs as separate delivery units. The transport
+    // limit may still split an oversized paragraph, but must not pack adjacent
+    // logical blocks first (Codex final replies arrive as one accumulated text).
     const blockChunks =
       (params.chunkerMode ?? "text") === "markdown"
-        ? chunkMarkdownTextWithMode(params.text, params.textLimit, "newline")
-        : chunkByParagraph(params.text, params.textLimit);
+        ? chunkByParagraph(params.text, params.textLimit, {
+            packAdjacent: false,
+            splitLongParagraphs: false,
+          }).flatMap((paragraphChunk) => chunkMarkdownText(paragraphChunk, params.textLimit!))
+        : chunkByParagraph(params.text, params.textLimit, { packAdjacent: false });
 
     if (!blockChunks.length && params.text) {
       blockChunks.push(params.text);

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -1,6 +1,10 @@
 // Message planning expands normalized payloads into ordered text/media send
 // units while preserving reply-to consumption rules.
-import { chunkByParagraph, chunkMarkdownText, type ChunkMode } from "../../auto-reply/chunk.js";
+import {
+  chunkByParagraph,
+  chunkMarkdownTextWithMode,
+  type ChunkMode,
+} from "../../auto-reply/chunk.js";
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { ReplyToOverride } from "./reply-policy.js";
 
@@ -135,12 +139,13 @@ export function planOutboundTextMessageUnits(params: {
     // Keep blank-line paragraphs as separate delivery units. The transport
     // limit may still split an oversized paragraph, but must not pack adjacent
     // logical blocks first (Codex final replies arrive as one accumulated text).
+    // Markdown uses the fence-aware newline splitter so blanks inside code
+    // fences are not treated as outbound boundaries.
     const blockChunks =
       (params.chunkerMode ?? "text") === "markdown"
-        ? chunkByParagraph(params.text, params.textLimit, {
+        ? chunkMarkdownTextWithMode(params.text, params.textLimit, "newline", {
             packAdjacent: false,
-            splitLongParagraphs: false,
-          }).flatMap((paragraphChunk) => chunkMarkdownText(paragraphChunk, params.textLimit!))
+          })
         : chunkByParagraph(params.text, params.textLimit, { packAdjacent: false });
 
     if (!blockChunks.length && params.text) {


### PR DESCRIPTION
Closes #109032

## What Problem This Solves

Fixes an issue where WhatsApp users with automatic visible replies and `chunkMode: newline` would see multi-paragraph Codex runtime replies collapse into one bubble, while the same configuration with the OpenClaw runtime kept separate bubbles.

## Why This Change Was Made

Codex finals arrive as one accumulated text blob. Shared outbound planning previously packed blank-line paragraphs up to the transport size limit before delivery, so coalescing could not separate them again. The fix stays in the configured delivery path (not the Codex projector):

- `planOutboundTextMessageUnits` with `chunkMode: newline` keeps each blank-line paragraph as its own unit; the transport limit only splits oversized paragraphs.
- `EmbeddedBlockChunker` force flushes with `flushOnParagraph` also preserve those boundaries, so a terminal flush of an under-max buffer does not re-merge paragraphs.

Length-mode delivery is unchanged. No Codex extension import of internal markdown packages.

## User Impact

With WhatsApp (or any channel) `streaming.chunkMode: newline`, multi-paragraph automatic replies from the Codex runtime deliver as separate bubbles, matching OpenClaw runtime behavior. Length-mode and single-paragraph replies are unaffected.

## Evidence

Focused Vitest on Windows 11 (Node v24.15.0), HEAD `23108bf8c0` (re-proof 2026-07-23; prior vitest also on `b986835d5d`):

```text
node scripts/run-vitest.mjs \
  src/infra/outbound/message-plan.test.ts \
  src/agents/embedded-agent-block-chunker.test.ts \
  src/auto-reply/chunk.test.ts
# Test Files  3 passed (3)
# Tests  83 passed (83)
```

Coverage:

- newline planning keeps two short paragraphs as two outbound units under a 4000-char transport limit
- force + `flushOnParagraph` emits Codex-style multi-paragraph finals as separate chunks
- existing packing defaults for `chunkByParagraph` / `chunkTextWithMode` remain covered by `chunk.test.ts`

### Live WhatsApp newline bubble proof (2026-07-23 tip re-proof)

Ran gateway from PR tip `23108bf8c0` on Windows 11 with sanitized config (`chunkMode: newline`, `selfChatMode: true`, DM allowlist). WhatsApp credentials reused from `~/.openclaw/credentials/whatsapp/default`.

Outbound send of three blank-line paragraphs (`Alpha` / `Beta` / `Gamma`) produced **three distinct WhatsApp message IDs** in one delivery:

```text
[whatsapp] Sent message 3EB0D97B209302881D05CD  (529ms)
[whatsapp] Sent message 3EB044A543FE61A47E8076  (266ms)
[whatsapp] Sent message 3EB03D4F69DBDCD18EEF74  (262ms)
```

CLI `message send --json` returned the final id `3EB03D4F69DBDCD18EEF74`; gateway logs show the three sequential sends to the same peer hash within ~1s.

### Earlier Live WhatsApp newline bubble proof (2026-07-21)

Ran gateway from this PR worktree (`OpenClaw 2026.7.2 (b986835)`) on Windows 11 with:

- `channels.whatsapp.streaming.chunkMode = "newline"`
- `selfChatMode = true`
- DM allowlist enabled

Outbound send of three blank-line paragraphs (`Alpha` / `Beta` / `Gamma`) produced **three distinct WhatsApp message IDs** in one delivery:

```text
[whatsapp] Sent message 3EB07F593035732B87E26C  (435ms)
[whatsapp] Sent message 3EB08385C27424ED07E2AF  (201ms)
[whatsapp] Sent message 3EB09C31E8AE9894879A1C  (201ms)
```

CLI `message send --json` returned the final id `3EB09C31E8AE9894879A1C`; gateway logs show the three sequential sends above to the same peer hash within ~1s.

Prior closed unmerged approach (#109543) split inside the Codex projector and bypassed channel chunk policy; this PR follows ClawSweeper guidance to keep the fix in canonical outbound planning under `chunkMode`.

This PR is AI-assisted (Cursor/Grok).

