### PR TITLE
fix(release): scan SQLite installer transcripts

### DIFF
--- a/scripts/docker/install-sh-e2e/run.sh
+++ b/scripts/docker/install-sh-e2e/run.sh
@@ -569,9 +569,29 @@ NODE
 }
 
 assert_session_used_tools() {
-  local jsonl="$1"
-  shift
-  node - <<'NODE' "$jsonl" "$@"
+  local profile="$1"
+  local session_id="$2"
+  shift 2
+  local jsonl
+  local export_workspace=""
+  jsonl="$(session_jsonl_path "$profile" "$session_id")"
+  if [[ ! -f "$jsonl" ]]; then
+    export_workspace="$(mktemp -d)"
+    local export_status=0
+    openclaw --profile "$profile" sessions export-trajectory \
+      --session-key "agent:main:explicit:${session_id}" \
+      --agent main \
+      --workspace "$export_workspace" \
+      --output scan \
+      --json >/dev/null || export_status="$?"
+    if [[ "$export_status" -ne 0 ]]; then
+      rm -rf "$export_workspace"
+      return "$export_status"
+    fi
+    jsonl="$export_workspace/.openclaw/trajectory-exports/scan/events.jsonl"
+  fi
+  local scan_status=0
+  node - <<'NODE' "$jsonl" "$@" || scan_status="$?"
 const fs = require("node:fs");
 const jsonl = process.argv[2];
 const required = new Set(process.argv.slice(3));
@@ -752,6 +772,10 @@ scan()
     process.exit(1);
   });
 NODE
+  if [[ -n "$export_workspace" ]]; then
+    rm -rf "$export_workspace"
+  fi
+  return "$scan_status"
 }
 
 session_jsonl_path() {
@@ -1027,11 +1051,11 @@ run_profile() {
   phase_mark_start "Verify tool usage via session transcript ($profile)"
   # Give the gateway a moment to flush transcripts.
   sleep 1
-  assert_session_used_tools "$(session_jsonl_path "$profile" "$TURN2_SESSION_ID")" write
-  assert_session_used_tools "$(session_jsonl_path "$profile" "$TURN2B_SESSION_ID")" read
-  assert_session_used_tools "$(session_jsonl_path "$profile" "$TURN3_SESSION_ID")" exec
-  assert_session_used_tools "$(session_jsonl_path "$profile" "$TURN3B_SESSION_ID")" write
-  assert_session_used_tools "$(session_jsonl_path "$profile" "$TURN4_SESSION_ID")" image write
+  assert_session_used_tools "$profile" "$TURN2_SESSION_ID" write
+  assert_session_used_tools "$profile" "$TURN2B_SESSION_ID" read
+  assert_session_used_tools "$profile" "$TURN3_SESSION_ID" exec
+  assert_session_used_tools "$profile" "$TURN3B_SESSION_ID" write
+  assert_session_used_tools "$profile" "$TURN4_SESSION_ID" image write
   phase_mark_passed "Verify tool usage via session transcript ($profile)"
 
   cleanup_profile

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4182,6 +4182,23 @@ output="$(cat "$sampler_log")"
     expect(helper).not.toContain('.split("\\n")');
   });
 
+  it("exports SQLite-backed installer E2E sessions before scanning tools", () => {
+    const runner = readFileSync(INSTALL_E2E_RUNNER_PATH, "utf8");
+    const start = runner.indexOf("assert_session_used_tools() {");
+    const end = runner.indexOf("\nsession_jsonl_path()", start);
+    const helper = runner.slice(start, end);
+
+    expect(helper).toContain('jsonl="$(session_jsonl_path "$profile" "$session_id")"');
+    expect(helper).toContain('if [[ ! -f "$jsonl" ]]');
+    expect(helper).toContain('openclaw --profile "$profile" sessions export-trajectory');
+    expect(helper).toContain('--session-key "agent:main:explicit:${session_id}"');
+    expect(helper).toContain('--workspace "$export_workspace"');
+    expect(helper).toContain(
+      'jsonl="$export_workspace/.openclaw/trajectory-exports/scan/events.jsonl"',
+    );
+    expect(helper).toContain('rm -rf "$export_workspace"');
+  });
+
   it("keeps OpenAI web search smoke on one gateway agent connection", () => {
     const runner = readFileSync(OPENAI_WEB_SEARCH_MINIMAL_E2E_PATH, "utf8");
     const scenario = readFileSync(OPENAI_WEB_SEARCH_MINIMAL_SCENARIO_PATH, "utf8");


### PR DESCRIPTION
## What Problem This Solves

The 2026.6.33 canonical Release Checks run failed its package/update Anthropic Docker lane after every installer, gateway, live-agent, and tool assertion passed. The v6.11 harness tried to scan a legacy JSONL transcript, but the installed moving `openclaw@beta` (`2026.7.2-beta.2`) stores that session in SQLite.

## Why This Change Was Made

Backport the exact installer-harness owner fix from #108458. When the legacy JSONL is absent, the harness asks the installed OpenClaw CLI to export that exact session to a temporary trajectory JSONL, scans the same required tool facts, then deletes the temporary workspace.

This is a direct `-x` backport with the same stable patch ID. It does not read SQLite directly, change OpenClaw runtime/storage behavior, or import current SQLite code into the v6.11 candidate.

## User Impact

No product or performance change. Frozen 6.x release validation can verify tool use from the current installed package regardless of whether that package persists sessions as JSONL or SQLite.

## Evidence

- Failing job: https://github.com/openclaw/openclaw/actions/runs/29622057404/job/88020974140
- Failure artifact: `8422798917`, `docker-e2e-package-update-anthropic`
- The lane passed upgrade, onboarding, gateway health, five Anthropic tool turns, and tool outputs before the final `ENOENT` transcript scan.
- Source: #108458 / `66e15906b5dcda33da708b0c0b238873482cc4e1`
- Stable patch ID matches source: `f5b680e84a58d48dbef794fe55648787ee02121d`
- `bash -n scripts/docker/install-sh-e2e/run.sh`
- Focused SQLite-export harness contract test: 1/1 passed
- `git diff --check`
- Exact-head focused Docker run passed: https://github.com/openclaw/openclaw/actions/runs/29623216333
- The repaired `Verify tool usage via session transcript` phase passed against `2026.7.2-beta.2` after all five Anthropic tool turns.
- Evidence artifact `8423018101`, `docker-e2e-install-e2e-anthropic`, digest `sha256:5bba19805595db14f1cad333d705c3e6d201bc5920cb6a46405efb088d7a79da`

Current main already contains #108458, so no post-release forward-port is required.
