### PR TITLE
fix(gateway): keep provider failures distinct from cancellations

### DIFF
--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -224,8 +224,12 @@ export function dispatchAgentRunFromGateway(params: {
     .catch(async (err: unknown) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
       const renderedErr = formatForLog(err);
-      const stopReason = resolveGatewayAgentAbortStopReason(params.abortController.signal);
-      const timeoutPhase = aborted ? resolveGatewayAgentAbortTimeoutPhase(stopReason) : undefined;
+      const stopReason = aborted
+        ? resolveGatewayAgentAbortStopReason(params.abortController.signal)
+        : undefined;
+      const timeoutPhase = stopReason
+        ? resolveGatewayAgentAbortTimeoutPhase(stopReason)
+        : undefined;
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -19,6 +19,7 @@ import {
   setDetachedTaskLifecycleRuntime,
 } from "../../tasks/task-runtime.test-helpers.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { dispatchAgentRunFromGateway } from "./agent-run-dispatch.js";
 import {
   applyGatewaySubagentRegistryTestDeps,
   getAgentTestMocks,
@@ -688,6 +689,42 @@ describe("gateway agent handler", () => {
           false,
         );
       });
+    });
+  });
+
+  it("settles ordinary async gateway agent rejections as failed", async () => {
+    const providerError = new Error("provider request failed");
+    mocks.agentCommand.mockRejectedValueOnce(providerError);
+    const context = makeContext();
+    const onSettled = vi.fn(() => true);
+    const respond = vi.fn();
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "background cli task",
+        sessionKey: "agent:main:main",
+        allowModelOverride: false,
+      },
+      runId: "agent-run-provider-error-settlement",
+      dedupeKeys: ["agent:agent-run-provider-error-settlement"],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onSettled,
+    });
+
+    await waitForAssertion(() => {
+      expect(onSettled).toHaveBeenCalledWith({
+        terminalOutcome: {
+          reason: "failed",
+          status: "error",
+          error: "Error: provider request failed",
+        },
+        onRecovered: expect.any(Function),
+      });
+      expect(respond).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an ordinary asynchronous provider failure was normalized as a cancelled run because Gateway settlement always attached the RPC stop reason, even when no abort occurred.

## Why This Change Was Made

Abort stop reasons and timeout phases are now derived only after the rejection is confirmed as an abort. Ordinary provider failures retain their error outcome, while RPC, restart, and timeout abort behavior remains unchanged.

AI-assisted. I reviewed the full dispatcher, terminal-outcome normalizer, settlement caller, and adjacent abort tests.

## User Impact

No wire-protocol change. Internal settlement consumers can now distinguish provider failures from operator cancellations correctly.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts -t 'async gateway agent rejections|settles ordinary'` — 10 passed.
- `node scripts/check-changed.mjs` — green on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29621766789
- Autoreview — clean; no accepted/actionable findings.
