### PR TITLE
fix(agents): do not treat zero-exit exec success as tool failure

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1638,6 +1638,77 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     expect(ctx.state.lastToolError).toBeUndefined();
   });
 
+  it("does not record lastToolError for zero-exit exec when event isError is a false positive", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-syntax-ok",
+        args: { command: "shellcheck script.sh" },
+      } as never,
+    );
+
+    // Upstream can set isError=true from stderr noise while exitCode is 0 and
+    // stdout is benign (shellcheck "SYNTAX OK"). Structured success must win.
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-syntax-ok",
+        isError: true,
+        result: {
+          content: [{ type: "text", text: "SYNTAX OK\n" }],
+          details: {
+            status: "completed",
+            exitCode: 0,
+            durationMs: 42,
+            aggregated: "SYNTAX OK\n",
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toBeUndefined();
+    expect(ctx.state.toolMetas.at(-1)).toMatchObject({
+      toolName: "exec",
+    });
+    expect(ctx.state.toolMetas.at(-1)?.isError).toBeUndefined();
+  });
+
+  it("still records lastToolError for genuine unstructured exec failures", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-unstructured-fail",
+        args: { command: "shellcheck" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-unstructured-fail",
+        isError: true,
+        result: {
+          content: [{ type: "text", text: "command not found: shellcheck" }],
+        },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toMatchObject({
+      toolName: "exec",
+      error: "command not found: shellcheck",
+    });
+  });
+
   it("emits a prepared validation diagnostic without model arguments", async () => {
     const { ctx, onAgentEvent } = createTestContext();
     const error =

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -82,6 +82,7 @@ import {
   extractToolErrorMessage,
   extractToolResultText,
   filterToolResultMediaUrls,
+  isStructuredToolSuccess,
   isToolResultError,
   isToolResultTimedOut,
   sanitizeToolArgs,
@@ -1413,7 +1414,11 @@ export async function handleToolExecutionEnd(
   const isError = evt.isError;
   const result = evt.result;
   const toolSendReceiptResult = ctx.consumeToolSendReceipt?.(toolCallId);
-  const observerIsError = isError || isToolResultError(result);
+  // Prefer structured success over a false-positive event isError. Upstream
+  // producers can mark isError from stderr noise while exitCode remains 0
+  // (shellcheck "SYNTAX OK", date, true) and must not become lastToolError.
+  const observerIsError =
+    isToolResultError(result) || (isError && !isStructuredToolSuccess(result));
   const sanitizedResult = sanitizeToolResult(result);
   const approvalUnavailable =
     isExecToolName(toolName) &&

--- a/src/agents/embedded-agent-subscribe.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.test.ts
@@ -9,6 +9,7 @@ import {
   extractToolResultText,
   extractToolErrorCode,
   extractToolErrorMessage,
+  isStructuredToolSuccess,
   isToolResultError,
   sanitizeToolArgs,
   sanitizeToolResult,
@@ -31,6 +32,46 @@ describe("extractToolErrorMessage", () => {
     expect(
       extractToolErrorMessage({ content: [{ type: "text", text: "plugin execution failed" }] }),
     ).toBe("plugin execution failed");
+  });
+
+  it("does not promote zero-exit success stdout as an error message", () => {
+    // shellcheck / date / true style: structured success + benign first-line text
+    expect(
+      extractToolErrorMessage({
+        content: [{ type: "text", text: "SYNTAX OK\n" }],
+        details: { status: "completed", exitCode: 0, aggregated: "SYNTAX OK\n" },
+      }),
+    ).toBeUndefined();
+    expect(
+      extractToolErrorMessage({
+        content: [{ type: "text", text: "SYNTAX OK" }],
+        details: { exitCode: 0 },
+      }),
+    ).toBeUndefined();
+    expect(
+      extractToolErrorMessage({
+        content: [{ type: "text", text: "Wed Jul 17 23:00:00 UTC 2026" }],
+        details: { status: "completed", exitCode: 0 },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("still surfaces unstructured failure text without structured success", () => {
+    expect(
+      extractToolErrorMessage({
+        content: [{ type: "text", text: "command not found: shellcheck" }],
+      }),
+    ).toBe("command not found: shellcheck");
+    expect(
+      extractToolErrorMessage({
+        content: [{ type: "text", text: "fatal: not a git repository" }],
+        details: {
+          status: "failed",
+          exitCode: 128,
+          aggregated: "fatal: not a git repository",
+        },
+      }),
+    ).toBe("fatal: not a git repository");
   });
 
   it("keeps error-like status values", () => {
@@ -203,6 +244,28 @@ describe("isToolResultError", () => {
     expect(isToolResultError({ details: { ok: true, status: "cancelled", timedOut: true } })).toBe(
       true,
     );
+  });
+});
+
+describe("isStructuredToolSuccess", () => {
+  it("recognizes zero-exit and completed structured successes", () => {
+    expect(
+      isStructuredToolSuccess({
+        content: [{ type: "text", text: "SYNTAX OK" }],
+        details: { status: "completed", exitCode: 0 },
+      }),
+    ).toBe(true);
+    expect(isStructuredToolSuccess({ details: { exitCode: 0 } })).toBe(true);
+    expect(isStructuredToolSuccess({ details: { status: "completed" } })).toBe(true);
+    expect(isStructuredToolSuccess({ details: { ok: true } })).toBe(true);
+  });
+
+  it("rejects failures and unstructured text-only results", () => {
+    expect(isStructuredToolSuccess({ details: { status: "failed" } })).toBe(false);
+    expect(isStructuredToolSuccess({ details: { exitCode: 1 } })).toBe(false);
+    expect(
+      isStructuredToolSuccess({ content: [{ type: "text", text: "plugin execution failed" }] }),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -30,12 +30,13 @@ import type {
 } from "./embedded-agent-messaging.types.js";
 import { normalizeToolName } from "./tool-policy.js";
 import {
+  isStructuredToolSuccess,
   isToolResultError,
   readToolResultDetails,
   readToolResultStatus,
 } from "./tool-result-error.js";
 
-export { isToolResultError };
+export { isStructuredToolSuccess, isToolResultError };
 
 const TOOL_RESULT_MAX_CHARS = 8000;
 const TOOL_ERROR_MAX_CHARS = 400;
@@ -869,6 +870,11 @@ export function extractToolErrorMessage(result: unknown): string | undefined {
   if (!result || typeof result !== "object") {
     return undefined;
   }
+  // Structured success (exitCode 0 / completed / ok) must never become an error
+  // message — including when aggregated stdout is present (shellcheck "SYNTAX OK").
+  if (isStructuredToolSuccess(result)) {
+    return undefined;
+  }
   const record = result as Record<string, unknown>;
   const fromDetails = extractDirectErrorField(record.details);
   if (fromDetails) {
@@ -904,6 +910,11 @@ export function extractToolErrorMessage(result: unknown): string | undefined {
   }
   const status = readToolResultStatus(result);
   if (status && !isToolResultError(result)) {
+    return undefined;
+  }
+  // Structured success (exitCode 0 / completed) must not surface stdout as an
+  // error message even when the event producer already set isError=true.
+  if (isStructuredToolSuccess(result)) {
     return undefined;
   }
   return text ? normalizeToolErrorText(text) : undefined;

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -112,6 +112,33 @@ export function isToolResultError(result: unknown): boolean {
   return typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0;
 }
 
+/**
+ * True when the tool result carries structured success provenance.
+ * Callers should prefer this over a misleading event-level `isError` flag so
+ * zero-exit exec outcomes (shellcheck "SYNTAX OK", date, true) are not
+ * reclassified as tool failures by upstream heuristics/stderr noise.
+ */
+export function isStructuredToolSuccess(result: unknown): boolean {
+  if (isToolResultError(result)) {
+    return false;
+  }
+  const details = readToolResultDetails(result);
+  if (!details) {
+    return false;
+  }
+  const ok = readToolErrorField(details, "ok");
+  const success = readToolErrorField(details, "success");
+  if (ok === true || success === true) {
+    return true;
+  }
+  const exitCode = readToolErrorField(details, "exitCode");
+  if (typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode === 0) {
+    return true;
+  }
+  const status = readToolResultStatus(result);
+  return status === "completed" || status === "ok" || status === "success" || status === "0";
+}
+
 export type ToolResultFailureKind = "blocked" | "cancelled" | "failed" | "timed_out";
 
 /** Classify a thrown tool error without inferring cancellation from message text. */


### PR DESCRIPTION
Closes #110222

## What Problem This Solves

Fixes an issue where users running successful exec commands (for example shellcheck reporting `SYNTAX OK`, or other zero-exit tools with short benign stdout) would still see **⚠️ Exec failed** and have `lastToolError` recorded, so the agent would treat a successful tool run as a failure and stop mid-work.

## Why This Change Was Made

Upstream tool events can set `isError=true` even when the structured result is a clear success (`exitCode: 0` / `status: completed`). Message extraction then promoted arbitrary stdout/aggregated text (including `SYNTAX OK`) into the user-visible error summary.

This PR prefers **structured success** over a misleading event-level `isError` flag when classifying tool terminal outcomes, and makes `extractToolErrorMessage` refuse to turn structured-success stdout into an error message. Genuine unstructured failures (text-only error results without structured success) still surface as errors.

Not a keyword filter on message text (that approach can hide real failures and leave the wrong classification intact).

Quality check: compatibility — no config/API shape change, same success path semantics tightened; performance — O(1) field reads on the existing tool-end path; usability — removes false-positive “Exec failed” for successful commands; security — no trust-boundary or secret handling changes.

## User Impact

Successful exec results no longer flip into false “Exec failed” / `lastToolError` state when the structured result already proves zero-exit success. Agents continue work after shellcheck-style verification chains. Real tool failures still produce error summaries.

## Evidence

Focused tests (local macOS, Crabbox not used):

```text
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-subscribe.tools.test.ts \
  src/agents/embedded-agent-subscribe.handlers.tools.test.ts

 Test Files  2 passed (2)
      Tests  183 passed (183)
```

New coverage includes:

- zero-exit / `SYNTAX OK` structured success must not extract an error message
- `handleToolExecutionEnd` with `isError: true` + exitCode 0 must not set `lastToolError`
- genuine unstructured exec failures still set `lastToolError`
- `isStructuredToolSuccess` recognizes success and rejects failures/text-only errors

Static: `git diff --check` clean; `oxfmt --check` on the five touched files passed.

Live embedded agent proof (same head): two real `exec` tools in one turn — zero-exit `SYNTAX OK` with transcript `isError=false`, and exit 127 failure with `isError=true`; CLI `toolSummary` `calls=2` / `failures=1`; no `lastToolError` / `Exec failed` strings in the agent JSON output. Details in **Real behavior proof**.

Note: `pnpm check:changed` did not finish within the local closeout window; closeout used focused Vitest + path-scoped format + `git diff --check` as the quality floor for this surface.

## Real behavior proof

- Behavior addressed: Zero-exit exec with benign stdout (`SYNTAX OK`) must not become `lastToolError` / “Exec failed” when structured details say success; genuine unstructured failures still surface.
- Environment: local macOS, openclaw checkout at commit `f6d55afbcb` (same as this PR head). Embedded agent via `node openclaw.mjs --dev agent --local` against isolated `~/.openclaw-dev`, model `deepseek/deepseek-v4-flash`, session `agent:main:pr-110244-proof-1784335587`, run `9344f19a-bd98-4948-9152-fe9f46068f7b`.
- Current-main contrast: On main, `observerIsError = evt.isError || isToolResultError(result)` allows a false-positive event flag to win, and `extractToolErrorMessage` can return aggregated/stdout text such as `SYNTAX OK` as the error message even when `exitCode` is 0. This branch prefers structured success for classification and refuses to promote structured-success stdout into an error message.
- Exact steps or command run after this patch:
  ```bash
  node openclaw.mjs --dev agent \
    --local --agent main \
    --session-key agent:main:pr-110244-proof-1784335587 \
    --message-file /tmp/pr-110244-proof/message.txt \
    --model deepseek/deepseek-v4-flash \
    --thinking off --timeout 180 --json
  ```
  Probe asked the agent to run two real `exec` tools in one turn:
  1. `printf 'SYNTAX OK
'; true` (zero-exit success)
  2. `sh -c 'echo command not found: shellcheck-not-installed-xyz; exit 127'` (genuine failure)
- Evidence after fix (redacted live session transcript / CLI JSON):
  - Agent reply:
    ```text
    SUCCESS_EXIT=0
    SUCCESS_OUT=SYNTAX OK
    FAIL_EXIT=127
    FAIL_NOTE=command 2 failed as expected with exit code 127
    ```
  - CLI `meta.toolSummary`: `{"calls": 2, "tools": ["exec"], "failures": 1}` — one success + one real failure in the same run; run `stopReason=stop`, `aborted=false`.
  - Session transcript tool results (from `~/.openclaw-dev` agent DB, redacted paths only):
    - Success toolResult: `toolName=exec`, `details.status=completed`, `details.exitCode=0`, content `SYNTAX OK`, **`isError=false`** (not promoted to tool error).
    - Failure toolResult: `toolName=exec`, `details.status=failed`, `details.exitCode=127`, `failureKind=shell-command-not-found`, **`isError=true`** (genuine failure preserved).
  - Full agent JSON output and stderr logs contain **no** `lastToolError` and **no** `Exec failed` string for this run.
  - Focused regression suite still green:
    ```text
    node scripts/run-vitest.mjs \
      src/agents/embedded-agent-subscribe.tools.test.ts \
      src/agents/embedded-agent-subscribe.handlers.tools.test.ts
    # Test Files  2 passed (2)
    #      Tests  183 passed (183)
    ```
    Including the false-positive case where the event flag is `isError: true` with structured `exitCode: 0` / `SYNTAX OK` (producer false positive cannot be forced from a healthy live exec path; covered by handler unit regression).
- Control check: Same runtime path handles both outcomes in one agent turn; success does not set a tool-error state; failure still reports as error with non-zero exit. Sibling Vitest cases for denial/validation/real exit-1 formatting remain green in the same suite.
- Observed result after fix: Live zero-exit exec with `SYNTAX OK` completed with `isError=false` and did not surface as `Exec failed` / `lastToolError`; live failing exec remained `isError=true` with exit 127; agent finished the turn normally.
- What was not tested: Live Discord/Telegram client-visible “⚠️ Exec failed” breadcrumb (issue was observed on Discord historically; this proof is embedded agent/tool session + transcript). Producer false-positive `isError=true` with exit 0 is unit-covered rather than live-forced.


## AI disclosure

This PR was authored with AI assistance (Grok).

