### PR TITLE
fix: restore startup with legacy WhatsApp allowlists

### DIFF
--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -83,6 +83,27 @@ describe("legacy channel pairing state migration", () => {
     );
   });
 
+  it("imports a built-in channel's explicit default account without channel config", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "whatsapp-default-allowFrom.json");
+    writeJson(filePath, {
+      version: 1,
+      allowFrom: ["+12025550101", "+12025550102", "+12025550103"],
+    });
+
+    const detected = detectLegacyChannelPairingState({ sourceDir });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 3 whatsapp/default allowFrom entries → shared SQLite state",
+    ]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("whatsapp", env).allowFrom).toEqual({
+      default: ["+12025550101", "+12025550102", "+12025550103"],
+    });
+  });
+
   it("merges with authoritative SQLite rows and keeps unreadable sources", async () => {
     const { env, sourceDir } = await createFixture();
     const createdAt = new Date().toISOString();
@@ -157,6 +178,27 @@ describe("legacy channel pairing state migration", () => {
     ]);
     expect(fs.existsSync(filePath)).toBe(true);
     expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+  });
+
+  it("does not infer default accounts for external channels", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "custom-channel-default-allowFrom.json");
+    writeJson(filePath, { version: 1, allowFrom: ["external-user"] });
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredChannelIds: ["custom-channel"],
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Legacy channel allowFrom channel/account is unresolved; left in place",
+      ),
+    ]);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(readChannelPairingStateSnapshot("custom-channel", env).allowFrom).toEqual({});
   });
 
   it("leaves overlapping channel and account filename interpretations in place", async () => {

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -112,6 +112,11 @@ function parseAllowFromFilename(
       targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
     } else if (matchingAccountIds.length > 1) {
       hasAccountCollision = true;
+    } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
+      // "default" is canonical, so bundled `<channel>-default` files resolve without config.
+      // Keep this on CHANNEL_IDS: knownChannelIds also includes configured and pairing-file ids.
+      // After safeAccountKey finds no match, those other channels must remain unresolved.
+      targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
     }
   }
   if (hasAccountCollision || targets.length > 1) {


### PR DESCRIPTION
Related: #108421

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## Summary

- Operator-selected backport of https://github.com/openclaw/openclaw/pull/108453
  to the 2026.7.2 beta train.
- Preserves Steffen Möller's original authorship and the upstream patch exactly.
- #109876 was considered but is not included: `62407b36d780` is already an
  ancestor of `release/2026.7.2`.

## What Problem This Solves

Fixes an issue where existing WhatsApp users with the legacy default-account
`whatsapp-default-allowFrom.json` allowlist could have Gateway startup blocked
during state migration on the 2026.7.2 beta train.

Source fix: https://github.com/openclaw/openclaw/pull/108453

## Root Cause

Before this fix, `src/infra/state-migrations.channel-pairing.ts` could resolve a
legacy `*-default-allowFrom.json` filename only through configured channel or
account metadata. An upgraded install may legitimately have
`credentials/whatsapp-default-allowFrom.json` without any `channels.whatsapp`
config. The migration therefore classified `whatsapp/default` as unresolved,
left the file in place, and returned a warning. The startup migration guard in
`src/commands/doctor-config-preflight.ts` treats any unresolved migration
warning as a readiness blocker, producing the #108421 startup failure.

The backport recognizes the canonical `default` account only when the parsed
channel is in the bundled channel registry. This repairs the shipped WhatsApp
upgrade state without extending default-account inference to external channels.

## Why This Change Was Made

This is the operator-selected backport of main commit `5e4107400963` from
#108453. It lets state migration associate an explicit legacy default-account
allowlist with its bundled channel while preserving unresolved handling for
external channels. The cherry-pick applied without conflicts and preserved
Steffen Möller's original authorship.

#109876 was also evaluated for this backport set, but its commit
`62407b36d780` is already an ancestor of `release/2026.7.2`. This PR therefore
carries only the legacy allowlist startup fix.

## User Impact

Operators upgrading an existing WhatsApp setup can start the Gateway without
manually removing or rewriting the legacy default-account allowlist first.

This is a focused beta-train backport. Maintainers should land it through the
reviewed non-main release-branch flow; `scripts/pr` prepare/merge is not used
for release-branch PRs.

## Real behavior proof

The exact release base without the cherry-pick and this PR head were each built
from source. Each run used a fresh synthetic OpenClaw state directory containing
`credentials/whatsapp-default-allowFrom.json` and a minimal local Gateway config
with no `channels.whatsapp` key. The base build failed closed before readiness;
the PR build migrated the allowlist into shared SQLite and reported ready. A
second startup was clean. A separate synthetic external-channel fixture remained
unresolved and on disk.

No real account, phone number, token, or user state was used. Paths below are
redacted and all allowlist values are reserved synthetic examples.

## Evidence

Runtime context:

- Release base without pick: `95c4b78283be3c193a7cb921b2c8def3689e57b1`
- Ported candidate: `f8ed872d6ccee2e5c155cd16c07b14e18bf51633`
- Linux source checkout, Node `v25.9.0`, pnpm `11.2.2`
- Both SHAs: `pnpm install --frozen-lockfile` as needed, then `pnpm build`

Gateway command for each positive/base case:

```console
$ OPENCLAW_STATE_DIR=<STATE_DIR> OPENCLAW_CONFIG_PATH=<STATE_DIR>/openclaw.json \
    node openclaw.mjs gateway run --port <PORT> --bind loopback
```

Redacted transcript, release branch without the pick:

```text
candidate_sha=f8ed872d6ccee2e5c155cd16c07b14e18bf51633
release_without_pick_sha=95c4b78283be3c193a7cb921b2c8def3689e57b1
candidate_build=PASS
release_without_pick_build=PASS
fixture=credentials/whatsapp-default-allowFrom.json
channels.whatsapp_present=false
gateway_exit=1
- Legacy channel allowFrom channel/account is unresolved; left in place at <STATE_DIR>/credentials/whatsapp-default-allowFrom.json
[openclaw] Reason: OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
readyz=UNAVAILABLE
legacy_file=LEFT_IN_PLACE
```

Redacted transcript, first startup from this PR's build:

```text
fixture=credentials/whatsapp-default-allowFrom.json
channels.whatsapp_present=false
- Migrated 3 whatsapp/default allowFrom entries → shared SQLite state
legacy_file=REMOVED
sqlite_rows=[{"channel_key":"whatsapp","account_id":"default","entry":"12025550101"},{"channel_key":"whatsapp","account_id":"default","entry":"12025550102"},{"channel_key":"whatsapp","account_id":"default","entry":"12025550103"}]
readyz={"ready":true,"failing":[],"uptimeMs":491}
```

Redacted transcript, second startup from the same migrated state:

```text
migration_or_unresolved_messages=NONE
readyz={"ready":true,"failing":[],"uptimeMs":732}
```

External-channel negative case:

```console
$ OPENCLAW_STATE_DIR=<STATE_DIR> OPENCLAW_CONFIG_PATH=<STATE_DIR>/openclaw.json \
    node openclaw.mjs doctor --non-interactive --fix
doctor_exit=0
- Legacy channel allowFrom channel/account is unresolved; left in place at <STATE_DIR>/credentials/custom-channel-default-allowFrom.json
legacy_file=LEFT_IN_PLACE
sqlite_row_count=0
```

Focused automated proof:

- `node scripts/run-vitest.mjs src/infra/state-migrations.channel-pairing.test.ts`
  - 1 test file passed
  - 6 tests passed
- `git diff --check origin/release/2026.7.2...HEAD` passed.
- Patch identity matches upstream commit `5e4107400963` exactly.
- Autoreview (`--mode branch --base origin/release/2026.7.2`) reported no
  accepted/actionable findings and assessed the patch as correct with 0.94
  confidence.

## Verification

- Release build without the pick reproduced #108421: unresolved warning,
  Gateway exit 1, legacy file retained, `/readyz` unavailable.
- PR build migrated all three synthetic WhatsApp entries to
  `state/openclaw.sqlite`, removed the legacy file, and returned ready.
- Second PR-build startup returned ready with no repeated migration or
  unresolved warning.
- External-channel default allowlist remained on disk and wrote zero SQLite
  allowlist rows.
- Focused migration tests and diff whitespace check passed.

## What was not tested

- No live WhatsApp account or message round trip was used; the changed behavior
  is pre-channel startup migration and Gateway readiness, proven through the
  built CLI with synthetic state.
- The preferred Blacksmith Testbox attempt was blocked because the local
  Blacksmith CLI was not authenticated. Per the trusted-source fallback rule,
  the same build/startup proof ran locally on a supported Node runtime.
- No broad/full test suite was run for this one-commit backport.

AI-assisted backport; the source commit was already reviewed on `main`.
