### PR TITLE
fix(gateway): stop reporting user cancellations as gateway draining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway agent cancellation attribution:** report operator-cancelled CLI agent tasks as cancelled without attaching the gateway-draining timeout phase, while preserving restart and maintenance-timeout ownership. Fixes #110209.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway agent cancellation attribution:** report operator-cancelled CLI agent tasks as cancelled without attaching the gateway-draining timeout phase, while preserving restart and maintenance-timeout ownership. Fixes #110209.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -64,6 +64,16 @@ function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "restart" | "r
   return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
 }
 
+function resolveAbortedAgentTaskStatus(stopReason: string | undefined): "cancelled" | "timed_out" {
+  return stopReason === "timeout" ? "timed_out" : "cancelled";
+}
+
+function resolveGatewayAgentAbortTimeoutPhase(
+  stopReason: "restart" | "rpc" | "timeout",
+): "gateway_draining" | undefined {
+  return stopReason === "restart" ? "gateway_draining" : undefined;
+}
+
 export function resolveAbortedAgentStopReason(entry?: ChatAbortControllerEntry): string {
   return entry?.abortStopReason?.trim() || "rpc";
 }
@@ -146,11 +156,12 @@ export function dispatchAgentRunFromGateway(params: {
   })
     .then(async (result) => {
       const aborted = result?.meta?.aborted === true;
+      const stopReason = aborted ? (result?.meta?.stopReason ?? "rpc") : undefined;
       const timeoutAttribution = readAgentRunTimeoutAttribution(result?.meta);
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
-          status: aborted ? "timed_out" : "succeeded",
+          status: aborted ? resolveAbortedAgentTaskStatus(stopReason) : "succeeded",
           terminalSummary: aborted ? "aborted" : "completed",
           log: params.context.logGateway,
         });
@@ -159,7 +170,7 @@ export function dispatchAgentRunFromGateway(params: {
         runId: params.runId,
         status: aborted ? ("timeout" as const) : ("ok" as const),
         summary: aborted ? "aborted" : "completed",
-        ...(aborted ? { stopReason: result?.meta?.stopReason ?? "rpc" } : {}),
+        ...(aborted ? { stopReason } : {}),
         ...(aborted && timeoutAttribution.timeoutPhase
           ? { timeoutPhase: timeoutAttribution.timeoutPhase }
           : {}),
@@ -213,28 +224,31 @@ export function dispatchAgentRunFromGateway(params: {
     .catch(async (err: unknown) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
       const renderedErr = formatForLog(err);
+      const stopReason = resolveGatewayAgentAbortStopReason(params.abortController.signal);
+      const timeoutPhase = aborted ? resolveGatewayAgentAbortTimeoutPhase(stopReason) : undefined;
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
-          status: aborted ? "timed_out" : resolveFailedTrackedAgentTaskStatus(err),
+          status: aborted
+            ? resolveAbortedAgentTaskStatus(stopReason)
+            : resolveFailedTrackedAgentTaskStatus(err),
           error: renderedErr,
           terminalSummary: renderedErr,
           log: params.context.logGateway,
         });
       }
       const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
-      const stopReason = resolveGatewayAgentAbortStopReason(params.abortController.signal);
       const terminalOutcome = buildAgentRunTerminalOutcome({
         status: aborted ? "timeout" : "error",
         error: renderedErr,
         stopReason,
-        timeoutPhase: aborted ? "gateway_draining" : undefined,
+        timeoutPhase,
       });
       const payload = {
         runId: params.runId,
         status: aborted ? ("timeout" as const) : ("error" as const),
         summary: aborted ? "aborted" : renderedErr,
-        ...(aborted ? { stopReason, timeoutPhase: "gateway_draining" as const } : {}),
+        ...(aborted ? { stopReason, ...(timeoutPhase ? { timeoutPhase } : {}) } : {}),
       };
       const persistTerminalDedupe = (settlementPersisted: boolean) => {
         setGatewayDedupeEntries({

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -430,7 +430,7 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("preserves aborted async gateway agent runs as timed out", async () => {
+  it("preserves aborted async gateway agent runs as cancelled", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-aborted-" }, async (root) => {
       useTestStateDir(root);
       resetTaskRegistryForTests();
@@ -454,7 +454,7 @@ describe("gateway agent handler", () => {
         expectRecordFields(findTaskByRunId("task-registry-agent-run-aborted"), {
           runtime: "cli",
           childSessionKey: "agent:main:main",
-          status: "timed_out",
+          status: "cancelled",
           terminalSummary: "aborted",
         });
         expectRecordFields(context.dedupe.get("agent:task-registry-agent-run-aborted")?.payload, {
@@ -466,7 +466,7 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("classifies aborted async gateway agent rejections as timed out", async () => {
+  it("classifies RPC-aborted async gateway agent rejections as cancelled", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-abort-error-" }, async (root) => {
       useTestStateDir(root);
       resetTaskRegistryForTests();
@@ -493,7 +493,7 @@ describe("gateway agent handler", () => {
         expectRecordFields(findTaskByRunId("task-registry-agent-run-abort-error"), {
           runtime: "cli",
           childSessionKey: "agent:main:main",
-          status: "timed_out",
+          status: "cancelled",
           error: "AbortError: This operation was aborted",
         });
         expectRecordFields(
@@ -505,6 +505,9 @@ describe("gateway agent handler", () => {
             stopReason: "rpc",
           },
         );
+        expect(
+          context.dedupe.get("agent:task-registry-agent-run-abort-error")?.payload,
+        ).not.toHaveProperty("timeoutPhase");
       });
     });
   });
@@ -536,11 +539,15 @@ describe("gateway agent handler", () => {
       );
 
       await waitForAssertion(() => {
+        expectRecordFields(findTaskByRunId(runId), {
+          status: "cancelled",
+        });
         expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
           runId,
           status: "timeout",
           summary: "aborted",
           stopReason: "restart",
+          timeoutPhase: "gateway_draining",
         });
       });
     });
@@ -585,6 +592,9 @@ describe("gateway agent handler", () => {
             stopReason: "timeout",
           },
         );
+        expect(
+          context.dedupe.get("agent:task-registry-agent-run-timeout-error")?.payload,
+        ).not.toHaveProperty("timeoutPhase");
       });
     });
   });


### PR DESCRIPTION
Closes #110209

## What Problem This Solves

Fixes an issue where operators stopping an async CLI agent turn would receive `timeoutPhase: gateway_draining` even though the Gateway remained healthy. The affected turn was also recorded as timed out instead of cancelled.

## Why This Change Was Made

The Gateway now preserves the abort owner: operator RPC cancellation records a cancelled task without a timeout phase, maintenance expiry remains timed out, and restart cancellation alone carries the gateway-draining phase. The existing wire-level `status: timeout` response remains unchanged for compatibility.

## User Impact

Operators and automation can distinguish a deliberate Stop action from Gateway shutdown or maintenance timeout. Control UI still ends the turn as Cancelled/Interrupted, while CLI task history now reports the matching cancellation state.

## Evidence

- Live OpenAI GPT-5.4 repro on a source-built Gateway at custom port 22922: before the fix, Stop returned `stopReason: rpc` plus `timeoutPhase: gateway_draining`; after the fix, the same `ask_user` cancellation returned `stopReason: rpc` with no timeout phase while `/health` stayed live.
- Live Control UI checks: pending `ask_user` survived a hard reload; duplicate submit was blocked; two concurrent sessions preserved distinct Unicode markers; a queued same-session turn drained after the blocking answer; Markdown, JSON, RTL, CJK, combining text, and emoji rendered correctly.
- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts` — 244 tests passed on the final rebased head.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/agent-run-dispatch.ts src/gateway/server-methods/agent.sessions-and-models.test-utils.ts CHANGELOG.md` — fresh Blacksmith Testbox changed gate passed: https://github.com/openclaw/openclaw/actions/runs/29618854313
- `autoreview --mode uncommitted` — clean; no accepted/actionable findings.

AI-assisted. I reviewed the implementation, live behavior, regression tests, and dependency contract.
