### PR TITLE
fix(llama-cpp): prevent local GGUF asset path failures

### DIFF
--- a/extensions/llama-cpp/src/node-llama.runtime.ts
+++ b/extensions/llama-cpp/src/node-llama.runtime.ts
@@ -42,5 +42,7 @@ export function resolveNodeLlamaCppImportUrl(): string {
 }
 
 export async function importNodeLlamaCpp(): Promise<NodeLlamaCppModule> {
-  return await import("node-llama-cpp");
+  // Keep this runtime-resolved: bundling node-llama-cpp rewrites its import.meta.url,
+  // which makes its package-relative native assets resolve from the OpenClaw bundle.
+  return await import(resolveNodeLlamaCppImportUrl());
 }


### PR DESCRIPTION
Refs #110077

## Summary

Keep `node-llama-cpp` external to OpenClaw's bundled plugin output by importing the package URL resolved from the llama-cpp plugin runtime. This preserves the dependency's package-relative native assets.

AI-assisted: yes. The implementation, dependency contract, generated bundle, and focused proof were reviewed before submission.

## What Problem This Solves

Fixes an issue where users running the in-process `llama-cpp` provider from a 2026.7.2 source build could receive `Local llama.cpp is unavailable` because `binariesGithubRelease.json` was looked up under the OpenClaw checkout instead of the installed `node-llama-cpp` package.

## Root Cause

`node-llama-cpp@3.19.0` computes all of its package asset paths from its own module URL. In the installed dependency, `node_modules/node-llama-cpp/dist/config.js:8-10` derives `llamaDirectory` from `fileURLToPath(import.meta.url)`, and line 27 derives `binariesGithubReleasePath` from that directory.

The llama-cpp plugin already had a `createRequire(import.meta.url)` resolver, but `importNodeLlamaCpp()` did not use it. Its literal `import("node-llama-cpp")` let tsdown follow the dependency and emit it as an OpenClaw chunk. Inside that chunk, `import.meta.url` identified the OpenClaw bundle, reproducing the reporter's checkout-relative asset path.

Provenance: clearly introduced by #109444 in `658b601ee584d42679b3b470a549f8a9601da113` on 2026-07-17. The blamed code author, PR author, and PR merger were all @steipete.

## Why This Change Was Made

The runtime boundary now imports `resolveNodeLlamaCppImportUrl()`. That keeps the value import lazy and runtime-resolved without adding a fallback or configuration surface. Existing type-only imports remain type-only, and embeddings continue using their existing resolved-URL path through memory-host.

## User Impact

Local GGUF inference can load `node-llama-cpp` from its installed package, so native binaries, release metadata, grammars, templates, and related assets remain relative to that package instead of the OpenClaw bundle.

## Evidence

### Import-edge classification

| Surface | Edge | Classification | Result |
| --- | --- | --- | --- |
| `extensions/llama-cpp/src/inference-provider.ts:2-9` | `import type { ... } from "node-llama-cpp"` | Type-only | Kept; erased before bundling |
| `extensions/llama-cpp/src/node-llama.runtime.ts:4` | `typeof import("node-llama-cpp")` | Type-only query | Kept; erased before bundling |
| `extensions/llama-cpp/src/node-llama.runtime.ts:44-48` | Runtime value import | Lazy boundary | Fixed to import the `createRequire`-resolved file URL |
| `extensions/llama-cpp/src/embedding-provider.ts:155-163` | Passes `resolveNodeLlamaCppImportUrl()` to memory-host | Runtime value import | Already safe |
| `packages/memory-host-sdk/src/host/node-llama.ts:76-80` | `import(moduleSpecifier)` | Computed lazy import | Already safe; bundler cannot follow the package literal |
| `extensions/llama-cpp/src/defaults.ts` | No dependency import | Static defaults only | Unaffected |
| `extensions/llama-cpp/src/setup.ts` | Imports the local runtime helper | Lazy boundary consumer | Fixed through the shared boundary |
| `extensions/memory-core` | No dependency import | Error-text detection only | Unaffected |

Repo scan:

```text
$ rg "node-llama-cpp" src packages extensions --glob '!*.test.ts'
# Direct production import sites reduce to the two type-only edges above, the llama-cpp runtime boundary, and memory-host's computed lazy import.
```

### Before: unchanged build at `9dedacf5779`

```text
$ pnpm build
[tsdown-build] invocation 1/1 finished in 70.0s
[build-all] phase timings: total 1m 33.5s; slowest tsdown-unified 1m 10.3s

$ rg -l "binariesGithubRelease" dist --glob '!*.map'
dist/dist-BEHAJMl3.js

$ wc -c dist/dist-BEHAJMl3.js
1686602 dist/dist-BEHAJMl3.js

$ sed -n '111,117p' dist/extensions/llama-cpp/index.js
const requireFromPlugin = createRequire(import.meta.url);
function resolveNodeLlamaCppImportUrl() {
  return pathToFileURL(requireFromPlugin.resolve("node-llama-cpp")).href;
}
async function importNodeLlamaCpp() {
  return await import("../../dist-BEHAJMl3.js");
}
```

The 1.69 MB emitted chunk contained `node_modules/node-llama-cpp/dist/config.js`, including the package asset marker. The build also emitted eight `[UNRESOLVED_IMPORT]` warnings from bundled `node-llama-cpp` optional platform binaries.

### After

```text
$ pnpm build
CLI bootstrap import guard passed.
OK: All 4 required plugin-sdk exports verified.
[build-all] phase timings: total 1m 33.2s; slowest tsdown-unified 1m 27.7s

$ rg -l "binariesGithubRelease" dist --glob '!*.map'
# no output (exit 1)

$ rg -n "INEFFECTIVE_DYNAMIC_IMPORT|UNRESOLVED_IMPORT|node_modules/node-llama-cpp" /tmp/openclaw-110077-after-build.log
# no output (exit 1)

$ sed -n '111,117p' dist/extensions/llama-cpp/index.js
const requireFromPlugin = createRequire(import.meta.url);
function resolveNodeLlamaCppImportUrl() {
  return pathToFileURL(requireFromPlugin.resolve("node-llama-cpp")).href;
}
async function importNodeLlamaCpp() {
  return await import(resolveNodeLlamaCppImportUrl());
}
```

## Real behavior proof

The built plugin was imported, registered, and its guided setup detection path was executed with Node ESM resolution tracing. The exact after-patch result was:

```text
Translating StandardModule file:///<worktree>/node_modules/node-llama-cpp/dist/index.js
responseURL: 'file:///<worktree>/node_modules/node-llama-cpp/dist/index.js'
{"detected":null}
```

This is the closest feasible Linux proof without downloading a multi-gigabyte GGUF: the built provider initializes and the dependency resolves from installed `node_modules`, not an OpenClaw `dist-*.js` chunk.

## Verification

```text
$ node scripts/run-vitest.mjs extensions/llama-cpp
Test Files  3 passed (3)
Tests       35 passed (35)

$ pnpm format extensions/llama-cpp/src/node-llama.runtime.ts
Finished in 4ms on 1 files using 1 threads.

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/llama-cpp/src/node-llama.runtime.ts
# passed (exit 0)

$ git diff --check
# passed (no output)

$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.92)
```

## What Was Not Tested

- No real GGUF generation was run on macOS/Metal; the focused provider tests and built Linux initialization path were used instead.
- `@openclaw/llama-cpp-provider@2026.7.2` is not published (`npm view` returned 404), so that exact registry artifact could not be packed. The closest published `2026.7.2-beta.2` artifact predates the chat-provider edge and did not contain the marker.
