### PR TITLE
feat(feeds): consume signed sharded catalogs

### DIFF
--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -8,8 +8,10 @@ import {
   type OfficialExternalPluginCatalogFeed,
 } from "./official-external-plugin-catalog.js";
 
-const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-feed.v1";
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-shard-root.v1";
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES = 16;
 
 type OfficialExternalPluginCatalogEnvelopeSignature = {
@@ -26,6 +28,31 @@ type OfficialExternalPluginCatalogTrustedSigningKey = {
   publicKey: string;
 };
 
+type OfficialExternalPluginCatalogEnvelopeVerificationError = {
+  ok: false;
+  error:
+    | "invalid-envelope"
+    | "unsupported-payload"
+    | "invalid-payload"
+    | "missing-trust-key"
+    | "invalid-signature";
+  message: string;
+  authenticatedPayload?: unknown;
+};
+
+export type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
+  | {
+      ok: true;
+      payloadType: string;
+      payload: unknown;
+      payloadBytes: Buffer;
+      signedBy: string;
+      signedByKeyIds?: readonly string[];
+      signatureCount?: number;
+      threshold?: number;
+    }
+  | OfficialExternalPluginCatalogEnvelopeVerificationError;
+
 type OfficialExternalPluginCatalogEnvelopeVerificationResult =
   | {
       ok: true;
@@ -35,17 +62,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationResult =
       signatureCount?: number;
       threshold?: number;
     }
-  | {
-      ok: false;
-      error:
-        | "invalid-envelope"
-        | "unsupported-payload"
-        | "invalid-payload"
-        | "missing-trust-key"
-        | "invalid-signature";
-      message: string;
-      authenticatedPayload?: unknown;
-    };
+  | OfficialExternalPluginCatalogEnvelopeVerificationError;
 function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   payloadType: string;
   payloadBytes: Buffer;
@@ -53,14 +70,15 @@ function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   return dssePreAuthenticationEncoding(params.payloadType, params.payloadBytes);
 }
 
-export function verifyOfficialExternalPluginCatalogSignedEnvelope(
+export function verifyOfficialExternalPluginCatalogEnvelopePayload(
   raw: unknown,
   params: {
     trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    acceptedPayloadTypes: ReadonlySet<string>;
     threshold?: number;
     allowLegacyBetaEnvelope?: boolean;
   },
-): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+): OfficialExternalPluginCatalogEnvelopePayloadVerificationResult {
   const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw, {
     allowLegacyBetaEnvelope: params.allowLegacyBetaEnvelope === true,
   });
@@ -71,7 +89,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       message: "hosted catalog signed envelope is malformed",
     };
   }
-  if (envelope.payloadType !== OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+  if (!params.acceptedPayloadTypes.has(envelope.payloadType)) {
     return {
       ok: false,
       error: "unsupported-payload",
@@ -119,17 +137,18 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   }
   if (trustedSignaturePublicKeys.size >= threshold) {
     const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
-    if (!decoded?.feed) {
+    if (!decoded) {
       return {
         ok: false,
         error: "invalid-payload",
         message: "hosted catalog signed envelope payload is invalid",
-        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
       };
     }
     return {
       ok: true,
-      feed: decoded.feed,
+      payloadType: envelope.payloadType,
+      payload: decoded.raw,
+      payloadBytes,
       signedBy: trustedSignatureKeyIds[0] ?? "",
       ...(threshold > 1
         ? {
@@ -157,6 +176,41 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
         error: "missing-trust-key",
         message: "hosted catalog signed envelope was not signed by a trusted key",
       };
+}
+
+export function verifyOfficialExternalPluginCatalogSignedEnvelope(
+  raw: unknown,
+  params: {
+    trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    threshold?: number;
+    allowLegacyBetaEnvelope?: boolean;
+  },
+): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+  const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
+    ...params,
+    acceptedPayloadTypes: new Set([OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE]),
+  });
+  if (!verification.ok) {
+    return verification;
+  }
+  if (!isOfficialExternalPluginCatalogFeed(verification.payload)) {
+    return {
+      ok: false,
+      error: "invalid-payload",
+      message: "hosted catalog signed envelope payload is invalid",
+      authenticatedPayload: verification.payload,
+    };
+  }
+  return {
+    ok: true,
+    feed: verification.payload,
+    signedBy: verification.signedBy,
+    ...(verification.signedByKeyIds ? { signedByKeyIds: verification.signedByKeyIds } : {}),
+    ...(verification.signatureCount !== undefined
+      ? { signatureCount: verification.signatureCount }
+      : {}),
+    ...(verification.threshold !== undefined ? { threshold: verification.threshold } : {}),
+  };
 }
 
 function parseOfficialExternalPluginCatalogSignedEnvelope(
@@ -258,13 +312,10 @@ function decodeOfficialExternalPluginCatalogEnvelopePayloadBytes(payload: string
 
 function decodeOfficialExternalPluginCatalogEnvelopePayload(
   payloadBytes: Buffer,
-): { raw: unknown; feed: OfficialExternalPluginCatalogFeed | null } | null {
+): { raw: unknown } | null {
   try {
     const raw = JSON.parse(payloadBytes.toString("utf8")) as unknown;
-    return {
-      raw,
-      feed: isOfficialExternalPluginCatalogFeed(raw) ? raw : null,
-    };
+    return { raw };
   } catch {
     return null;
   }

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -40,7 +40,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationError = {
   authenticatedPayload?: unknown;
 };
 
-export type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
+type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
   | {
       ok: true;
       payloadType: string;
@@ -63,6 +63,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationResult =
       threshold?: number;
     }
   | OfficialExternalPluginCatalogEnvelopeVerificationError;
+
 function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   payloadType: string;
   payloadBytes: Buffer;

--- a/src/plugins/official-external-plugin-catalog-shards.test.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.test.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  parseOfficialExternalPluginCatalogShardRoot,
+  parseOfficialExternalPluginCatalogShardedSnapshot,
+  serializeOfficialExternalPluginCatalogShardedSnapshot,
+  validateOfficialExternalPluginCatalogShardSet,
+} from "./official-external-plugin-catalog-shards.js";
+
+function shardBody(index: number, ids: readonly string[]): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    sequence: 7,
+    index,
+    entries: ids.map((id) => ({ type: "plugin", id })),
+  });
+}
+
+function rootFor(shardBodies: readonly string[]) {
+  return {
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    sequence: 7,
+    generatedAt: "2026-07-17T12:00:00Z",
+    expiresAt: "2026-07-24T12:00:00Z",
+    metadata: { description: "ClawHub plugins" },
+    entryCount: shardBodies.length,
+    shards: shardBodies.map((body, index) => ({
+      index,
+      url: `https://clawhub.ai/v1/feeds/plugins/shards/${index}.json`,
+      sha256: createHash("sha256").update(body).digest("hex"),
+      byteLength: Buffer.byteLength(body, "utf8"),
+      entryCount: 1,
+    })),
+  };
+}
+
+describe("official external plugin catalog shards", () => {
+  it("assembles a complete deterministically ordered shard set", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"]), shardBody(1, ["@acme/beta"])];
+    const root = parseOfficialExternalPluginCatalogShardRoot(rootFor(bodies));
+
+    expect(validateOfficialExternalPluginCatalogShardSet(root, bodies)).toMatchObject({
+      schemaVersion: 1,
+      id: "clawhub-official",
+      sequence: 7,
+      entries: [{ id: "@acme/alpha" }, { id: "@acme/beta" }],
+    });
+  });
+
+  it("rejects cross-shard ordering and duplicate identities", () => {
+    const unordered = [shardBody(0, ["@acme/beta"]), shardBody(1, ["@acme/alpha"])];
+    expect(() =>
+      validateOfficialExternalPluginCatalogShardSet(
+        parseOfficialExternalPluginCatalogShardRoot(rootFor(unordered)),
+        unordered,
+      ),
+    ).toThrow("shard set ordering is invalid");
+
+    const duplicated = [shardBody(0, ["@acme/alpha"]), shardBody(1, ["@acme/alpha"])];
+    expect(() =>
+      validateOfficialExternalPluginCatalogShardSet(
+        parseOfficialExternalPluginCatalogShardRoot(rootFor(duplicated)),
+        duplicated,
+      ),
+    ).toThrow("identity is duplicated");
+  });
+
+  it("rejects malformed roots before any shard fetch", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"])];
+    expect(() =>
+      parseOfficialExternalPluginCatalogShardRoot({
+        ...rootFor(bodies),
+        unexpected: true,
+      }),
+    ).toThrow("shard root is malformed");
+    expect(() =>
+      parseOfficialExternalPluginCatalogShardRoot({
+        ...rootFor(bodies),
+        shards: [{ ...rootFor(bodies).shards[0], sha256: "ABC" }],
+      }),
+    ).toThrow("lowercase SHA-256 hex");
+  });
+
+  it("round-trips the exact authenticated root and shard bytes for fallback", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"])];
+    const rootBody = '{"signed":"root"}';
+    const serialized = serializeOfficialExternalPluginCatalogShardedSnapshot({
+      rootBody,
+      shardBodies: bodies,
+    });
+
+    expect(parseOfficialExternalPluginCatalogShardedSnapshot(JSON.parse(serialized))).toEqual({
+      kind: "official-external-plugin-catalog-shards-v1",
+      rootBody,
+      shardBodies: bodies,
+    });
+  });
+});

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import { isRecord } from "../utils.js";
+import type {
+  OfficialExternalPluginCatalogEntry,
+  OfficialExternalPluginCatalogFeed,
+} from "./official-external-plugin-catalog.js";
+
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES = 1024 * 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS = 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES = 1_000_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES = 256 * 1024 * 1024;
+const SHARDED_SNAPSHOT_KIND = "official-external-plugin-catalog-shards-v1";
+
+export type OfficialExternalPluginCatalogShardDescriptor = {
+  index: number;
+  url: string;
+  sha256: string;
+  byteLength: number;
+  entryCount: number;
+};
+
+export type OfficialExternalPluginCatalogShardRoot = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  metadata: { description: string | null };
+  entryCount: number;
+  shards: readonly OfficialExternalPluginCatalogShardDescriptor[];
+};
+
+type OfficialExternalPluginCatalogShard = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  index: number;
+  entries: readonly OfficialExternalPluginCatalogEntry[];
+};
+
+export type OfficialExternalPluginCatalogShardedSnapshot = {
+  kind: typeof SHARDED_SNAPSHOT_KIND;
+  rootBody: string;
+  shardBodies: readonly string[];
+};
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).toSorted();
+  const expected = [...keys].toSorted();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function requireNonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function parseRfc3339Instant(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length > 64) {
+    throw new Error(`${label} is invalid`);
+  }
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/u.exec(
+      value,
+    );
+  if (!match) {
+    throw new Error(`${label} is invalid`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = Number(match[8] ?? "0");
+  const offsetMinute = Number(match[9] ?? "0");
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth[month - 1]! ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59 ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function parseShardDescriptor(
+  value: unknown,
+  expectedIndex: number,
+): OfficialExternalPluginCatalogShardDescriptor {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["index", "url", "sha256", "byteLength", "entryCount"])
+  ) {
+    throw new Error("hosted catalog shard descriptor is malformed");
+  }
+  const index = requireNonNegativeInteger(value.index, "hosted catalog shard index");
+  if (index !== expectedIndex) {
+    throw new Error("hosted catalog shard indexes must be contiguous");
+  }
+  if (typeof value.sha256 !== "string" || !/^[a-f0-9]{64}$/u.test(value.sha256)) {
+    throw new Error("hosted catalog shard digest must be lowercase SHA-256 hex");
+  }
+  const byteLength = requireNonNegativeInteger(value.byteLength, "hosted catalog shard byteLength");
+  if (byteLength < 1 || byteLength > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES) {
+    throw new Error("hosted catalog shard byteLength is invalid");
+  }
+  const entryCount = requireNonNegativeInteger(value.entryCount, "hosted catalog shard entryCount");
+  if (entryCount < 1 || entryCount > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES) {
+    throw new Error("hosted catalog shard entryCount is invalid");
+  }
+  if (typeof value.url !== "string" || Buffer.byteLength(value.url, "utf8") > 2048) {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS");
+  }
+  let url: URL;
+  try {
+    url = new URL(value.url);
+  } catch {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS");
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS without credentials");
+  }
+  return {
+    index,
+    url: url.href,
+    sha256: value.sha256,
+    byteLength,
+    entryCount,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogShardRoot(
+  value: unknown,
+): OfficialExternalPluginCatalogShardRoot {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "schemaVersion",
+      "feedId",
+      "sequence",
+      "generatedAt",
+      "expiresAt",
+      "metadata",
+      "entryCount",
+      "shards",
+    ]) ||
+    value.schemaVersion !== 1 ||
+    typeof value.feedId !== "string" ||
+    value.feedId.trim().length === 0 ||
+    value.feedId.length > 256 ||
+    !isRecord(value.metadata) ||
+    !hasExactKeys(value.metadata, ["description"]) ||
+    (value.metadata.description !== null && typeof value.metadata.description !== "string") ||
+    !Array.isArray(value.shards)
+  ) {
+    throw new Error("hosted catalog shard root is malformed");
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+    OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES
+  ) {
+    throw new Error("hosted catalog shard root exceeds its byte limit");
+  }
+  if (
+    typeof value.metadata.description === "string" &&
+    Buffer.byteLength(value.metadata.description, "utf8") > 1024
+  ) {
+    throw new Error("hosted catalog shard root description exceeds its limit");
+  }
+  const sequence = requireNonNegativeInteger(value.sequence, "hosted catalog shard root sequence");
+  const generatedAt = parseRfc3339Instant(
+    value.generatedAt,
+    "hosted catalog shard root generatedAt",
+  );
+  const expiresAt = parseRfc3339Instant(value.expiresAt, "hosted catalog shard root expiresAt");
+  if (Date.parse(expiresAt) <= Date.parse(generatedAt)) {
+    throw new Error("hosted catalog shard root validity window is invalid");
+  }
+  const entryCount = requireNonNegativeInteger(
+    value.entryCount,
+    "hosted catalog shard root entryCount",
+  );
+  if (entryCount > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES) {
+    throw new Error("hosted catalog shard root entryCount exceeds its limit");
+  }
+  if (value.shards.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS) {
+    throw new Error("hosted catalog shard root exceeds its shard limit");
+  }
+  if ((entryCount === 0) !== (value.shards.length === 0)) {
+    throw new Error("hosted catalog empty shard roots must have no shard descriptors");
+  }
+  const shards = value.shards.map(parseShardDescriptor);
+  const urls = new Set<string>();
+  const digests = new Set<string>();
+  let describedEntries = 0;
+  let describedBytes = 0;
+  for (const shard of shards) {
+    if (urls.has(shard.url) || digests.has(shard.sha256)) {
+      throw new Error("hosted catalog shard descriptors must be unique");
+    }
+    urls.add(shard.url);
+    digests.add(shard.sha256);
+    describedEntries += shard.entryCount;
+    describedBytes += shard.byteLength;
+  }
+  if (describedEntries !== entryCount) {
+    throw new Error("hosted catalog shard root entryCount does not match its descriptors");
+  }
+  if (describedBytes > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES) {
+    throw new Error("hosted catalog shard set exceeds its aggregate byte limit");
+  }
+  return {
+    schemaVersion: 1,
+    feedId: value.feedId,
+    sequence,
+    generatedAt,
+    expiresAt,
+    metadata: { description: value.metadata.description },
+    entryCount,
+    shards,
+  };
+}
+
+function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["schemaVersion", "feedId", "sequence", "index", "entries"]) ||
+    value.schemaVersion !== 1 ||
+    typeof value.feedId !== "string" ||
+    value.feedId.trim().length === 0 ||
+    !Array.isArray(value.entries)
+  ) {
+    throw new Error("hosted catalog shard is malformed");
+  }
+  const sequence = requireNonNegativeInteger(value.sequence, "hosted catalog shard sequence");
+  const index = requireNonNegativeInteger(value.index, "hosted catalog shard index");
+  if (
+    value.entries.length < 1 ||
+    value.entries.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES
+  ) {
+    throw new Error("hosted catalog shard entry count is invalid");
+  }
+  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  let previousId: string | undefined;
+  for (const entry of value.entries) {
+    if (
+      !isRecord(entry) ||
+      entry.type !== "plugin" ||
+      typeof entry.id !== "string" ||
+      entry.id.trim().length === 0
+    ) {
+      throw new Error("hosted catalog shard entry is invalid");
+    }
+    if (previousId !== undefined && previousId.localeCompare(entry.id) >= 0) {
+      throw new Error("hosted catalog shard entries must use deterministic id ordering");
+    }
+    previousId = entry.id;
+    entries.push(entry);
+  }
+  return { schemaVersion: 1, feedId: value.feedId, sequence, index, entries };
+}
+
+export function validateOfficialExternalPluginCatalogShardSet(
+  root: OfficialExternalPluginCatalogShardRoot,
+  shardBodies: readonly string[],
+): OfficialExternalPluginCatalogFeed {
+  if (shardBodies.length !== root.shards.length) {
+    throw new Error("hosted catalog shard set is incomplete");
+  }
+  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const identities = new Set<string>();
+  let previousId: string | undefined;
+  for (const [index, body] of shardBodies.entries()) {
+    const descriptor = root.shards[index];
+    if (!descriptor) {
+      throw new Error("hosted catalog shard set is incomplete");
+    }
+    const bytes = Buffer.from(body, "utf8");
+    if (
+      bytes.length !== descriptor.byteLength ||
+      createHash("sha256").update(bytes).digest("hex") !== descriptor.sha256
+    ) {
+      throw new Error("hosted catalog shard bytes do not match their signed descriptor");
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(body) as unknown;
+    } catch {
+      throw new Error("hosted catalog shard payload is not valid JSON");
+    }
+    const shard = parseShard(raw);
+    if (
+      shard.feedId !== root.feedId ||
+      shard.sequence !== root.sequence ||
+      shard.index !== index ||
+      shard.entries.length !== descriptor.entryCount
+    ) {
+      throw new Error("hosted catalog shard does not match its signed root");
+    }
+    for (const entry of shard.entries) {
+      const identity = `${entry.type}\0${entry.id}`;
+      if (identities.has(identity)) {
+        throw new Error("hosted catalog shard set identity is duplicated");
+      }
+      identities.add(identity);
+      if (previousId !== undefined && previousId.localeCompare(entry.id as string) >= 0) {
+        throw new Error("hosted catalog shard set ordering is invalid");
+      }
+      previousId = entry.id as string;
+      entries.push(entry);
+    }
+  }
+  if (entries.length !== root.entryCount) {
+    throw new Error("hosted catalog shard set entry count is incomplete");
+  }
+  return {
+    schemaVersion: 1,
+    id: root.feedId,
+    sequence: root.sequence,
+    generatedAt: root.generatedAt,
+    ...(root.metadata.description === null ? {} : { description: root.metadata.description }),
+    entries,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogShardedSnapshot(
+  value: unknown,
+): OfficialExternalPluginCatalogShardedSnapshot | null {
+  if (!isRecord(value) || value.kind !== SHARDED_SNAPSHOT_KIND) {
+    return null;
+  }
+  if (
+    !hasExactKeys(value, ["kind", "rootBody", "shardBodies"]) ||
+    typeof value.rootBody !== "string" ||
+    !Array.isArray(value.shardBodies) ||
+    !value.shardBodies.every((body): body is string => typeof body === "string")
+  ) {
+    throw new Error("hosted catalog sharded snapshot is malformed");
+  }
+  return { kind: SHARDED_SNAPSHOT_KIND, rootBody: value.rootBody, shardBodies: value.shardBodies };
+}
+
+export function serializeOfficialExternalPluginCatalogShardedSnapshot(params: {
+  rootBody: string;
+  shardBodies: readonly string[];
+}): string {
+  return JSON.stringify({
+    kind: SHARDED_SNAPSHOT_KIND,
+    rootBody: params.rootBody,
+    shardBodies: params.shardBodies,
+  });
+}

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -332,6 +332,7 @@ export function validateOfficialExternalPluginCatalogShardSet(
     id: root.feedId,
     sequence: root.sequence,
     generatedAt: root.generatedAt,
+    expiresAt: root.expiresAt,
     ...(root.metadata.description === null ? {} : { description: root.metadata.description }),
     entries,
   };

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -1,19 +1,15 @@
 import { createHash } from "node:crypto";
 import { isRecord } from "../utils.js";
-import type {
-  OfficialExternalPluginCatalogEntry,
-  OfficialExternalPluginCatalogFeed,
-} from "./official-external-plugin-catalog.js";
 
-export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
-export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES = 1024 * 1024;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS = 1024;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES = 1_000_000;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES = 256 * 1024 * 1024;
 const SHARDED_SNAPSHOT_KIND = "official-external-plugin-catalog-shards-v1";
 
-export type OfficialExternalPluginCatalogShardDescriptor = {
+type OfficialExternalPluginCatalogShardDescriptor = {
   index: number;
   url: string;
   sha256: string;
@@ -32,15 +28,30 @@ export type OfficialExternalPluginCatalogShardRoot = {
   shards: readonly OfficialExternalPluginCatalogShardDescriptor[];
 };
 
+type OfficialExternalPluginCatalogShardEntry = Record<string, unknown> & {
+  type: "plugin";
+  id: string;
+};
+
 type OfficialExternalPluginCatalogShard = {
   schemaVersion: 1;
   feedId: string;
   sequence: number;
   index: number;
-  entries: readonly OfficialExternalPluginCatalogEntry[];
+  entries: readonly OfficialExternalPluginCatalogShardEntry[];
 };
 
-export type OfficialExternalPluginCatalogShardedSnapshot = {
+type OfficialExternalPluginCatalogShardedFeed = {
+  schemaVersion: 1;
+  id: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  description?: string;
+  entries: readonly OfficialExternalPluginCatalogShardEntry[];
+};
+
+type OfficialExternalPluginCatalogShardedSnapshot = {
   kind: typeof SHARDED_SNAPSHOT_KIND;
   rootBody: string;
   shardBodies: readonly string[];
@@ -254,7 +265,7 @@ function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
   ) {
     throw new Error("hosted catalog shard entry count is invalid");
   }
-  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const entries: OfficialExternalPluginCatalogShardEntry[] = [];
   let previousId: string | undefined;
   for (const entry of value.entries) {
     if (
@@ -269,7 +280,7 @@ function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
       throw new Error("hosted catalog shard entries must use deterministic id ordering");
     }
     previousId = entry.id;
-    entries.push(entry);
+    entries.push(entry as OfficialExternalPluginCatalogShardEntry);
   }
   return { schemaVersion: 1, feedId: value.feedId, sequence, index, entries };
 }
@@ -277,11 +288,11 @@ function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
 export function validateOfficialExternalPluginCatalogShardSet(
   root: OfficialExternalPluginCatalogShardRoot,
   shardBodies: readonly string[],
-): OfficialExternalPluginCatalogFeed {
+): OfficialExternalPluginCatalogShardedFeed {
   if (shardBodies.length !== root.shards.length) {
     throw new Error("hosted catalog shard set is incomplete");
   }
-  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const entries: OfficialExternalPluginCatalogShardEntry[] = [];
   const identities = new Set<string>();
   let previousId: string | undefined;
   for (const [index, body] of shardBodies.entries()) {
@@ -317,10 +328,10 @@ export function validateOfficialExternalPluginCatalogShardSet(
         throw new Error("hosted catalog shard set identity is duplicated");
       }
       identities.add(identity);
-      if (previousId !== undefined && previousId.localeCompare(entry.id as string) >= 0) {
+      if (previousId !== undefined && previousId.localeCompare(entry.id) >= 0) {
         throw new Error("hosted catalog shard set ordering is invalid");
       }
-      previousId = entry.id as string;
+      previousId = entry.id;
       entries.push(entry);
     }
   }

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -132,9 +132,7 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
           })
         : document;
     const payload =
-      typeof wireDocument.payload === "string"
-        ? decodeBase64Payload(wireDocument.payload)
-        : body;
+      typeof wireDocument.payload === "string" ? decodeBase64Payload(wireDocument.payload) : body;
     const feed =
       typeof wireDocument.payload === "string"
         ? (JSON.parse(payload) as {

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -116,19 +116,32 @@ function decodeBase64Payload(payload: string): string {
 function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicState | undefined {
   try {
     const document = JSON.parse(body) as {
+      kind?: unknown;
+      rootBody?: unknown;
       payload?: unknown;
       sequence?: unknown;
       generatedAt?: unknown;
     };
-    const payload =
-      typeof document.payload === "string" ? decodeBase64Payload(document.payload) : body;
-    const feed =
-      typeof document.payload === "string"
-        ? (JSON.parse(payload) as {
+    const wireDocument =
+      document.kind === "official-external-plugin-catalog-shards-v1" &&
+      typeof document.rootBody === "string"
+        ? (JSON.parse(document.rootBody) as {
+            payload?: unknown;
             sequence?: unknown;
             generatedAt?: unknown;
           })
         : document;
+    const payload =
+      typeof wireDocument.payload === "string"
+        ? decodeBase64Payload(wireDocument.payload)
+        : body;
+    const feed =
+      typeof wireDocument.payload === "string"
+        ? (JSON.parse(payload) as {
+            sequence?: unknown;
+            generatedAt?: unknown;
+          })
+        : wireDocument;
     if (!isOfficialExternalPluginCatalogSequence(feed.sequence)) {
       return undefined;
     }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -33,6 +33,8 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 }
 
 const HOSTED_CATALOG_PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
+const HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-shard-root.v1";
 
 type HostedCatalogConfig = NonNullable<
   NonNullable<
@@ -176,6 +178,127 @@ function toLegacyBetaSignedEnvelope(body: string): string {
       signature: signature.sig,
     })),
   });
+}
+
+function signedHostedCatalogDocument(params: {
+  document: unknown;
+  payloadType: string;
+  privateKeyPem?: string;
+}): { body: string; privateKeyPem: string; publicKeyPem: string } {
+  const keys = params.privateKeyPem
+    ? {
+        privateKeyPem: params.privateKeyPem,
+        publicKeyPem: crypto
+          .createPublicKey(params.privateKeyPem)
+          .export({ type: "spki", format: "pem" }),
+      }
+    : (() => {
+        const generated = crypto.generateKeyPairSync("ed25519", {
+          publicKeyEncoding: { type: "spki", format: "pem" },
+          privateKeyEncoding: { type: "pkcs8", format: "pem" },
+        });
+        return { privateKeyPem: generated.privateKey, publicKeyPem: generated.publicKey };
+      })();
+  const payloadBytes = Buffer.from(JSON.stringify(params.document), "utf8");
+  const payloadTypeBytes = Buffer.from(params.payloadType, "utf8");
+  const signingInput = Buffer.concat([
+    Buffer.from(
+      `DSSEv1 ${payloadTypeBytes.length} ${params.payloadType} ${payloadBytes.length} `,
+      "utf8",
+    ),
+    payloadBytes,
+  ]);
+  return {
+    body: JSON.stringify({
+      payloadType: params.payloadType,
+      payload: payloadBytes.toString("base64url"),
+      signatures: [
+        {
+          keyid: "acme-root",
+          sig: crypto
+            .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
+            .toString("base64url"),
+        },
+      ],
+    }),
+    ...keys,
+  };
+}
+
+function shardedHostedCatalogFixture() {
+  const shardBodies = [
+    JSON.stringify({
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      index: 0,
+      entries: [
+        {
+          type: "plugin",
+          id: "@acme/alpha",
+          title: "Alpha",
+          version: "1.0.0",
+          state: "available",
+          publisher: { id: "acme", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "acme-npm",
+                package: "@acme/alpha",
+                version: "1.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    JSON.stringify({
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      index: 1,
+      entries: [
+        {
+          type: "plugin",
+          id: "@acme/beta",
+          title: "Beta",
+          version: "2.0.0",
+          state: "available",
+          publisher: { id: "acme", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "acme-npm",
+                package: "@acme/beta",
+                version: "2.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  ];
+  const shards = shardBodies.map((body, index) => ({
+    index,
+    url: `https://packages.acme.example/openclaw/shards/${index}.json`,
+    sha256: crypto.createHash("sha256").update(body).digest("hex"),
+    byteLength: Buffer.byteLength(body, "utf8"),
+    entryCount: 1,
+  }));
+  const signedRoot = signedHostedCatalogDocument({
+    payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+    document: {
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      generatedAt: "2026-06-22T00:00:12.000Z",
+      expiresAt: "2026-06-29T00:00:12.000Z",
+      metadata: { description: "Acme plugins" },
+      entryCount: 2,
+      shards,
+    },
+  });
+  return { shardBodies, shards, signedRoot };
 }
 
 function signedCatalogConfig(publicKeyPem: string, keyId = "acme-root"): HostedCatalogConfig {
@@ -773,6 +896,144 @@ describe("official external plugin catalog", () => {
     } finally {
       closeOpenClawStateDatabaseForTest();
       rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads signed catalog shards and re-verifies their durable offline snapshot", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, {
+          status: 200,
+          headers: { etag: '"root-12"' },
+        });
+      }
+      const shard = fixture.shards.find((candidate) => candidate.url === url);
+      if (!shard) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(fixture.shardBodies[shard.index], { status: 200 });
+    });
+
+    const live = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore,
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(live.source).toBe("hosted");
+    expect(live.entries.map((entry) => entry.id)).toEqual(["@acme/alpha", "@acme/beta"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const snapshot = await snapshotStore.read("https://packages.acme.example/openclaw/feed");
+    expect(JSON.parse(snapshot?.body ?? "null")).toMatchObject({
+      kind: "official-external-plugin-catalog-shards-v1",
+      rootBody: fixture.signedRoot.body,
+      shardBodies: fixture.shardBodies,
+    });
+
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      offline: true,
+      snapshotStore,
+      now: () => new Date("2026-06-23T00:00:00.000Z"),
+    });
+    expect(offline.source).toBe("hosted-snapshot");
+    expect(offline.entries.map((entry) => entry.id)).toEqual(["@acme/alpha", "@acme/beta"]);
+
+    const expiredOffline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      offline: true,
+      snapshotStore,
+      now: () => new Date("2026-06-30T00:00:00.000Z"),
+    });
+    expect(expiredOffline.source).toBe("bundled-fallback");
+    expect(expiredOffline.entries).toEqual([]);
+  });
+
+  it("fails closed when catalog shard bytes do not match the signed root", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, { status: 200 });
+      }
+      const shard = fixture.shards.find((candidate) => candidate.url === url);
+      return new Response(
+        shard?.index === 0
+          ? fixture.shardBodies[0]?.replace('"Alpha"', '"Alphx"')
+          : fixture.shardBodies[1],
+        { status: 200 },
+      );
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard bytes do not match their signed descriptor");
+    }
+  });
+
+  it("rejects signed catalog shard URLs outside the root origin before fetching them", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const root = JSON.parse(
+      Buffer.from(JSON.parse(fixture.signedRoot.body).payload as string, "base64url").toString(
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    const shards = root.shards as Array<Record<string, unknown>>;
+    shards[0] = { ...shards[0], url: "https://cdn.example.net/catalog/0.json" };
+    const signedRoot = signedHostedCatalogDocument({
+      document: root,
+      payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      privateKeyPem: fixture.signedRoot.privateKeyPem,
+    });
+    const fetchImpl = vi.fn(async () => new Response(signedRoot.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard URL must use the signed root origin");
+    }
+  });
+
+  it("rejects expired signed shard roots before fetching any shard", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const fetchImpl = vi.fn(async () => new Response(fixture.signedRoot.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-30T00:00:00.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard root has expired");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -882,7 +882,7 @@ describe("official external plugin catalog", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : input.toString();
       if (url === "https://packages.acme.example/openclaw/feed") {
-        return new Response(fixture.signedRoot.body, {
+        return dsseResponse(fixture.signedRoot.body, {
           status: 200,
           headers: { etag: '"root-12"' },
         });
@@ -929,8 +929,12 @@ describe("official external plugin catalog", () => {
       snapshotStore,
       now: () => new Date("2026-06-30T00:00:00.000Z"),
     });
-    expect(expiredOffline.source).toBe("bundled-fallback");
-    expect(expiredOffline.entries).toEqual([]);
+    expect(expiredOffline.source).toBe("hosted-snapshot");
+    expect(expiredOffline.entries).toMatchObject([
+      { id: "@acme/alpha", state: "unavailable" },
+      { id: "@acme/beta", state: "unavailable" },
+    ]);
+    expect(expiredOffline.entries.every((entry) => entry.install === undefined)).toBe(true);
   });
 
   it("fails closed when catalog shard bytes do not match the signed root", async () => {
@@ -938,7 +942,7 @@ describe("official external plugin catalog", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : input.toString();
       if (url === "https://packages.acme.example/openclaw/feed") {
-        return new Response(fixture.signedRoot.body, { status: 200 });
+        return dsseResponse(fixture.signedRoot.body, { status: 200 });
       }
       const shard = fixture.shards.find((candidate) => candidate.url === url);
       return new Response(
@@ -971,7 +975,7 @@ describe("official external plugin catalog", () => {
       const url = input instanceof Request ? input.url : input.toString();
       fetchedUrls.push(url);
       if (url === "https://packages.acme.example/openclaw/feed") {
-        return new Response(fixture.signedRoot.body, { status: 200 });
+        return dsseResponse(fixture.signedRoot.body, { status: 200 });
       }
       if (url.endsWith("/0.json")) {
         return new Response(null, { status: 503 });
@@ -1017,7 +1021,7 @@ describe("official external plugin catalog", () => {
       payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
       privateKeyPem: fixture.signedRoot.privateKeyPem,
     });
-    const fetchImpl = vi.fn(async () => new Response(signedRoot.body, { status: 200 }));
+    const fetchImpl = vi.fn(async () => dsseResponse(signedRoot.body, { status: 200 }));
 
     const result = await loadHostedCatalog({
       feedProfile: "acme",
@@ -1036,7 +1040,7 @@ describe("official external plugin catalog", () => {
 
   it("rejects expired signed shard roots before fetching any shard", async () => {
     const fixture = shardedHostedCatalogFixture();
-    const fetchImpl = vi.fn(async () => new Response(fixture.signedRoot.body, { status: 200 }));
+    const fetchImpl = vi.fn(async () => dsseResponse(fixture.signedRoot.body, { status: 200 }));
 
     const result = await loadHostedCatalog({
       feedProfile: "acme",
@@ -1049,7 +1053,7 @@ describe("official external plugin catalog", () => {
     expect(result.source).toBe("bundled-fallback");
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     if (result.source === "bundled-fallback") {
-      expect(result.error).toContain("shard root has expired");
+      expect(result.error).toContain("shard root expired at");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -225,59 +225,36 @@ function signedHostedCatalogDocument(params: {
   };
 }
 
-function shardedHostedCatalogFixture() {
-  const shardBodies = [
-    JSON.stringify({
+function shardedHostedCatalogFixture(shardCount = 2) {
+  const shardBodies = Array.from({ length: shardCount }, (_, index) => {
+    const name = index === 0 ? "alpha" : index === 1 ? "beta" : `plugin-${index}`;
+    const title = index === 0 ? "Alpha" : index === 1 ? "Beta" : `Plugin ${index}`;
+    return JSON.stringify({
       schemaVersion: 1,
       feedId: "openclaw-official-external-plugins",
       sequence: 12,
-      index: 0,
+      index,
       entries: [
         {
           type: "plugin",
-          id: "@acme/alpha",
-          title: "Alpha",
-          version: "1.0.0",
+          id: `@acme/${name}`,
+          title,
+          version: `${index + 1}.0.0`,
           state: "available",
           publisher: { id: "acme", trust: "official" },
           install: {
             candidates: [
               {
                 sourceRef: "acme-npm",
-                package: "@acme/alpha",
-                version: "1.0.0",
+                package: `@acme/${name}`,
+                version: `${index + 1}.0.0`,
               },
             ],
           },
         },
       ],
-    }),
-    JSON.stringify({
-      schemaVersion: 1,
-      feedId: "openclaw-official-external-plugins",
-      sequence: 12,
-      index: 1,
-      entries: [
-        {
-          type: "plugin",
-          id: "@acme/beta",
-          title: "Beta",
-          version: "2.0.0",
-          state: "available",
-          publisher: { id: "acme", trust: "official" },
-          install: {
-            candidates: [
-              {
-                sourceRef: "acme-npm",
-                package: "@acme/beta",
-                version: "2.0.0",
-              },
-            ],
-          },
-        },
-      ],
-    }),
-  ];
+    });
+  });
   const shards = shardBodies.map((body, index) => ({
     index,
     url: `https://packages.acme.example/openclaw/shards/${index}.json`,
@@ -294,7 +271,7 @@ function shardedHostedCatalogFixture() {
       generatedAt: "2026-06-22T00:00:12.000Z",
       expiresAt: "2026-06-29T00:00:12.000Z",
       metadata: { description: "Acme plugins" },
-      entryCount: 2,
+      entryCount: shardCount,
       shards,
     },
   });
@@ -985,6 +962,45 @@ describe("official external plugin catalog", () => {
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain("shard bytes do not match their signed descriptor");
     }
+  });
+
+  it("stops queued shard downloads after the first failure", async () => {
+    const fixture = shardedHostedCatalogFixture(8);
+    const fetchedUrls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      fetchedUrls.push(url);
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, { status: 200 });
+      }
+      if (url.endsWith("/0.json")) {
+        return new Response(null, { status: 503 });
+      }
+      if (init?.signal?.aborted) {
+        throw init.signal.reason instanceof Error ? init.signal.reason : new Error("aborted");
+      }
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () =>
+            reject(
+              init.signal?.reason instanceof Error ? init.signal.reason : new Error("aborted"),
+            ),
+          { once: true },
+        );
+      });
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchedUrls.some((url) => /\/[4-7]\.json$/u.test(url))).toBe(false);
   });
 
   it("rejects signed catalog shard URLs outside the root origin before fetching them", async () => {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -794,6 +794,17 @@ async function parseHostedCatalogFeedBody(params: {
       feed = verification.payload;
     } else {
       const root = parseOfficialExternalPluginCatalogShardRoot(verification.payload);
+      const rootGeneratedAtMs = parseOfficialExternalPluginCatalogTimestamp(root.generatedAt);
+      const rootExpiresAtMs = parseOfficialExternalPluginCatalogTimestamp(root.expiresAt);
+      if (rootGeneratedAtMs === undefined || rootExpiresAtMs === undefined) {
+        throw new Error("hosted catalog shard root requires valid timestamps");
+      }
+      if (rootExpiresAtMs <= rootGeneratedAtMs) {
+        throw new Error("hosted catalog shard root expiresAt must be later than generatedAt");
+      }
+      if (rootExpiresAtMs <= params.now.getTime() && params.allowExpired !== true) {
+        throw new Error(`hosted catalog shard root expired at ${root.expiresAt}`);
+      }
       const shardBodies = snapshot?.shardBodies ?? (await params.loadShardBodies?.(root));
       if (!shardBodies) {
         throw new Error("hosted catalog shard set is unavailable");

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -744,6 +744,7 @@ async function parseHostedCatalogFeedBody(params: {
       OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
       OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
       verifyOfficialExternalPluginCatalogEnvelopePayload,
+      verifyOfficialExternalPluginCatalogSignedEnvelope,
     } = await import("./official-external-plugin-catalog-envelope.js");
     const {
       parseOfficialExternalPluginCatalogShardedSnapshot,
@@ -755,15 +756,30 @@ async function parseHostedCatalogFeedBody(params: {
     const wireBody = snapshot?.rootBody ?? params.body;
     const raw = snapshot ? (JSON.parse(snapshot.rootBody) as unknown) : document;
     const threshold = params.verification.threshold ?? 1;
-    const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
-      trustedKeys: params.verification.keys,
-      acceptedPayloadTypes: new Set([
-        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
-        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
-      ]),
-      threshold,
-      ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
-    });
+    const verification =
+      isRecord(raw) && raw.payloadType === OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE
+        ? (() => {
+            const feedVerification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+              trustedKeys: params.verification.keys,
+              threshold,
+              ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
+            });
+            return feedVerification.ok
+              ? {
+                  ...feedVerification,
+                  payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+                  payload: feedVerification.feed,
+                }
+              : feedVerification;
+          })()
+        : verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
+            trustedKeys: params.verification.keys,
+            acceptedPayloadTypes: new Set([
+              OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+            ]),
+            threshold,
+            ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
+          });
     if (!verification.ok) {
       const invalidTimestampSequence =
         verification.error === "invalid-payload" && "authenticatedPayload" in verification
@@ -809,7 +825,11 @@ async function parseHostedCatalogFeedBody(params: {
       if (!shardBodies) {
         throw new Error("hosted catalog shard set is unavailable");
       }
-      feed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      const shardedFeed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      if (!isOfficialExternalPluginCatalogFeed(shardedFeed)) {
+        throw new Error("hosted catalog shard set contains an invalid feed");
+      }
+      feed = shardedFeed;
       snapshotBody =
         snapshot === null
           ? serializeOfficialExternalPluginCatalogShardedSnapshot({

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import pLimit from "p-limit";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -14,6 +15,7 @@ import type {
   PluginPackageInstall,
 } from "./manifest.js";
 import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS } from "./official-external-plugin-bundled-catalogs.js";
+import type { OfficialExternalPluginCatalogShardRoot } from "./official-external-plugin-catalog-shards.js";
 
 type ManifestKey = typeof MANIFEST_KEY;
 
@@ -284,8 +286,10 @@ const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalP
   };
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
 const DSSE_ENVELOPE_MEDIA_TYPE = "application/vnd.dsse+json";
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY = 4;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
 const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
 
@@ -727,18 +731,37 @@ async function parseHostedCatalogFeedBody(params: {
   now: Date;
   allowExpired?: boolean;
   allowMissingExpiry?: boolean;
+  loadShardBodies?: (root: OfficialExternalPluginCatalogShardRoot) => Promise<readonly string[]>;
 }): Promise<{
   feed: OfficialExternalPluginCatalogFeed;
   trust?: HostedOfficialExternalPluginCatalogTrustState;
   expired?: boolean;
+  snapshotBody?: string;
+  wireBody?: string;
 }> {
-  const raw = JSON.parse(params.body) as unknown;
+  const document = JSON.parse(params.body) as unknown;
   if (params.verification?.mode === "signed") {
-    const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
-      await import("./official-external-plugin-catalog-envelope.js");
+    const {
+      OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+      OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      verifyOfficialExternalPluginCatalogEnvelopePayload,
+    } = await import("./official-external-plugin-catalog-envelope.js");
+    const {
+      parseOfficialExternalPluginCatalogShardedSnapshot,
+      parseOfficialExternalPluginCatalogShardRoot,
+      serializeOfficialExternalPluginCatalogShardedSnapshot,
+      validateOfficialExternalPluginCatalogShardSet,
+    } = await import("./official-external-plugin-catalog-shards.js");
+    const snapshot = parseOfficialExternalPluginCatalogShardedSnapshot(document);
+    const wireBody = snapshot?.rootBody ?? params.body;
+    const raw = snapshot ? (JSON.parse(snapshot.rootBody) as unknown) : document;
     const threshold = params.verification.threshold ?? 1;
-    const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+    const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
       trustedKeys: params.verification.keys,
+      acceptedPayloadTypes: new Set([
+        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      ]),
       threshold,
       ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
     });
@@ -754,15 +777,44 @@ async function parseHostedCatalogFeedBody(params: {
       }
       throw new Error(verification.message);
     }
-    if (params.expectedFeedId && verification.feed.id !== params.expectedFeedId) {
+    let feed: OfficialExternalPluginCatalogFeed;
+    let snapshotBody: string | undefined;
+    if (verification.payloadType === OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+      if (!isOfficialExternalPluginCatalogFeed(verification.payload)) {
+        const invalidTimestampSequence = readOfficialExternalPluginCatalogInvalidTimestampSequence(
+          verification.payload,
+        );
+        if (invalidTimestampSequence !== undefined) {
+          throw new HostedCatalogFeedTimestampError(
+            "hosted catalog signed envelope payload is invalid",
+            invalidTimestampSequence,
+          );
+        }
+        throw new Error("hosted catalog signed envelope payload is invalid");
+      }
+      feed = verification.payload;
+    } else {
+      const root = parseOfficialExternalPluginCatalogShardRoot(verification.payload);
+      const shardBodies = snapshot?.shardBodies ?? (await params.loadShardBodies?.(root));
+      if (!shardBodies) {
+        throw new Error("hosted catalog shard set is unavailable");
+      }
+      feed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      snapshotBody =
+        snapshot === null
+          ? serializeOfficialExternalPluginCatalogShardedSnapshot({
+              rootBody: params.body,
+              shardBodies,
+            })
+          : params.body;
+    }
+    if (params.expectedFeedId && feed.id !== params.expectedFeedId) {
       throw new Error(
-        `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
+        `hosted catalog feed id "${feed.id}" did not match expected "${params.expectedFeedId}"`,
       );
     }
-    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(
-      verification.feed.generatedAt,
-    );
-    const expiresAt = normalizeOptionalString(verification.feed.expiresAt);
+    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(feed.generatedAt);
+    const expiresAt = normalizeOptionalString(feed.expiresAt);
     if (generatedAtMs === undefined) {
       throw new Error("hosted catalog signed feed requires a valid generatedAt value");
     }
@@ -790,7 +842,7 @@ async function parseHostedCatalogFeedBody(params: {
       );
     }
     return {
-      feed: enforceHostedCatalogFeedInstallAuthority(verification.feed),
+      feed: enforceHostedCatalogFeedInstallAuthority(feed),
       trust: {
         mode: "signed",
         signedBy: verification.signedBy,
@@ -799,17 +851,19 @@ async function parseHostedCatalogFeedBody(params: {
         verifiedAt: params.verifiedAt,
       },
       ...(expired ? { expired: true } : {}),
+      ...(snapshotBody ? { snapshotBody } : {}),
+      ...(snapshot ? { wireBody } : {}),
     };
   }
-  if (!isOfficialExternalPluginCatalogFeed(raw)) {
+  if (!isOfficialExternalPluginCatalogFeed(document)) {
     throw new Error("hosted catalog feed did not match a supported schema version");
   }
-  if (params.expectedFeedId && raw.id !== params.expectedFeedId) {
+  if (params.expectedFeedId && document.id !== params.expectedFeedId) {
     throw new Error(
-      `hosted catalog feed id "${raw.id}" did not match expected "${params.expectedFeedId}"`,
+      `hosted catalog feed id "${document.id}" did not match expected "${params.expectedFeedId}"`,
     );
   }
-  return { feed: enforceHostedCatalogFeedInstallAuthority(raw) };
+  return { feed: enforceHostedCatalogFeedInstallAuthority(document) };
 }
 
 function enforceHostedCatalogFeedInstallAuthority(
@@ -879,9 +933,6 @@ async function loadHostedCatalogSnapshotResult(params: {
   if (checksum !== params.snapshot.metadata.checksum) {
     throw new Error("hosted catalog snapshot checksum mismatch");
   }
-  if (params.expectedSha256 && params.expectedSha256 !== checksum) {
-    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
-  }
   const parsed = await parseHostedCatalogFeedBody({
     body: params.snapshot.body,
     expectedFeedId: params.expectedFeedId,
@@ -892,6 +943,10 @@ async function loadHostedCatalogSnapshotResult(params: {
     allowExpired: true,
     allowMissingExpiry: true,
   });
+  const wireChecksum = sha256Hex(parsed.wireBody ?? params.snapshot.body);
+  if (params.expectedSha256 && params.expectedSha256 !== wireChecksum) {
+    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
+  }
   const entries = dedupeOfficialExternalPluginCatalogEntries(
     filterOfficialExternalPluginCatalogEntriesBySourceRefs(
       parseOfficialExternalPluginCatalogEntries(parsed.feed),
@@ -908,7 +963,7 @@ async function loadHostedCatalogSnapshotResult(params: {
     source: "hosted-snapshot",
     entries: visibleEntries,
     feed: parsed.expired ? { ...parsed.feed, entries: visibleEntries } : parsed.feed,
-    metadata: params.snapshot.metadata,
+    metadata: { ...params.snapshot.metadata, checksum: wireChecksum },
     snapshot: params.snapshot,
     ...(parsed.trust ? { trust: parsed.trust } : {}),
     error: parsed.expired
@@ -1031,6 +1086,62 @@ async function resolveHostedCatalogSnapshotStore(params: {
   });
 }
 
+async function loadHostedCatalogShardBodies(params: {
+  root: OfficialExternalPluginCatalogShardRoot;
+  rootUrl: string;
+  hostnameAllowlist: readonly string[];
+  fetchImpl?: FetchLike;
+  timeoutMs: number;
+  chunkTimeoutMs: number;
+}): Promise<readonly string[]> {
+  const rootOrigin = new URL(params.rootUrl).origin;
+  for (const descriptor of params.root.shards) {
+    if (new URL(descriptor.url).origin !== rootOrigin) {
+      throw new Error("hosted catalog shard URL must use the signed root origin");
+    }
+  }
+  const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
+  const limit = pLimit(DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY);
+  return await Promise.all(
+    params.root.shards.map((descriptor) =>
+      limit(async () => {
+        let response: Response | undefined;
+        let release: (() => Promise<void>) | undefined;
+        try {
+          const guarded = await fetchWithSsrFGuard({
+            url: descriptor.url,
+            fetchImpl: params.fetchImpl,
+            init: { method: "GET" },
+            requireHttps: true,
+            maxRedirects: 2,
+            timeoutMs: params.timeoutMs,
+            policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
+            auditContext: "official-external-plugin-catalog-shard",
+          });
+          response = guarded.response;
+          release = guarded.release;
+          if (new URL(guarded.finalUrl).origin !== rootOrigin) {
+            throw new Error("hosted catalog shard redirect changed the signed root origin");
+          }
+          if (!response.ok) {
+            throw new Error(`hosted catalog shard returned HTTP ${response.status}`);
+          }
+          return await readHostedCatalogResponseText({
+            response,
+            maxBytes: descriptor.byteLength,
+            chunkTimeoutMs: params.chunkTimeoutMs,
+          });
+        } finally {
+          if (response?.bodyUsed !== true) {
+            await response?.body?.cancel().catch(() => undefined);
+          }
+          await release?.().catch(() => undefined);
+        }
+      }),
+    ),
+  );
+}
+
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   feedUrl?: string;
   feedProfile?: string;
@@ -1133,6 +1244,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     });
     response = guarded.response;
     release = guarded.release;
+    const rootFinalUrl = guarded.finalUrl;
     const base = metadataBase(response);
     if (response.status === 304) {
       return await snapshotOrBundledFallbackResult({
@@ -1187,7 +1299,11 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     }
     const body = await readHostedCatalogResponseText({
       response,
-      maxBytes: params?.maxBytes ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES,
+      maxBytes:
+        params?.maxBytes ??
+        (source.verification?.mode === "signed"
+          ? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES
+          : DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES),
       chunkTimeoutMs:
         params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
     });
@@ -1217,6 +1333,18 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       verification: source.verification,
       verifiedAt,
       now,
+      loadShardBodies: async (root) =>
+        await loadHostedCatalogShardBodies({
+          root,
+          rootUrl: rootFinalUrl,
+          hostnameAllowlist: source.hostnameAllowlist,
+          fetchImpl: params?.fetchImpl,
+          timeoutMs:
+            params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+          chunkTimeoutMs:
+            params?.chunkTimeoutMs ??
+            DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
+        }),
     }).catch(async (err: unknown) => {
       return await snapshotOrBundledFallbackResult({
         error: err,
@@ -1280,10 +1408,15 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
       },
     );
+    const snapshotBody = parsed.snapshotBody ?? body;
+    const snapshotMetadata = {
+      ...metadata,
+      checksum: sha256Hex(snapshotBody),
+    };
     await snapshotStore
       ?.write({
-        body,
-        metadata,
+        body: snapshotBody,
+        metadata: snapshotMetadata,
         savedAt: verifiedAt,
         ...(parsed.trust ? { trust: parsed.trust } : {}),
         ...(parsed.trust?.mode === "signed"

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import pLimit from "p-limit";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -1101,10 +1100,23 @@ async function loadHostedCatalogShardBodies(params: {
     }
   }
   const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
-  const limit = pLimit(DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY);
-  return await Promise.all(
-    params.root.shards.map((descriptor) =>
-      limit(async () => {
+  const controller = new AbortController();
+  const bodies = Array.from({ length: params.root.shards.length }, () => "");
+  let nextIndex = 0;
+  let firstError: unknown;
+  let failed = false;
+  const worker = async () => {
+    while (!controller.signal.aborted) {
+      const index = nextIndex;
+      if (index >= params.root.shards.length) {
+        return;
+      }
+      nextIndex += 1;
+      const descriptor = params.root.shards[index];
+      if (!descriptor) {
+        return;
+      }
+      try {
         let response: Response | undefined;
         let release: (() => Promise<void>) | undefined;
         try {
@@ -1115,6 +1127,7 @@ async function loadHostedCatalogShardBodies(params: {
             requireHttps: true,
             maxRedirects: 2,
             timeoutMs: params.timeoutMs,
+            signal: controller.signal,
             policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
             auditContext: "official-external-plugin-catalog-shard",
           });
@@ -1126,7 +1139,7 @@ async function loadHostedCatalogShardBodies(params: {
           if (!response.ok) {
             throw new Error(`hosted catalog shard returned HTTP ${response.status}`);
           }
-          return await readHostedCatalogResponseText({
+          bodies[index] = await readHostedCatalogResponseText({
             response,
             maxBytes: descriptor.byteLength,
             chunkTimeoutMs: params.chunkTimeoutMs,
@@ -1137,9 +1150,31 @@ async function loadHostedCatalogShardBodies(params: {
           }
           await release?.().catch(() => undefined);
         }
-      }),
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          firstError = error;
+          controller.abort(error);
+        }
+        return;
+      }
+    }
+  };
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(
+          DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY,
+          params.root.shards.length,
+        ),
+      },
+      worker,
     ),
   );
+  if (failed) {
+    throw firstError;
+  }
+  return bodies;
 }
 
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {


### PR DESCRIPTION
<!-- feed-stack:start -->
## Feed stack

Review and merge in this order:

1. **#110250 — signed sharded catalog consumer**
2. #113333 — signed incremental change consumer

The signed-feed trust foundation is already on `main` via #101981. Producer counterparts are openclaw/clawhub#3163 for shards and openclaw/clawhub#3160 for changes. Consumer review and merge do not require the production signing key; deployed producer/key proof remains an activation gate.
<!-- feed-stack:end -->

## Summary

- consume a signed sharded plugin catalog root through the configured hosted catalog URL
- verify the DSSE root before shard fetches, constrain shard URLs and redirects to the root origin, and fetch with bounded concurrency through the SSRF guard
- verify exact UTF-8 length and SHA-256 before parsing each shard, then enforce identity, sequence, index, count, uniqueness, and deterministic ordering
- persist the signed root plus immutable shard bytes so offline and HTTP 304 fallback re-verifies the trust chain
- preserve signed rollback, equivocation, expiry, identity binding, and install-authority behavior

## Bounds

- root payload: 1 MiB; signed root response: 2 MiB
- up to 1,024 shards and 1,000,000 entries
- shard: 1 MiB and 10,000 entries
- aggregate described shard bytes: 256 MiB
- shard fetch concurrency: 4

## Validation

- `npx -y node@24.15.0 scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog-shards.test.ts src/plugins/official-external-plugin-catalog-envelope.test.ts src/plugins/official-external-plugin-catalog.test.ts` — 81 tests passed
- targeted `oxfmt` and `oxlint`
- `git diff --check`

## Real behavior proof

Cross-repo exact-head proof completed on 2026-07-25:

- openclaw/clawhub#3163 at `408f26e09c95825ff97c991fdaec53d62056ea65` used its production `buildCatalogFeedShards`, shard-root HTTP handler, schema serializer, and DSSE signer to produce a signed root plus digest-addressed shard with an ephemeral Ed25519 key.
- the pre-rebase review head `973131fc6dff5ee44bed127c62932410bc55e049` loaded those exact producer bytes through the production hosted-catalog loader, verified the DSSE signature and shard descriptor length/digest/schema/origin invariants, persisted the root and shard through the SQLite snapshot store, then reloaded and re-verified them in offline mode.
- producer marker: `CLAWHUB_SIGNED_SHARD_PRODUCED` (`sequence=42`, `entries=2`, `shards=1`, DSSE media type)
- consumer marker: `OPENCLAW_SIGNED_SHARD_ACCEPTED_AND_REPLAYED` (`liveSource=hosted`, `offlineSource=hosted-snapshot`, `persisted=true`, `offlineReverified=true`)
- current review head `64d6a2f19c5ec813312887731ed1eecff41a3c20` is rebased onto current main and includes the focused topology cleanup; 81 focused tests, type-aware lint, deadcode:full, both zero-cycle checks, and diff checks pass on this head.

The transport was injected locally so the two public PR heads could be exercised together before deployment; producer representation/signature and consumer verification/persistence/replay used the real implementations. The ephemeral private key and generated bundle were deleted after the run. Full markers are recorded in the maintainer proof comment below.

Maintainer decision: accept this consumer as a staged, inactive contract. The production signing key, deployed endpoint, and live production proof remain activation gates; they are not review or merge dependencies.


