### PR TITLE
fix(test): converge Slack harness state across module reloads

### DIFF
--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -81,7 +81,7 @@ type SlackTestState = {
 // keeps every module incarnation and the cached client converged.
 const slackTestState: SlackTestState = vi.hoisted(() => {
   const globalState = globalThis as { __slackTestState?: SlackTestState };
-  globalState.__slackTestState ??= {
+  globalState["__slackTestState"] ??= {
     config: {} as Record<string, unknown>,
     appConstructorArgs: undefined,
     appStartMock: vi.fn(),
@@ -98,7 +98,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
     socketModeLogger: undefined,
     createSlackStartupAuthClientMock: vi.fn(),
   } as SlackTestState;
-  return globalState.__slackTestState;
+  return globalState["__slackTestState"];
 });
 
 export const getSlackTestState = (): SlackTestState => slackTestState;
@@ -256,7 +256,7 @@ export async function stopSlackMonitor(params: {
   await params.run;
   // A stopped provider's handlers must not satisfy the next start's
   // waitForSlackEvent — see the reset-time clear above.
-  (globalThis as { __slackHandlers?: Map<string, SlackHandler> }).__slackHandlers?.clear();
+  (globalThis as { __slackHandlers?: Map<string, SlackHandler> })["__slackHandlers"]?.clear();
 }
 
 async function runSlackEventOnce(
@@ -311,7 +311,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   // with isolate=false a stale "message" handler makes waitForSlackEvent
   // return before THIS test's provider registers, dispatching through the old
   // provider's closure config (reactions silently suppressed, replies fine).
-  (globalThis as { __slackHandlers?: Map<string, SlackHandler> }).__slackHandlers?.clear();
+  (globalThis as { __slackHandlers?: Map<string, SlackHandler> })["__slackHandlers"]?.clear();
   if (lastSlackTestStateDir) {
     fs.rmSync(lastSlackTestStateDir, { recursive: true, force: true });
   }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -74,23 +74,32 @@ type SlackTestState = {
   createSlackStartupAuthClientActual?: SlackStartupAuthClientFactory;
 };
 
-const slackTestState: SlackTestState = vi.hoisted(() => ({
-  config: {} as Record<string, unknown>,
-  appConstructorArgs: undefined,
-  appStartMock: vi.fn(),
-  appStopMock: vi.fn(),
-  sendMock: vi.fn(),
-  replyMock: vi.fn(),
-  updateLastRouteMock: vi.fn(),
-  reactMock: vi.fn(),
-  reactionAddMock: vi.fn(),
-  reactionRemoveMock: vi.fn(),
-  readAllowFromStoreMock: vi.fn(),
-  upsertPairingRequestMock: vi.fn(),
-  resolveSlackUserAllowlistMock: vi.fn(),
-  socketModeLogger: undefined,
-  createSlackStartupAuthClientMock: vi.fn(),
-}));
+// globalThis-backed singleton: with isolate=false, a vi.resetModules() in any
+// sibling file recreates this module while the cached __slackClient on
+// globalThis keeps routing reactions to the OLD instance's mocks — tests then
+// assert on fresh mocks that never receive calls. One shared state object
+// keeps every module incarnation and the cached client converged.
+const slackTestState: SlackTestState = vi.hoisted(() => {
+  const globalState = globalThis as { __slackTestState?: SlackTestState };
+  globalState.__slackTestState ??= {
+    config: {} as Record<string, unknown>,
+    appConstructorArgs: undefined,
+    appStartMock: vi.fn(),
+    appStopMock: vi.fn(),
+    sendMock: vi.fn(),
+    replyMock: vi.fn(),
+    updateLastRouteMock: vi.fn(),
+    reactMock: vi.fn(),
+    reactionAddMock: vi.fn(),
+    reactionRemoveMock: vi.fn(),
+    readAllowFromStoreMock: vi.fn(),
+    upsertPairingRequestMock: vi.fn(),
+    resolveSlackUserAllowlistMock: vi.fn(),
+    socketModeLogger: undefined,
+    createSlackStartupAuthClientMock: vi.fn(),
+  } as SlackTestState;
+  return globalState.__slackTestState;
+});
 
 export const getSlackTestState = (): SlackTestState => slackTestState;
 
@@ -245,6 +254,9 @@ export async function stopSlackMonitor(params: {
   await flush();
   params.controller.abort();
   await params.run;
+  // A stopped provider's handlers must not satisfy the next start's
+  // waitForSlackEvent — see the reset-time clear above.
+  (globalThis as { __slackHandlers?: Map<string, SlackHandler> }).__slackHandlers?.clear();
 }
 
 async function runSlackEventOnce(
@@ -295,6 +307,11 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   // so a carried-over DB would dedupe unrelated test messages. realpath keeps
   // macOS /var vs /private/var symlinks out of resolver assertions.
   closeOpenClawStateDatabaseForTest();
+  // Clear worker-global Bolt handler registrations from previous test files:
+  // with isolate=false a stale "message" handler makes waitForSlackEvent
+  // return before THIS test's provider registers, dispatching through the old
+  // provider's closure config (reactions silently suppressed, replies fine).
+  (globalThis as { __slackHandlers?: Map<string, SlackHandler> }).__slackHandlers?.clear();
   if (lastSlackTestStateDir) {
     fs.rmSync(lastSlackTestStateDir, { recursive: true, force: true });
   }

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -440,7 +440,8 @@ describe("monitorSlackProvider tool results", () => {
       assistant?: { threads?: { setStatus?: ReturnType<typeof vi.fn> } };
     };
     const setStatus = client.assistant?.threads?.setStatus;
-    expect(setStatus).toHaveBeenCalledTimes(2);
+    // Status updates run detached from the awaited dispatch; wait on the mock.
+    await vi.waitFor(() => expect(setStatus).toHaveBeenCalledTimes(2), { timeout: 5_000 });
     expect(setStatus).toHaveBeenNthCalledWith(1, {
       token: "bot-token",
       channel_id: "C1",
@@ -655,11 +656,17 @@ describe("monitorSlackProvider tool results", () => {
       { awaitDispatch: true },
     );
 
-    expect(reactMock).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "456",
-      name: "eyes",
-    });
+    // Ack reactions apply via the status-reaction debounce/queue, detached
+    // from the awaited dispatch; wait on the mock instead of asserting inline.
+    await vi.waitFor(
+      () =>
+        expect(reactMock).toHaveBeenCalledWith({
+          channel: "C1",
+          timestamp: "456",
+          name: "eyes",
+        }),
+      { timeout: 5_000 },
+    );
   });
 
   it("keeps ack reaction when no reply is delivered and status reactions are disabled", async () => {
@@ -669,7 +676,7 @@ describe("monitorSlackProvider tool results", () => {
     await runMentionGatedChannelMessage();
 
     expect(sendMock).not.toHaveBeenCalled();
-    expect(reactMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(reactMock).toHaveBeenCalledTimes(1), { timeout: 5_000 });
     expect(reactMock).toHaveBeenCalledWith({
       channel: "C1",
       timestamp: "456",
@@ -684,7 +691,7 @@ describe("monitorSlackProvider tool results", () => {
     await runMentionGatedChannelMessage();
 
     expect(sendMock).not.toHaveBeenCalled();
-    expect(reactMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(reactMock).toHaveBeenCalledTimes(1), { timeout: 5_000 });
     expect(reactMock).toHaveBeenCalledWith({
       channel: "C1",
       timestamp: "456",
@@ -718,11 +725,15 @@ describe("monitorSlackProvider tool results", () => {
 
     expect(replyMock).toHaveBeenCalledTimes(1);
     expect(sendMock).not.toHaveBeenCalled();
-    expect(reactMock).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "456",
-      name: "eyes",
-    });
+    await vi.waitFor(
+      () =>
+        expect(reactMock).toHaveBeenCalledWith({
+          channel: "C1",
+          timestamp: "456",
+          name: "eyes",
+        }),
+      { timeout: 5_000 },
+    );
   });
 
   it("keeps the error reaction when dispatch fails before any reply is delivered", async () => {
@@ -732,11 +743,15 @@ describe("monitorSlackProvider tool results", () => {
     await expect(runMentionGatedChannelMessage()).rejects.toThrow("boom");
 
     expect(sendMock).not.toHaveBeenCalled();
-    expectReactionFlow({
-      startsWith: ["eyes", "x"],
-      includes: "x",
-      endsWith: "x",
-    });
+    await vi.waitFor(
+      () =>
+        expectReactionFlow({
+          startsWith: ["eyes", "x"],
+          includes: "x",
+          endsWith: "x",
+        }),
+      { timeout: 5_000 },
+    );
   });
 
   it("replies with pairing code when dmPolicy is pairing and no allowFrom is set", async () => {


### PR DESCRIPTION
## What Problem This Solves

Five reaction tests in `monitor.tool-result.test.ts` remained flaky in roughly half of full `extensions/slack` suite runs even after #110105. With `isolate=false`, a sibling test file can call `vi.resetModules()` and recreate the Slack test-helper module while the worker-global cached `__slackClient` continues routing reactions to the old module instance's mocks. The affected tests then assert against fresh mocks that never receive those calls. Replies still work because their runtime is freshly injected, which hid the split state.

## Why This Change Was Made

The Slack harness state now lives in a `globalThis`-backed singleton, so every test-helper module incarnation and the cached Slack client converge on the same mocks. Reaction assertions now wait for the event-driven debounce/queue work instead of asserting synchronously. Stale Bolt handler registrations are also cleared during reset and shutdown so a prior provider cannot satisfy a later test's event wait.

## User Impact

No production behavior changes. Slack test runs stop reporting false reaction failures caused by cross-file module resets, improving full-suite CI reliability and diagnosis signal.

## Evidence

- Before: the five reaction tests failed in roughly 50% of full `extensions/slack` suite runs.
- After: 13 of 14 full `extensions/slack` runs passed, including eight consecutive green runs. The single earlier 18-failure outlier did not reproduce across the 14-run investigation.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor.tool-result.test.ts`: 29/29 tests passed after rebasing onto current `origin/main`.
- `node scripts/check-deadcode-exports.mjs`: production, full-tree, and script scans passed with 0 entries.
- `node scripts/check-deadcode-unused-files.mjs`: production and full-tree scans passed with 0 entries.
- `git diff --check origin/main...HEAD`: passed.
