### PR TITLE
test(telegram): inject album media fetch transport

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -776,8 +776,6 @@ describe("createTelegramBot", () => {
         },
       },
     });
-    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
       async () =>
         new Response(new Uint8Array([0xff, 0xd8, 0xff, 0x00]), {
@@ -785,6 +783,12 @@ describe("createTelegramBot", () => {
           headers: { "content-type": "image/jpeg" },
         }),
     );
+    createTelegramBot({
+      token: "tok",
+      testTimings: TELEGRAM_TEST_TIMINGS,
+      proxyFetch: fetchSpy,
+    });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
     const messageBase = {
       chat: { id: -9_876_543_215, type: "group", title: "Bot mixed album" },
       from: { id: 8_765_432_105, is_bot: true, username: "peer_bot" },
@@ -852,8 +856,6 @@ describe("createTelegramBot", () => {
         },
       },
     });
-    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
       async () =>
         new Response(new Uint8Array([0xff, 0xd8, 0xff, 0x00]), {
@@ -861,6 +863,12 @@ describe("createTelegramBot", () => {
           headers: { "content-type": "image/jpeg" },
         }),
     );
+    createTelegramBot({
+      token: "tok",
+      testTimings: TELEGRAM_TEST_TIMINGS,
+      proxyFetch: fetchSpy,
+    });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
     const messageBase = {
       chat: { id: -9_876_543_216, type: "group", title: "Bot photo album" },
       from: { id: 8_765_432_106, is_bot: true, username: "peer_bot" },


### PR DESCRIPTION
## What Problem This Solves

The 2026.6.33 extended-stable Plugin Prerelease run failed three Telegram assertions in job 88018924900. Two peer-bot album tests let media downloads escape to the real Telegram transport, and the detached work then contaminated a later framed-batch assertion.

## Why This Change Was Made

The old-branch tests mocked `globalThis.fetch`, but v2026.6.11 resolves and captures its Telegram transport when the bot is constructed. Inject the same mock through the existing `proxyFetch` test seam so the v6.11-adapted tests exercise deterministic media downloads.

This changes tests only. It does not change Telegram runtime behavior, release workflows, packages, versions, or publication surfaces.

## User Impact

No product behavior changes. This removes a release-validation-only false failure and prevents unfinished media work from leaking between tests.

## Evidence

- Failing validation: https://github.com/openclaw/openclaw/actions/runs/29622057657/job/88018924900
- Before: both album tests reproduced individually with zero agent dispatches; instrumentation showed media resolution entered but the mocked fetch was never used.
- After: `extensions/telegram/src/bot.create-telegram-bot.test.ts` passes 146/146.
- `pnpm exec oxfmt --check extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `git diff --check`
- Current main no longer contains these historical extended-stable tests, so no main follow-up is required.
