### PR TITLE
fix(ci): pin v6.11 iOS formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2307,7 +2307,32 @@ jobs:
           install-bun: "false"
 
       - name: Install iOS Swift tooling
-        run: brew install xcodegen swiftlint swiftformat
+        run: |
+          set -euo pipefail
+          brew install xcodegen swiftlint
+          swiftformat_version="0.61.1"
+          swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
+          swiftformat_archive="$RUNNER_TEMP/swiftformat-$swiftformat_version.zip"
+          swift_tools_dir="$RUNNER_TEMP/openclaw-swift-tools"
+          curl --fail --location --silent --show-error \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-max-time 120 \
+            --output "$swiftformat_archive" \
+            "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip"
+          if [[ "$(shasum -a 256 "$swiftformat_archive" | awk '{print $1}')" != "$swiftformat_checksum" ]]; then
+            echo "SwiftFormat $swiftformat_version archive checksum mismatch" >&2
+            exit 1
+          fi
+          mkdir -p "$swift_tools_dir"
+          unzip -q "$swiftformat_archive" -d "$swift_tools_dir"
+          chmod +x "$swift_tools_dir/swiftformat"
+          echo "$swift_tools_dir" >> "$GITHUB_PATH"
+          [[ "$("$swift_tools_dir/swiftformat" --version)" == "$swiftformat_version" ]]
+          # The generated Xcode phase prepends Homebrew ahead of GITHUB_PATH.
+          # Point that lookup at the verified formatter or the build can bypass the pin.
+          swiftformat_link="$(brew --prefix)/bin/swiftformat"
+          ln -sfn "$swift_tools_dir/swiftformat" "$swiftformat_link"
+          [[ "$("$swiftformat_link" --version)" == "$swiftformat_version" ]]
 
       - name: Build iOS app
         run: pnpm ios:build

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -444,20 +444,29 @@ describe("ci workflow guards", () => {
     }
   });
 
-  it("pins the v6.11 SwiftFormat contract for macOS CI", () => {
+  it("pins the v6.11 SwiftFormat contract for Apple CI", () => {
     const workflow = readCiWorkflow();
-    const install = workflow.jobs["macos-swift"].steps.find(
-      (step) => step.name === "Install XcodeGen / SwiftLint / SwiftFormat",
-    );
+    const installSteps = [
+      workflow.jobs["macos-swift"].steps.find(
+        (step) => step.name === "Install XcodeGen / SwiftLint / SwiftFormat",
+      ),
+      workflow.jobs["ios-build"].steps.find((step) => step.name === "Install iOS Swift tooling"),
+    ];
 
-    expect(install.run).toContain('swiftformat_version="0.61.1"');
-    expect(install.run).toContain(
-      'swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"',
+    for (const install of installSteps) {
+      expect(install.run).toContain('swiftformat_version="0.61.1"');
+      expect(install.run).toContain(
+        'swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"',
+      );
+      expect(install.run).toContain(
+        "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip",
+      );
+      expect(install.run).not.toContain("brew install xcodegen swiftlint swiftformat");
+    }
+    expect(installSteps[1].run).toContain('swiftformat_link="$(brew --prefix)/bin/swiftformat"');
+    expect(installSteps[1].run).toContain(
+      'ln -sfn "$swift_tools_dir/swiftformat" "$swiftformat_link"',
     );
-    expect(install.run).toContain(
-      "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip",
-    );
-    expect(install.run).not.toContain("brew install xcodegen swiftlint swiftformat");
   });
 
   it("bounds the Windows Crabbox hydrate main fetch", () => {


### PR DESCRIPTION
## What Problem This Solves

Canonical Full Release Validation run `29619930698` failed in CI child `29619948239`, iOS job `88012875723`. The candidate-owned workflow installed moving Homebrew SwiftFormat 0.62.1, and the generated Xcode lint phase rejected 54 unchanged v6.11 Swift files under newer formatting rules.

## Why This Change Was Made

This is the bounded iOS adaptation of upstream #105242 / `265ca345a1ea60a782e3e30e4b0436fda7a9a679`.

- install checksum-verified SwiftFormat 0.61.1, the v6.11 source contract;
- keep bounded download/retry behavior;
- point the generated Xcode phase's Homebrew-first lookup at the verified binary;
- extend the existing workflow guard to cover both macOS and iOS jobs.

Native sources are intentionally unchanged. Main already contains the generic upstream fix.

## User Impact

None at runtime. This changes only frozen release validation tooling. It does not alter product code, native artifacts, package versions, npm inventory, publication permissions, or release scope. The 2026.6.33 release remains npm-only.

## Evidence

- `actionlint .github/workflows/ci.yml`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 32/32 passed
- `node_modules/.bin/oxfmt --check test/scripts/ci-workflow-guards.test.ts`
- `git diff --check`
- Failure: https://github.com/openclaw/openclaw/actions/runs/29619948239/job/88012875723
- Upstream owner fix: https://github.com/openclaw/openclaw/pull/105242

After merge, npm preflight and all-groups Full Release Validation will be rerun from the new exact `extended-stable/2026.6.33` head. No tag or publication has occurred.
