### PR TITLE
fix(ci): refresh stuck dependency snapshot

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -124,11 +124,13 @@ runs:
       if: inputs.sticky-disk == 'true'
       uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
       with:
-        # One stable disk per Node line. The v2 per-PR/per-manifest-hash keys
+        # One stable disk per Node line. v4 resets the v3 lineage after
+        # Blacksmith repeatedly acknowledged commits but kept restoring its
+        # original snapshot. The v2 per-PR/per-manifest-hash keys
         # saturated Blacksmith's installation-wide sticky-disk budget. Install
         # inputs, runner platform, and the exact Node patch live in the runtime
         # marker below, so changes refresh this disk in place.
-        key: ${{ github.repository }}-node-deps-bind-v3-${{ inputs.node-version }}
+        key: ${{ github.repository }}-node-deps-bind-v4-${{ inputs.node-version }}
         path: /var/tmp/openclaw-node-deps
         # Single semantic writer: only the designated trusted-push job may
         # commit, so pull_request clones stay read-only. Like every sticky

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2020,7 +2020,7 @@ describe("ci workflow guards", () => {
     // per-PR/per-manifest-hash keys saturated that cap. Install inputs and exact
     // runtime patches belong in the marker, not the backing-disk key.
     expect(mountStep.with.key).toBe(
-      "${{ github.repository }}-node-deps-bind-v3-${{ inputs.node-version }}",
+      "${{ github.repository }}-node-deps-bind-v4-${{ inputs.node-version }}",
     );
     expect(mountStep.with.commit).toBe(
       "${{ inputs.save-sticky-disk == 'true' && github.event_name != 'pull_request' && 'true' || 'false' }}",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Blacksmith repeatedly acknowledged dependency sticky-disk commits but subsequent jobs continued restoring the original v3 fingerprint. Every reader therefore performed a runner-local install instead of reaching the intended exact-match skip.

## Why This Change Was Made

Rotates the single bounded dependency snapshot lineage from v3 to v4 and keeps the existing semantic fingerprint, sole-writer, and disposable-reader design unchanged. This allocates one replacement disk instead of reviving hash- or PR-scoped key growth; v3 can be deleted after a verified v4 restore.

## User Impact

No product behavior changes. CI receives a fresh dependency snapshot lineage so warm jobs can skip `pnpm install` again.

## Evidence

- PR #110158 exact-head CI passed all 66 jobs: https://github.com/openclaw/openclaw/actions/runs/29616260423
- v3 writer commit succeeded at 22:18:07, but the same Blacksmith scale pool restored the old v3 fingerprint at 22:19:38: https://github.com/openclaw/openclaw/actions/runs/29617430254 and https://github.com/openclaw/openclaw/actions/runs/29617516217
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`: 81 passed, 1 skipped.
- `node scripts/check-workflows.mjs`: actionlint, zizmor, and composite interpolation guard passed.
- `git diff --check`: passed.
- Fresh Autoreview: no accepted or actionable findings, 0.99.
