### PR TITLE
fix(release): carry the Z.AI API Platform waiver

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -592,7 +592,6 @@ jobs:
               add_profile_suite native-live-src-gateway-profiles-opencode-go-smoke "stable"
               add_profile_suite native-live-src-gateway-profiles-openrouter "full"
               add_profile_suite native-live-src-gateway-profiles-xai "full"
-              add_profile_suite native-live-src-gateway-profiles-zai "full"
               add_profile_suite native-live-src-gateway-backends "stable full"
               add_profile_suite native-live-src-infra "stable full"
               add_profile_suite native-live-test "stable full"
@@ -609,7 +608,7 @@ jobs:
               add_profile_suite live-gateway-advisory-docker "full"
               add_profile_suite live-gateway-advisory-docker-deepseek-fireworks "full"
               add_profile_suite live-gateway-advisory-docker-opencode-openrouter "full"
-              add_profile_suite live-gateway-advisory-docker-xai-zai "full"
+              add_profile_suite live-gateway-advisory-docker-xai "full"
               add_profile_suite live-cli-backend-docker "stable full"
               add_profile_suite live-acp-bind-docker "stable full"
               add_profile_suite live-codex-harness-docker "stable full"
@@ -667,6 +666,17 @@ jobs:
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           RELEASE_TEST_PROFILE: ${{ inputs.release_test_profile }}
         run: node scripts/plan-release-workflow-matrix.mjs >> "$GITHUB_OUTPUT"
+
+      - name: Record temporary Z.AI API Platform omission
+        if: inputs.include_live_suites
+        shell: bash
+        run: |
+          {
+            echo
+            echo "### Temporary provider omission"
+            echo
+            echo "Z.AI API Platform validation is temporarily disabled while its CI account is unavailable. Z.AI Coding Plan validation remains enabled."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   validate_release_live_cache:
     needs: validate_selected_ref
@@ -2692,7 +2702,9 @@ jobs:
         include:
           - suite_id: native-live-src-agents
             label: Native live agents
-            command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
+            # Keep the dedicated Coding Plan suite below while temporarily omitting
+            # API Platform calls from the broad agents shard.
+            command: ZAI_API_KEY= Z_AI_API_KEY= node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
             timeout_minutes: 60
             profile_env_only: false
             profiles: stable full
@@ -2811,13 +2823,6 @@ jobs:
           - suite_id: native-live-src-gateway-profiles-xai
             label: Native live gateway profiles xAI
             command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
-            timeout_minutes: 30
-            profile_env_only: false
-            advisory: true
-            profiles: full
-          - suite_id: native-live-src-gateway-profiles-zai
-            label: Native live gateway profiles Z.ai
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=zai node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
             timeout_minutes: 30
             profile_env_only: false
             advisory: true
@@ -3064,10 +3069,10 @@ jobs:
             profile_env_only: false
             advisory: true
             profiles: full
-          - suite_id: live-gateway-advisory-docker-xai-zai
+          - suite_id: live-gateway-advisory-docker-xai
             suite_group: live-gateway-advisory-docker
-            label: Docker live gateway advisory xAI/Z.ai
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai,zai OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
+            label: Docker live gateway advisory xAI
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
             timeout_minutes: 40
             profile_env_only: false
             advisory: true

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2702,9 +2702,7 @@ jobs:
         include:
           - suite_id: native-live-src-agents
             label: Native live agents
-            # Keep the dedicated Coding Plan suite below while temporarily omitting
-            # API Platform calls from the broad agents shard.
-            command: ZAI_API_KEY= Z_AI_API_KEY= node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
+            command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
             timeout_minutes: 60
             profile_env_only: false
             profiles: stable full

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -130,11 +130,6 @@ const LIVE_MODEL_PROVIDERS = [
     profiles: "full",
   },
   {
-    provider_label: "Z.ai",
-    providers: "zai",
-    profiles: "full",
-  },
-  {
     provider_label: "Fireworks",
     providers: "fireworks",
     profiles: "full",

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -33,6 +33,7 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["test/image-generation.infer-cli.live.test.ts", ["OPENCLAW_LIVE_INFER_CLI_TEST"]],
 ]);
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);
+const ZAI_LIVE_TEST_FILE = "src/agents/zai.live.test.ts";
 
 /** Live-test shards included in release validation. */
 export const RELEASE_LIVE_TEST_SHARDS = Object.freeze([
@@ -246,9 +247,13 @@ function isMoonshotLiveTest(file) {
 export function selectLiveShardFiles(shard, files = collectAllLiveTestFiles()) {
   switch (shard) {
     case "native-live-src-agents":
-      return files.filter((file) => file.startsWith("src/agents/") || file.startsWith("src/llm/"));
+      return files.filter(
+        (file) =>
+          file !== ZAI_LIVE_TEST_FILE &&
+          (file.startsWith("src/agents/") || file.startsWith("src/llm/")),
+      );
     case "native-live-src-agents-zai-coding":
-      return files.filter((file) => file === "src/agents/zai.live.test.ts");
+      return files.filter((file) => file === ZAI_LIVE_TEST_FILE);
     case "native-live-src-gateway":
       return files.filter(
         (file) => file.startsWith("src/gateway/") || file.startsWith("src/crestodian/"),

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1010,7 +1010,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("suite_id: native-live-src-agents");
     expect(workflow).toContain("Checkout trusted live shard harness");
     expect(workflow).toContain(
-      "command: ZAI_API_KEY= Z_AI_API_KEY= node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
+      "command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
     );
     expect(workflow).toContain("suite_id: native-live-src-agents-zai-coding");
     expect(workflow).toContain(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1010,7 +1010,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("suite_id: native-live-src-agents");
     expect(workflow).toContain("Checkout trusted live shard harness");
     expect(workflow).toContain(
-      "command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
+      "command: ZAI_API_KEY= Z_AI_API_KEY= node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
     );
     expect(workflow).toContain("suite_id: native-live-src-agents-zai-coding");
     expect(workflow).toContain(
@@ -1038,7 +1038,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain(
       'add_profile_suite live-gateway-advisory-docker-opencode-openrouter "full"',
     );
-    expect(workflow).toContain('add_profile_suite live-gateway-advisory-docker-xai-zai "full"');
+    expect(workflow).toContain('add_profile_suite live-gateway-advisory-docker-xai "full"');
     expect(workflow).toContain('add_profile_suite live-cli-backend-docker "stable full"');
     expect(workflow).toContain('add_profile_suite live-subagent-announce-docker "stable full"');
     expect(workflow).toContain(
@@ -1048,12 +1048,12 @@ describe("package artifact reuse", () => {
     expect(workflow).not.toContain("src/agents/openai-ws-stream.e2e.test.ts");
     expect(workflow).toContain("suite_id: live-gateway-advisory-docker-deepseek-fireworks");
     expect(workflow).toContain("suite_id: live-gateway-advisory-docker-opencode-openrouter");
-    expect(workflow).toContain("suite_id: live-gateway-advisory-docker-xai-zai");
+    expect(workflow).toContain("suite_id: live-gateway-advisory-docker-xai");
     expect(workflow).toContain("suite_id: live-subagent-announce-docker");
     expect(workflow).toContain("suite_group: live-gateway-advisory-docker");
     expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek,fireworks");
     expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=opencode-go,openrouter");
-    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai,zai");
+    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai");
     expect(workflow).toContain("inputs.live_suite_filter == 'live-gateway-advisory-docker'");
     expect(workflow).toContain("OPENCLAW_LIVE_CLI_BACKEND_MODEL=claude-cli/claude-sonnet-4-6");
     expect(workflow).toContain("OPENCLAW_LIVE_CLI_BACKEND_AUTH=api-key");
@@ -1115,7 +1115,8 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-opencode-go");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-openrouter");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-xai");
-    expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-zai");
+    expect(workflow).not.toContain("suite_id: native-live-src-gateway-profiles-zai");
+    expect(workflow).toContain("Z.AI API Platform validation is temporarily disabled");
     expect(workflow).not.toContain(
       "OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek,opencode-go,openrouter,xai,zai",
     );

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -86,7 +86,6 @@ const PROFILE_EXPECTATIONS = [
       "opencode-go",
       "openrouter",
       "xai",
-      "zai",
       "fireworks",
     ],
   },
@@ -172,7 +171,6 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       "opencode-go",
       "openrouter",
       "xai",
-      "zai",
       "fireworks",
     ]);
   });
@@ -202,7 +200,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     });
 
     expect(plan.liveModels.count).toBe(0);
-    expect(plan.liveModels.omitted).toHaveLength(10);
+    expect(plan.liveModels.omitted).toHaveLength(9);
     expect(plan.liveModels.omitted[0]?.reason).toBe(
       "Docker live model matrix disabled by input selection",
     );

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -47,10 +47,7 @@ describe("scripts/test-live-shard", () => {
 
     expect(allFiles.length).toBeGreaterThan(0);
     expect([...new Set(selectedFiles)].toSorted((a, b) => a.localeCompare(b))).toEqual(allFiles);
-    expect(duplicateFiles).toEqual([
-      "src/agents/zai.live.test.ts",
-      "extensions/music-generation-providers.live.test.ts",
-    ]);
+    expect(duplicateFiles).toEqual(["extensions/music-generation-providers.live.test.ts"]);
     expect(musicProviderFanout).toEqual([
       "native-live-extensions-media-music-google",
       "native-live-extensions-media-music-minimax",
@@ -86,6 +83,9 @@ describe("scripts/test-live-shard", () => {
   it("keeps slow gateway backend and media-capable extension files in their own shards", () => {
     expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
       "src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts",
+    );
+    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).not.toContain(
+      "src/agents/zai.live.test.ts",
     );
     expect(selectLiveShardFiles("native-live-src-agents-zai-coding", allFiles)).toEqual([
       "src/agents/zai.live.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Canonical Full Release Validation `29620608973` correctly used candidate-owned workflows, but Release Checks child `29620688377` still ran the known-broken Z.AI API Platform probes. Job `88015298867` reproduced the existing account outage: both global endpoint probes returned zero assistant content while 68 sibling live tests passed.

The maintainer-approved temporary waiver from #109246 and its shard companion #109272 had been merged only into `main` for the discarded temporary-harness design. Candidate-owned validation therefore needs the same release machinery frozen on `extended-stable/2026.6.33`.

## Why This Change Was Made

Two dependency-ordered commits:

1. Cherry-pick #109246 / `954c77d4ef9d4e0f587344032eda90f694149d16`:
   - omit Z.AI API Platform from the Docker model matrix;
   - omit the native Z.AI gateway profile;
   - keep the combined advisory lane as xAI-only;
   - record the temporary omission in workflow summaries.
2. Adapt only the Z.AI shard portion of #109272 / `c4b2183db66f0f8f8b60edaf09f9c33b2f349a03`:
   - exclude `src/agents/zai.live.test.ts` from the broad agents shard;
   - retain it exactly in the dedicated Z.AI Coding Plan shard.

No Android compatibility change is imported because the candidate-owned v6.11 CI does not need it.

## User Impact

No product behavior change. Z.AI API Platform validation remains temporarily waived while its CI account is unavailable; Z.AI Coding Plan validation remains required. No provider runtime, credential, native, package, version, npm inventory, or publication code changes. The release remains npm-only.

The waiver must be reverted after the replacement API Platform credential passes a real completion probe.

## Evidence

- `actionlint .github/workflows/openclaw-live-and-e2e-checks-reusable.yml`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/release-workflow-matrix-plan.test.ts test/scripts/test-live-shard.test.ts` — 78/78 passed
- `node_modules/.bin/oxfmt --check ...` — clean
- `git diff --check`
- direct shard proof: broad agents excludes `src/agents/zai.live.test.ts`; Coding Plan selects exactly that file
- failure: https://github.com/openclaw/openclaw/actions/runs/29620688377/job/88015298867
- source waiver: https://github.com/openclaw/openclaw/pull/109246
- source shard repair: https://github.com/openclaw/openclaw/pull/109272

After merge, npm preflight and all-groups Full Release Validation will run from the new exact canonical SHA. No tag or publication has occurred.
