### PR TITLE
fix(perf): gateway startup benchmark reports n/a CPU/RSS on Windows

### DIFF
--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -12,7 +12,6 @@ import {
   getFreePort,
   parseProcessRssKb,
   readProcessRssMb,
-  readProcessTreeCpuMs,
   requestProbeStatus,
 } from "./lib/gateway-bench-probes.ts";
 import { selectSlowStartupTraceDurations } from "./lib/gateway-startup-trace-ranking.js";
@@ -798,16 +797,20 @@ async function runGatewaySample(options: {
     detached: process.platform !== "win32",
     env,
   });
-  const cpuStartMs = readProcessTreeCpuMs(child.pid);
+  const isWindows = process.platform === "win32";
   const sampleRss = () => {
     const rssMb = readProcessRssMb(child.pid);
     if (rssMb != null) {
       maxRssMb = maxRssMb == null ? rssMb : Math.max(maxRssMb, rssMb);
     }
   };
-  sampleRss();
-  const rssTimer = setInterval(sampleRss, 100);
-  rssTimer.unref?.();
+  // Reading RSS on Windows spawns a CIM query, so sample once at ready (below) instead of hot-polling;
+  // Unix `ps` is cheap enough to poll for the startup peak.
+  const rssTimer = isWindows ? null : setInterval(sampleRss, 100);
+  if (!isWindows) {
+    sampleRss();
+  }
+  rssTimer?.unref?.();
   const childExitPromise = new Promise<{ exitCode: number | null; signal: string | null }>(
     (resolve) => {
       child.once("exit", (exitCode, signal) => {
@@ -859,15 +862,21 @@ async function runGatewaySample(options: {
     }),
   ]);
   const readyAt = performance.now();
-  const cpuEndMs = readProcessTreeCpuMs(child.pid);
-  const cpuMs = cpuStartMs == null || cpuEndMs == null ? null : Math.max(0, cpuEndMs - cpuStartMs);
-  const cpuCoreRatio = cpuMs == null ? null : cpuMs / Math.max(1, readyAt - startAt);
+  // Sample RSS while the gateway is still alive; on Windows this is the primary (non-polled) sample.
+  sampleRss();
   const exit = await stopChild(child);
-  clearInterval(rssTimer);
+  if (rssTimer) {
+    clearInterval(rssTimer);
+  }
   sampleRss();
   // stopChild is the bounded teardown wait; the raw exit promise may never settle.
   void childExitPromise.catch(() => null);
   rmSync(root, { force: true, maxRetries: 3, recursive: true, retryDelay: 100 });
+  // The gateway emits its own CPU total (process.cpuUsage) in the memory.ready startup trace, so read a
+  // ready-anchored value here with no external process query. The value is fixed at the ready boundary,
+  // so reading it after teardown drains stdout cannot let post-ready work inflate the reported CPU.
+  const cpuMs = startupTrace["memory.ready.cpuMs"] ?? null;
+  const cpuCoreRatio = cpuMs == null ? null : cpuMs / Math.max(1, readyAt - startAt);
 
   return {
     cpuCoreRatio,

--- a/scripts/lib/gateway-bench-probes.ts
+++ b/scripts/lib/gateway-bench-probes.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { request } from "node:http";
 import { createServer } from "node:net";
+import path from "node:path";
 import { expectDefined } from "../../packages/normalization-core/src/expect.js";
 
 export async function getFreePort(): Promise<number> {
@@ -57,8 +58,11 @@ function classifyProbeErrorKind(error: unknown): string {
 }
 
 export function readProcessRssMb(pid: number | undefined): number | null {
-  if (!pid || process.platform === "win32") {
+  if (!pid || !Number.isInteger(pid) || pid <= 0) {
     return null;
+  }
+  if (process.platform === "win32") {
+    return readWin32ProcessWorkingSetMb(pid);
   }
   const result = spawnSync("ps", ["-o", "rss=", "-p", String(pid)], {
     encoding: "utf8",
@@ -171,4 +175,48 @@ function parsePsCpuTimeMs(raw: string): number | null {
     );
   }
   return null;
+}
+
+// Windows has no fast `ps` equivalent (wmic is removed on recent builds), so per-process RSS comes from
+// a CIM Win32_Process query. Callers keep this to a single sample per run, never a hot poll.
+const WIN32_PROCESS_QUERY_TIMEOUT_MS = 10_000;
+
+function readWin32ProcessWorkingSetMb(pid: number): number | null {
+  const raw = runWin32ProcessQuery(
+    `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | Select-Object -ExpandProperty WorkingSetSize`,
+  );
+  if (raw === null) {
+    return null;
+  }
+  const bytes = Number(raw.trim());
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return null;
+  }
+  return bytes / (1024 * 1024);
+}
+
+function runWin32ProcessQuery(script: string): string | null {
+  const result = spawnSync(
+    resolvePowershellPath(),
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: WIN32_PROCESS_QUERY_TIMEOUT_MS,
+      windowsHide: true,
+    },
+  );
+  if (result.status !== 0 || typeof result.stdout !== "string") {
+    return null;
+  }
+  const trimmed = result.stdout.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function resolvePowershellPath(): string {
+  const systemRoot = process.env.SystemRoot ?? process.env.windir;
+  return systemRoot
+    ? path.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+    : "powershell.exe";
 }

--- a/src/gateway/restart-trace.test.ts
+++ b/src/gateway/restart-trace.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
-  collectGatewayProcessMemoryUsageMb,
+  collectGatewayProcessUsageMetrics,
   createGatewayRestartTraceHandoffEnv,
 } from "./restart-trace.js";
 
@@ -24,9 +24,10 @@ describe("gateway restart trace handoff", () => {
   });
 
   it("includes restart resource counts with ready memory metrics", () => {
-    const metrics = Object.fromEntries(collectGatewayProcessMemoryUsageMb());
+    const metrics = Object.fromEntries(collectGatewayProcessUsageMetrics());
 
     expect(metrics.rssMb).toEqual(expect.any(Number));
+    expect(metrics.cpuMs).toEqual(expect.any(Number));
     expect(metrics.activeTimersCount).toEqual(expect.any(Number));
     expect(metrics.processSigusr1ListenersCount).toEqual(expect.any(Number));
     expect(metrics.processSigtermListenersCount).toEqual(expect.any(Number));
@@ -36,7 +37,7 @@ describe("gateway restart trace handoff", () => {
   it("counts active timer resources", () => {
     const timer = setTimeout(() => {}, 10_000);
     try {
-      const metrics = Object.fromEntries(collectGatewayProcessMemoryUsageMb());
+      const metrics = Object.fromEntries(collectGatewayProcessUsageMetrics());
 
       expect(metrics.activeTimersCount).toBeGreaterThanOrEqual(1);
     } finally {

--- a/src/gateway/restart-trace.ts
+++ b/src/gateway/restart-trace.ts
@@ -196,16 +196,23 @@ export function recordGatewayRestartTraceDetail(name: string, metrics: RestartTr
   emitRestartTraceDetail(name, metrics);
 }
 
-/** Collects process memory/resource metrics for restart trace diagnostics. */
-export function collectGatewayProcessMemoryUsageMb(): ReadonlyArray<readonly [string, number]> {
+/** Collects process CPU/memory/resource metrics for restart and startup trace diagnostics. */
+export function collectGatewayProcessUsageMetrics(): ReadonlyArray<readonly [string, number]> {
   const usage = process.memoryUsage();
   const toMb = (bytes: number) => bytes / 1024 / 1024;
+  // process.cpuUsage() reports cumulative user+system CPU for this process and all its threads
+  // (including worker threads) in microseconds. Emitted at the ready boundary, it gives the gateway
+  // startup benchmark an exact, ready-anchored CPU total with no external process query. The gateway
+  // is a single OS process during startup (plugins load in-process; supervisors spawn post-ready), so
+  // this matches a process-tree sum; child-process CPU, if any were spawned before ready, is excluded.
+  const cpu = process.cpuUsage();
   const metrics: Array<readonly [string, number]> = [
     ["rssMb", toMb(usage.rss)],
     ["heapTotalMb", toMb(usage.heapTotal)],
     ["heapUsedMb", toMb(usage.heapUsed)],
     ["externalMb", toMb(usage.external)],
     ["arrayBuffersMb", toMb(usage.arrayBuffers)],
+    ["cpuMs", (cpu.user + cpu.system) / 1000],
   ];
   const resources = collectGatewayProcessResourceCounts();
   if (resources) {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -22,7 +22,7 @@ import {
 } from "./chat-abort.js";
 import { abortQueuedChatTurns, type QueuedChatTurnMap } from "./chat-queued-turns.js";
 import {
-  collectGatewayProcessMemoryUsageMb,
+  collectGatewayProcessUsageMetrics,
   measureGatewayRestartTrace,
   recordGatewayRestartTrace,
 } from "./restart-trace.js";
@@ -1046,7 +1046,7 @@ export function createGatewayCloseHandler(
     recordGatewayRestartTrace("restart.close.total", durationMs, [
       ["reason", reason],
       ["restartExpectedMs", restartExpectedMs ?? "none"],
-      ...collectGatewayProcessMemoryUsageMb(),
+      ...collectGatewayProcessUsageMetrics(),
     ]);
     return { durationMs, warnings };
   };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -109,7 +109,7 @@ import {
   pluginConfigTargetsChanged,
 } from "./plugin-channel-reload-targets.js";
 import {
-  collectGatewayProcessMemoryUsageMb,
+  collectGatewayProcessUsageMetrics,
   finishGatewayRestartTrace,
   recordGatewayRestartTraceDetail,
   recordGatewayRestartTraceSpan,
@@ -2172,12 +2172,12 @@ export async function startGatewayServer(
           }),
       ),
     ));
-    startupTrace.detail("memory.ready", collectGatewayProcessMemoryUsageMb());
+    startupTrace.detail("memory.ready", collectGatewayProcessUsageMetrics());
     startupTrace.mark("ready");
     if (sidecarStartup === "defer") {
       log.info("gateway ready");
     }
-    finishGatewayRestartTrace("restart.ready", collectGatewayProcessMemoryUsageMb());
+    finishGatewayRestartTrace("restart.ready", collectGatewayProcessUsageMetrics());
     postAttachRuntimeReturned = true;
     activateScheduledServicesWhenReady();
 
@@ -2310,7 +2310,7 @@ export async function startGatewayServer(
         logCron,
         log,
         recordPostReadyMemory: () => {
-          startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
+          startupTrace.detail("memory.post-ready", collectGatewayProcessUsageMetrics());
         },
       });
       // The loop closes the previous server before this generation starts, so retired
@@ -2330,7 +2330,7 @@ export async function startGatewayServer(
         errorMessage: "retained npm generation cleanup failed",
       });
     } else {
-      startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
+      startupTrace.detail("memory.post-ready", collectGatewayProcessUsageMetrics());
     }
   } catch (err) {
     await closeOnStartupFailure();

--- a/test/scripts/gateway-bench-probes.test.ts
+++ b/test/scripts/gateway-bench-probes.test.ts
@@ -1,0 +1,108 @@
+// Verifies the process probes: `ps` CPU/RSS on Unix, and Windows RSS via a CIM Win32_Process query.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({ spawnSync: spawnSyncMock }));
+
+import {
+  parseProcessRssKb,
+  readProcessRssMb,
+  readProcessTreeCpuMs,
+} from "../../scripts/lib/gateway-bench-probes.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function mockSpawn(result: { status: number | null; stdout: string }): void {
+  spawnSyncMock.mockReturnValue(result);
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  spawnSyncMock.mockReset();
+});
+
+describe("parseProcessRssKb", () => {
+  it("parses a positive integer", () => {
+    expect(parseProcessRssKb(" 144080 \n")).toBe(144_080);
+  });
+
+  it("rejects zero, negatives, and non-numeric values", () => {
+    expect(parseProcessRssKb("0")).toBeNull();
+    expect(parseProcessRssKb("-5")).toBeNull();
+    expect(parseProcessRssKb("abc")).toBeNull();
+    expect(parseProcessRssKb("")).toBeNull();
+  });
+});
+
+describe("readProcessRssMb (Unix)", () => {
+  it("converts `ps` RSS kilobytes to megabytes", () => {
+    setPlatform("linux");
+    mockSpawn({ status: 0, stdout: "144080\n" });
+    expect(readProcessRssMb(1234)).toBeCloseTo(144_080 / 1024, 5);
+  });
+
+  it("returns null when `ps` fails", () => {
+    setPlatform("linux");
+    mockSpawn({ status: 1, stdout: "" });
+    expect(readProcessRssMb(1234)).toBeNull();
+  });
+
+  it("returns null for an invalid pid without spawning", () => {
+    setPlatform("linux");
+    expect(readProcessRssMb(undefined)).toBeNull();
+    expect(readProcessRssMb(0)).toBeNull();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("readProcessTreeCpuMs (Unix)", () => {
+  it("sums CPU time across the tree rooted at rootPid", () => {
+    setPlatform("linux");
+    mockSpawn({
+      status: 0,
+      stdout: ["100 1 00:10", "200 100 00:05", "300 100 01:00", "400 999 00:30"].join("\n"),
+    });
+    // 100=10s + 200=5s + 300=60s; 400 belongs to a different parent and is excluded.
+    expect(readProcessTreeCpuMs(100)).toBe(75_000);
+  });
+
+  it("returns null when the root pid is absent", () => {
+    setPlatform("linux");
+    mockSpawn({ status: 0, stdout: "200 100 00:05" });
+    expect(readProcessTreeCpuMs(999_999)).toBeNull();
+  });
+
+  it("returns null when `ps` fails", () => {
+    setPlatform("linux");
+    mockSpawn({ status: 1, stdout: "" });
+    expect(readProcessTreeCpuMs(100)).toBeNull();
+  });
+});
+
+describe("readProcessRssMb (Windows)", () => {
+  it("converts CIM WorkingSetSize bytes to megabytes", () => {
+    setPlatform("win32");
+    mockSpawn({ status: 0, stdout: "144080896\n" });
+    expect(readProcessRssMb(1234)).toBeCloseTo(144_080_896 / (1024 * 1024), 5);
+  });
+
+  it("returns null on empty or failed output", () => {
+    setPlatform("win32");
+    mockSpawn({ status: 0, stdout: "   " });
+    expect(readProcessRssMb(1234)).toBeNull();
+    mockSpawn({ status: 1, stdout: "" });
+    expect(readProcessRssMb(1234)).toBeNull();
+  });
+});
+
+describe("readProcessTreeCpuMs (Windows)", () => {
+  it("is unavailable on Windows (startup CPU comes from the gateway ready trace)", () => {
+    setPlatform("win32");
+    expect(readProcessTreeCpuMs(100)).toBeNull();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> AI-assisted (GitHub Copilot CLI, Codex/gpt-5.6-sol autoreview). I understand what the code does; a sanitized session transcript is included below.

## What Problem This Solves

Fixes an issue where developers profiling OpenClaw on Windows would see `cpu=n/a cpuCore=n/a rss=n/a` in the gateway startup benchmark (`pnpm test:gateway:cpu-scenarios` / `scripts/bench-gateway-startup.ts`). The CPU-per-core and RSS observations that the hot-CPU regression gate relies on were never captured on Windows, so the benchmark could not report — or gate on — startup CPU and memory there.

## Why This Change Was Made

`scripts/lib/gateway-bench-probes.ts` implemented `readProcessRssMb` and `readProcessTreeCpuMs` only for Unix (via `ps`) and returned `null` on `win32`.

- **RSS:** `readProcessRssMb` gains a Windows implementation via a CIM `Win32_Process` `WorkingSetSize` query (with PID validation). The Unix `ps` path is unchanged.
- **CPU:** measured at the gateway's own **ready boundary** instead of via an external process query. The gateway already emits a `memory.ready` startup-trace snapshot; it now also reports `process.cpuUsage()` as `cpuMs`, and the bench reads `memory.ready.cpuMs`. This is exact and ready-anchored on every platform and retires the external `ps`/CIM CPU read from the startup bench, so post-ready work can no longer be charged to startup CPU. `readProcessTreeCpuMs` stays for the Unix-only restart bench.

This directly resolves the ClawSweeper/Codex review's [P1]: the earlier Windows approach read CPU via a synchronous CIM query that ran *after* `readyAt`, so post-ready CPU could inflate the ratio and falsely trip the hot-CPU gate. Reading a child-reported value fixed at the ready instant removes that skew.

**Behavior notes:**
- The gateway's `memory.ready` / `memory.post-ready` / `restart.ready` / close startup-trace lines gain a `cpuMs=` field on **all** platforms (one cheap `process.cpuUsage()` call; additive diagnostics only).
- During startup the gateway is a single OS process (plugins load in-process; worker threads share the PID; supervisors spawn *after* ready), so `process.cpuUsage()` equals the previous process-tree sum — verified empirically (no child processes at ready). On Unix this also slightly improves accuracy (exact ready anchor; no `ps` fork per sample).

## User Impact

Developers and maintainers running the Windows gateway startup benchmark now get real `cpuMs`, `cpuCoreRatio`, and `maxRssMb` values instead of `n/a`, and the CPU value is anchored to the ready boundary on every platform, so the hot-CPU regression gate is accurate. No product runtime behavior changes beyond the additive `cpuMs=` trace field.

## Evidence

AI-assisted; reviewers should inspect the code, tests, and CI. Highlights:

**Before (Windows):** `[gateway-startup-bench] default run 1/1: ... cpu=n/a cpuCore=n/a rss=n/a`

**After — gateway emits ready-anchored CPU (Windows 11 build 26652, Node v24.18.0):**
```
[gateway] startup trace: memory.ready rssMb=1015.3 ... cpuMs=52468.0 ...
=== parsed cpuMs: 52468.0
=== gateway child processes (ParentProcessId=9408): (none)
```
(~52.5 CPU-s over a ~55 s startup → cpuCoreRatio ≈ 0.95; no child processes at ready, so `process.cpuUsage()` == the old process-tree sum.)

- New/updated cross-platform unit tests — `test/scripts/gateway-bench-probes.test.ts` (`ps` + Windows CIM RSS, Unix CPU, null/failure paths) and a `cpuMs` assertion in `src/gateway/restart-trace.test.ts`:
  ```
  ✓ test/scripts/gateway-bench-probes.test.ts (11 tests)
  ✓ src/gateway/restart-trace.test.ts (3 tests)
  ```
- Static checks green: `pnpm tsgo` (core), `pnpm tsgo:scripts`, `pnpm check:test-types`, `oxfmt --check`, `oxlint`.
- `autoreview` (Codex `gpt-5.6-sol`, high) — **clean** ("patch is correct"): consistently replaces the external Windows CPU probe with a ready-anchored in-process metric, updates all call sites, and preserves Unix behavior.

**Note:** As a fork PR, upstream CI may require maintainer approval to run.

**Scope:** `scripts/bench-gateway-startup.ts`, `scripts/lib/gateway-bench-probes.ts`, `src/gateway/restart-trace.ts` (+ its test), `src/gateway/server.impl.ts`, `src/gateway/server-close.ts`, and the new probe test — +195/−22 across 7 files.

## Agent Transcript

<details>
<summary>Redacted agent transcript (GitHub Copilot CLI — trimmed to this fix)</summary>

```text
source: local GitHub Copilot CLI session (redacted)
omitted: raw tool outputs, system/tool context, reasoning, local paths, secrets
scope: trimmed to the Windows CPU/RSS probes fix and the ClawSweeper review response;
       unrelated earlier session tasks are excluded

[user] let's fix readProcessTreeCpuMs / readProcessRssMb

[assistant] Root cause: both probes early-return null on win32 and use Unix `ps`, so the gateway
startup bench logs cpu/cpuCore/rss as n/a on Windows.

[assistant] Added Windows CIM implementations (RSS from WorkingSetSize; CPU from process-tree
KernelModeTime+UserModeTime), kept out of the startup-timing window; added cross-platform tests.
Validated (14 tests, tsgo, oxfmt/oxlint) and opened a draft PR upstream.

[user] let's address this comment: <ClawSweeper/Codex review>

[assistant] The review's [P1]: on Windows the external CIM CPU read runs ~hundreds of ms after
readyAt, so post-ready CPU is charged to startup CPU and can falsely trip the hot-CPU gate. RSS
accepted.

[user] wouldn't a process-only (not tree-based) measurement fundamentally change what's measured?

[assistant] Investigated the gateway's startup process model: plugins load in-process, worker
threads share the PID (counted either way), and supervisors spawn after ready — so for the startup
bench there are no child processes and process.cpuUsage() equals the ps tree-sum. The tree->process
shift is definitional, not numerical, for this benchmark.

[user] proceed with process.cpuUsage() cross-platform, with an empirical check + a code comment.

[assistant] Emitted process.cpuUsage() as cpuMs in the gateway's existing memory.ready trace; the
bench now reads memory.ready.cpuMs (exact, ready-anchored, cross-platform) and the external CPU
query is retired. Reverted the Windows CIM CPU code; kept Windows CIM RSS. Empirical proof on
Windows: memory.ready reported cpuMs=52468.0 at ready with no child processes, confirming
process==tree here. tsgo/check:test-types/tests/oxfmt/oxlint green; autoreview clean ("patch is
correct").
```

</details>
