### PR TITLE
fix: doctor upgrade 7.1 / 7.2-beta.1 - 7.2-beta.2 fails on fractional restart handoffs

### DIFF
--- a/src/infra/restart-handoff.test.ts
+++ b/src/infra/restart-handoff.test.ts
@@ -284,6 +284,46 @@ describe("gateway restart handoff", () => {
     });
   });
 
+  it("canonicalizes fractional restart trace timing before persistence", () => {
+    const env = createHandoffEnv();
+
+    const handoff = expectWrittenHandoff({
+      env,
+      pid: 12_345,
+      restartKind: "update-process",
+      supervisorMode: "systemd",
+      createdAt: 1_000,
+      restartTrace: {
+        startedAt: 10_000.9,
+        lastAt: 10_250.4,
+      },
+    });
+
+    expect(handoff.restartTrace).toStrictEqual({
+      startedAt: 10_000,
+      lastAt: 10_250,
+    });
+    const { db } = openOpenClawStateDatabase({ env });
+    expect(
+      db
+        .prepare(
+          `SELECT
+             typeof(restart_trace_started_at) AS started_type,
+             restart_trace_started_at,
+             typeof(restart_trace_last_at) AS last_type,
+             restart_trace_last_at
+           FROM gateway_restart_handoff
+           WHERE handoff_key = 'current'`,
+        )
+        .get(),
+    ).toEqual({
+      started_type: "integer",
+      restart_trace_started_at: 10_000,
+      last_type: "integer",
+      restart_trace_last_at: 10_250,
+    });
+  });
+
   it("keeps restart trace timing for slow but valid drains", () => {
     const env = createHandoffEnv();
 

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -176,8 +176,8 @@ function normalizeRestartTraceHandoff(
     return undefined;
   }
   return {
-    startedAt: record.startedAt,
-    lastAt: record.lastAt,
+    startedAt: Math.floor(record.startedAt),
+    lastAt: Math.floor(record.lastAt),
   };
 }
 

--- a/src/state/openclaw-state-db-restart-handoff-migration.test.ts
+++ b/src/state/openclaw-state-db-restart-handoff-migration.test.ts
@@ -1,0 +1,137 @@
+// Covers doctor repair of shipped fractional restart-handoff trace timestamps.
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  detectOpenClawStateDatabaseSchemaMigrations,
+  openOpenClawStateDatabase,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+  repairOpenClawStateDatabaseSchema,
+} from "./openclaw-state-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("gateway restart handoff state migration", () => {
+  it("repairs fractional trace timestamps while doctor migrates version 2 to STRICT", () => {
+    const stateDir = tempDirs.make("openclaw-state-restart-handoff-");
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = openOpenClawStateDatabase(options).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    const strictCreateSql = (
+      legacy
+        .prepare(
+          "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'gateway_restart_handoff'",
+        )
+        .get() as { sql: string }
+    ).sql;
+    const flexibleCreateSql = strictCreateSql.replace(/\s+STRICT$/u, "");
+    expect(flexibleCreateSql).not.toBe(strictCreateSql);
+    legacy.exec(`
+      DROP INDEX idx_gateway_restart_handoff_expiry;
+      ALTER TABLE gateway_restart_handoff RENAME TO gateway_restart_handoff_strict;
+      ${flexibleCreateSql};
+      DROP TABLE gateway_restart_handoff_strict;
+      PRAGMA user_version = 2;
+      UPDATE schema_meta SET schema_version = 2 WHERE meta_key = 'primary';
+    `);
+    const now = Date.now();
+    const insert = legacy.prepare(`
+      INSERT INTO gateway_restart_handoff (
+        handoff_key,
+        kind,
+        version,
+        intent_id,
+        pid,
+        process_instance_id,
+        created_at,
+        expires_at,
+        reason,
+        restart_trace_started_at,
+        restart_trace_last_at,
+        source,
+        restart_kind,
+        supervisor_mode,
+        updated_at_ms
+      ) VALUES (?, 'gateway-supervisor-restart-handoff', 1, ?, 4242, ?, ?, ?,
+                'update.run', ?, ?, 'gateway-update', 'update-process', 'systemd', ?)
+    `);
+    insert.run(
+      "expired",
+      "expired-intent",
+      "expired-process",
+      now - 120_000,
+      now - 60_000,
+      now - 130_000 + 0.9,
+      now - 129_000 + 0.4,
+      now,
+    );
+    insert.run(
+      "current",
+      "live-intent",
+      "live-process",
+      now - 1_000,
+      now + 59_000,
+      now - 5_000 + 0.9,
+      now - 1_000 + 0.4,
+      now,
+    );
+    legacy.close();
+
+    expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([
+      { kind: "strict-tables-v3", path: databasePath },
+      { kind: "session-watch-cursor-provenance-v4", path: databasePath },
+    ]);
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: [
+        "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
+        "Migrated shared state tables to SQLite STRICT typing (1)",
+      ],
+      warnings: [],
+    });
+
+    const migrated = openOpenClawStateDatabase(options);
+    expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+    expect(
+      migrated.db
+        .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+        .get(),
+    ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
+    expect(
+      migrated.db
+        .prepare("SELECT strict FROM pragma_table_list WHERE name = 'gateway_restart_handoff'")
+        .get(),
+    ).toEqual({ strict: 1 });
+    expect(
+      migrated.db
+        .prepare(
+          `SELECT
+             handoff_key,
+             typeof(restart_trace_started_at) AS started_type,
+             restart_trace_started_at,
+             typeof(restart_trace_last_at) AS last_type,
+             restart_trace_last_at
+           FROM gateway_restart_handoff
+           ORDER BY handoff_key`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        handoff_key: "current",
+        started_type: "integer",
+        restart_trace_started_at: Math.floor(now - 5_000 + 0.9),
+        last_type: "integer",
+        restart_trace_last_at: Math.floor(now - 1_000 + 0.4),
+      },
+    ]);
+  });
+});

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -82,6 +82,31 @@ export function repairAgentDatabasesCompositePrimaryKey(db: DatabaseSync): boole
   return true;
 }
 
+export function repairLegacyGatewayRestartHandoffsForStrictMigration(db: DatabaseSync): void {
+  if (!tableExists(db, "gateway_restart_handoff")) {
+    return;
+  }
+  // Schema v2 accepted fractional performance-clock values in INTEGER-affinity columns.
+  // Expired handoffs are transient; retain live rows by canonicalizing only those REAL cells.
+  db.prepare("DELETE FROM gateway_restart_handoff WHERE expires_at <= ?").run(Date.now());
+  db.exec(`
+    UPDATE gateway_restart_handoff
+    SET
+      restart_trace_started_at = CASE
+        WHEN typeof(restart_trace_started_at) = 'real'
+          THEN CAST(restart_trace_started_at AS INTEGER)
+        ELSE restart_trace_started_at
+      END,
+      restart_trace_last_at = CASE
+        WHEN typeof(restart_trace_last_at) = 'real'
+          THEN CAST(restart_trace_last_at AS INTEGER)
+        ELSE restart_trace_last_at
+      END
+    WHERE typeof(restart_trace_started_at) = 'real'
+       OR typeof(restart_trace_last_at) = 'real';
+  `);
+}
+
 export function markCurrentStateSchemaVersion(db: DatabaseSync): void {
   // Pre-v2 databases can legitimately predate the audit table. Leave their
   // version untouched so normal open can create the complete v2 schema first.

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -58,6 +58,7 @@ import {
   dropLegacyStateTables,
   markCurrentStateSchemaVersion,
   repairAgentDatabasesCompositePrimaryKey,
+  repairLegacyGatewayRestartHandoffsForStrictMigration,
 } from "./openclaw-state-db-schema-repair.js";
 import * as sessionWatchMigration from "./openclaw-state-db-session-watch-migration.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
@@ -174,6 +175,9 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
         if (tableExists(db, "audit_events")) {
           ensureAdditiveStateColumns(db);
           db.exec(OPENCLAW_STATE_SCHEMA_SQL);
+          if (previousVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION) {
+            repairLegacyGatewayRestartHandoffsForStrictMigration(db);
+          }
           const strictMigration = migrateSqliteSchemaToStrictInTransaction(
             db,
             OPENCLAW_STATE_SCHEMA_SQL,
@@ -242,6 +246,7 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
         db.exec(OPENCLAW_STATE_SCHEMA_SQL);
         migrateLegacyCronRunLogsToTaskRuns(db);
         if (previousVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION) {
+          repairLegacyGatewayRestartHandoffsForStrictMigration(db);
           migrateSqliteSchemaToStrictInTransaction(db, OPENCLAW_STATE_SCHEMA_SQL, {
             databaseLabel: pathname,
           });


### PR DESCRIPTION
Closes #110237

## What Problem This Solves

Fixes an issue where users upgrading from `2026.7.2-beta.1` could have `openclaw doctor --fix` abort while migrating the shared state database to SQLite STRICT tables after a Gateway restart handoff recorded fractional trace timestamps.

## Why This Change Was Made

Restart-trace timestamps are now canonicalized to integer milliseconds at the restart-handoff persistence boundary. During the existing schema-v2-to-v3 transition, doctor prunes expired transient handoffs and converts only known REAL trace cells on live handoffs before the generic STRICT-table rebuild.

The generic STRICT migrator remains lossless and table-agnostic. The repair is owned by the restart-handoff/state-schema boundary, and the SQLite schema version is unchanged.

## User Impact

Affected upgrades can complete without manual SQLite repair. Expired restart handoffs are discarded as transient state, while valid live handoffs are preserved with canonical integer timing values. Future packaged Gateways write integral timestamps directly into the STRICT table.

## Evidence

- [Path-scoped `pnpm check:changed`](https://crabbox.openclaw.ai/portal/runs/run_0ab0df500d04) passed against the exact `47afe8f` base, including formatting, core/core-test typechecks, focused lint, import-cycle checks, and SQLite/storage guards.
- Fresh Codex autoreview: no findings; patch correct at 0.90 confidence.
- [Direct AWS Crabbox package-upgrade proof](https://crabbox.openclaw.ai/portal/runs/run_5f23a0df5622) (`provider=aws`, lease `cbx_736420105e5a`, run `run_5f23a0df5622`):
  - verified the synced changed-file digest and built the candidate with head provenance `1c5846a`;
  - exact packaged beta.1 (`a911e58`) ran a real Gateway, reached `/readyz`, and exited through its supervised SIGUSR1 restart path, which persisted live REAL restart-trace cells in the schema-v2 non-STRICT table;
  - exact packaged beta.2 (`54d98a4`) reproduced the REAL-to-INTEGER STRICT migration failure and atomic rollback to schema version 2; the diagnostic copy removed only the unrelated shipped `operator_approvals` blocker before doctor and did not alter the handoff row;
  - an untouched copy of the beta.1 state was upgraded to the packed candidate with zero SQL writes before doctor; doctor succeeded, reached `user_version=5` and schema metadata version 5, made `gateway_restart_handoff` STRICT, retained the live handoff with floored INTEGER trace values, passed `integrity_check`, and had zero foreign-key violations;
  - a second candidate doctor run succeeded, proving migration idempotence;
  - the packaged candidate exercised the same supervised restart path and wrote a new handoff whose trace cells were INTEGER in the STRICT table;
  - the candidate reached `/readyz` after an in-process restart, and CLI/Gateway/RPC all reported `2026.7.2`;
  - the owned AWS lease was released after the run.

AI-assisted with Codex. The implementation, migration policy, regression coverage, and package-level upgrade evidence were reviewed by the author.
