### PR TITLE
fix: deliver generated media once after image_generate completion

### DIFF
--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1098,6 +1098,62 @@ describe("createMediaGenerationTaskLifecycle", () => {
     expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("assigns completion-handoff ownership so the agent is not told to re-attach MEDIA", async () => {
+    // Host-owned durable delivery already carries the generated artifact. Asking
+    // the resumed agent to also attach MEDIA lines produces a second channel send.
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: true,
+      path: "queued",
+    });
+    const lifecycle = createImageMediaLifecycle();
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-once",
+          runId: "tool:image_generate:once",
+          requesterSessionKey: "agent:main:telegram:direct:123",
+          taskLabel: "proof dog image",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:123",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-dog.png",
+        mediaUrls: ["/tmp/generated-dog.png"],
+        attachments: [
+          {
+            type: "image",
+            path: "/tmp/generated-dog.png",
+            mimeType: "image/png",
+            name: "generated-dog.png",
+          },
+        ],
+      }),
+    ).resolves.toEqual({ status: "delivered" });
+
+    const announceParams = subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mock
+      .calls[0]?.[0] as
+      | {
+          durableGeneratedMediaHandoff?: boolean;
+          internalEvents?: Array<{ replyInstruction?: string; mediaUrls?: string[] }>;
+        }
+      | undefined;
+    expect(announceParams?.durableGeneratedMediaHandoff).toBe(true);
+    const replyInstruction = announceParams?.internalEvents?.[0]?.replyInstruction ?? "";
+    expect(announceParams?.internalEvents?.[0]?.mediaUrls).toEqual(["/tmp/generated-dog.png"]);
+    expect(replyInstruction).toMatch(/owned by this completion handoff/i);
+    expect(replyInstruction).toMatch(/Do not re-send, re-attach, or echo MEDIA lines/i);
+    expect(replyInstruction).not.toMatch(/final-reply MEDIA lines/i);
+    expect(replyInstruction).not.toMatch(/every structured attachment from the internal event/i);
+    // Message-tool-only routes still need a caption path; attachments stay host-owned.
+    expect(replyInstruction).toMatch(/message\(action=["']send["']\)/i);
+    expect(replyInstruction).toMatch(/short caption and no attachments/i);
+    expect(replyInstruction).toMatch(/short normal final reply caption/i);
+  });
+
   it("does not direct-deliver generated media after requester abandonment", async () => {
     // Abandoned requester sessions are terminal; direct delivery would re-open a
     // conversation the task lifecycle already decided to stop.

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -377,6 +377,11 @@ function failMediaGenerationTaskRun(params: {
   }
 }
 
+/**
+ * Durable completion handoffs already own outbound media delivery.
+ * The resumed agent may only supply caption text through the active
+ * visible-reply contract; re-attaching MEDIA creates a second channel send.
+ */
 function buildMediaGenerationReplyInstruction(params: {
   status: "ok" | "error";
   completionLabel: string;
@@ -384,8 +389,10 @@ function buildMediaGenerationReplyInstruction(params: {
   if (params.status === "ok") {
     return [
       `The ${params.completionLabel} is ready for the original chat.`,
-      'Use the current visible-reply contract: if this session requires message-tool replies, call message(action="send") with a short caption and every structured attachment from the internal event, then reply only NO_REPLY.',
-      "Otherwise, write the normal final reply and attach every generated media path with final-reply MEDIA lines.",
+      "Generated media delivery is already owned by this completion handoff.",
+      "Do not re-send, re-attach, or echo MEDIA lines / structured attachments from the internal event.",
+      'Use the current visible-reply contract for caption text only: if this session requires message-tool replies, call message(action="send") with a short caption and no attachments, then reply only NO_REPLY.',
+      "Otherwise, write a short normal final reply caption with no MEDIA lines, or reply NO_REPLY if no caption is needed.",
     ].join(" ");
   }
   return [

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -138,8 +138,12 @@ describe("music generate background helpers", () => {
       },
     });
 
+    // Shared helper assigns host-owned completion delivery; agent gets caption-only
+    // guidance (including message-tool caption sends without attachments).
     expectReplyInstructionContains("visible-reply contract");
-    expectReplyInstructionContains("final-reply MEDIA lines");
+    expectReplyInstructionContains("completion handoff");
+    expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
+    expectReplyInstructionContains("short caption and no attachments");
   });
 
   it("keeps failed completion notices in the durable agent-loop handoff", async () => {
@@ -189,8 +193,10 @@ describe("music generate background helpers", () => {
         },
       });
 
+      // Same shared ownership instruction for legacy group/channel keys.
       expectReplyInstructionContains("visible-reply contract");
-      expectReplyInstructionContains("final-reply MEDIA lines");
+      expectReplyInstructionContains("completion handoff");
+      expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
     },
   );
 });


### PR DESCRIPTION
Closes #108976

## What Problem This Solves

Fixes an issue where Telegram (and other channel) users received each `image_generate` result twice: once from the resumed agent reply that re-attached media, and once from the durable completion handoff that already owns delivery.

## Why This Change Was Made

Successful generated-media completions already set `durableGeneratedMediaHandoff` and carry `mediaUrls` / attachments for host-owned delivery. The wake instruction previously told the resumed agent to also attach every MEDIA path or structured attachment, which creates a second visible send when the agent follows that prompt.

The instruction now assigns a single media owner (the completion handoff) while preserving caption delivery on both contracts:

- message-tool-only: `message(action="send")` with a short caption and no attachments, then `NO_REPLY`
- automatic final replies: short caption text with no MEDIA lines, or `NO_REPLY`

Image, video, and music generation share this helper, so the ownership rule applies across those sibling tools without a Telegram-specific branch.

## User Impact

After `image_generate` (and sibling media tools) completes, users receive each generated artifact once, with an optional caption, instead of two identical channel deliveries a few seconds apart.

## Evidence

Focused Vitest on Windows 11 (Node v24.15.0), HEAD `5c1fa8fd86`:

```text
node scripts/run-vitest.mjs \
  src/agents/tools/media-generate-background-shared.test.ts \
  src/agents/tools/music-generate-background.test.ts
# Test Files  2 passed (2)
# Tests  35 passed (35)
```

Coverage:

- shared regression asserts completion-handoff ownership, forbids MEDIA re-attach wording, and keeps message-tool caption-only guidance for message-tool-only routes
- music sibling expectations match the same shared ownership contract

Control check: wake still sets `durableGeneratedMediaHandoff: true` and still includes `mediaUrls` / attachments on the internal event for host delivery.

### Live Telegram after-fix proof

Ran on Windows 11 against this branch HEAD `8e3e5bd877be` with a local gateway + Telegram polling bot. Chat IDs and bot token redacted.

**Caption path** (agent asked for a short caption after `image_generate`):

```text
Attachment: ...\media\tool-image-generation\image-1---13ec9f75-0501-41c7-81e5-ff6f82c5a819.png
[telegram] outbound send ok accountId=default chatId=<redacted> messageId=6 operation=sendPhoto deliveryKind=photo
[agents/agent-command] [agent] run image_generate:1c08cc38-2ae1-4949-a83d-d23b7e561363:ok:agent-loop ended with stopReason=stop
```

Result: exactly one `operation=sendPhoto` for that completion (no second `sendPhoto` within the settle window).

**No-caption path** (agent instructed to answer `NO_REPLY` after `image_generate`):

```text
Attachment: ...\media\tool-image-generation\image-1---cc4e39d3-574c-4f23-a221-ab93c78b5991.png
[telegram] outbound send ok accountId=default chatId=<redacted> messageId=7 operation=sendPhoto deliveryKind=photo
[agents/agent-command] [agent] run image_generate:8c2bac74-ca29-48e0-87ca-e06a3dddc286:ok:agent-loop ended with stopReason=stop
```

Result: exactly one `operation=sendPhoto` for that completion (`sendPhoto` count delta = 1 after settle).

CI status on HEAD `8e3e5bd877be`:

- `openclaw/ci-gate` and core check jobs: green
- Mantis Telegram proof check can be re-run against this live evidence

Prior closed unmerged approach (#109061) forbade the message tool entirely and dropped captions on message-tool-only routes; this PR keeps caption-only `message(action="send")` while still forbidding media re-attachment.

Adjacent open #95803 targets messaging-tool vs pending-tool-media dedupe, not this completion-handoff ownership instruction.

This PR is AI-assisted (Cursor/Grok).
