### PR TITLE
fix(release): stabilize frozen validation tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2127,7 +2127,27 @@ jobs:
           git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
 
       - name: Install XcodeGen / SwiftLint / SwiftFormat
-        run: brew install xcodegen swiftlint swiftformat
+        run: |
+          set -euo pipefail
+          brew install xcodegen swiftlint
+          swiftformat_version="0.61.1"
+          swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
+          swiftformat_archive="$RUNNER_TEMP/swiftformat-$swiftformat_version.zip"
+          swift_tools_dir="$RUNNER_TEMP/openclaw-swift-tools"
+          curl --fail --location --silent --show-error \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-max-time 120 \
+            --output "$swiftformat_archive" \
+            "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip"
+          if [[ "$(shasum -a 256 "$swiftformat_archive" | awk '{print $1}')" != "$swiftformat_checksum" ]]; then
+            echo "SwiftFormat $swiftformat_version archive checksum mismatch" >&2
+            exit 1
+          fi
+          mkdir -p "$swift_tools_dir"
+          unzip -q "$swiftformat_archive" -d "$swift_tools_dir"
+          chmod +x "$swift_tools_dir/swiftformat"
+          echo "$swift_tools_dir" >> "$GITHUB_PATH"
+          [[ "$("$swift_tools_dir/swiftformat" --version)" == "$swiftformat_version" ]]
 
       - name: Detect Swift toolchain cache key
         id: swift-toolchain

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2033,8 +2033,8 @@ jobs:
             --target bare \
             --platform linux/amd64 \
             --tag "$IMAGE_REF" \
-            --sbom=true \
-            --provenance=mode=max \
+            --sbom=false \
+            --provenance=false \
             .
 
       - name: Build functional Docker E2E image artifact
@@ -2051,8 +2051,8 @@ jobs:
             --build-context openclaw_package=.artifacts/docker-e2e-package \
             --platform linux/amd64 \
             --tag "$IMAGE_REF" \
-            --sbom=true \
-            --provenance=mode=max \
+            --sbom=false \
+            --provenance=false \
             .
 
       - name: Pack Docker E2E image artifact
@@ -2221,8 +2221,8 @@ jobs:
             OPENCLAW_EXTENSIONS=${{ steps.image.outputs.live_image_extensions }}
           platforms: linux/amd64
           tags: ${{ steps.image.outputs.live_image }}
-          sbom: true
-          provenance: mode=max
+          sbom: false
+          provenance: false
           load: true
           push: false
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -444,6 +444,22 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("pins the v6.11 SwiftFormat contract for macOS CI", () => {
+    const workflow = readCiWorkflow();
+    const install = workflow.jobs["macos-swift"].steps.find(
+      (step) => step.name === "Install XcodeGen / SwiftLint / SwiftFormat",
+    );
+
+    expect(install.run).toContain('swiftformat_version="0.61.1"');
+    expect(install.run).toContain(
+      'swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"',
+    );
+    expect(install.run).toContain(
+      "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip",
+    );
+    expect(install.run).not.toContain("brew install xcodegen swiftlint swiftformat");
+  });
+
   it("bounds the Windows Crabbox hydrate main fetch", () => {
     const workflow = readFileSync(".github/workflows/crabbox-hydrate.yml", "utf8");
 

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -471,6 +471,8 @@ describe("release validation no-push transport", () => {
       const build = step(dockerProducer, name);
       expect(build.if).toContain("shared_image_policy == 'no-push-artifact'");
       expect(build.run).toContain("--load");
+      expect(build.run).toContain("--sbom=false");
+      expect(build.run).toContain("--provenance=false");
       expect(build.run).not.toContain("--push");
     }
     const packDockerArtifact = step(dockerProducer, "Pack Docker E2E image artifact");
@@ -544,7 +546,9 @@ describe("release validation no-push transport", () => {
     });
     expect(step(liveProducer, "Build shared live-test image").with).toMatchObject({
       load: true,
+      provenance: false,
       push: false,
+      sbom: false,
     });
     const dockerLoginCondition = step(dockerProducer, "Log in to GHCR").if;
     expect(dockerLoginCondition).toContain("shared_image_policy == 'existing-only'");


### PR DESCRIPTION
## What Problem This Solves

Canonical Full Release Validation https://github.com/openclaw/openclaw/actions/runs/29618658630 reached candidate-owned CI and release children, exposing two deterministic frozen-tooling mismatches:

- macOS CI job https://github.com/openclaw/openclaw/actions/runs/29618679716/job/88009169925 installed today's Homebrew SwiftFormat and rejected 118 unchanged v6.11-era Swift files;
- no-write Docker image jobs attempted local `--load` while retaining SBOM/provenance attestations, which Docker's local exporter rejects as manifest lists.

No product test failed. Both failures are validation tool contracts that drifted from the frozen source tree.

## Why This Change Was Made

1. Pin the reviewed v6.11 formatter contract: SwiftFormat `0.61.1`, archive SHA-256 `b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584`. This adapts #104728 (`7772d798dd67c96a3e2d13d8dedc3d42c98bcc46`), #104740 (`ce671c3513769b10877e6181dfc7f6b48cf86e05`), and bounded download work #108685 (`e0394c2ab43133978b7452e96dea715a6efdbd3b`).
2. Disable SBOM/provenance only for validation-owned local image loads, matching #103891 (`69f8198ba3d31d6a83b39b837e7f97a0ea0f1885`). Docker cannot load attestation manifest lists into the local engine; the resulting image bytes are still packed and integrity-bound as immutable workflow artifacts.

The alternatives—reformatting 118 native files or restoring registry-published validation images—would import broad native churn or reintroduce publication permissions into this npm-only extended-stable release.

## User Impact

No runtime, package, dependency, version, or native behavior changes. Candidate validation becomes reproducible and remains no-write.

Release scope remains `v2026.6.33`, npm `extended-stable`, core plus the canonical `all-publishable` official plugin inventory at exact version `2026.6.33`. No tag or publication has occurred; Docker/native/GitHub Release/ClawHub/mobile/website publication remains excluded.

Security: the official SwiftFormat archive is fail-closed against an exact SHA-256 and bounded by connection/total/retry timeouts. Registry-published images retain attestations outside this validation-only path; local validation images remain content-bound by artifact digest and archive SHA-256.

## Evidence

- Parent failure: https://github.com/openclaw/openclaw/actions/runs/29618658630
- SwiftFormat failure: https://github.com/openclaw/openclaw/actions/runs/29618679716/job/88009169925
- Local-load failure: https://github.com/openclaw/openclaw/actions/runs/29618681467/job/88009435210
- Live SwiftFormat archive checksum: `b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584`
- `actionlint` on both touched workflows: pass
- Six focused release/workflow suites: 115/115 pass
- Changed-test oxfmt: pass
- `git diff --check`: pass

After merge, npm preflight and Full Release Validation will be rerun from the canonical branch at its new exact head. No historical evidence will be reused.
