### PR TITLE
fix(memory-wiki): reject malformed ChatGPT timestamps

### DIFF
--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -210,7 +210,7 @@ function isoFromUnix(raw: unknown): string | undefined {
   const numeric =
     typeof raw === "number"
       ? raw
-      : /^(?:0|[1-9]\d*)(?:\.\d+)?(?![\s\S])/.test(raw)
+      : /^[+-]?(?:0|[1-9]\d*)(?:\.\d+)?(?![\s\S])/.test(raw)
         ? Number(raw)
         : undefined;
   if (numeric === undefined || !Number.isFinite(numeric)) {

--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -207,8 +207,13 @@ function isoFromUnix(raw: unknown): string | undefined {
   if (typeof raw !== "number" && typeof raw !== "string") {
     return undefined;
   }
-  const numeric = Number(raw);
-  if (!Number.isFinite(numeric)) {
+  const numeric =
+    typeof raw === "number"
+      ? raw
+      : /^(?:0|[1-9]\d*)(?:\.\d+)?(?![\s\S])/.test(raw)
+        ? Number(raw)
+        : undefined;
+  if (numeric === undefined || !Number.isFinite(numeric)) {
     return undefined;
   }
   return timestampMsToIsoString(numeric * 1000);

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -790,7 +790,9 @@ cli note
     const conversations = JSON.parse(await fs.readFile(conversationsPath, "utf8")) as Array<
       Record<string, unknown>
     >;
-    expectDefined(conversations[0], "first ChatGPT conversation").update_time = 9_000_000_000_000;
+    const conversation = expectDefined(conversations[0], "first ChatGPT conversation");
+    conversation.create_time = -1;
+    conversation.update_time = 9_000_000_000_000;
     await fs.writeFile(conversationsPath, `${JSON.stringify(conversations, null, 2)}\n`, "utf8");
 
     const result = JSON.parse(

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -809,8 +809,8 @@ cli note
     );
     expect(sourceFile).toBeDefined();
     const pageContent = await fs.readFile(path.join(rootDir, "sources", sourceFile ?? ""), "utf8");
-    expect(pageContent).toContain("- Created: 2024-04-06T00:26:40.000Z");
-    expect(pageContent).toContain("- Updated: 2024-04-06T00:26:40.000Z");
+    expect(pageContent).toContain("- Created: 1969-12-31T23:59:59.000Z");
+    expect(pageContent).toContain("- Updated: 1969-12-31T23:59:59.000Z");
   });
 
   it("rejects malformed ChatGPT Unix timestamp strings", async () => {

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -812,4 +812,67 @@ cli note
     expect(pageContent).toContain("- Created: 2024-04-06T00:26:40.000Z");
     expect(pageContent).toContain("- Updated: 2024-04-06T00:26:40.000Z");
   });
+
+  it("rejects malformed ChatGPT Unix timestamp strings", async () => {
+    const { rootDir, config } = await createCliVault({ initialize: true });
+    const exportDir = await createChatGptExport(rootDir);
+    const conversationsPath = path.join(exportDir, "conversations.json");
+    const conversations = JSON.parse(await fs.readFile(conversationsPath, "utf8")) as Array<
+      Record<string, unknown>
+    >;
+    const conversation = expectDefined(conversations[0], "first ChatGPT conversation");
+    conversation.create_time = "1712363200";
+    conversation.update_time = "1.7123668e9";
+    await fs.writeFile(conversationsPath, `${JSON.stringify(conversations, null, 2)}\n`, "utf8");
+
+    const result = JSON.parse(
+      await runRegisteredWikiCommand(config, [
+        "chatgpt",
+        "import",
+        "--export",
+        exportDir,
+        "--json",
+      ]),
+    ) as { createdCount: number };
+
+    expect(result.createdCount).toBe(1);
+    const sourceFile = (await fs.readdir(path.join(rootDir, "sources"))).find(
+      (entry) => entry !== "index.md",
+    );
+    expect(sourceFile).toBeDefined();
+    const pageContent = await fs.readFile(path.join(rootDir, "sources", sourceFile ?? ""), "utf8");
+    expect(pageContent).toContain("- Created: 2024-04-06T00:26:40.000Z");
+    expect(pageContent).toContain("- Updated: 2024-04-06T00:26:40.000Z");
+  });
+
+  it("rejects ChatGPT timestamp strings with trailing line terminators", async () => {
+    const { rootDir, config } = await createCliVault({ initialize: true });
+    const exportDir = await createChatGptExport(rootDir);
+    const conversationsPath = path.join(exportDir, "conversations.json");
+    const conversations = JSON.parse(await fs.readFile(conversationsPath, "utf8")) as Array<
+      Record<string, unknown>
+    >;
+    const conversation = expectDefined(conversations[0], "first ChatGPT conversation");
+    conversation.update_time = "1712366800\n";
+    await fs.writeFile(conversationsPath, `${JSON.stringify(conversations, null, 2)}\n`, "utf8");
+
+    const result = JSON.parse(
+      await runRegisteredWikiCommand(config, [
+        "chatgpt",
+        "import",
+        "--export",
+        exportDir,
+        "--json",
+      ]),
+    ) as { createdCount: number };
+
+    expect(result.createdCount).toBe(1);
+    const sourceFile = (await fs.readdir(path.join(rootDir, "sources"))).find(
+      (entry) => entry !== "index.md",
+    );
+    expect(sourceFile).toBeDefined();
+    const pageContent = await fs.readFile(path.join(rootDir, "sources", sourceFile ?? ""), "utf8");
+    expect(pageContent).toContain("- Created: 2024-04-06T00:26:40.000Z");
+    expect(pageContent).toContain("- Updated: 2024-04-06T00:26:40.000Z");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ChatGPT imports could silently accept malformed Unix timestamp strings and stamp memory-wiki pages with incorrect dates.

## Why This Change Was Made

`isoFromUnix` now only parses canonical numbers or decimal-string timestamps and rejects malformed strings before converting to ISO dates. The regression coverage exercises valid numeric/decimal inputs and malformed inputs with trailing characters so the importer stays strict.

## User Impact

Users importing ChatGPT exports get correct created/updated dates from valid timestamps and a clear rejection path for malformed timestamp fields instead of silent corruption.

## Evidence

Current head: `cd9fea68f3159de7b50cf34f63b809e6db262bad`.

- Regression coverage in `extensions/memory-wiki/src/cli.test.ts` now covers valid numeric timestamps, decimal-string timestamps, and malformed timestamp strings with trailing line terminators.
- The importer change in `extensions/memory-wiki/src/chatgpt-import.ts` rejects malformed string timestamps before converting them to ISO dates.