### PR TITLE
fix(telegram): prevent gateway CPU spin on immediate empty polls

### DIFF
--- a/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
@@ -23,7 +23,10 @@ function htmlResponse(status: number, body: string): Response {
   });
 }
 
-function createRuntime(responses: Response[]): {
+function createRuntime(
+  responses: Response[],
+  options: { stopAfterPollSuccesses?: number } = {},
+): {
   calls: number[];
   messages: TelegramIngressWorkerMessage[];
   done: Promise<void>;
@@ -31,6 +34,7 @@ function createRuntime(responses: Response[]): {
   const calls: number[] = [];
   const messages: TelegramIngressWorkerMessage[] = [];
   const listeners = new Set<(message: TelegramIngressWorkerCommand) => void>();
+  let pollSuccesses = 0;
   const sendCommand = (message: TelegramIngressWorkerCommand) => {
     for (const listener of listeners) {
       listener(message);
@@ -40,7 +44,10 @@ function createRuntime(responses: Response[]): {
     postMessage(message) {
       messages.push(message);
       if (message.type === "poll-success") {
-        sendCommand({ type: "stop" });
+        pollSuccesses += 1;
+        if (pollSuccesses >= (options.stopAfterPollSuccesses ?? 1)) {
+          sendCommand({ type: "stop" });
+        }
       }
     },
     onMessage(listener) {
@@ -77,6 +84,29 @@ async function flushRuntime(): Promise<void> {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("telegram ingress worker poll cadence", () => {
+  it("paces fast successful empty getUpdates responses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    const runtime = createRuntime(
+      [jsonResponse(200, { ok: true, result: [] }), jsonResponse(200, { ok: true, result: [] })],
+      { stopAfterPollSuccesses: 2 },
+    );
+
+    expect(runtime.calls).toHaveLength(1);
+    await flushRuntime();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(runtime.calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await runtime.done;
+
+    expect(runtime.calls).toHaveLength(2);
+    const secondCall = expectDefined(runtime.calls[1], "second Telegram poll call");
+    const firstCall = expectDefined(runtime.calls[0], "first Telegram poll call");
+    expect(secondCall - firstCall).toBe(1000);
+  });
 });
 
 describe("telegram ingress worker durable-before-offset", () => {

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -21,6 +21,7 @@ const pollLimit = 100;
 // getUpdates can return up to 100 updates; 4 MiB is a generous bound that no legitimate
 // Telegram Bot API response will reach, guarding against misbehaving/hostile endpoints.
 const TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const emptyPollMinIntervalMs = 1000;
 const retryInitialMs = 1000;
 const retryMaxMs = 30_000;
 
@@ -284,6 +285,14 @@ export async function runTelegramIngressWorkerRuntime(params: {
           count: result.length,
           finishedAt: Date.now(),
         });
+        if (result.length === 0) {
+          // A Bot API endpoint or proxy can return before the requested long-poll timeout.
+          // Pace empty successes so that behavior cannot spin this worker in a tight loop.
+          const elapsedMs = Math.max(0, Date.now() - startedAt);
+          if (elapsedMs < emptyPollMinIntervalMs) {
+            await sleep(emptyPollMinIntervalMs - elapsedMs, stopController.signal);
+          }
+        }
       } catch (err) {
         if (stopped) {
           break;


### PR DESCRIPTION
No linked issue — this is a small, production-reproduced reliability fix.

## What Problem This Solves

Fixes an issue where operators using Telegram polling through a local or custom Bot API endpoint could see the gateway consume an entire CPU core when that endpoint returned successful empty `getUpdates` responses immediately instead of holding the requested long poll.

## Why This Change Was Made

Successful empty polls now have a one-second start-to-start minimum, using the worker's existing abort-aware sleep. Non-empty batches still drain immediately, and retry, spool, acknowledgement, offset, configuration, and protocol behavior are unchanged.

## User Impact

Telegram polling can no longer hammer the Bot API and starve the gateway when an endpoint repeatedly returns empty successes too quickly. Normal long polls and polls containing updates gain no added delay, and shutdown remains immediate.

## Evidence

Production incident (sanitized, 2026-05-22):

- Before: the gateway held about one CPU core, health reported `eventLoop.degraded=true` for CPU, and `strace` showed thousands of local Bot API syscalls over a few seconds.
- After applying the equivalent one-second empty-success floor and restarting: health reported `eventLoop.degraded=false`; observed CPU core ratios settled at 0.062 and then 0.032, and gateway threads were sleeping.
- Current operational check with that equivalent local hotfix: `ok=true`, `eventLoop.degraded=false`, CPU core ratio 0.077, and both Telegram polling accounts connected. The PR-head source was not installed on production for this validation.

Exact PR-head controlled runtime proof (sanitized, 2026-07-17):

- Verified clean SHA `834efa45f731df102496069136902bc88ebfe16d`; the runtime entry's `HEAD` blob and worktree blob both resolved to `93ba5914b1b95632dead69a28a0e8e27614037c3`, with empty `git status` before and after.
- Bundled that exact runtime entry only to `/tmp` (bundle SHA-256 `d9ba32461d2c7178392d6e2027fae72d9313d930770bd9eae7dca57ce7897d3b`) and launched its real `parentPort`/`workerData` bootstrap in a Node Worker.
- Pointed the Worker's real HTTP transport at a loopback-only Bot API stand-in that immediately returned `HTTP 200 {"ok":true,"result":[]}`. The request carried `timeout: 30` and `limit: 100`; the credential was synthetic and no external network or production service was used.
- Sent stop immediately after the fifth empty success, while the Worker was in the new empty-success cadence sleep, exercising its abort-aware path.

```text
endpoint=127.0.0.1:<ephemeral>/bot<redacted>/getUpdates
credential=synthetic-only
external_network_used=false
request_contract={timeout:30,limit:100}
successful_empty_polls=5
poll_1 start=2026-07-17T23:00:50.334Z relative_ms=0
poll_2 start=2026-07-17T23:00:51.335Z relative_ms=1001
poll_3 start=2026-07-17T23:00:52.336Z relative_ms=2002
poll_4 start=2026-07-17T23:00:53.337Z relative_ms=3003
poll_5 start=2026-07-17T23:00:54.338Z relative_ms=4004
worker_start_to_start_intervals_ms=1001,1001,1001,1001
abort_during=empty-success cadence sleep
stop_to_worker_exit_ms=9.0
steady_wall_ms=3987.9
whole_process_cpu_core_ratio=0.035
main_event_loop_delay_p99_ms=10.4
main_event_loop_delay_max_ms=11.2
poll_errors=0
assert_five_empty_successes=PASS
assert_cadence_at_least_1000_ms=PASS
assert_prompt_abort=PASS
assert_request_contract=PASS
assert_no_poll_errors=PASS
```

Regression and validation:

- The new fake-timer regression failed against `main` because the second empty poll started immediately; it passes on this branch and proves no second call at 999 ms and a call at 1000 ms.
- `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-worker.runtime.test.ts extensions/telegram/src/polling-liveness.test.ts extensions/telegram/src/request-timeouts.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- targeted `oxfmt --check`, typed `oxlint`, and `git diff --check`
- `autoreview --mode local`: clean, no accepted/actionable findings; overall `patch is correct` (0.96 confidence)

AI-assisted: yes (Codex). I reviewed the Bot API contract, the affected runtime path, the production evidence, and the final patch, and I understand the change.
