### PR TITLE
fix(macos): stop Canvas presents from stealing focus

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Window.swift
@@ -46,7 +46,8 @@ extension CanvasWindowController {
         guard case .panel = self.presentation, let window else { return }
         self.repositionPanel(using: anchorProvider)
         window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        // Agent-driven presents must not steal focus; the elevated panel stays visible without activation.
+        // User entry points such as AppNavigationActions own activation.
         window.makeFirstResponder(self.webView)
         VoiceWakeOverlayController.shared.bringToFrontIfVisible()
         self.onVisibilityChanged?(true)

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Window.swift
@@ -45,10 +45,10 @@ extension CanvasWindowController {
     func presentAnchoredPanel(anchorProvider: @escaping () -> NSRect?) {
         guard case .panel = self.presentation, let window else { return }
         self.repositionPanel(using: anchorProvider)
-        window.makeKeyAndOrderFront(nil)
-        // Agent-driven presents must not steal focus; the elevated panel stays visible without activation.
-        // User entry points such as AppNavigationActions own activation.
-        window.makeFirstResponder(self.webView)
+        // Agent-driven presents must not steal focus: order front without app
+        // activation or key status. becomesKeyOnlyIfNeeded gives the panel key
+        // when the user clicks into it; user entry points own app activation.
+        window.orderFrontRegardless()
         VoiceWakeOverlayController.shared.bringToFrontIfVisible()
         self.onVisibilityChanged?(true)
     }

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -193,7 +193,8 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
             return
         }
 
-        self.showWindow(nil)
+        // The window is built in init, so skip showWindow(_:); it would make the
+        // window key and steal focus from the user's current window.
         self.window?.orderFrontRegardless()
         if let path {
             self.load(target: path, trustedA2UIActions: trustedA2UIActions)

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -194,7 +194,7 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
         }
 
         self.showWindow(nil)
-        self.window?.makeKeyAndOrderFront(nil)
+        self.window?.orderFrontRegardless()
         if let path {
             self.load(target: path, trustedA2UIActions: trustedA2UIActions)
         }

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -195,7 +195,6 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
 
         self.showWindow(nil)
         self.window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
         if let path {
             self.load(target: path, trustedA2UIActions: trustedA2UIActions)
         }

--- a/docs/platforms/mac/canvas.md
+++ b/docs/platforms/mac/canvas.md
@@ -29,6 +29,7 @@ If no `index.html` exists at the root, the app shows a built-in scaffold page.
 ## Panel behavior
 
 - Borderless, resizable panel anchored near the menu bar (or mouse cursor).
+- Presenting Canvas does not switch apps or steal keyboard focus.
 - Remembers size/position per session.
 - Auto-reloads when local canvas files change.
 - Only one Canvas panel is visible at a time (session switches as needed).


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent running `canvas.present` or `canvas.navigate` would yank the user out of whatever app they were using: Canvas presentation called `NSApp.activate(ignoringOtherApps: true)` and forced the panel to key-window status, so agent-driven presents switched apps and stole keyboard focus mid-typing. Follow-up to #110107, which stopped content operations from presenting; this removes the focus theft from the explicit presents that remain.

## Why This Change Was Made

The Canvas panel already has an elevated window level (`statusBar - 1`, joins all Spaces) and `becomesKeyOnlyIfNeeded = true`, so it is visible above normal windows without app activation, and it takes key status naturally when the user clicks into it. Presentation now uses `orderFrontRegardless()` with no app activation, no forced key status, and no forced first responder; the non-panel presentation path also drops `showWindow(_:)` (which makes a window key) since the window is built in init. User entry points (`AppNavigationActions`) keep their own explicit `NSApp.activate`, so opening Canvas from the menu or Dock behaves as before. Named tradeoff: typing into a Canvas text field right after an agent present needs one click into the panel first - that is the panel's `becomesKeyOnlyIfNeeded` contract working as intended.

## User Impact

Agents can pop up or navigate the Canvas without interrupting what you are typing or switching you out of your current app. The panel appears on top; interacting with it is one click away. User-initiated opens (menu bar, Dock) still bring OpenClaw forward as before.

## Evidence

- `swift test --package-path apps/macos --filter "CanvasManagerVisibilityTests|CanvasWindowSmokeTests"`: 10/10 pass on the rebased head (visibility semantics unchanged; `orderFrontRegardless` still makes the panel visible).
- SwiftFormat clean; SwiftLint 0 violations in 317 files; `git diff --check` clean.
- Structured autoreview (Codex gpt-5.6-sol) iterated twice - it caught that `makeKeyAndOrderFront` and `showWindow(_:)` still forced key status even without `NSApp.activate`; both paths now order front without key. Final run clean: "consistently replaces focus-stealing presentation calls with orderFrontRegardless(), which displays the existing Canvas window without activating the app or changing key-window status."
- Docs updated: `docs/platforms/mac/canvas.md` notes presenting Canvas does not switch apps or steal keyboard focus.
