### PR TITLE
fix(acp): deliver bound follow-up turns to external harnesses

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createApprovalNativeRouteReporter } from "../../infra/approval-native-route-coordinator.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
@@ -1054,10 +1055,39 @@ describe("dispatchReplyFromConfig", () => {
       SessionKey: sourceSessionKey,
       BodyForAgent: "continue",
     });
+    const preparedLookup = vi.fn(async ({ agentId }: { agentId: string }) => {
+      if (agentId !== "main") {
+        throw new Error(`unexpected prepared reply dispatch owner ${agentId}`);
+      }
+      return Object.freeze({
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+        workspaceDir: "/tmp/main-workspace",
+        config: cfg,
+        modelCatalog: { entries: [], routeVariants: [] },
+        inboundPluginRegistry: createTestRegistry([]),
+      });
+    });
+    const runtimeLoaders = await import("./dispatch-from-config.runtime-loaders.js");
+    const preparedLoader = vi.spyOn(runtimeLoaders, "loadPreparedModelRuntime").mockResolvedValue({
+      loadPublishedGatewayReplyDispatchRuntime: preparedLookup,
+    } as never);
 
-    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    let result: Awaited<ReturnType<typeof dispatchReplyFromConfig>>;
+    try {
+      result = await dispatchReplyFromConfig({
+        ctx,
+        cfg,
+        dispatcher,
+        replyResolver,
+        usePublishedModelRuntime: true,
+      });
+    } finally {
+      preparedLoader.mockRestore();
+    }
 
     expect(result.queuedFinal).toBe(true);
+    expect(preparedLookup).toHaveBeenCalledWith({ agentId: "main" });
     expect(sessionBindingMocks.resolveByConversation).toHaveBeenCalledWith({
       channel: "discord",
       accountId: "default",

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -324,10 +324,17 @@ export async function gatherDispatchRequest(
   const routeReplyThreadId = replyRoute.threadId ?? routeThreadId;
   const inboundAudio = hasInboundAudio(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
+  // A bound ACP key names an external harness, not a configured model-runtime owner.
+  // Keep the source owner for Gateway dispatch while ACP execution uses the bound target below.
+  const preparedReplyDispatchAgentId = boundAcpDispatchSessionKey
+    ? resolveSessionAgentId({ sessionKey, config: cfg, fallbackAgentId: ctx.AgentId })
+    : sessionAgentId;
   const preparedReplyDispatchRuntime = params.usePublishedModelRuntime
     ? await traceReplyPhase("reply.load_prepared_dispatch_runtime", async () => {
         const { loadPublishedGatewayReplyDispatchRuntime } = await loadPreparedModelRuntime();
-        return await loadPublishedGatewayReplyDispatchRuntime({ agentId: sessionAgentId });
+        return await loadPublishedGatewayReplyDispatchRuntime({
+          agentId: preparedReplyDispatchAgentId,
+        });
       })
     : undefined;
   const workspaceDir =

--- a/src/gateway/gateway-acp-bind.live.test.ts
+++ b/src/gateway/gateway-acp-bind.live.test.ts
@@ -118,6 +118,30 @@ function extractAssistantTexts(messages: unknown[]): string[] {
   return texts;
 }
 
+function findAssistantReplyAfterUserToken(messages: unknown[], token: string): string | null {
+  let sawTokenUserMessage = false;
+  for (const entry of messages) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const role = (entry as { role?: unknown }).role;
+    const text = extractFirstTextBlock(entry);
+    if (role === "user" && typeof text === "string" && text.includes(token)) {
+      sawTokenUserMessage = true;
+      continue;
+    }
+    if (
+      sawTokenUserMessage &&
+      role === "assistant" &&
+      typeof text === "string" &&
+      text.trim().length > 0
+    ) {
+      return text;
+    }
+  }
+  return null;
+}
+
 function createAcpProbePhrase(words: string, nonce: string): string {
   return `${words} ${nonce.toLowerCase()}`;
 }
@@ -318,6 +342,43 @@ describe("ACP bind live probe prompts", () => {
   });
 });
 
+describe("ACP bind transcript correlation", () => {
+  const textMessage = (role: "assistant" | "user", text: string) => ({
+    role,
+    content: [{ type: "text", text }],
+  });
+
+  it("does not accept an assistant reply that precedes the routed user turn", () => {
+    expect(
+      findAssistantReplyAfterUserToken(
+        [textMessage("assistant", "late spawn reply"), textMessage("user", "follow-up token")],
+        "follow-up token",
+      ),
+    ).toBeNull();
+  });
+
+  it("skips non-text assistant entries before the routed textual reply", () => {
+    expect(
+      findAssistantReplyAfterUserToken(
+        [
+          textMessage("user", "follow-up token"),
+          { role: "assistant", content: [{ type: "toolCall", name: "read" }] },
+          textMessage("assistant", "bound reply"),
+        ],
+        "follow-up token",
+      ),
+    ).toBe("bound reply");
+  });
+});
+
+describe("ACP bind agent.wait diagnostics", () => {
+  it("includes the terminal error returned by the gateway", () => {
+    expect(formatAgentWaitFailure({ status: "error", error: "ACP turn failed" })).toContain(
+      "ACP turn failed",
+    );
+  });
+});
+
 function formatAssistantTextPreview(texts: string[], maxChars = 600): string {
   const combined = texts.join("\n\n").trim();
   if (!combined) {
@@ -416,7 +477,7 @@ async function waitForAgentRunOk(
   runId: string,
   timeoutMs = LIVE_TIMEOUT_MS,
 ) {
-  const result: { status?: string } = await client.request(
+  const result: { status?: string; [key: string]: unknown } = await client.request(
     "agent.wait",
     {
       runId,
@@ -427,8 +488,12 @@ async function waitForAgentRunOk(
     },
   );
   if (result?.status !== "ok") {
-    throw new Error(`agent.wait failed for ${runId}: status=${String(result?.status)}`);
+    throw new Error(`agent.wait failed for ${runId}: ${formatAgentWaitFailure(result)}`);
   }
+}
+
+function formatAgentWaitFailure(result: { status?: string; [key: string]: unknown }): string {
+  return JSON.stringify(result);
 }
 
 async function sendChatAndWait(params: {
@@ -747,25 +812,35 @@ describeLive("gateway live (ACP bind)", () => {
           }
         }
         if (!firstBoundHistory) {
-          try {
-            const firstBoundTurn = await waitForAssistantTurn({
-              client,
+          // Correlate by transcript order instead of counts: a late spawn reply
+          // precedes this uniquely tokened user turn and cannot satisfy the check.
+          const deadline = Date.now() + 60_000;
+          let correlatedHistory: { messages?: unknown[] } | null = null;
+          let correlatedAssistantText = "";
+          while (Date.now() < deadline && !correlatedHistory) {
+            const history: { messages?: unknown[] } = await client.request("chat.history", {
               sessionKey: spawnedSessionKey,
-              minAssistantCount: 1,
-              timeoutMs: 60_000,
+              limit: 200,
             });
-            firstBoundHistory = {
-              messages: firstBoundTurn.messages,
-              lastAssistantText: firstBoundTurn.lastAssistantText,
-              matchedAssistantText: firstBoundTurn.lastAssistantText,
-            };
-          } catch (error) {
-            if (liveAgent !== "claude") {
-              throw error;
+            correlatedAssistantText =
+              findAssistantReplyAfterUserToken(history.messages ?? [], followupToken) ?? "";
+            if (correlatedAssistantText) {
+              correlatedHistory = history;
+            } else {
+              await sleep(500);
             }
-            firstBoundHistory = { messages: [], lastAssistantText: "", matchedAssistantText: "" };
-            logLiveStep("bound follow-up response not observed; continuing to marker probe");
           }
+          if (!correlatedHistory) {
+            throw new Error(
+              `bound follow-up did not land: no assistant reply after the ${followupToken} user turn`,
+            );
+          }
+          const assistantTexts = extractAssistantTexts(correlatedHistory.messages ?? []);
+          firstBoundHistory = {
+            messages: correlatedHistory.messages ?? [],
+            lastAssistantText: assistantTexts.at(-1) ?? "",
+            matchedAssistantText: correlatedAssistantText,
+          };
         }
         const observedFollowupToken =
           firstBoundHistory.matchedAssistantText.includes(followupToken);
@@ -773,7 +848,7 @@ describeLive("gateway live (ACP bind)", () => {
 
         let recallHistory: Awaited<ReturnType<typeof waitForAssistantText>> | null = null;
         const expectedRecallAssistantCount = firstAssistantCount + 1;
-        const maxRecallAttempts = liveAgent === "claude" ? 3 : 1;
+        const maxRecallAttempts = 1;
         for (let attempt = 0; attempt < maxRecallAttempts && !recallHistory; attempt += 1) {
           await sendChatAndWait({
             client,
@@ -792,7 +867,7 @@ describeLive("gateway live (ACP bind)", () => {
               sessionKey: spawnedSessionKey,
               contains: followupToken,
               minAssistantCount: expectedRecallAssistantCount,
-              timeoutMs: liveAgent === "claude" ? 60_000 : 25_000,
+              timeoutMs: 25_000,
             });
           } catch {
             if (attempt === maxRecallAttempts - 1) {
@@ -802,40 +877,15 @@ describeLive("gateway live (ACP bind)", () => {
           }
         }
         if (!recallHistory) {
-          if (liveAgent === "claude") {
-            try {
-              const recallTurn = await waitForAssistantTurn({
-                client,
-                sessionKey: spawnedSessionKey,
-                minAssistantCount: expectedRecallAssistantCount,
-                timeoutMs: 60_000,
-              });
-              recallHistory = {
-                messages: recallTurn.messages,
-                lastAssistantText: recallTurn.lastAssistantText,
-                matchedAssistantText: recallTurn.lastAssistantText,
-              };
-              logLiveStep(
-                "bound memory recall response did not repeat token; using turn progression",
-              );
-            } catch {
-              recallHistory = firstBoundHistory;
-              logLiveStep(
-                "bound memory recall response not observed; continuing from previous bound transcript",
-              );
-            }
-          } else {
-            // Live ACP harnesses can miss or significantly delay this intermediate recall turn.
-            // Continue from the previously observed bound transcript and validate marker/image/cron
-            // on subsequent turns.
-            recallHistory = firstBoundHistory;
-            logLiveStep(
-              "bound memory recall response not observed; continuing from previous bound transcript",
-            );
-          }
+          // The intermediate recall is advisory for every connector; the later
+          // marker remains the shared strict proof of bound transcript progress.
+          recallHistory = firstBoundHistory;
+          logLiveStep(
+            "bound memory recall response not observed; continuing from previous bound transcript",
+          );
         }
         const recallAssistantText = recallHistory.matchedAssistantText;
-        if (liveAgent === "claude" && recallAssistantText.includes(recallToken)) {
+        if (recallAssistantText.includes(recallToken)) {
           expect(recallAssistantText).toContain(followupToken);
           expect(recallAssistantText).toContain(recallToken);
         }
@@ -913,7 +963,7 @@ describeLive("gateway live (ACP bind)", () => {
                 client,
                 sessionKey: spawnedSessionKey,
                 minAssistantCount: markerAssistantCount + 1,
-                timeoutMs: liveAgent === "claude" ? 60_000 : 45_000,
+                timeoutMs: 45_000,
               });
             } catch {
               if (attempt === 1) {


### PR DESCRIPTION
Refs #109684.

## What Problem This Solves

Bound ACP follow-up turns could fail before reaching Claude, Codex, or Gemini because the Gateway treated the external ACP harness id in the bound target session key as a configured OpenClaw model-runtime owner. The terminal reason was also hidden by a live-test helper that reported only `status=error`.

## Why This Change Was Made

The Gateway now keeps two identities distinct during a bound ACP reroute: the configured source agent owns the prepared reply-dispatch runtime, while the bound ACP session still owns ACP policy, state, transcript, and execution. This preserves the prepared publication invariant without adding a fallback or publishing synthetic owners for external harness ids.

The live test now includes the full bounded `agent.wait` payload in failures, correlates the first textual reply after the uniquely tokened user turn, and removes every Claude-only assertion, retry, fallback, and timeout exemption.

## User Impact

Messages sent to a conversation bound to an ACP session can reach the bound harness again even when its harness id is not an entry in `agents.list`. Claude is held to the same live bind contract as Codex and Gemini, and future terminal failures retain their actionable reason.

## Evidence

- Before repair, exact-target live run https://github.com/openclaw/openclaw/actions/runs/31343073659 failed on the first rerouted follow-up with `prepared reply dispatch runtime owner was not published for claude` after authentication and bind succeeded.
- The deterministic regression failed before the production fix with `unexpected prepared reply dispatch owner opencode` at `src/auto-reply/reply/dispatch-from-config.gather.ts:330`; the same focused command passes on this head: 1 passed, 339 skipped.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts src/gateway/gateway-acp-bind.live.test.ts`: 7 passed, 1 skipped without live credentials.
- Blacksmith Testbox `tbx_01kzmgbsab360q3ye7xcd92r33`: `node scripts/check-changed.mjs` completed with `exitCode: 0` after typecheck, lint, import-cycle, boundary, formatting, package, and guard checks.
- Exact-head live run https://github.com/openclaw/openclaw/actions/runs/31344753434 exercised the repaired Claude path: all 8 tests passed in 229.30s, including the rerouted follow-up, recall, marker, image, and best-effort cron path. The workflow then reported that the Vitest process group was still alive 1,000ms after SIGKILL during post-test cleanup. That identical teardown error is also present in the pre-fix run https://github.com/openclaw/openclaw/actions/runs/31329045105, so it predates this change and is tracked as a separate process-reaping defect rather than a failure of this behavior proof.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/31344712778 is green after one retry of an unrelated Control UI budget check that was initially 6 bytes over its gzip ceiling. No baseline or budget file was changed.
- Codex-backed autoreview is clean with no accepted/actionable findings. Production LOC: +8/-1. Tests: +133/-53.

### ClawSweeper rank-up moves

- Applied: repaired the rerouted-turn runtime failure without restoring connector-specific exemptions.
- Applied with scoped evidence: the exact-head live behavior passed, while the post-test process-group leak is independently proven in both the pre-fix and repaired runs.

### Direct Codex contract inspection

Inspected sibling `openai/codex` commit `57f42a81131ccf5933e7ec5dc659c381eeb5d72b` directly:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:311-325` defines resuming a persistent thread by `thread_id`.
- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:71-75` binds `turn/start` to that thread id.
- `codex-rs/app-server/src/request_processors/turn_processor.rs:474-576` loads the thread and submits the new user input.
- `codex-rs/app-server/src/thread_state.rs:158-177` retains the non-empty final agent message.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1020-1034,1268-1302` publishes item and terminal turn completion.

The OpenClaw failure occurred before any of those harness-specific contracts were invoked.
