### PR TITLE
fix(agents): run embedded gateway fallback on a fresh session after abnormal close

### DIFF
--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -32,7 +32,7 @@ export type ImageContent = {
 export type AgentCommandResultMetaOverrides = {
   transport?: "embedded";
   fallbackFrom?: "gateway";
-  fallbackReason?: "gateway_timeout";
+  fallbackReason?: "gateway_timeout" | "gateway_closed";
   fallbackSessionId?: string;
   fallbackSessionKey?: string;
 };

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -183,10 +183,12 @@ function createGatewayTimeoutError() {
 }
 
 function createGatewayClosedError() {
-  const err = new Error("gateway closed before response");
+  const err = new Error("gateway closed (1006 abnormal closure): no close reason");
   err.name = "GatewayTransportError";
   return Object.assign(err, {
     kind: "closed",
+    code: 1006,
+    reason: "no close reason",
     connectionDetails: {
       url: "ws://127.0.0.1:18789",
       urlSource: "local loopback",
@@ -1606,9 +1608,12 @@ describe("agentCliCommand", () => {
       );
       expect(resultMetaOverrides.transport).toBe("embedded");
       expect(resultMetaOverrides.fallbackFrom).toBe("gateway");
+      expect(resultMetaOverrides.fallbackReason).toBe("gateway_closed");
       expect(
         mockMessages(runtime.error).some((message) =>
-          message.includes("EMBEDDED FALLBACK: Gateway agent failed"),
+          message.includes(
+            "Gateway agent connection closed; running embedded agent with fresh session",
+          ),
         ),
       ).toBe(true);
       expect(runtime.log).toHaveBeenCalledWith("local");
@@ -1654,9 +1659,18 @@ describe("agentCliCommand", () => {
     }
   });
 
-  it("preserves explicit session keys for embedded fallback when the gateway closes", async () => {
+  it("uses a fresh embedded session when an accepted gateway turn closes abnormally", async () => {
     await withTempStore(async () => {
-      callGateway.mockRejectedValue(createGatewayClosedError());
+      callGateway.mockImplementationOnce(async (requestValue: unknown) => {
+        const request = requireRecord(requestValue, "gateway request");
+        const onAccepted = request.onAccepted as ((payload: unknown) => void) | undefined;
+        onAccepted?.({
+          status: "accepted",
+          runId: "accepted-run",
+          sessionKey: "agent:main:incident-42",
+        });
+        throw createGatewayClosedError();
+      });
       mockLocalAgentReply();
 
       await agentCliCommand({ message: "hi", sessionKey: "agent:main:incident-42" }, runtime);
@@ -1667,29 +1681,39 @@ describe("agentCliCommand", () => {
         requireFirstCallArg(agentCommand, "embedded agent"),
         "embedded agent options",
       );
-      expect(fallbackOpts.sessionKey).toBe("agent:main:incident-42");
+      const fallbackSessionId = String(fallbackOpts.sessionId);
+      const fallbackSessionKey = String(fallbackOpts.sessionKey);
+      expect(fallbackSessionId).toMatch(/^gateway-fallback-/);
+      expect(fallbackSessionKey).toBe(`agent:main:explicit:${fallbackSessionId}`);
+      expect(fallbackSessionKey).not.toBe("agent:main:incident-42");
+      expect(fallbackOpts.runId).toBe(fallbackSessionId);
       expect(fallbackOpts.resultMetaOverrides).toMatchObject({
         transport: "embedded",
         fallbackFrom: "gateway",
+        fallbackReason: "gateway_closed",
+        fallbackSessionId,
+        fallbackSessionKey,
       });
     });
   });
 
-  it("propagates harness-owned session rejection from embedded gateway fallback", async () => {
+  it("does not pass a harness-owned session key into closed gateway fallback", async () => {
     await withTempStore(async () => {
       const sessionKey = "agent:main:harness:codex:supervision:missing-fallback";
       callGateway.mockRejectedValue(createGatewayClosedError());
-      agentCommand.mockRejectedValueOnce(new Error(AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE));
+      mockLocalAgentReply();
 
-      await expect(agentCliCommand({ message: "hi", sessionKey }, runtime)).rejects.toThrow(
-        AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
-      );
+      await agentCliCommand({ message: "hi", sessionKey }, runtime);
 
       expect(callGateway).toHaveBeenCalledOnce();
       expect(agentCommand).toHaveBeenCalledOnce();
-      expect(
-        requireRecord(requireFirstCallArg(agentCommand, "embedded agent"), "options"),
-      ).toMatchObject({ sessionKey });
+      const fallbackOpts = requireRecord(
+        requireFirstCallArg(agentCommand, "embedded agent"),
+        "options",
+      );
+      const fallbackSessionId = String(fallbackOpts.sessionId);
+      expect(fallbackOpts.sessionKey).toBe(`agent:main:explicit:${fallbackSessionId}`);
+      expect(fallbackOpts.sessionKey).not.toBe(sessionKey);
     });
   });
 
@@ -1887,7 +1911,7 @@ describe("agentCliCommand", () => {
       expect(resultMetaOverrides.fallbackFrom).toBe("gateway");
       expect(
         mockMessages(jsonRuntime.error).some((message) =>
-          message.includes("EMBEDDED FALLBACK: Gateway agent failed"),
+          message.includes("EMBEDDED FALLBACK: Gateway agent connection closed"),
         ),
       ).toBe(true);
       expect(loggingState.forceConsoleToStderr).toBe(true);

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -64,7 +64,7 @@ const EMBEDDED_FALLBACK_META = {
   transport: "embedded",
   fallbackFrom: "gateway",
 } as const;
-const GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX = "gateway-fallback-";
+const GATEWAY_FALLBACK_SESSION_PREFIX = "gateway-fallback-";
 const GATEWAY_TRANSIENT_CONNECT_RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 15_000] as const;
 
 type AgentCliOpts = {
@@ -308,8 +308,15 @@ function shouldRetryGatewayDispatchWithShellEnvFallback(err: unknown): boolean {
   );
 }
 
-function isGatewayAgentEmbeddedFallbackError(err: unknown): boolean {
-  return isGatewayTransportError(err);
+function resolveGatewayAgentEmbeddedFallbackReason(
+  err: unknown,
+): "gateway_timeout" | "gateway_closed" | undefined {
+  if (isGatewayAgentTimeoutError(err)) {
+    return "gateway_timeout";
+  }
+  // GatewayTransportErrorKind is exactly "closed" | "timeout", so this branch
+  // pair covers every transport error; non-transport errors never fell back.
+  return isGatewayTransportError(err) && err.kind === "closed" ? "gateway_closed" : undefined;
 }
 
 function isTransientGatewayAgentConnectClose(err: unknown): boolean {
@@ -612,22 +619,22 @@ function returnAfterSignalExit<T>(
   return exitForReceivedSignal(signal, runtime) ? undefined : value;
 }
 
-function createGatewayTimeoutFallbackSessionId(): string {
-  return `${GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX}${randomUUID()}`;
+function createGatewayFallbackSessionId(): string {
+  return `${GATEWAY_FALLBACK_SESSION_PREFIX}${randomUUID()}`;
 }
 
-function createGatewayTimeoutFallbackSession(agentId?: string): {
+function createGatewayFallbackSession(agentId?: string): {
   sessionId: string;
   sessionKey: string;
 } {
-  const sessionId = createGatewayTimeoutFallbackSessionId();
+  const sessionId = createGatewayFallbackSessionId();
   return {
     sessionId,
     sessionKey: `agent:${normalizeAgentId(agentId)}:explicit:${sessionId.trim()}`,
   };
 }
 
-async function resolveAgentIdForGatewayTimeoutFallback(
+async function resolveAgentIdForGatewayFallback(
   opts: AgentDispatchOpts,
 ): Promise<string | undefined> {
   const explicitSessionKey = opts.sessionKey?.trim();
@@ -963,44 +970,31 @@ export async function agentCliCommand(
         }
         throw err;
       }
-      if (isGatewayAgentTimeoutError(err)) {
-        const fallbackAgentId = await resolveAgentIdForGatewayTimeoutFallback(dispatchOpts);
-        const fallbackSession = createGatewayTimeoutFallbackSession(fallbackAgentId);
-        runtime.error?.(
-          `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSession.sessionId}: ${String(err)}`,
-        );
-        const agentCommand = await loadEmbeddedAgentCommand();
-        const result = await agentCommand(
-          {
-            ...localOpts,
-            sessionId: fallbackSession.sessionId,
-            sessionKey: fallbackSession.sessionKey,
-            runId: fallbackSession.sessionId,
-            resultMetaOverrides: {
-              ...EMBEDDED_FALLBACK_META,
-              fallbackReason: "gateway_timeout",
-              fallbackSessionId: fallbackSession.sessionId,
-              fallbackSessionKey: fallbackSession.sessionKey,
-            },
-          },
-          runtime,
-          deps,
-        );
-        return returnAfterSignalExit(result, signalBridge.getReceivedSignal(), runtime);
-      }
-
-      if (!isGatewayAgentEmbeddedFallbackError(err)) {
+      const fallbackReason = resolveGatewayAgentEmbeddedFallbackReason(err);
+      if (!fallbackReason) {
         throw err;
       }
 
+      const fallbackAgentId = await resolveAgentIdForGatewayFallback(dispatchOpts);
+      const fallbackSession = createGatewayFallbackSession(fallbackAgentId);
+      // Transport loss is ambiguous: the Gateway may still own or recover the original turn.
+      // Keep embedded work on a separate session so both processes cannot write one transcript.
       runtime.error?.(
-        `EMBEDDED FALLBACK: Gateway agent failed; running embedded agent: ${String(err)}`,
+        `EMBEDDED FALLBACK: Gateway agent ${fallbackReason === "gateway_timeout" ? "timed out" : "connection closed"}; running embedded agent with fresh session ${fallbackSession.sessionId}: ${String(err)}`,
       );
       const agentCommand = await loadEmbeddedAgentCommand();
       const result = await agentCommand(
         {
           ...localOpts,
-          resultMetaOverrides: EMBEDDED_FALLBACK_META,
+          sessionId: fallbackSession.sessionId,
+          sessionKey: fallbackSession.sessionKey,
+          runId: fallbackSession.sessionId,
+          resultMetaOverrides: {
+            ...EMBEDDED_FALLBACK_META,
+            fallbackReason,
+            fallbackSessionId: fallbackSession.sessionId,
+            fallbackSessionKey: fallbackSession.sessionKey,
+          },
         },
         runtime,
         deps,


### PR DESCRIPTION
## What Problem This Solves

When the gateway is hard-killed (e.g. SIGKILL, WebSocket 1006 abnormal closure) while an `openclaw agent` turn is in flight, the CLI's embedded fallback re-ran the agent locally **reusing the same explicit session key**. Meanwhile the relaunched gateway's `main-session-restart-recovery` also resumes that same session — so two processes can drive one session concurrently across process boundaries (duplicate/conflicting transcript writes). The existing timeout fallback already used a distinct `gateway-fallback-*` session; the abnormal-close path did not.

## Why This Change Was Made

Found during the R4 whole-system QA campaign (restart/recovery stress, live keys, isolated gateways). Repro: start a long agent turn, SIGKILL the gateway mid-turn → CLI logs `EMBEDDED FALLBACK` and enqueues `lane=session:agent:main:<same-key>` while the relaunched gateway logs `resumed interrupted main session` for the same key.

## User Impact

After a gateway crash mid-turn, embedded fallback now always runs on a fresh `gateway-fallback-*` session (for both timeout and closed transport failures, with a `fallbackReason` recorded in result metadata), so it can never collide with gateway-side session recovery. Gateway recovery of the original session is unaffected.

## Evidence

- `resolveGatewayAgentEmbeddedFallbackReason` unifies both fallback triggers; `GatewayTransportErrorKind` is exactly `"closed" | "timeout"` (`src/gateway/call.ts:120`, constructed only at `call.ts:846/:859`), so the pair is exhaustive — no transport failure loses fallback.
- Regression test: accepted turn followed by WebSocket 1006 proves fallback does not reuse the original explicit session key (`src/commands/agent-via-gateway.test.ts`). Focused suite: 74/74 pass.
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.91), no actionable findings". Net prod LOC −8.
