### PR TITLE
fix(sessions): honor configured entry caps on writes

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1561,6 +1561,61 @@ describe("sqlite session normalization", () => {
     ).toEqual(["agent:main:newer", "agent:main:newest"]);
   });
 
+  it("preserves an active SQLite cron entry when durable entries exceed maxEntries", async () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          maxEntries: 1,
+        },
+      },
+    });
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scopeFor = (sessionKey: string) => ({
+      agentId: "main",
+      env,
+      sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    const cronKey = "agent:main:cron:job-1";
+    const cronEntry = {
+      lifecycleRevision: "cron-revision-1",
+      sessionId: "cron-session",
+      updatedAt: Date.now(),
+    };
+
+    for (const [sessionKey, sessionId] of [
+      ["agent:main:slack:channel:C1", "channel-session-1"],
+      ["agent:main:slack:channel:C2", "channel-session-2"],
+    ] as const) {
+      await patchSqliteSessionEntry(
+        scopeFor(sessionKey),
+        () => ({ sessionId, updatedAt: Date.now() - 1 }),
+        {
+          fallbackEntry: { sessionId, updatedAt: Date.now() - 1 },
+          replaceEntry: true,
+          skipMaintenance: true,
+        },
+      );
+    }
+
+    await patchSqliteSessionEntry(scopeFor(cronKey), () => cronEntry, {
+      fallbackEntry: cronEntry,
+      replaceEntry: true,
+    });
+    await patchSqliteSessionEntry(scopeFor(cronKey), () => ({
+      model: "gpt-5.5",
+      updatedAt: Date.now() + 1,
+    }));
+
+    expect(loadSqliteSessionEntry(scopeFor(cronKey))).toMatchObject({
+      lifecycleRevision: "cron-revision-1",
+      model: "gpt-5.5",
+      sessionId: "cron-session",
+    });
+  });
+
   it("evicts old SQLite transcript rows only when no remaining entry references them", async () => {
     vi.mocked(getRuntimeConfig).mockReturnValue({
       session: {

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -531,14 +531,13 @@ function wouldCapActiveSession(params: {
  */
 export function capEntryCount(
   store: Record<string, SessionEntry>,
-  overrideMax?: number,
+  maxEntries: number,
   opts: {
     log?: boolean;
     onCapped?: (params: { key: string; entry: SessionEntry }) => void;
     preserveKeys?: ReadonlySet<string>;
   } = {},
 ): number {
-  const maxEntries = overrideMax ?? resolveMaintenanceConfigFromInput().maxEntries;
   const preservedCount = Object.entries(store).filter(([key, entry]) =>
     shouldPreserveMaintenanceEntry({ key, entry, preserveKeys: opts.preserveKeys }),
   ).length;

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -1483,6 +1483,37 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(loaded).toHaveProperty("session-50");
   });
 
+  it("updateSessionStore honors configured maxEntries without an explicit override", async () => {
+    const now = Date.now();
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        oldest: makeEntry(now - 2),
+        recent: makeEntry(now - 1),
+      }),
+      "utf-8",
+    );
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          maxEntries: 2,
+        },
+      },
+    });
+
+    await updateSessionStore(storePath, (store) => {
+      store.newest = makeEntry(now);
+    });
+
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(loaded)).toHaveLength(2);
+    expect(loaded).toHaveProperty("newest");
+    expect(loaded).toHaveProperty("recent");
+    expect(loaded.oldest).toBeUndefined();
+  });
+
   it("loadSessionStore honors configured maxEntries without an explicit override", async () => {
     mockLoadConfig.mockReturnValue({
       session: {


### PR DESCRIPTION
Closes #109191
Related: #108344

AI-assisted implementation; I reviewed the resulting code and validation.

## What Problem This Solves

Fixes an issue where session-store writes could silently apply the built-in 500-entry cap instead of the operator's configured `session.maintenance.maxEntries`.

It also locks down the current SQLite cron behavior so an active in-flight cron session is not evicted when durable channel entries already exceed the configured cap.

## Why This Change Was Made

The cap helper now requires its caller to provide the already-resolved maximum. This removes a silent fallback that could never observe runtime configuration, while preserving the existing maintenance owner boundary where file and SQLite write paths resolve the full policy.

Current production callers already provide that resolved value. The added regressions exercise the actual file-write and SQLite-write paths rather than calling the cap helper directly.

## User Impact

Configured session-entry limits are applied consistently during writes. Active cron lifecycle state remains available across consecutive persistence operations even when protected entries fill the cap, avoiding `CronSessionLifecycleClaimError` from maintenance eviction.

## Evidence

- `node scripts/run-vitest.mjs src/config/sessions/store.pruning.test.ts src/config/sessions/store.pruning.integration.test.ts src/config/sessions/session-accessor.conformance.test.ts`
  - 3 test files passed
  - 128 tests passed
- `oxfmt --check` passed for all three changed files.
- `oxlint` passed for all three changed files.
- `git diff HEAD^ --check` passed.
- Autoreview completed with no accepted or actionable findings.

The broader changed-files gate reached an unrelated current-main max-lines baseline failure for `src/config/schema.help.ts`; the focused session tests and static checks above are green.
