### PR TITLE
fix(codex): retire shared app-server client only when unclaimed

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -21,8 +21,8 @@ import type { CodexAttemptPrompt } from "./run-attempt-prompt.js";
 import { releaseCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import {
+  clearSharedCodexAppServerClientIfCurrentAndUnclaimed,
   retainSharedCodexAppServerClientIfCurrent,
-  retireSharedCodexAppServerClientIfCurrent,
 } from "./shared-client.js";
 import type { CodexAppServerThreadLifecycleBinding } from "./thread-lifecycle.js";
 import { createCodexTrajectoryRecorder, type CodexHostTrajectoryRecorder } from "./trajectory.js";
@@ -132,16 +132,17 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       return;
     }
     state.sharedCodexClientRetiredForOneShotCleanup = true;
-    const retired = retireSharedCodexAppServerClientIfCurrent(state.client);
-    embeddedAgentLog.info("codex app-server one-shot cleanup retired shared client", {
+    const retired = clearSharedCodexAppServerClientIfCurrentAndUnclaimed(state.client);
+    embeddedAgentLog.info("codex app-server one-shot cleanup checked shared client retirement", {
       runId: params.runId,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
-      activeLeases: retired?.activeLeases ?? null,
-      closed: retired?.closed ?? false,
-      matchedSharedClient: Boolean(retired),
+      activeLeases: retired.activeLeases,
+      pendingAcquires: retired.pendingAcquires,
+      closed: retired.closed,
+      matchedSharedClient: retired.found,
     });
-    if (retired?.closed) {
+    if (retired.closed) {
       await state.client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
     }
   };

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2022,8 +2022,11 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("retires the shared Codex app-server client after one-shot cleanup turns", async () => {
-    const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
-    retireSpy.mockReturnValue({ activeLeases: 0, closed: true });
+    const retireSpy = vi.spyOn(
+      sharedClientModule,
+      "clearSharedCodexAppServerClientIfCurrentAndUnclaimed",
+    );
+    retireSpy.mockReturnValue({ found: true, activeLeases: 0, pendingAcquires: 0, closed: true });
     const events: string[] = [];
     const closeAndWait = vi.fn(async () => {
       events.push("closeAndWait");
@@ -2086,8 +2089,11 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("retires the shared Codex app-server client after one-shot turn start failures", async () => {
-    const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
-    retireSpy.mockReturnValue({ activeLeases: 0, closed: true });
+    const retireSpy = vi.spyOn(
+      sharedClientModule,
+      "clearSharedCodexAppServerClientIfCurrentAndUnclaimed",
+    );
+    retireSpy.mockReturnValue({ found: true, activeLeases: 0, pendingAcquires: 0, closed: true });
     const events: string[] = [];
     const closeAndWait = vi.fn(async () => {
       events.push("closeAndWait");
@@ -2132,7 +2138,10 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("keeps the shared Codex app-server client warm without one-shot cleanup", async () => {
-    const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
+    const retireSpy = vi.spyOn(
+      sharedClientModule,
+      "clearSharedCodexAppServerClientIfCurrentAndUnclaimed",
+    );
     const closeAndWait = vi.fn(async () => true);
     let notify: ((notification: CodexServerNotification) => Promise<void>) | undefined;
     const request = vi.fn(async (method: string) => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -88,6 +88,7 @@ import {
 let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerModels;
 let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSharedCodexAppServerClient;
 let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrent;
+let clearSharedCodexAppServerClientIfCurrentAndUnclaimed: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrentAndUnclaimed;
 let clearSharedCodexAppServerClientIfCurrentAndWait: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrentAndWait;
 let createIsolatedCodexAppServerClient: typeof import("./shared-client.js").createIsolatedCodexAppServerClient;
 let getLeasedSharedCodexAppServerClient: typeof import("./shared-client.js").getLeasedSharedCodexAppServerClient;
@@ -188,6 +189,7 @@ describe("shared Codex app-server client", () => {
     ({
       clearSharedCodexAppServerClient,
       clearSharedCodexAppServerClientIfCurrent,
+      clearSharedCodexAppServerClientIfCurrentAndUnclaimed,
       clearSharedCodexAppServerClientIfCurrentAndWait,
       createIsolatedCodexAppServerClient,
       getLeasedSharedCodexAppServerClient,
@@ -1729,6 +1731,44 @@ describe("shared Codex app-server client", () => {
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(false);
+  });
+
+  it("keeps the current client registered while a staggered sibling lease is active", async () => {
+    const first = createClientHarness();
+    const replacement = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(replacement.client);
+
+    const completedRunLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    const siblingRunLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(first, "openclaw/0.143.0 (macOS; test)");
+    await expect(completedRunLease).resolves.toBe(first.client);
+    await expect(siblingRunLease).resolves.toBe(first.client);
+
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+    expect(clearSharedCodexAppServerClientIfCurrentAndUnclaimed(first.client)).toEqual({
+      found: true,
+      closed: false,
+      activeLeases: 1,
+      pendingAcquires: 0,
+    });
+    expect(first.process.stdin.destroyed).toBe(false);
+
+    const staggeredLease = await getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    expect(staggeredLease).toBe(first.client);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+    expect(clearSharedCodexAppServerClientIfCurrentAndUnclaimed(first.client)).toEqual({
+      found: true,
+      closed: true,
+      activeLeases: 0,
+      pendingAcquires: 0,
+    });
+    expect(first.process.stdin.destroyed).toBe(true);
   });
 
   it("rejects pending acquires during shared-client retirement", async () => {


### PR DESCRIPTION
## What Problem This Solves

Under staggered concurrent OpenAI turns (mixed distinct-session fan-out), one turn's one-shot cleanup retired the shared codex app-server client **while a sibling turn still held a lease on it**, so the sibling failed with `MissingAgentHarnessError: Requested agent harness "codex" is not registered`. Log signature: `codex app-server one-shot cleanup retired shared client` immediately followed by the harness error.

## Why This Change Was Made

Found during the R4 live-key stress QA campaign: mixed 8-way distinct-session fan-out with slightly staggered OpenAI turns failed 1-2 of the OpenAI turns per run; 4 fully simultaneous OpenAI turns passed (the stagger — one run finishing one-shot cleanup while another is mid-flight — is required). Upstream contract check (sibling `../codex` checkout): `codex-rs/app-server/src/lib.rs:954-974` — on `ConnectionClosed` the server drops the connection state and closes its `rpc_gate` (killing in-flight subscriptions), and with stdio transport (`lib.rs:676` single-client mode) the last connection closing shuts the server down (`break "last_connection_closed"`, `lib.rs:972-973`). So the shared stdio client must never be detached while any run still consumes it.

## User Impact

Concurrent/staggered OpenAI (codex-harness) turns no longer intermittently fail with `MissingAgentHarnessError`. One-shot cleanup now releases the finished run's own lease and retires the shared client only when it is current **and unclaimed** (no active leases, no pending acquisitions), using the existing unclaimed-only retirement gate in `shared-client.ts`. Suspect-client forced retirement is unchanged; zero-consumer retirement behaves exactly as before.

## Evidence

- Fix: `extensions/codex/src/app-server/run-attempt-resources.ts` (net prod diff 8+/7−) — no timeout widening, no retry shim; reuses the existing lease accounting (`activeLeases`/`pendingAcquires`) and unclaimed-only retirement (`shared-client.ts:1161-1179`).
- Deterministic regression: two concurrent leases → one run completes and drives one-shot retirement → client stays current/open for the sibling; staggered re-acquire gets the same client; final release retires and closes (`shared-client.test.ts`). Suites: shared-client 53/53, run-attempt 115/115.
- `node scripts/check-changed.mjs` exit 0 (typecheck/format/lint/boundaries/import-cycles) via Testbox run https://github.com/openclaw/openclaw/actions/runs/29619450607.
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.91), no actionable findings".
