### PR TITLE
feat(ios): harvest shared chat capabilities — verbosity, trace toggle, live talk level, sessions entry

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7646,6 +7646,14 @@
       ]
     },
     {
+      "locale": "fa",
+      "source": "Sessions…",
+      "translations": [
+        "جلسه‌ها…",
+        "نشست‌ها…"
+      ]
+    },
+    {
       "locale": "ar",
       "source": "Setup",
       "translations": [
@@ -7692,6 +7700,38 @@
       "translations": [
         "Configurar",
         "Configuração"
+      ]
+    },
+    {
+      "locale": "de",
+      "source": "Show reasoning & tool activity",
+      "translations": [
+        "Denkprozess und Tool-Aktivität anzeigen",
+        "Gedankengang und Werkzeugaktivität anzeigen"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Show reasoning & tool activity",
+      "translations": [
+        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
+        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Show reasoning & tool activity",
+      "translations": [
+        "Akıl yürütme ve araç etkinliğini göster",
+        "Akıl yürütmeyi ve araç etkinliğini göster"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Show reasoning & tool activity",
+      "translations": [
+        "Показувати міркування та активність інструментів",
+        "Показувати міркування та дії інструментів"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -16635,7 +16635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 137,
+      "line": 147,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -16643,7 +16643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 151,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -16651,7 +16651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 145,
+      "line": 155,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -16659,7 +16659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 166,
+      "line": 177,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -16667,7 +16667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 179,
+      "line": 190,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -16675,7 +16675,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 296,
+      "line": 318,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -16683,7 +16683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 321,
+      "line": 343,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -16691,15 +16691,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 356,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
       "id": "native.apple.1876037e64a74110"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 369,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Sessions…",
+      "surface": "apple",
+      "id": "native.apple.a1b0d289758e2213"
+    },
+    {
       "kind": "ui-call",
-      "line": 349,
+      "line": 382,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -16707,15 +16715,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 394,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
       "id": "native.apple.ced228bb4d20a726"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 404,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Show reasoning & tool activity",
+      "surface": "apple",
+      "id": "native.apple.f26cef22f417abb4"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 371,
+      "line": 413,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -16723,7 +16739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 440,
+      "line": 482,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -16731,7 +16747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 440,
+      "line": 482,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -16739,7 +16755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 453,
+      "line": 495,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -16747,7 +16763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 458,
+      "line": 500,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -16755,7 +16771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 461,
+      "line": 503,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -16763,7 +16779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 559,
+      "line": 601,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -16771,7 +16787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 560,
+      "line": 602,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -16779,7 +16795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 563,
+      "line": 605,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -16787,7 +16803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 564,
+      "line": 606,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -16795,7 +16811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 567,
+      "line": 609,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -16803,7 +16819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 568,
+      "line": 610,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -10439,6 +10439,11 @@
       "translated": "دردشة جديدة في Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "الجلسات…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "مهام الخلفية"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "تصدير النص"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "إظهار الاستدلال ونشاط الأدوات"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -10439,6 +10439,11 @@
       "translated": "Neuer Chat im Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sitzungen…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Hintergrundaufgaben"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Transkript exportieren"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Denkprozess und Tool-Aktivität anzeigen"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -10439,6 +10439,11 @@
       "translated": "Nuevo chat en worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sesiones…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Tareas en segundo plano"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Exportar transcripción"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Mostrar el razonamiento y la actividad de las herramientas"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -10439,6 +10439,11 @@
       "translated": "چت جدید در Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "نشست‌ها…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "وظایف پس‌زمینه"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "خروجی گرفتن از رونوشت"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "نمایش استدلال و فعالیت ابزارها"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -10439,6 +10439,11 @@
       "translated": "Nouveau chat dans le worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessions…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Tâches en arrière-plan"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Exporter la transcription"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Afficher le raisonnement et l’activité des outils"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -10439,6 +10439,11 @@
       "translated": "Worktree में नया चैट"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "सत्र…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "बैकग्राउंड कार्य"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "प्रतिलेख निर्यात करें"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "तर्क और टूल गतिविधि दिखाएँ"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -10439,6 +10439,11 @@
       "translated": "Chat Baru di Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sesi…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Tugas Latar Belakang"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Ekspor Transkrip"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Tampilkan penalaran & aktivitas alat"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -10439,6 +10439,11 @@
       "translated": "Nuova chat nel worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessioni…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Attività in background"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Esporta trascrizione"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Mostra il ragionamento e l'attività degli strumenti"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -10439,6 +10439,11 @@
       "translated": "worktree で新規チャット"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "セッション…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "バックグラウンドタスク"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "トランスクリプトをエクスポート"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "推論とツールのアクティビティを表示"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -10439,6 +10439,11 @@
       "translated": "Worktree에서 새 채팅"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "세션…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "백그라운드 작업"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "대화 기록 내보내기"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "추론 및 도구 활동 표시"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -10439,6 +10439,11 @@
       "translated": "Nieuwe chat in worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessies…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Achtergrondtaken"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Transcript exporteren"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Redenering en toolactiviteit tonen"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -10439,6 +10439,11 @@
       "translated": "Nowy czat w worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sesje…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Zadania w tle"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Eksportuj transkrypcję"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Pokaż tok rozumowania i aktywność narzędzi"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -10439,6 +10439,11 @@
       "translated": "Novo Chat no Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessões…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Tarefas em segundo plano"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Exportar transcrição"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Mostrar raciocínio e atividade das ferramentas"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -10439,6 +10439,11 @@
       "translated": "Новый чат в Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Сеансы…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Фоновые задачи"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Экспортировать стенограмму"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Показывать ход рассуждений и действия инструментов"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -10439,6 +10439,11 @@
       "translated": "Ny chatt i worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessioner…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Bakgrundsuppgifter"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Exportera transkript"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Visa resonemang och verktygsaktivitet"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -10439,6 +10439,11 @@
       "translated": "แชทใหม่ใน Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "เซสชัน…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "งานเบื้องหลัง"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "ส่งออกบันทึกการสนทนา"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -10439,6 +10439,11 @@
       "translated": "Worktree'de Yeni Sohbet"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Oturumlar…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Arka Plan Görevleri"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Dökümü dışa aktar"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Akıl yürütmeyi ve araç etkinliğini göster"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -10439,6 +10439,11 @@
       "translated": "Новий чат у Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Сеанси…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Фонові завдання"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Експортувати транскрипт"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Показувати міркування та активність інструментів"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -10439,6 +10439,11 @@
       "translated": "Trò chuyện mới trong Worktree"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Phiên…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "Tác vụ nền"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "Xuất bản ghi cuộc trò chuyện"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "Hiển thị quá trình suy luận và hoạt động của công cụ"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -10439,6 +10439,11 @@
       "translated": "在 Worktree 中新建聊天"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "会话…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "后台任务"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "导出转录"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "显示推理和工具活动"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -10439,6 +10439,11 @@
       "translated": "在 Worktree 中新增聊天"
     },
     {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "工作階段…"
+    },
+    {
       "id": "native.apple.17c13312e7532c89",
       "source": "Background Tasks",
       "translated": "背景任務"
@@ -10447,6 +10452,11 @@
       "id": "native.apple.ced228bb4d20a726",
       "source": "Export Transcript",
       "translated": "匯出逐字稿"
+    },
+    {
+      "id": "native.apple.f26cef22f417abb4",
+      "source": "Show reasoning & tool activity",
+      "translated": "顯示推理與工具活動"
     },
     {
       "id": "native.apple.940e1f943750c94b",

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -208,7 +208,8 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             sessionKey: target.sessionKey,
             agentID: target.agentID,
             model: patch.model,
-            thinkingLevel: patch.thinkingLevel)
+            thinkingLevel: patch.thinkingLevel,
+            verboseLevel: patch.verboseLevel)
         let response = if let expectedRoute {
             try await self.gateway.request(
                 request,

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -9,11 +9,14 @@ struct ChatProTab: View {
     }
 
     @Environment(NodeAppModel.self) private var appModel
+    @AppStorage("openclaw.webchat.showAssistantTrace")
+    private var showsAssistantTrace = true
     @State private var viewModel: OpenClawChatViewModel?
     @State private var viewModelOwnerID = ""
     @State private var transcriptShareItem: TranscriptShareItem?
     @State private var showsTranscriptExportError = false
     @State private var showsBackgroundTasks = false
+    @State private var showsSessions = false
     // Transport can start unscoped while the UI uses its "main" fallback.
     // Track the real agent so gateway metadata replaces the captured transport.
     @State private var viewModelTransportAgentID = ""
@@ -133,6 +136,13 @@ struct ChatProTab: View {
             .sheet(isPresented: self.$showsBackgroundTasks) {
                 BackgroundTasksScreen(agentID: self.currentAgentID)
             }
+            .sheet(isPresented: self.$showsSessions) {
+                NavigationStack {
+                    CommandSessionsScreen(
+                        usesNativeNavigationChrome: true,
+                        openChat: { self.showsSessions = false })
+                }
+            }
             .alert(
                 String(localized: "Unable to Export Transcript"),
                 isPresented: self.$showsTranscriptExportError)
@@ -155,6 +165,7 @@ struct ChatProTab: View {
                 drawsBackground: false,
                 showsSessionSwitcher: false,
                 userAccent: self.chatUserAccent,
+                showsAssistantTrace: self.showsAssistantTrace,
                 assistantName: self.agentDisplayName,
                 assistantAvatarText: self.agentBadge,
                 assistantAvatarTint: OpenClawBrand.accent,
@@ -273,10 +284,21 @@ struct ChatProTab: View {
             isGatewayConnected: self.appModel.talkMode.isGatewayConnected,
             statusText: self.appModel.talkMode.statusText,
             providerLabel: self.appModel.talkMode.gatewayTalkProviderLabel,
+            level: self.talkLevel,
             toggle: { sessionKey in
                 self.appModel.focusChatSession(sessionKey)
                 self.appModel.setTalkEnabled(!self.appModel.talkMode.isEnabled)
             })
+    }
+
+    private var talkLevel: Double {
+        if self.appModel.talkMode.isSpeaking {
+            return self.appModel.talkMode.playbackLevel ?? 0
+        }
+        if self.appModel.talkMode.isListening {
+            return self.appModel.talkMode.micLevel
+        }
+        return 0
     }
 
     private var voiceNoteControl: OpenClawChatVoiceNoteControl {
@@ -340,6 +362,17 @@ struct ChatProTab: View {
                 .disabled(self.viewModel == nil || !self.gatewayConnected || self.isAttachmentOwnerPinned)
             }
 
+            Button {
+                self.showsSessions = true
+            } label: {
+                Label {
+                    Text(String(localized: "Sessions…"))
+                        .font(OpenClawType.body)
+                } icon: {
+                    Image(systemName: "rectangle.stack")
+                }
+            }
+
             Divider()
 
             Button {
@@ -365,6 +398,15 @@ struct ChatProTab: View {
                 }
             }
             .disabled(self.viewModel == nil)
+
+            Toggle(isOn: self.$showsAssistantTrace) {
+                Label {
+                    Text(String(localized: "Show reasoning & tool activity"))
+                        .font(OpenClawType.body)
+                } icon: {
+                    Image(systemName: "brain.head.profile")
+                }
+            }
         } label: {
             Image(systemName: "ellipsis.circle")
         }

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -147,6 +147,35 @@ struct IOSGatewayChatTransportTests {
         #expect(request.params["thinkingLevel"]?.value as? String == "high")
     }
 
+    @Test func `verbosity patches preserve set and clear values`() async throws {
+        let recorder = RequestRecorder()
+        let transport = IOSGatewayChatTransport(
+            gateway: GatewayNodeSession(),
+            globalAgentId: " Reviewer ",
+            sessionMutationRequest: { request in
+                await recorder.record(request)
+            })
+
+        _ = try await transport.patchSessionSettings(
+            sessionKey: "global",
+            agentID: nil,
+            patch: OpenClawChatSessionSettingsPatch(verboseLevel: .some("full")))
+        _ = try await transport.patchSessionSettings(
+            sessionKey: "global",
+            agentID: nil,
+            patch: OpenClawChatSessionSettingsPatch(verboseLevel: .some(nil)))
+
+        let requests = await recorder.all()
+        #expect(requests.count == 2)
+        #expect(requests.allSatisfy { $0.method == "sessions.patch" })
+        #expect(requests.allSatisfy { $0.params["key"]?.value as? String == "global" })
+        #expect(requests.allSatisfy { $0.params["agentId"]?.value as? String == "reviewer" })
+        #expect(requests[0].params["verboseLevel"]?.value as? String == "full")
+        #expect(requests[1].params["verboseLevel"]?.value is NSNull)
+        #expect(requests.allSatisfy { $0.params["model"] == nil })
+        #expect(requests.allSatisfy { $0.params["thinkingLevel"] == nil })
+    }
+
     @Test func `requests fail fast when gateway not connected`() async {
         let gateway = GatewayNodeSession()
         let transport = IOSGatewayChatTransport(gateway: gateway)

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -222,6 +222,8 @@ struct OpenClawTypographyTests {
         #expect(proComponents.contains("secondaryActionTitle.text"))
 
         #expect(chatTab.contains("Text(\"Export Transcript\")"))
+        #expect(chatTab.contains("Text(String(localized: \"Sessions…\"))"))
+        #expect(chatTab.contains("Text(String(localized: \"Show reasoning & tool activity\"))"))
         #expect(chatTab.contains(".font(OpenClawType.body)"))
         #expect(!chatTab.contains("Button(\"Export Transcript\")"))
 

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -18,6 +18,7 @@ Availability: iPhone app builds are distributed through Apple channels when enab
 - Browses the selected agent's workspace read-only from the Agents surface (Files): directory drill-down, syntax-highlighted text previews, image previews, and share-sheet export. No write operations; previews are size-capped by the gateway.
 - Keeps a small read-only offline cache of recent chat sessions and transcripts per paired gateway: cold opens paint the last known transcript immediately and refresh once the gateway responds, recent chats stay browsable while disconnected, and reset/forget purges the protected local cache.
 - Queues text messages sent while disconnected in a durable per-gateway outbox (up to 50): queued bubbles show in the transcript, flush in order on reconnect with idempotent retries, remain durable until canonical history confirms the send, retry with backoff before surfacing a retry/delete action, and expire instead of sending after 48 hours offline; reset/forget clears the queue with the cache.
+- Chat actions can open the full Sessions screen without leaving Chat and can show or hide assistant reasoning and tool activity. The inline Talk control animates from live microphone or playback level while listening or speaking.
 - Speaks assistant messages on demand: long-press a message in Chat and choose **Listen**. The app plays supported gateway `tts.speak` clips with the configured TTS provider and falls back to on-device speech when gateway audio is unavailable or unplayable. Playback stops on session switch or backgrounding.
 
 ## Requirements


### PR DESCRIPTION
## What Problem This Solves

Several capabilities that already exist in the shared chat package or on macOS never reached iOS: the session verbosity setting is silently dropped by the iOS transport, assistant reasoning/tool traces cannot be shown at all, the talk button gives no visual feedback while listening or speaking, and reaching session management requires leaving the chat tab.

## Why This Change Was Made

iOS and macOS share `OpenClawKit`; this harvests recent shared-package work for iOS with small host wiring (audit-verified injection points):

- `IOSGatewayChatTransport` now forwards `verboseLevel` in `sessions.patch` instead of dropping it (parity with the macOS transport fix in #109712).
- The chat actions menu gains a persisted "Show reasoning & tool activity" toggle using the same `openclaw.webchat.showAssistantTrace` key and default-on semantics as macOS — iOS previously never passed the flag, so traces were permanently hidden.
- The shared talk button now animates with the live level: microphone level while listening, playback level while speaking (both already observable on `TalkModeManager`).
- A "Sessions…" menu item presents the existing sessions screen as a sheet directly from chat; selecting a session closes the sheet and focuses it.

## User Impact

iPhone/iPad chat gains visible reasoning and tool activity on demand, a live talk waveform, `/verbose` settings that actually stick, and in-place session management — using code that already shipped for macOS and the shared package.

## Evidence

- Focused simulator tests: `xcodebuild … test -only-testing:OpenClawTests/IOSGatewayChatTransportTests -only-testing:OpenClawTests/OpenClawTypographyTests` — 23 tests, 0 failures (includes new verbosity set/clear coverage).
- CI-equivalent build: `IOS_DEST='generic/platform=iOS Simulator' pnpm ios:build` — BUILD SUCCEEDED.
- `pnpm format:swift`, `pnpm lint:swift`, `pnpm native:i18n:check`, Apple/Android catalog tests — clean; the two new strings translated across all 21 locales.
- Structured review (uncommitted mode) — clean, no findings.
- Not exercised: live paired-gateway session selection and talk audio on the offline simulator; wiring is unit-tested and mirrors the macOS-proven paths.
