### PR TITLE
fix(gateway): serialize same-session agent hook dispatches to stop claim-race drops

### DIFF
--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -1054,4 +1054,99 @@ describe("gateway server hooks", () => {
       drainSystemEvents(resolveMainKey());
     });
   });
+
+  // Live Gateway HTTP proof for #110109: same-session FIFO + cross-session overlap.
+  test("serializes same-session /hooks/agent bursts while cross-session stays concurrent", async () => {
+    function deferredCronRun() {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const run = vi.fn(async (params: { message?: string; sessionKey?: string }) => {
+        await gate;
+        return { status: "ok" as const, summary: `done:${params.message ?? ""}` };
+      });
+      return { run, release };
+    }
+
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:"],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      // Cold concurrent first-request burst (no warmup): proves the process-wide
+      // session queue survives lazy handler init races on a running Gateway.
+      const first = deferredCronRun();
+      const second = deferredCronRun();
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockImplementationOnce(first.run).mockImplementationOnce(second.run);
+
+      const sameSessionPosts = await Promise.all([
+        postHook(port, "/hooks/agent", {
+          message: "review submitted",
+          name: "Review",
+          sessionKey: "hook:pr:110109",
+          deliver: false,
+        }),
+        postHook(port, "/hooks/agent", {
+          message: "inline comment",
+          name: "Comment",
+          sessionKey: "hook:pr:110109",
+          deliver: false,
+        }),
+      ]);
+      expect(sameSessionPosts.map((response) => response.status)).toEqual([200, 200]);
+
+      await expect
+        .poll(() => first.run.mock.calls.length, { timeout: 2_000, interval: 10 })
+        .toBe(1);
+      expect(second.run).not.toHaveBeenCalled();
+
+      first.release();
+      await expect
+        .poll(() => second.run.mock.calls.length, { timeout: 2_000, interval: 10 })
+        .toBe(1);
+      const secondMessage = (second.run.mock.calls[0]?.[0] as { message?: string } | undefined)
+        ?.message;
+      expect(secondMessage).toBe("inline comment");
+      second.release();
+      await waitForCronIsolatedRuns(2);
+
+      // Cross-session: both keys start without either finishing first.
+      const crossA = deferredCronRun();
+      const crossB = deferredCronRun();
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockImplementationOnce(crossA.run).mockImplementationOnce(crossB.run);
+
+      const crossPosts = await Promise.all([
+        postHook(port, "/hooks/agent", {
+          message: "session-a",
+          name: "A",
+          sessionKey: "hook:pr:a",
+          deliver: false,
+        }),
+        postHook(port, "/hooks/agent", {
+          message: "session-b",
+          name: "B",
+          sessionKey: "hook:pr:b",
+          deliver: false,
+        }),
+      ]);
+      expect(crossPosts.map((response) => response.status)).toEqual([200, 200]);
+
+      await expect
+        .poll(() => crossA.run.mock.calls.length, { timeout: 2_000, interval: 10 })
+        .toBe(1);
+      await expect
+        .poll(() => crossB.run.mock.calls.length, { timeout: 2_000, interval: 10 })
+        .toBe(1);
+      crossA.release();
+      crossB.release();
+      await waitForCronIsolatedRuns(2);
+    });
+  });
 });

--- a/src/gateway/server/hooks.agent-serialization.test.ts
+++ b/src/gateway/server/hooks.agent-serialization.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Same-session agent hook dispatches must be serialized, not raced.
+ *
+ * Concurrent runs for one sessionKey race on the cron session-lifecycle claim;
+ * the losers throw CronSessionLifecycleClaimError and their payloads are
+ * silently dropped (openclaw/openclaw#110109). These tests pin the queueing
+ * behavior in dispatchAgentHook that prevents the race.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueSystemEventMock = vi.fn();
+const requestHeartbeatMock = vi.fn();
+const runCronIsolatedAgentTurnMock = vi.fn();
+const resolveMainSessionKeyMock = vi.fn(() => "main-session");
+const loadConfigMock = vi.fn(() => ({}));
+const logHooksInfoMock = vi.fn();
+const logHooksWarnMock = vi.fn();
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeat: requestHeartbeatMock,
+}));
+vi.mock("../../cron/isolated-agent.js", () => ({
+  runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
+}));
+vi.mock("../../config/sessions.js", () => ({
+  resolveMainSessionKeyFromConfig: resolveMainSessionKeyMock,
+  resolveMainSessionKey: vi.fn(
+    (cfg?: { session?: { mainKey?: string } }) => `agent:main:${cfg?.session?.mainKey ?? "main"}`,
+  ),
+  resolveAgentMainSessionKey: vi.fn(
+    (params: { cfg?: { session?: { mainKey?: string } }; agentId: string }) =>
+      `agent:${params.agentId}:${params.cfg?.session?.mainKey ?? "main"}`,
+  ),
+}));
+vi.mock("../../config/io.js", () => ({
+  getRuntimeConfig: loadConfigMock,
+}));
+
+let capturedDispatchAgentHook: ((...args: unknown[]) => unknown) | undefined;
+
+vi.mock("./hooks-request-handler.js", () => ({
+  createHooksRequestHandler: vi.fn((opts: Record<string, unknown>) => {
+    capturedDispatchAgentHook = opts.dispatchAgentHook as typeof capturedDispatchAgentHook;
+    return vi.fn();
+  }),
+}));
+
+const { createGatewayHooksRequestHandler } = await import("./hooks.js");
+
+function buildMinimalParams() {
+  return {
+    deps: {} as never,
+    getHooksConfig: () => null,
+    getClientIpConfig: () => ({
+      trustedProxies: undefined,
+      allowRealIpFallback: false,
+    }),
+    bindHost: "127.0.0.1",
+    port: 18789,
+    logHooks: {
+      warn: logHooksWarnMock,
+      debug: vi.fn(),
+      info: logHooksInfoMock,
+      error: vi.fn(),
+    } as never,
+  };
+}
+
+function buildAgentPayload(name: string, sessionKey: string, message = "test message") {
+  return {
+    message,
+    name,
+    agentId: undefined,
+    idempotencyKey: undefined,
+    wakeMode: "now" as const,
+    sessionKey,
+    sourcePath: "/hooks/agent",
+    deliver: false,
+    channel: "last" as const,
+    to: undefined,
+    model: undefined,
+    thinking: undefined,
+    timeoutSeconds: undefined,
+    allowUnsafeExternalContent: undefined,
+    externalContentSource: undefined,
+  };
+}
+
+function dispatchAgentHook(payload: unknown): unknown {
+  if (!capturedDispatchAgentHook) {
+    throw new Error("dispatchAgentHook missing");
+  }
+  return capturedDispatchAgentHook(payload);
+}
+
+/** A runCronIsolatedAgentTurn stand-in that blocks until released. */
+function deferredRun() {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const run = vi.fn(async (params: { message: string }) => {
+    await gate;
+    return {
+      status: "ok",
+      summary: `done:${params.message}`,
+      delivered: false,
+    };
+  });
+  return { run, release };
+}
+
+describe("dispatchAgentHook same-session serialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedDispatchAgentHook = undefined;
+    createGatewayHooksRequestHandler(buildMinimalParams());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queues a same-session burst so the second wake is never dropped", async () => {
+    const first = deferredRun();
+    const second = deferredRun();
+    runCronIsolatedAgentTurnMock
+      .mockImplementationOnce(first.run)
+      .mockImplementationOnce(second.run);
+
+    dispatchAgentHook(buildAgentPayload("Review", "pr:12077", "review submitted"));
+    dispatchAgentHook(buildAgentPayload("Comment", "pr:12077", "inline comment"));
+
+    // Only the first run starts; the second waits instead of racing the claim.
+    await vi.waitFor(() => expect(first.run).toHaveBeenCalledTimes(1));
+    expect(second.run).not.toHaveBeenCalled();
+    expect(logHooksInfoMock).toHaveBeenCalledWith(
+      "hook agent run queued behind in-flight same-session run",
+      { sessionKey: "pr:12077" },
+    );
+
+    first.release();
+    await vi.waitFor(() => expect(second.run).toHaveBeenCalledTimes(1));
+    const secondCall = second.run.mock.calls[0]?.[0];
+    expect(secondCall?.message).toBe("inline comment");
+
+    second.release();
+    await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("processes a same-session burst strictly in arrival order", async () => {
+    const started: string[] = [];
+    runCronIsolatedAgentTurnMock.mockImplementation(async (params: { message: string }) => {
+      started.push(params.message);
+      await Promise.resolve();
+      return { status: "ok", summary: "done", delivered: false };
+    });
+
+    dispatchAgentHook(buildAgentPayload("A", "pr:1", "first"));
+    dispatchAgentHook(buildAgentPayload("B", "pr:1", "second"));
+    dispatchAgentHook(buildAgentPayload("C", "pr:1", "third"));
+
+    await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(3));
+    expect(started).toEqual(["first", "second", "third"]);
+  });
+
+  it("does not serialize hooks targeting different session keys", async () => {
+    const first = deferredRun();
+    const second = deferredRun();
+    runCronIsolatedAgentTurnMock
+      .mockImplementationOnce(first.run)
+      .mockImplementationOnce(second.run);
+
+    dispatchAgentHook(buildAgentPayload("A", "pr:1"));
+    dispatchAgentHook(buildAgentPayload("B", "pr:2"));
+
+    // Both start without either finishing — cross-session concurrency intact.
+    await vi.waitFor(() => expect(first.run).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(second.run).toHaveBeenCalledTimes(1));
+
+    first.release();
+    second.release();
+    await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("keeps draining the session queue after a run fails", async () => {
+    runCronIsolatedAgentTurnMock
+      .mockRejectedValueOnce(new Error('Session "pr:1" changed while starting work. Retry.'))
+      .mockResolvedValueOnce({
+        status: "ok",
+        summary: "done",
+        delivered: false,
+      });
+
+    dispatchAgentHook(buildAgentPayload("A", "pr:1", "loser"));
+    dispatchAgentHook(buildAgentPayload("B", "pr:1", "survivor"));
+
+    await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+    const survivorCall = runCronIsolatedAgentTurnMock.mock.calls[1]?.[0] as
+      | { message?: string }
+      | undefined;
+    expect(survivorCall?.message).toBe("survivor");
+  });
+});

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -41,6 +41,11 @@ const loadCronIsolatedAgentModule = () => {
   return cronIsolatedAgentModulePromise;
 };
 
+// Process-wide same-session chain (not per handler instance). Lazy hooks handler
+// creation can race two createGatewayHooksRequestHandler calls on concurrent first
+// requests; a module-level map keeps those bursts serialized on one queue.
+const agentHookRunChains = new Map<string, Promise<void>>();
+
 function resolveHookEventSessionKey(params: { cfg: OpenClawConfig; agentId?: string }): string {
   return params.agentId
     ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId })
@@ -118,8 +123,6 @@ export function createGatewayHooksRequestHandler(params: {
   // silently dropped (#110109). Same-session events append to one session anyway,
   // so serialize them: chain each run behind the previous in-flight run for that
   // sessionKey while different keys stay concurrent.
-  const agentHookRunChains = new Map<string, Promise<void>>();
-
   const enqueueAgentHookRun = (sessionKey: string, run: () => Promise<void>) => {
     const prior = agentHookRunChains.get(sessionKey);
     if (prior) {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -32,6 +32,15 @@ import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-requ
  */
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
+// Concurrent hook dispatches share one in-flight isolated-agent import instead of
+// racing duplicate loaders for the same module graph.
+let cronIsolatedAgentModulePromise: Promise<typeof import("../../cron/isolated-agent.js")> | null =
+  null;
+const loadCronIsolatedAgentModule = () => {
+  cronIsolatedAgentModulePromise ??= import("../../cron/isolated-agent.js");
+  return cronIsolatedAgentModulePromise;
+};
+
 function resolveHookEventSessionKey(params: { cfg: OpenClawConfig; agentId?: string }): string {
   return params.agentId
     ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId })
@@ -104,6 +113,31 @@ export function createGatewayHooksRequestHandler(params: {
 }) {
   const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
 
+  // Concurrent same-session agent hook runs race on the cron session-lifecycle
+  // claim; losers throw CronSessionLifecycleClaimError and their payloads are
+  // silently dropped (#110109). Same-session events append to one session anyway,
+  // so serialize them: chain each run behind the previous in-flight run for that
+  // sessionKey while different keys stay concurrent.
+  const agentHookRunChains = new Map<string, Promise<void>>();
+
+  const enqueueAgentHookRun = (sessionKey: string, run: () => Promise<void>) => {
+    const prior = agentHookRunChains.get(sessionKey);
+    if (prior) {
+      logHooks.info("hook agent run queued behind in-flight same-session run", {
+        sessionKey,
+      });
+    }
+    // `run` handles its own failures, but chain through both branches so a
+    // defect in one run can never stall the session queue forever.
+    const next = prior ? prior.then(run, run) : run();
+    agentHookRunChains.set(sessionKey, next);
+    void next.finally(() => {
+      if (agentHookRunChains.get(sessionKey) === next) {
+        agentHookRunChains.delete(sessionKey);
+      }
+    });
+  };
+
   const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(value.text, {
@@ -151,7 +185,7 @@ export function createGatewayHooksRequestHandler(params: {
     };
 
     let hookEventSessionKey: string | undefined;
-    void runWithGatewayIndependentRootWorkContinuation(async () => {
+    const runAgentHook = async () => {
       try {
         // Agent hooks run after the HTTP response path has returned, so failure
         // handling must record a system event instead of throwing to the caller.
@@ -160,7 +194,7 @@ export function createGatewayHooksRequestHandler(params: {
           cfg,
           agentId: value.agentId,
         });
-        const { runCronIsolatedAgentTurn } = await import("../../cron/isolated-agent.js");
+        const { runCronIsolatedAgentTurn } = await loadCronIsolatedAgentModule();
         const result = await runCronIsolatedAgentTurn({
           cfg,
           deps,
@@ -223,7 +257,10 @@ export function createGatewayHooksRequestHandler(params: {
           });
         }
       }
-    });
+    };
+    enqueueAgentHookRun(sessionKey, () =>
+      runWithGatewayIndependentRootWorkContinuation(runAgentHook),
+    );
 
     return runId;
   };


### PR DESCRIPTION
Closes #110109

## What Problem This Solves

Fixes an issue where operators sending multiple near-simultaneous `/hooks/agent` events for the same session (for example a webhook burst: review + inline comments) would silently lose later events when `cron.maxConcurrentRuns > 1`. The first run claimed the session lifecycle lock; losers threw `CronSessionLifecycleClaimError` with no retry, so legitimate automation wakes never ran.

## Why This Change Was Made

Serialize agent-hook runs **per resolved `sessionKey`** at the gateway dispatch boundary: later same-session dispatches chain behind the in-flight run (FIFO), while different session keys stay concurrent. Isolated-agent module load is memoized so concurrent dispatches share one import. This matches the durable fix shape (session-owned queue at hook dispatch) rather than blind pattern retries that can replay side effects after work has started.

Compatibility: no config, protocol, or public API change — only in-process ordering of detached hook work. Performance: different sessions still overlap; idle per-session chains are deleted after the last run. Usability: previously dropped wakes are retained in order. Security: no trust-boundary change; still runs through the existing hook sanitize and system-event paths.

## User Impact

Same-session hook bursts complete in arrival order instead of silently discarding losers. Cross-session concurrency and existing single-hook behavior are unchanged.

## Evidence

Verification host: local macOS (Crabbox bypass).

```text
node scripts/run-vitest.mjs \
  src/gateway/server/hooks.agent-serialization.test.ts \
  src/gateway/server/hooks.agent-trust.test.ts \
  src/gateway/server.hooks.test.ts
# Test Files  3 passed (3)
# Tests  40 passed (40)

# Dispatch-level serialization (hooks.agent-serialization.test.ts):
# - queues a same-session burst so the second wake is never dropped
# - processes a same-session burst strictly in arrival order
# - does not serialize hooks targeting different session keys
# - keeps draining the session queue after a run fails

# Live Gateway HTTP burst (server.hooks.test.ts, withGatewayServer):
# - cold concurrent first-request same-session POST /hooks/agent burst
# - second same-session isolated run starts only after the first releases
# - second payload message preserved as "inline comment" (FIFO)
# - concurrent cross-session POSTs both start before either finishes
# Full server.hooks suite: 26/26 passed including the new burst case

# Follow-up code: process-wide agentHookRunChains Map (module scope) so lazy
# concurrent first-request handler init cannot split same-session serialization

# Static (closeout):
# oxfmt on touched files: pass
# git diff --check: pass
```

Head: `5b880417e4`

## Real behavior proof

- Behavior addressed: Concurrent same-session `/hooks/agent` dispatches no longer race the cron session-lifecycle claim and drop loser payloads; they run FIFO for one `sessionKey` while other keys stay concurrent. The session queue is process-wide (module scope), so a cold concurrent first-request burst on a running Gateway still serializes correctly even if lazy handler creation races.
- Environment: local macOS openclaw checkout; live Gateway via `withGatewayServer` (real HTTP listener + hooks request path) with mocked `runCronIsolatedAgentTurn` so isolated turns block/release under test control without a paid model call.
- Current-main contrast: On main, each dispatch immediately starts an independent root-work continuation, so two same-session runs can both enter `runCronIsolatedAgentTurn` and compete for the lifecycle claim; the loser surfaces only as `Hook (error): Session … changed while starting work. Retry.` with no retry owner.
- Exact steps or command run after this patch:
  ```bash
  node scripts/run-vitest.mjs \
    src/gateway/server/hooks.agent-serialization.test.ts \
    src/gateway/server.hooks.test.ts -t "serializes same-session"
  ```
  Live Gateway case (no warmup): Promise.all of two same-session POST `/hooks/agent` with deferred first run; assert second isolated run is not called until first releases; assert second message is `inline comment`; then two different session keys both start before either finishes.
- Evidence after fix: dispatch serialization 4/4 + live Gateway burst 1/1 + full `server.hooks.test.ts` 26/26 + agent-trust 10/10 (40 total across the three files). Second same-session HTTP wake starts only after the first release; cross-session overlap retained.
- Control check: cross-session concurrency case proves serialization is keyed by `sessionKey` only; agent-trust suite still covers admission retention, non-ok announce, and detached work behavior on the same dispatch surface.
- Observed result after fix: same-session HTTP bursts queue and complete in arrival order with no dropped second wake on a cold Gateway; different sessions still run in parallel; queue continues after a failed run (dispatch-level case).
- What was not tested: live multi-process Gateway HTTP POST burst against a full agent/model turn; end-to-end cron scheduler ownership for non-hook jobs (unchanged).

## AI disclosure

This PR was authored with AI assistance (Grok).

