### PR TITLE
fix(onboarding): leave session.dmScope unset so the personal-agent default "main" applies

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -197,7 +197,7 @@ By default, OpenClaw routes all DMs into the main session for cross-device conti
 | `per-account-channel-peer` | Like above, split further by account (multi-account channels).         |
 | `per-peer`                 | Each sender gets one session across all channels of the same type.     |
 
-Local CLI onboarding writes `session.dmScope: "per-channel-peer"` when unset, and preserves any explicit existing value.
+Local CLI onboarding preserves an explicit `session.dmScope` and otherwise leaves it unset, so the `"main"` default applies: all direct messages across channels share the agent's rolling main session (the personal-agent default). For shared or multi-user inboxes, set `session.dmScope: "per-channel-peer"`; `openclaw security audit` recommends isolation when it detects multi-user DM traffic.
 
 This is a messaging-context boundary, not a host-admin boundary. If users are mutually adversarial and share the same Gateway host/config, run separate gateways per trust boundary instead.
 

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -238,7 +238,7 @@ Typical fields in `~/.openclaw/openclaw.json`:
 - `agents.defaults.model` / `models.providers` (if Minimax chosen)
 - `tools.profile` (local onboarding defaults to `"coding"` when unset; existing explicit values are preserved)
 - `gateway.*` (mode, bind, auth, tailscale)
-- `session.dmScope` (local onboarding defaults this to `"per-channel-peer"` when unset; existing explicit values are preserved. Details: [CLI Setup Reference](/start/wizard-cli-reference#outputs-and-internals))
+- `session.dmScope` (onboarding preserves explicit values and otherwise leaves it unset, so the `"main"` default keeps all direct messages across channels in the agent's rolling main session—the personal-agent default. For shared or multi-user inboxes, use `"per-channel-peer"`; `openclaw security audit` recommends isolation when it detects multi-user DM traffic. Details: [CLI Setup Reference](/start/wizard-cli-reference#outputs-and-internals))
 - `channels.telegram.botToken`, `channels.discord.token`, `channels.matrix.*`, `channels.signal.*`, `channels.imessage.*`
 - Channel DM allowlists when you opt in during the channel prompts. Discord, Matrix, Microsoft Teams, and Slack resolve names to IDs when possible; other channels take IDs directly (for example numeric Telegram sender IDs or WhatsApp phone numbers).
 - `skills.install.nodeManager`

--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -123,7 +123,7 @@ Follow-on models that tighten fidelity around real-world failure modes: non-atom
 
 ### Routing dmScope precedence and identityLinks
 
-**Claim:** routing keeps DM sessions isolated by default and only collapses sessions when explicitly configured, via channel precedence and identity links. Channel-specific `dmScope` overrides win over global defaults; `identityLinks` collapse sessions only within explicit linked groups, not across unrelated peers.
+**Claim:** `dmScope` precedence and identity links behave deterministically: the default `main` scope shares one rolling session across a single owner's DMs (the personal-agent default), while any configured isolating scope (`per-peer`, `per-channel-peer`, `per-account-channel-peer`) keeps DM sessions strictly separated. Channel-specific `dmScope` overrides win over global defaults; `identityLinks` collapse sessions only within explicit linked groups, not across unrelated peers. Multi-user inboxes are expected to opt into an isolating scope (the runtime security audit recommends this when it detects multi-user DM traffic).
 
 | Result         | Targets                                                                   |
 | -------------- | ------------------------------------------------------------------------- |

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -325,7 +325,7 @@ Typical fields in `~/.openclaw/openclaw.json`:
 - `agents.defaults.model` / `models.providers` (if Minimax chosen)
 - `tools.profile` (local onboarding defaults to `"coding"` when unset; existing explicit values are preserved)
 - `gateway.*` (mode, bind, auth, tailscale)
-- `session.dmScope` (local onboarding defaults this to `per-channel-peer` when unset; existing explicit values are preserved)
+- `session.dmScope` (onboarding preserves explicit values and otherwise leaves it unset, so the `main` default keeps all direct messages across channels in the agent's rolling main session—the personal-agent default. For shared or multi-user inboxes, use `per-channel-peer`; `openclaw security audit` recommends isolation when it detects multi-user DM traffic)
 - `channels.telegram.botToken`, `channels.discord.token`, `channels.matrix.*`, `channels.signal.*`, `channels.imessage.*`
 - Channel allowlists (Discord, iMessage, Signal, Slack, Telegram, WhatsApp) when you opt in during prompts; Discord and Slack also resolve entered names to IDs
 - `skills.install.nodeManager`

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -113,7 +113,7 @@ flow and skip that prompt.
     - Gateway port **18789**
     - Gateway auth **Token** (auto-generated, even on loopback)
     - Tool policy: `tools.profile: "coding"` for new setups (an existing explicit profile is preserved)
-    - DM isolation: `session.dmScope: "per-channel-peer"` for new setups. Details: [CLI setup reference](/start/wizard-cli-reference#outputs-and-internals)
+    - DM sessions: onboarding preserves an explicit `session.dmScope` and otherwise leaves it unset, so the `"main"` default keeps all direct messages across channels in the agent's rolling main session—the personal-agent default. For shared or multi-user inboxes, use `"per-channel-peer"`; `openclaw security audit` recommends isolation when it detects multi-user DM traffic. Details: [CLI setup reference](/start/wizard-cli-reference#outputs-and-internals)
     - Tailscale exposure **Off**
     - Telegram and WhatsApp DMs default to **allowlist**: Telegram asks for a numeric Telegram user ID, WhatsApp asks for a phone number
 

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -4,11 +4,12 @@ import type { OpenClawConfig } from "../config/config.js";
 import { applyLocalSetupWorkspaceConfig } from "./onboard-config.js";
 
 describe("applyLocalSetupWorkspaceConfig", () => {
-  it("sets secure dmScope default when unset", () => {
+  it("leaves dmScope unset when not configured", () => {
     const baseConfig: OpenClawConfig = {};
     const result = applyLocalSetupWorkspaceConfig(baseConfig, "/tmp/workspace");
 
-    expect(result.session?.dmScope).toBe("per-channel-peer");
+    expect(result.session?.dmScope).toBeUndefined();
+    expect(result).not.toHaveProperty("session.dmScope");
     expect(result.gateway?.mode).toBe("local");
     expect(result.agents?.defaults?.workspace).toBe("/tmp/workspace");
     expect(result.tools?.profile).toBe("coding");

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -1,11 +1,8 @@
 /** Shared config mutations used by interactive and non-interactive onboarding. */
 import { setConfigValueAtPath } from "../config/config-paths.js";
-import type { DmScope } from "../config/types.base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolProfileId } from "../config/types.tools.js";
 
-/** Default DM scoping selected during local onboarding. */
-const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
 /** Default tool profile selected during local onboarding. */
 const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "coding";
 
@@ -26,10 +23,6 @@ export function applyLocalSetupWorkspaceConfig(
     gateway: {
       ...baseConfig.gateway,
       mode: "local",
-    },
-    session: {
-      ...baseConfig.session,
-      dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
     },
     tools: {
       ...baseConfig.tools,

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -7,6 +7,9 @@ import type { ToolProfileId } from "../config/types.tools.js";
 const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "coding";
 
 /** Applies local gateway/workspace defaults without overwriting explicit user defaults. */
+// Deliberately writes no session.dmScope: the schema default "main" (one rolling
+// personal-agent session across channels) is the product default. Multi-user DM
+// isolation is opt-in; `openclaw security audit` nudges it when traffic warrants.
 export function applyLocalSetupWorkspaceConfig(
   baseConfig: OpenClawConfig,
   workspaceDir: string,


### PR DESCRIPTION
## What Problem This Solves

The config schema and every runtime consumer default `session.dmScope` to `"main"` — one rolling personal-agent session shared by all DM channels. But local onboarding silently wrote `session.dmScope: "per-channel-peer"`, so every freshly onboarded install diverged from the documented product default: DMs from Telegram, WhatsApp, iMessage, and web each got isolated per-channel sessions, and the agent felt amnesic across channels.

## Why This Change Was Made

Owner decision: OpenClaw's default posture is a personal agent — one brain, all channels. Onboarding now leaves `dmScope` unset so the schema default `"main"` applies. Isolation stays fully supported and opt-in (`session.dmScope: "per-channel-peer"` etc.), and `openclaw security audit` already recommends isolation when it detects multi-user DM traffic. An inline comment records the decision.

Security tradeoff, considered and accepted: on a genuinely shared inbox, `main` merges sender contexts. Mitigations: DM senders are gated by pairing/allowlists before any session exists; the audit nudge fires on multi-user traffic; docs now spell out the isolation escape hatch. Structured review flagged this (P1) — rejected as conflicting with the explicit product contract.

## User Impact

Fresh installs get the cross-channel rolling main session by default. Existing configs are untouched — explicit `dmScope` values are preserved (covered by unchanged preserve-tests). No migration needed; generated config gets smaller.

## Evidence

- `src/commands/onboard-config.ts` — session mutation removed; existing session config flows through the base spread
- `src/commands/onboard-config.test.ts` — asserts `dmScope` absent when unconfigured; preserve-tests unchanged: 5/5 passed via `node scripts/run-vitest.mjs src/commands/onboard-config.test.ts`
- Docs updated: `docs/start/wizard.md`, `docs/start/wizard-cli-reference.md`, `docs/reference/wizard.md`, `docs/gateway/security/index.md`
- Non-interactive onboarding probe confirmed generated config carries no `dmScope`, gateway `local`, tools profile `coding`
