### PR TITLE
improve(mxc): document sandbox config options and flag network access as dangerous

### DIFF
--- a/extensions/mxc/openclaw.plugin.json
+++ b/extensions/mxc/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "mxc",
   "name": "MXC Sandbox Execution",
-  "description": "OS-level sandboxed tool execution via MXC for MXC-capable Windows hosts: runs commands in ProcessContainer (Windows) with configured MXC policy files.",
+  "description": "OS-level sandboxed tool execution via MXC: runs commands in a Windows ProcessContainer with configured MXC policy files.",
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.mxc"]
@@ -12,31 +12,70 @@
     "properties": {
       "mxcBinaryPath": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "description": "Absolute path to the MXC executor (wxc-exec.exe). When unset, the executor is discovered from the installed @microsoft/mxc-sdk."
       },
       "containment": {
         "type": "string",
-        "enum": ["process", "processcontainer"]
+        "enum": ["process", "processcontainer"],
+        "description": "Windows containment mode. 'process' and 'processcontainer' currently both resolve to the Windows ProcessContainer sandbox."
       },
       "network": {
         "type": "string",
-        "enum": ["none", "default"]
+        "enum": ["none", "default"],
+        "description": "Outbound network policy. 'none' blocks all network; 'default' allows outbound access via the internetClient capability."
       },
       "timeoutSeconds": {
         "type": "number",
         "minimum": 1,
-        "maximum": 2147000
+        "maximum": 2147000,
+        "description": "Per-command execution timeout in seconds. Capped to the sandbox policy baseline timeout when both are set."
       },
       "debug": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Forward verbose debug output from the MXC SDK launcher."
       },
       "mxcPolicyPaths": {
         "type": "array",
         "items": {
           "type": "string",
           "minLength": 1
-        }
+        },
+        "description": "Absolute MXC policy file paths applied on top of the built-in sandbox baseline policy."
       }
+    }
+  },
+  "configContracts": {
+    "dangerousFlags": [{ "path": "network", "equals": "default" }]
+  },
+  "uiHints": {
+    "mxcBinaryPath": {
+      "label": "MXC Executor Path",
+      "help": "Optional absolute path to the MXC executor (wxc-exec.exe). Leave unset to auto-discover from the installed @microsoft/mxc-sdk.",
+      "advanced": true
+    },
+    "containment": {
+      "label": "Containment Mode",
+      "help": "Windows containment mode. 'process' and 'processcontainer' currently both resolve to the Windows ProcessContainer sandbox."
+    },
+    "network": {
+      "label": "Network Policy",
+      "help": "'none' blocks all outbound network; 'default' allows outbound access via the internetClient capability, which weakens sandbox isolation."
+    },
+    "timeoutSeconds": {
+      "label": "Command Timeout (seconds)",
+      "help": "Per-command execution timeout, from 1 to 2147000 seconds. Capped to the sandbox policy baseline timeout when both are set.",
+      "advanced": true
+    },
+    "debug": {
+      "label": "Debug Logging",
+      "help": "Forward verbose debug output from the MXC SDK launcher.",
+      "advanced": true
+    },
+    "mxcPolicyPaths": {
+      "label": "MXC Policy Files",
+      "help": "Absolute MXC policy file paths applied on top of the built-in sandbox baseline policy.",
+      "advanced": true
     }
   }
 }

--- a/extensions/mxc/src/config.ts
+++ b/extensions/mxc/src/config.ts
@@ -42,16 +42,26 @@ const nonEmptyTrimmedString = (message: string) =>
   z.string({ error: message }).trim().min(1, { error: message });
 
 const MxcPluginConfigSchema = z.strictObject({
-  mxcBinaryPath: nonEmptyTrimmedString("mxcBinaryPath must be a non-empty string").optional(),
+  mxcBinaryPath: nonEmptyTrimmedString("mxcBinaryPath must be a non-empty string")
+    .describe(
+      "Absolute path to the MXC executor (wxc-exec.exe). When unset, the executor is discovered from the installed @microsoft/mxc-sdk.",
+    )
+    .optional(),
   containment: z
     .enum(MXC_CONTAINMENTS, {
       error: `containment must be one of ${MXC_CONTAINMENTS.join(", ")}`,
     })
+    .describe(
+      "Windows containment mode. 'process' and 'processcontainer' currently both resolve to the Windows ProcessContainer sandbox.",
+    )
     .optional(),
   network: z
     .enum(MXC_NETWORK_MODES, {
       error: `network must be one of ${MXC_NETWORK_MODES.join(", ")}`,
     })
+    .describe(
+      "Outbound network policy. 'none' blocks all network; 'default' allows outbound access via the internetClient capability.",
+    )
     .optional(),
   timeoutSeconds: z
     .number({
@@ -61,12 +71,21 @@ const MxcPluginConfigSchema = z.strictObject({
     .max(MAX_TIMER_TIMEOUT_SECONDS, {
       error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
     })
+    .describe(
+      "Per-command execution timeout in seconds. Capped to the sandbox policy baseline timeout when both are set.",
+    )
     .optional(),
-  debug: z.boolean({ error: "debug must be a boolean" }).optional(),
+  debug: z
+    .boolean({ error: "debug must be a boolean" })
+    .describe("Forward verbose debug output from the MXC SDK launcher.")
+    .optional(),
   mxcPolicyPaths: z
     .array(nonEmptyTrimmedString("mxcPolicyPaths must be an array of non-empty strings"), {
       error: "mxcPolicyPaths must be an array of non-empty strings",
     })
+    .describe(
+      "Absolute MXC policy file paths applied on top of the built-in sandbox baseline policy.",
+    )
     .optional(),
 });
 

--- a/extensions/mxc/test/config.test.ts
+++ b/extensions/mxc/test/config.test.ts
@@ -109,6 +109,8 @@ describe("createMxcPluginConfigSchema", () => {
       type: "number",
       minimum: 1,
       maximum: MAX_TIMER_TIMEOUT_SECONDS,
+      description:
+        "Per-command execution timeout in seconds. Capped to the sandbox policy baseline timeout when both are set.",
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Operators configuring the MXC sandbox plugin (`plugins.entries.mxc`) in the OpenClaw
dashboard and config surfaces saw bare, undocumented fields: humanized keys like
"Containment" and "Network" with no explanatory help, and no signal that enabling
outbound network access weakens the sandbox. Sibling sandbox/execution plugins
(openshell, acpx, codex) already ship this metadata, so MXC was inconsistent and harder
to configure safely.

## Why This Change Was Made

Adds cheap, behavior-neutral manifest metadata to `extensions/mxc/openclaw.plugin.json`
(mirrored from the Zod config schema so the manifest↔schema drift test stays green):

- **`configContracts.dangerousFlags`** flags `network: "default"` — the one setting that
  actually weakens isolation (it flips the container to allow outbound egress via the
  `internetClient` capability). `containment` is intentionally **not** flagged, because
  `"process"` and `"processcontainer"` currently both resolve to the same Windows
  ProcessContainer.
- **Per-field `uiHints`** (label / help / advanced) for all six config fields.
- **Field `description`s** on the config schema, added via `.describe()` in
  `src/config.ts` and mirrored into the manifest.
- Manifest `description` aligned with the plugin entry.

No runtime, validation, or activation behavior changes — existing configs validate
identically, no new config keys, no migration.

## User Impact

- The dashboard config form (Settings → Plugins → MXC Sandbox Execution) now shows proper
  labels and help for every field — Containment Mode, Network Policy, Debug Logging, MXC
  Executor Path, MXC Policy Files, and Command Timeout — with advanced fields grouped.
- Enabling `network: "default"` is now surfaced as a dangerous config flag in the gateway
  startup security warning and `openclaw security audit`.
- No breaking changes, no new config keys, no migration required.

## Evidence

- **Branch refresh:** rebased onto the latest `origin/main`
  (`c715d89de81efefa92f9220a64f19fc2412ddf7f`), which matched
  `upstream/main`; PR head `e1e7e85e33ca15752819157abb030d54990e16ef`
  is 0 behind / 1 ahead with one commit and the same clean three-file diff.
- **Focused tests (exact head):** `node scripts/run-vitest.mjs extensions/mxc` —
  109/109 passing, including the manifest↔schema drift test.
- **Types:** `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — pass.
- **Format:** `oxfmt --check` — clean.
- **Fresh source review (exact head):** Codex autoreview (`gpt-5.5`, branch vs
  `origin/main`) — 0 findings, "patch is correct", confidence 0.86.
- **Security-audit behavior proof (real CLI, isolated temporary config/state):**

  ```text
  Head: e1e7e85e33ca15752819157abb030d54990e16ef

  plugins.entries.mxc.config.network = none
  Matching dangerous-flag findings: 0

  plugins.entries.mxc.config.network = default
  Matching dangerous-flag findings: 1
  checkId: config.insecure_or_dangerous_flags
  severity: warn
  title: Insecure or dangerous config flag enabled
  detail: Detected enabled flag: plugins.entries.mxc.config.network=default.
  ```

  Command shape (paths redacted):
  `OPENCLAW_CONFIG_PATH=<temp>/openclaw-<mode>.json
  OPENCLAW_STATE_DIR=<temp>/state
  OPENCLAW_BUNDLED_PLUGINS_DIR=<temp>/bundled-plugins
  node openclaw.mjs --no-color security audit --json`.
  Bundled discovery used a temporary copy of the current mxc manifest/package
  so the proof was isolated to this plugin; no user config or state was changed.
- **Live dashboard verification:** connected to a local Gateway and confirmed all six
  fields render with the new labels and help text in the plugin config form. The
  `network: "default"` help reads: *"'none' blocks all outbound network; 'default' allows
  outbound access via the internetClient capability, which weakens sandbox isolation."*

<img width="726" height="754" alt="mxc-config-full" src="https://github.com/user-attachments/assets/819c8dc9-4959-4e85-ba81-96a9ec1cea9d" />

---

🤖 Prepared with AI assistance (GitHub Copilot CLI); all changes were human-reviewed.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted agent session transcript (trimmed to this PR's work)</summary>

Sanitized local GitHub Copilot CLI session. Local paths, URLs, and tokens redacted; raw
tool output, system prompts, and an unrelated local-tooling debugging detour omitted.

**[user]** review existing extension plugin manifests and the OpenClaw plugin docs, then
review the `mxc` sandbox plugin and make recommendations for expanding its manifest

**[assistant]** Reviewed the plugin docs (building-plugins, manifest), the authoritative
`PluginManifest` schema (`src/plugins/manifest.ts`), and peer manifests (openshell, acpx,
codex, bonjour). Found mxc's manifest minimal for a security-sensitive sandbox.
Recommended: R1 `configContracts.dangerousFlags`, R2 per-field `uiHints`, R3
`configSchema`/Zod descriptions, R4 catalog/version, R5 aligned description. Noted the
drift test (`index.test.ts`) pins the manifest schema to the Zod-generated one, so R3 must
be driven from `src/config.ts`.

**[user]** for R1, I thought `process` and `processcontainer` were basically equivalent?
please verify

**[assistant]** Verified — you're right. `README.md` states both "currently resolve to
Windows ProcessContainer", and `mxc-container-config.ts` emits the same `processContainer`
block regardless of the value (`containment` is only passed through). Flagging `process`
would be a false positive, so corrected R1 to flag only `network:"default"` — the sole
real sandbox-weakening toggle (`defaultPolicy:"allow"` + `internetClient` capability).

**[assistant]** Implemented R1/R2/R3/R5 (R4 dropped after grounding: `catalog` is a curated
featured list and a top-level `version` duplicates package.json). Added `.describe()` to
each Zod field and mirrored the generated schema into the manifest. Validation:
`extensions/mxc` 105/105, `tsgo:extensions` (+ test types), `oxfmt --check` clean.

**[user]** commit and push

**[assistant]** Committed the three files and pushed the branch.

**[user]** does the sandbox/plugin config get surfaced in the dashboard anywhere?

**[assistant]** Yes — traced it in code: manifest `uiHints` + `configSchema` →
manifest-registry → `collectPluginSchemaMetadata` → merged into the served config schema at
`plugins.entries.mxc.config` → Control UI config form (`config-form.render.ts` renders
label/help/advanced). `dangerousFlags` instead surface in the gateway startup security
warning and `openclaw security audit`.

**[user]** capture proof from my locally running dashboard

**[assistant]** Connected a browser to the local Gateway and confirmed all six mxc config
fields render with the new labels and help text (Containment Mode, Network Policy incl.
"…weakens sandbox isolation", Debug Logging, MXC Executor Path, MXC Policy Files, Command
Timeout). Captured screenshots.

**[user]** get ready to open a draft PR against upstream openclaw/openclaw, referencing
CONTRIBUTING.md

**[assistant]** Confirmed the fork parent, drafted the PR body per the template,
re-validated (105/105), and opened this draft PR.

</details>
<!-- agent-transcript:end -->
