### PR TITLE
fix(mcp): own sandbox CSP fail-closed validation in the decoder

### DIFF
--- a/src/agents/mcp-app-sandbox.ts
+++ b/src/agents/mcp-app-sandbox.ts
@@ -91,6 +91,10 @@ export function resolveMcpAppSandboxPort(gatewayPort: number, configuredPort?: n
   return sandboxPort;
 }
 
+// Malformed input must throw: the gateway sandbox endpoint relies on it to fail
+// closed with 400 instead of serving proxy HTML under a default policy. That
+// includes valid JSON that is not a usable CSP — encodeCsp omits the query
+// param entirely in that case, so a present-but-empty value is never legitimate.
 export function decodeMcpAppSandboxCsp(value: string | null): McpAppCsp | undefined {
   if (!value) {
     return undefined;
@@ -99,7 +103,11 @@ export function decodeMcpAppSandboxCsp(value: string | null): McpAppCsp | undefi
     throw new Error("MCP App CSP metadata is too large");
   }
   const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
-  return normalizeMcpAppCsp(decoded);
+  const normalized = normalizeMcpAppCsp(decoded);
+  if (!normalized) {
+    throw new Error("MCP App CSP metadata is not a valid policy");
+  }
+  return normalized;
 }
 
 /** Trusted outer document. The untrusted app HTML is written only into its inner iframe. */

--- a/src/agents/mcp-app-sandbox.ts
+++ b/src/agents/mcp-app-sandbox.ts
@@ -96,7 +96,7 @@ export function resolveMcpAppSandboxPort(gatewayPort: number, configuredPort?: n
 // includes valid JSON that is not a usable CSP — encodeCsp omits the query
 // param entirely in that case, so a present-but-empty value is never legitimate.
 export function decodeMcpAppSandboxCsp(value: string | null): McpAppCsp | undefined {
-  if (!value) {
+  if (value === null) {
     return undefined;
   }
   if (value.length > MCP_APP_SANDBOX_CSP_MAX_ENCODED_BYTES) {

--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -51,6 +51,7 @@ describe("MCP App sandbox HTTP origin", () => {
     expect(request(`${buildMcpAppSandboxPath()}?csp=not-json`).res.statusCode).toBe(400);
     const jsonButNotCsp = Buffer.from("null", "utf8").toString("base64url");
     expect(request(`${buildMcpAppSandboxPath()}?csp=${jsonButNotCsp}`).res.statusCode).toBe(400);
+    expect(request(`${buildMcpAppSandboxPath()}?csp=`).res.statusCode).toBe(400);
     expect(request("http://[", "GET").res.statusCode).toBe(400);
   });
 });

--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -49,6 +49,8 @@ describe("MCP App sandbox HTTP origin", () => {
     expect(request("/", "GET").res.statusCode).toBe(404);
     expect(request(buildMcpAppSandboxPath(), "POST").res.statusCode).toBe(404);
     expect(request(`${buildMcpAppSandboxPath()}?csp=not-json`).res.statusCode).toBe(400);
+    const jsonButNotCsp = Buffer.from("null", "utf8").toString("base64url");
+    expect(request(`${buildMcpAppSandboxPath()}?csp=${jsonButNotCsp}`).res.statusCode).toBe(400);
     expect(request("http://[", "GET").res.statusCode).toBe(400);
   });
 });

--- a/src/gateway/mcp-app-sandbox-http.ts
+++ b/src/gateway/mcp-app-sandbox-http.ts
@@ -30,13 +30,9 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
     return;
   }
 
-  const encodedCsp = url.searchParams.get("csp");
   let csp;
   try {
-    csp = decodeMcpAppSandboxCsp(encodedCsp);
-    if (encodedCsp !== null && !csp) {
-      throw new Error("invalid MCP App sandbox policy");
-    }
+    csp = decodeMcpAppSandboxCsp(url.searchParams.get("csp"));
   } catch {
     res.statusCode = 400;
     res.setHeader("Content-Type", "text/plain; charset=utf-8");

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -28,6 +28,9 @@ const SHARED_TEST_SETUP = Symbol.for("openclaw.sharedTestSetup");
 const EMBEDDED_RUN_STATE = Symbol.for("openclaw.embeddedRunState");
 const REPLY_RUN_REGISTRY = Symbol.for("openclaw.replyRunRegistry");
 const DIAGNOSTIC_EVENTS_STATE = Symbol.for("openclaw.diagnosticEvents.state.v1");
+const DIAGNOSTIC_EVENT_LISTENER_PRESENCE = Symbol.for(
+  "openclaw.diagnosticEventListenerPresence.v1",
+);
 const nativeTimerGlobals = {
   setTimeout: globalThis.setTimeout,
   clearTimeout: globalThis.clearTimeout,
@@ -230,6 +233,17 @@ function resetOpenClawGlobalDiagnosticState(): void {
   state?.toolExecutionListeners?.clear();
   state?.asyncQueue?.splice(0);
   Reflect.deleteProperty(globalStore, DIAGNOSTIC_EVENTS_STATE);
+  // The listener-presence mirror is a separate globalThis record; clearing the
+  // sets above without zeroing it leaves hasInternalDiagnosticEventListeners()
+  // true for the next file (e.g. an import-time registration like
+  // diagnostic-run-activity.ts whose stop handle died with the module registry).
+  const presence = globalStore[DIAGNOSTIC_EVENT_LISTENER_PRESENCE] as
+    | { internalCount?: number; trustedCount?: number }
+    | undefined;
+  if (presence) {
+    presence.internalCount = 0;
+    presence.trustedCount = 0;
+  }
 }
 
 const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");


### PR DESCRIPTION
## What Problem This Solves

Hardening + cleanup on the MCP App sandbox CSP path, plus the root-cause fix for the diagnostics-listener CI flake.

1. **Decoder-owned fail-closed CSP validation.** #110275 restored the 400 for syntactically invalid `?csp=` JSON and #110264 added a handler-level guard for values that decode but do not normalize to a usable policy. This PR moves that invariant into `decodeMcpAppSandboxCsp` — the function that owns decode semantics — so any caller inherits fail-closed behavior: valid-JSON-but-not-a-CSP (base64url of `null`, `{}`, wrong-shaped objects) and explicitly empty (`?csp=`) values throw. The now-unreachable handler guard from #110264 is deleted. Endpoint behavior is unchanged from current main; the invariant has one owner and, unlike main today, regression tests.
2. **Non-isolated runner: reset the listener-presence mirror between files.** `resetOpenClawGlobalDiagnosticState` clears the diagnostic listener sets and deletes the state key, but the presence counts live under a separate `globalThis` record (`src/infra/diagnostic-event-listener-presence.ts`) and survived, so `hasInternalDiagnosticEventListeners()` stayed true for every later file in an `isolate:false` worker once any file leaked a registration. Concrete leak path: `src/logging/diagnostic-run-activity.ts` registers a listener at module-eval time; its stop handle dies with the module-registry reset. This flaked `model-call-diagnostics.test.ts` in run 29624203224 (`checks-node-compact-large-2`). #110288 landed the victim-side `beforeEach` reset; this fixes the class for every file in every non-isolated shard. Follow-up filed for removing the import-time registration itself.

> History note: this PR originally removed the stale-batch orphan tests and reverted the CSP guard; both were superseded (#110272, #110275) and the branch was rebased down to the remaining delta.

## Why This Change Was Made

The two malformed-CSP classes were found by Codex review while reverting the stale guard commit; the gaps predate it. One canonical owner for the invariant instead of a decoder/handler split, per repo policy. The runner fix removes a whole class of cross-file listener-state flakes.

## User Impact

The gateway MCP App sandbox endpoint keeps returning 400 for every malformed `?csp=` class (now tested); no behavior change for absent or valid parameters. CI: cross-file diagnostic listener leakage can no longer fail unrelated tests in non-isolated shards.

## Evidence

- Sole production caller of `decodeMcpAppSandboxCsp` is `src/gateway/mcp-app-sandbox-http.ts` (git grep); `encodeCsp` never emits a present-but-empty param, so such values are malformed by definition.
- New regression assertions: base64url(`null`) → 400 and `?csp=` → 400 in `src/gateway/mcp-app-sandbox-http.test.ts`.
- Leak audit (all diagnostic-listener registrations across src/ui/packages/extensions tests): every direct test registration is balanced via finally-stop or afterEach reset; the surviving state was exactly the presence mirror + the import-time registration named above.
- Codex autoreview (branch mode): clean on the prior shape ("patch is correct, 0.98"); rerun on this bundle in progress. PR CI on this head is the authoritative gate.
