### PR TITLE
fix(anthropic): reject malformed usage numbers

### DIFF
--- a/extensions/anthropic/usage-number.test.ts
+++ b/extensions/anthropic/usage-number.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { finiteNumber } from "./usage.js";
+
+describe("Anthropic usage number parsing", () => {
+  it("accepts canonical decimal numbers", () => {
+    expect(finiteNumber(12.5)).toBe(12.5);
+    expect(finiteNumber("12.5")).toBe(12.5);
+    expect(finiteNumber("0")).toBe(0);
+  });
+
+  it("rejects malformed decimal strings", () => {
+    expect(finiteNumber("1e1")).toBeUndefined();
+    expect(finiteNumber("0x10")).toBeUndefined();
+    expect(finiteNumber("12.5\n")).toBeUndefined();
+    expect(finiteNumber(" 12.5 ")).toBeUndefined();
+  });
+});

--- a/extensions/anthropic/usage-number.test.ts
+++ b/extensions/anthropic/usage-number.test.ts
@@ -1,17 +1,114 @@
 import { describe, expect, it } from "vitest";
-import { finiteNumber } from "./usage.js";
+import { fetchAnthropicUsage } from "./usage.js";
 
 describe("Anthropic usage number parsing", () => {
-  it("accepts canonical decimal numbers", () => {
-    expect(finiteNumber(12.5)).toBe(12.5);
-    expect(finiteNumber("12.5")).toBe(12.5);
-    expect(finiteNumber("0")).toBe(0);
+  it.each([
+    [12.5, 0.125],
+    ["12.5", 0.125],
+    ["0", 0],
+  ])("accepts canonical decimal amounts %p", async (amount, expected) => {
+    const snapshot = await fetchAnthropicUsage({
+      config: {},
+      env: {},
+      provider: "anthropic",
+      token: adminToken("sk-ant-admin-test"),
+      timeoutMs: 5_000,
+      fetchFn: buildAdminUsageFetch(amount),
+    });
+
+    expect(snapshot.billing).toEqual([
+      {
+        type: "spend",
+        label: "30-day API spend",
+        amount: expected,
+        unit: "USD",
+        period: "30d",
+      },
+    ]);
+    expect(snapshot.costHistory).toMatchObject({
+      daily: [{ amount: expected }],
+      categories: [{ name: "Claude API", amount: expected }],
+    });
   });
 
-  it("rejects malformed decimal strings", () => {
-    expect(finiteNumber("1e1")).toBeUndefined();
-    expect(finiteNumber("0x10")).toBeUndefined();
-    expect(finiteNumber("12.5\n")).toBeUndefined();
-    expect(finiteNumber(" 12.5 ")).toBeUndefined();
-  });
+  it.each(["1e1", "0x10", "12.5\n", " 12.5 "])(
+    "rejects malformed decimal strings %p",
+    async (amount) => {
+      const snapshot = await fetchAnthropicUsage({
+        config: {},
+        env: {},
+        provider: "anthropic",
+        token: adminToken("sk-ant-admin-test"),
+        timeoutMs: 5_000,
+        fetchFn: buildAdminUsageFetch(amount),
+      });
+
+      expect(snapshot.billing).toEqual([
+        {
+          type: "spend",
+          label: "30-day API spend",
+          amount: 0,
+          unit: "USD",
+          period: "30d",
+        },
+      ]);
+      expect(snapshot.costHistory).toMatchObject({
+        daily: [{ amount: 0 }],
+        categories: [{ name: "Claude API", amount: 0 }],
+      });
+    },
+  );
 });
+
+function adminToken(token: string): string {
+  return `openclaw:anthropic-admin:v1:${JSON.stringify({ token })}`;
+}
+
+function buildAdminUsageFetch(amount: unknown) {
+  return async (input: string | URL | Request) => {
+    const url = requestUrl(input);
+    if (url.pathname.endsWith("/organizations/cost_report")) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              starting_at: "2026-07-06T00:00:00Z",
+              ending_at: "2026-07-07T00:00:00Z",
+              results: [{ amount, currency: "USD", description: "Claude API" }],
+            },
+          ],
+          has_more: false,
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        data: [
+          {
+            starting_at: "2026-07-06T00:00:00Z",
+            ending_at: "2026-07-07T00:00:00Z",
+            results: [
+              {
+                uncached_input_tokens: 1_000,
+                cache_creation: {
+                  ephemeral_1h_input_tokens: 100,
+                  ephemeral_5m_input_tokens: 50,
+                },
+                cache_read_input_tokens: 300,
+                output_tokens: 250,
+                model: "claude-opus-4-8",
+              },
+            ],
+          },
+        ],
+        has_more: false,
+      }),
+      { status: 200 },
+    );
+  };
+}
+
+function requestUrl(input: string | URL | Request): URL {
+  return new URL(input instanceof Request ? input.url : input);
+}

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -24,6 +24,7 @@ const ANTHROPIC_ADMIN_TOKEN_PREFIX = "openclaw:anthropic-admin:v1:";
 const ANTHROPIC_USAGE_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 const ANTHROPIC_USAGE_HISTORY_DAYS = 30;
 const MAX_PAGES = 100;
+const DECIMAL_NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/;
 
 type AnthropicUsagePage = {
   data: unknown[];
@@ -82,11 +83,13 @@ function objectRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-function finiteNumber(value: unknown): number | undefined {
+export function finiteNumber(value: unknown): number | undefined {
+  const decimalMatch =
+    typeof value === "string" ? DECIMAL_NUMBER_PATTERN.exec(value)?.[0] : undefined;
   const parsed =
     typeof value === "number"
       ? value
-      : typeof value === "string" && value.trim()
+      : decimalMatch === value
         ? Number(value)
         : Number.NaN;
   return Number.isFinite(parsed) ? parsed : undefined;

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -83,7 +83,7 @@ function objectRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-export function finiteNumber(value: unknown): number | undefined {
+function finiteNumber(value: unknown): number | undefined {
   const decimalMatch =
     typeof value === "string" ? DECIMAL_NUMBER_PATTERN.exec(value)?.[0] : undefined;
   const parsed =

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -87,11 +87,7 @@ function finiteNumber(value: unknown): number | undefined {
   const decimalMatch =
     typeof value === "string" ? DECIMAL_NUMBER_PATTERN.exec(value)?.[0] : undefined;
   const parsed =
-    typeof value === "number"
-      ? value
-      : decimalMatch === value
-        ? Number(value)
-        : Number.NaN;
+    typeof value === "number" ? value : decimalMatch === value ? Number(value) : Number.NaN;
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where Anthropic usage values could accept malformed numeric forms like scientific notation or hex strings instead of canonical decimal values.

## Why This Change Was Made
The parser now accepts finite numbers and canonical decimal strings only, so usage data stays exact and predictable at the boundary that feeds Anthropic usage reporting.

## User Impact
Malformed usage inputs are rejected earlier, while normal decimal usage values continue to work.

## Evidence
- Current head: `18744e0c1f6fe5c2dab07298f824dce9ec41e8b5`
- Runtime proof: `node --import tsx --input-type=module` script on the refreshed head returned `0.125` for `12.5` and `"12.5"`, and `0` for `1e1`, `0x10`, `"12.5\n"`, and `" 12.5 "`.
- Focused test: `pnpm test extensions/anthropic/usage-number.test.ts` passed (`1` Vitest shard, `7` tests).