### PR TITLE
feat(ui): permanent OpenClaw presence — pinned sidebar entry and Settings dock

### DIFF
--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -13,7 +13,7 @@ const settingsRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.route
 
 describe("sidebar pinned routes", () => {
   it("keeps operational destinations visible by default", () => {
-    expect(DEFAULT_SIDEBAR_PINNED_ROUTES).toEqual(["usage", "cron", "plugins"]);
+    expect(DEFAULT_SIDEBAR_PINNED_ROUTES).toEqual(["custodian", "usage", "cron", "plugins"]);
   });
 
   it("drops the retired overview route from persisted pins", () => {
@@ -45,7 +45,12 @@ describe("sidebar pinned routes", () => {
     expect(settingsRoutes).toEqual(
       expect.arrayContaining(["worktrees", "activity", "channels", "config"]),
     );
-    expect(settingsRoutes.every((routeId) => isSettingsNavigationRoute(routeId))).toBe(true);
+    expect(
+      settingsRoutes
+        .filter((routeId) => routeId !== "custodian")
+        .every((routeId) => isSettingsNavigationRoute(routeId)),
+    ).toBe(true);
+    expect(isSettingsNavigationRoute("custodian")).toBe(false);
     expect(normalizeSidebarPinnedRoutes(["activity", "worktrees", "usage"])).toEqual(["usage"]);
   });
 
@@ -56,6 +61,12 @@ describe("sidebar pinned routes", () => {
     ]);
     expect(sidebarMoreRoutes(["usage"])).toContain("plugins");
     expect(settingsRoutes).not.toContain("plugins");
+  });
+
+  it("keeps OpenClaw pinnable and linked from Settings without Settings chrome", () => {
+    expect(SIDEBAR_NAV_ROUTES).toContain("custodian");
+    expect(settingsRoutes).toContain("custodian");
+    expect(isSettingsNavigationRoute("custodian")).toBe(false);
   });
 
   it("normalizes persisted pinned routes, dropping unknown and duplicate entries", () => {

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -366,6 +366,7 @@ describe("SIDEBAR_NAV_ROUTES", () => {
     const settingsRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.routes);
     expect(SIDEBAR_NAV_ROUTES).not.toContain("config");
     expect(settingsRoutes).toEqual([
+      "custodian",
       "profile",
       "config",
       "appearance",

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -16,6 +16,7 @@ type NavigationItem = {
 // Skills and Skill Workshop are tabs inside the Plugins hub, not sidebar items.
 // Session management lives in Settings (SETTINGS_NAVIGATION_GROUPS below).
 export const SIDEBAR_NAV_ROUTES = [
+  "custodian",
   "workboard",
   "usage",
   "cron",
@@ -40,6 +41,7 @@ export type SidebarNavRoute = (typeof SIDEBAR_NAV_ROUTES)[number];
 // Keep the highest-value operational destinations visible on first use. Users
 // can still replace this set through the customize menu.
 export const DEFAULT_SIDEBAR_PINNED_ROUTES = [
+  "custodian",
   "usage",
   "cron",
   "plugins",
@@ -121,7 +123,7 @@ export function settingsSearchTextMatches(value: string, query: string): boolean
 
 // Grouping feeds the full-page settings sidebar (settings-sidebar.ts).
 export const SETTINGS_NAVIGATION_GROUPS = [
-  { labelKey: null, routes: ["profile", "config", "appearance"] },
+  { labelKey: null, routes: ["custodian", "profile", "config", "appearance"] },
   {
     labelKey: "nav.settingsGroupConnections",
     routes: ["connection", "channels", "communications"],
@@ -156,6 +158,12 @@ export const SETTINGS_NAVIGATION_GROUPS = [
 
 const SETTINGS_NAVIGATION_ROUTES: readonly NavigationRouteId[] = SETTINGS_NAVIGATION_GROUPS.flatMap(
   (group) => group.routes,
+);
+
+// Custodian is linked from Settings, but remains a workspace destination with
+// normal app chrome when opened from either Settings or the pinned sidebar.
+const SETTINGS_TAKEOVER_ROUTES = SETTINGS_NAVIGATION_ROUTES.filter(
+  (routeId) => routeId !== "custodian",
 );
 
 const NAVIGATION_ICONS: NavigationItem = {
@@ -195,7 +203,7 @@ const NAVIGATION_ICONS: NavigationItem = {
 };
 
 export function isSettingsNavigationRoute(routeId: NavigationRouteId): boolean {
-  return (SETTINGS_NAVIGATION_ROUTES as readonly NavigationRouteId[]).includes(routeId);
+  return (SETTINGS_TAKEOVER_ROUTES as readonly NavigationRouteId[]).includes(routeId);
 }
 
 export function navigationIconForRoute(routeId: NavigationRouteId): IconName {
@@ -305,7 +313,13 @@ export function titleForRoute(routeId: NavigationRouteId): string {
  * sibling sections.
  */
 export function settingsNavigationLabelForRoute(routeId: NavigationRouteId): string {
-  return routeId === "config" ? t("nav.settingsGeneral") : titleForRoute(routeId);
+  if (routeId === "config") {
+    return t("nav.settingsGeneral");
+  }
+  if (routeId === "custodian") {
+    return t("nav.askOpenClaw");
+  }
+  return titleForRoute(routeId);
 }
 
 export function subtitleForRoute(routeId: NavigationRouteId): string {

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -366,7 +366,7 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(sessionStorage.length).toBe(1);
   });
 
-  it("persists sidebar customization across save and load, normalizing bad values", () => {
+  it("persists custodian unpinning across save and load, normalizing bad values", () => {
     setTestLocation({
       protocol: "https:",
       host: "gateway.example:8443",
@@ -403,7 +403,7 @@ describe("loadSettings default gateway URL derivation", () => {
     persisted.navWidth = 220;
     localStorage.setItem(scopedKey, JSON.stringify(persisted));
 
-    expect(loadSettings().sidebarPinnedRoutes).toEqual(["usage", "cron", "plugins"]);
+    expect(loadSettings().sidebarPinnedRoutes).toEqual(["custodian", "usage", "cron", "plugins"]);
     expect(loadSettings().navWidth).toBe(258);
   });
 

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -305,6 +305,14 @@ afterEach(() => {
 });
 
 describe("AppSidebar update card wiring", () => {
+  it("shows OpenClaw in the default pinned routes", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+
+    const link = sidebar.querySelector<HTMLAnchorElement>('.nav-item[href="/custodian"]');
+    expect(link?.textContent?.trim()).toBe("OpenClaw");
+  });
+
   it("renders the update card in the footer after the attention slot and forwards its action", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));

--- a/ui/src/components/settings-sidebar.test.ts
+++ b/ui/src/components/settings-sidebar.test.ts
@@ -18,6 +18,34 @@ afterEach(() => {
 });
 
 describe("settings sidebar search", () => {
+  it("links Ask OpenClaw to the shared custodian route", () => {
+    const onNavigate = vi.fn();
+    render(
+      renderSettingsSidebar({
+        basePath: "",
+        activeRouteId: "config",
+        connected: true,
+        version: "",
+        updateAvailable: null,
+        updateRunning: false,
+        onUpdate: vi.fn(),
+        searchQuery: "",
+        onExit: vi.fn(),
+        onNavigate,
+        onSearchQueryChange: vi.fn(),
+        preloadTimers: new Map(),
+      }),
+      container,
+    );
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      '.settings-sidebar__item[href="/custodian"]',
+    );
+    expect(link?.textContent?.trim()).toBe("Ask OpenClaw");
+    link?.click();
+    expect(onNavigate).toHaveBeenCalledWith("custodian");
+  });
+
   it("does not match the middle of a word for a short query", () => {
     render(
       renderSettingsSidebar({

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -34,6 +34,10 @@ async function roundedWidth(locator: Locator): Promise<number> {
   return Math.round((await locator.boundingBox())?.width ?? 0);
 }
 
+function visibleDrawerButton(page: Page) {
+  return page.locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible").first();
+}
+
 async function expectLobsterOnFooterLedge(sidebar: Locator) {
   const footer = sidebar.locator(".sidebar-shell__footer");
   const sprite = footer.locator(".lobster-pet:not(.lobster-pet--passer)").first();
@@ -169,7 +173,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       );
       await expect
         .poll(() => trimmedTextContents(pinnedItems))
-        .toEqual(["Usage", "Automations", "Plugins"]);
+        .toEqual(["OpenClaw", "Usage", "Automations", "Plugins"]);
       await expect.poll(() => sidebar.locator(".sidebar-brand").count()).toBe(1);
       // Desktop renders no topbar row: the sidebar owns navigation.
       await expect.poll(() => page.locator(".topbar").isVisible()).toBe(false);
@@ -300,6 +304,8 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect
         .poll(() => trimmedTextContents(settingsLinks))
         .toEqual([
+          "Ask OpenClaw",
+          "Approvals",
           "Infrastructure",
           "Devices",
           "Worktrees",
@@ -358,8 +364,16 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => settingsSearch.inputValue()).toBe("");
       await captureSettingsSidebarProof(settingsSidebar, "01g-settings-search-reset.png");
       await holdUiProof(page);
-      await settingsSidebar.getByRole("button", { name: "Back to app" }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/chat");
+      await settingsSidebar.getByRole("link", { name: "Ask OpenClaw" }).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/custodian");
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .not.toContain("shell--onboarding");
+      await expect.poll(() => sidebar.isVisible()).toBe(true);
+      await expect
+        .poll(() => page.getByRole("button", { name: "Exit setup" }).isVisible())
+        .toBe(false);
+      await page.goto(`${server.baseUrl}chat`);
       await captureUiProof(page, "01-default-pinned.png");
 
       const moreButton = sidebar.locator("button.nav-item--action");
@@ -387,36 +401,38 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
         .not.toContain("Workboard");
       const tasksItem = menu.getByRole("menuitemcheckbox", { name: "Tasks" });
       await expect.poll(() => tasksItem.getAttribute("aria-checked")).toBe("false");
-      const usageItem = menu.getByRole("menuitemcheckbox", { name: "Usage" });
-      await expect.poll(() => usageItem.getAttribute("aria-checked")).toBe("true");
+      const custodianItem = menu.getByRole("menuitemcheckbox", { name: "OpenClaw" });
+      await expect.poll(() => custodianItem.getAttribute("aria-checked")).toBe("true");
       await expect
-        .poll(() => usageItem.evaluate((element) => element === document.activeElement))
+        .poll(() => custodianItem.evaluate((element) => element === document.activeElement))
         .toBe(true);
       await captureUiProof(page, "02-customize-menu.png");
 
-      await usageItem.click();
-      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Automations", "Plugins"]);
+      await custodianItem.click();
+      await expect
+        .poll(() => trimmedTextContents(pinnedItems))
+        .toEqual(["Usage", "Automations", "Plugins"]);
       await tasksItem.click();
       await expect
         .poll(() => trimmedTextContents(pinnedItems))
-        .toEqual(["Automations", "Plugins", "Tasks"]);
+        .toEqual(["Usage", "Automations", "Plugins", "Tasks"]);
       await page.reload();
       await expect
         .poll(() => trimmedTextContents(pinnedItems))
-        .toEqual(["Automations", "Plugins", "Tasks"]);
+        .toEqual(["Usage", "Automations", "Plugins", "Tasks"]);
       // The More menu is transient: closed after reload, unpinned routes inside.
       await expect.poll(() => moreButton.getAttribute("aria-expanded")).toBe("false");
       await moreButton.click();
       await expect
         .poll(() => trimmedTextContents(moreMenu.getByRole("menuitem")))
-        .toContain("Usage");
+        .toContain("OpenClaw");
       await captureUiProof(page, "03-persisted-customization.png");
 
       await moreMenu.getByRole("menuitem", { name: "Edit pinned items" }).click();
       await menu.getByRole("menuitem", { name: "Reset pinned items" }).click();
       await expect
         .poll(() => trimmedTextContents(pinnedItems))
-        .toEqual(["Usage", "Automations", "Plugins"]);
+        .toEqual(["OpenClaw", "Usage", "Automations", "Plugins"]);
 
       // The sidebar search field is the command palette entry point.
       const searchButton = sidebar.locator(".sidebar-search");
@@ -464,7 +480,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
         .toContain("shell--nav-collapsed");
 
       await page.setViewportSize({ height: 900, width: 900 });
-      const drawerButton = page.locator(".topbar-nav-toggle");
+      const drawerButton = visibleDrawerButton(page);
       await expect.poll(() => drawerButton.isVisible()).toBe(true);
       await drawerButton.click();
       await expect
@@ -484,8 +500,8 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
           page.locator(".shell-nav").evaluate((element) => element.getBoundingClientRect().left),
         )
         .toBe(0);
-      // The narrow-viewport topbar centers the brand between drawer toggle and search.
-      await expect.poll(() => page.locator(".topbar-brand").isVisible()).toBe(true);
+      // Narrow Chat merges navigation controls into its title bar.
+      await expect.poll(() => page.locator(".chat-pane__header").first().isVisible()).toBe(true);
       await captureUiProof(page, "05-expanded-tablet-drawer.png");
 
       // Widening with the drawer open must not leave its stale state blocking
@@ -510,7 +526,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
         .poll(() => page.locator(".shell").getAttribute("class"))
         .not.toContain("shell--nav-drawer-open");
       await page.setViewportSize({ height: 852, width: 393 });
-      await expect.poll(() => page.locator(".topbar-brand").isVisible()).toBe(true);
+      await expect.poll(() => page.locator(".chat-pane__header").first().isVisible()).toBe(true);
       await expect
         .poll(() =>
           page.locator(".shell-nav").evaluate((element) => element.getBoundingClientRect().right),
@@ -624,7 +640,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => page.locator(".topbar").isVisible()).toBe(false);
 
       await page.setViewportSize({ height: 900, width: 900 });
-      const drawerButton = page.locator(".topbar-nav-toggle");
+      const drawerButton = visibleDrawerButton(page);
       await expect.poll(() => drawerButton.isVisible()).toBe(true);
       await drawerButton.click();
       await expect.poll(() => sidebar.isVisible()).toBe(true);
@@ -676,7 +692,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await captureUiProof(page, "08-lobster-footer-ledge-desktop.png");
 
       await page.setViewportSize({ height: 900, width: 900 });
-      await page.locator(".topbar-nav-toggle").click();
+      await visibleDrawerButton(page).click();
       await expect.poll(() => sidebar.isVisible()).toBe(true);
       await expectLobsterOnFooterLedge(sidebar);
       await captureUiProof(page, "09-lobster-footer-ledge-drawer.png");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1549,6 +1549,7 @@ export const en: TranslationMap = {
     chat: "Chat",
     settings: "Settings",
     settingsGeneral: "General",
+    askOpenClaw: "Ask OpenClaw",
     settingsGroupConnections: "Connections",
     settingsGroupAgents: "Agents & Tools",
     settingsGroupSystem: "System",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -13,7 +13,10 @@ import {
 } from "../../test-helpers/application-context.ts";
 import "./custodian-page.ts";
 
-type TestCustodianPage = HTMLElement & { updateComplete: Promise<boolean> };
+type TestCustodianPage = HTMLElement & {
+  onboarding: boolean;
+  updateComplete: Promise<boolean>;
+};
 
 type ContextHarness = {
   context: ApplicationContext;
@@ -99,9 +102,7 @@ async function mountPage(
   provider: ApplicationContextProvider;
 }> {
   const provider = createApplicationContextProvider(context);
-  const page = document.createElement("openclaw-custodian-page") as TestCustodianPage & {
-    onboarding: boolean;
-  };
+  const page = document.createElement("openclaw-custodian-page") as TestCustodianPage;
   page.onboarding = options.onboarding ?? true;
   provider.append(page);
   document.body.append(provider);
@@ -592,6 +593,32 @@ describe("custodian page", () => {
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "status" });
   });
 
+  it("starts a fresh welcome when onboarding mode changes", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Normal caretaker conversation.",
+        action: "none",
+      })
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Onboarding proposal.",
+        action: "none",
+      });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await vi.waitFor(() => expect(page.textContent).toContain("Normal caretaker conversation."));
+
+    page.onboarding = true;
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(page.textContent).toContain("Onboarding proposal."));
+
+    expect(page.textContent).not.toContain("Normal caretaker conversation.");
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ welcomeVariant: "onboarding" });
+    expect(request.mock.calls[1]?.[1]).not.toHaveProperty("message");
+  });
+
   it("exits setup through normal chat navigation", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
@@ -600,7 +627,7 @@ describe("custodian page", () => {
     });
     const { context } = createContext(request);
     const { page } = await mountPage(context);
-    (page as TestCustodianPage & { onboarding: boolean }).onboarding = true;
+    page.onboarding = true;
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
 

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -569,6 +569,7 @@ describe("custodian page", () => {
     });
     const { context } = createContext(request);
     const { page } = await mountPage(context);
+    (page as TestCustodianPage & { onboarding: boolean }).onboarding = true;
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
 

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -91,12 +91,18 @@ function createContext(request: ReturnType<typeof vi.fn>): ContextHarness {
   };
 }
 
-async function mountPage(context: ApplicationContext): Promise<{
+async function mountPage(
+  context: ApplicationContext,
+  options: { onboarding?: boolean } = {},
+): Promise<{
   page: TestCustodianPage;
   provider: ApplicationContextProvider;
 }> {
   const provider = createApplicationContextProvider(context);
-  const page = document.createElement("openclaw-custodian-page") as TestCustodianPage;
+  const page = document.createElement("openclaw-custodian-page") as TestCustodianPage & {
+    onboarding: boolean;
+  };
+  page.onboarding = options.onboarding ?? true;
   provider.append(page);
   document.body.append(provider);
   await page.updateComplete;
@@ -559,6 +565,31 @@ describe("custodian page", () => {
     expect(page.querySelector<HTMLButtonElement>('[data-option-value="Ask first"]')?.disabled).toBe(
       true,
     );
+  });
+
+  it("requests the normal caretaker greeting outside onboarding", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "OpenClaw here. Everything is healthy.",
+      action: "none",
+    });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await page.updateComplete;
+
+    // The onboarding variant seeds the first-run setup proposal; permanent
+    // presence visits must not re-enter that flow.
+    expect(request.mock.calls[0]?.[1]).not.toHaveProperty("welcomeVariant");
+
+    const composer = page.querySelector<HTMLTextAreaElement>("textarea")!;
+    composer.value = "status";
+    composer.dispatchEvent(new Event("input"));
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request.mock.calls[1]?.[1]).not.toHaveProperty("welcomeVariant");
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "status" });
   });
 
   it("exits setup through normal chat navigation", async () => {

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -105,10 +105,16 @@ export class CustodianPage extends OpenClawLightDomElement {
     return JSON.stringify([gatewayUrl, token, password, bootstrapToken, this.lastHelloDeviceToken]);
   }
 
+  private currentSessionScopeKey(): string {
+    // Mode selects the welcome contract, so changing it starts a new session
+    // instead of carrying the previous route's transcript across modes.
+    return JSON.stringify([this.onboarding, this.connectionScopeKey()]);
+  }
+
   private synchronizeClient(): void {
     const snapshot = this.context.gateway.snapshot;
     const client = snapshot.connected ? snapshot.client : null;
-    const scopeKey = this.connectionScopeKey();
+    const scopeKey = this.currentSessionScopeKey();
     const scopeChanged = this.sessionScopeKey !== null && this.sessionScopeKey !== scopeKey;
     if (client === this.activeClient && !scopeChanged) {
       return;

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -143,7 +143,12 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.sessionScopeKey = scopeKey;
     this.sessionStarted = true;
     this.clearConversation();
-    void this.requestReply(client, { sessionId: this.sessionId, welcomeVariant: "onboarding" });
+    // The onboarding variant seeds the first-run setup proposal; the permanent
+    // presence surface gets the normal caretaker greeting instead.
+    void this.requestReply(client, {
+      sessionId: this.sessionId,
+      ...(this.onboarding ? { welcomeVariant: "onboarding" as const } : {}),
+    });
   }
 
   private clearConversation(): void {
@@ -223,7 +228,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.input = "";
     void this.requestReply(client, {
       sessionId: this.sessionId,
-      welcomeVariant: "onboarding",
+      ...(this.onboarding ? { welcomeVariant: "onboarding" as const } : {}),
       message,
     });
   }

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import type { SystemAgentChatParams, SystemAgentChatResult } from "@openclaw/gateway-protocol";
 import { html, nothing, type PropertyValues } from "lit";
-import { state } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
@@ -42,6 +42,9 @@ function errorMessage(error: unknown): string {
 export class CustodianPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
+
+  /** Onboarding mode shows the Exit setup control; the route view sets this. */
+  @property({ attribute: false }) onboarding = false;
 
   @state() private messages: CustodianMessage[] = [];
   @state() private input = "";
@@ -293,9 +296,11 @@ export class CustodianPage extends OpenClawLightDomElement {
               <p>${t("custodian.subtitle")}</p>
             </div>
           </div>
-          <button class="btn btn--ghost" type="button" @click=${() => this.exitSetup()}>
-            ${t("custodian.exitSetup")}
-          </button>
+          ${this.onboarding
+            ? html`<button class="btn btn--ghost" type="button" @click=${() => this.exitSetup()}>
+                ${t("custodian.exitSetup")}
+              </button>`
+            : nothing}
         </header>
 
         <div class="custodian__messages" aria-live="polite">

--- a/ui/src/pages/custodian/route-view.ts
+++ b/ui/src/pages/custodian/route-view.ts
@@ -1,18 +1,8 @@
-import { html, nothing } from "lit";
+import { html } from "lit";
 import type { CustodianRouteData } from "./route.ts";
 
 export function renderCustodianRoute(data: CustodianRouteData | undefined) {
-  const onboarding = data?.onboarding === true;
   return html`
-    ${onboarding
-      ? nothing
-      : html`<style>
-          openclaw-custodian-page.custodian-route--normal .custodian__header > .btn {
-            display: none;
-          }
-        </style>`}
-    <openclaw-custodian-page
-      class=${onboarding ? "custodian-route--onboarding" : "custodian-route--normal"}
-    ></openclaw-custodian-page>
+    <openclaw-custodian-page .onboarding=${data?.onboarding === true}></openclaw-custodian-page>
   `;
 }

--- a/ui/src/pages/custodian/route-view.ts
+++ b/ui/src/pages/custodian/route-view.ts
@@ -1,0 +1,18 @@
+import { html, nothing } from "lit";
+import type { CustodianRouteData } from "./route.ts";
+
+export function renderCustodianRoute(data: CustodianRouteData | undefined) {
+  const onboarding = data?.onboarding === true;
+  return html`
+    ${onboarding
+      ? nothing
+      : html`<style>
+          openclaw-custodian-page.custodian-route--normal .custodian__header > .btn {
+            display: none;
+          }
+        </style>`}
+    <openclaw-custodian-page
+      class=${onboarding ? "custodian-route--onboarding" : "custodian-route--normal"}
+    ></openclaw-custodian-page>
+  `;
+}

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -67,7 +67,7 @@ describe("custodian route", () => {
     expect(loadRoute("?onboarding=1")).toEqual({ onboarding: true });
   });
 
-  it("shows Exit setup only in onboarding mode", async () => {
+  it("renders Exit setup only in onboarding mode", async () => {
     const provider = createApplicationContextProvider(createContext());
     document.body.append(provider);
 
@@ -76,19 +76,13 @@ describe("custodian route", () => {
       "openclaw-custodian-page",
     );
     await normalPage?.updateComplete;
-    const normalExit = normalPage?.querySelector<HTMLButtonElement>(".custodian__header > .btn");
-    expect(normalPage?.className).toBe("custodian-route--normal");
-    expect(getComputedStyle(normalExit!).display).toBe("none");
+    expect(normalPage?.querySelector(".custodian__header > .btn")).toBeNull();
 
     render(renderCustodianRoute({ onboarding: true }), provider);
     const onboardingPage = provider.querySelector<
       HTMLElement & { updateComplete: Promise<boolean> }
     >("openclaw-custodian-page");
     await onboardingPage?.updateComplete;
-    const onboardingExit = onboardingPage?.querySelector<HTMLButtonElement>(
-      ".custodian__header > .btn",
-    );
-    expect(onboardingPage?.className).toBe("custodian-route--onboarding");
-    expect(getComputedStyle(onboardingExit!).display).not.toBe("none");
+    expect(onboardingPage?.querySelector(".custodian__header > .btn")).not.toBeNull();
   });
 });

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -27,7 +27,7 @@ function loadRoute(search: string): CustodianRouteData {
     revalidating: false,
     location: location(search),
     deps: search,
-    cause: "navigate",
+    cause: "navigation",
   } satisfies RouteLoaderOptions) as CustodianRouteData;
 }
 

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+
+import type { RouteLoaderOptions, RouteLocation } from "@openclaw/uirouter";
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  ApplicationContext,
+  ApplicationGateway,
+  ApplicationGatewaySnapshot,
+} from "../../app/context.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import "./custodian-page.ts";
+import { renderCustodianRoute } from "./route-view.ts";
+import { page, type CustodianRouteData } from "./route.ts";
+
+function location(search: string): RouteLocation {
+  return { pathname: "/custodian", search, hash: "" };
+}
+
+function loadRoute(search: string): CustodianRouteData {
+  if (!page.loader) {
+    throw new Error("custodian route has no loader");
+  }
+  return page.loader({} as ApplicationContext, {
+    signal: new AbortController().signal,
+    shouldRun: () => true,
+    revalidating: false,
+    location: location(search),
+    deps: search,
+    cause: "navigate",
+  } satisfies RouteLoaderOptions) as CustodianRouteData;
+}
+
+function createContext(): ApplicationContext {
+  const snapshot: ApplicationGatewaySnapshot = {
+    client: null,
+    connected: false,
+    reconnecting: false,
+    hello: null,
+    assistantAgentId: "main",
+    sessionKey: "main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const gateway = {
+    snapshot,
+    connection: {
+      gatewayUrl: "ws://gateway.test/control",
+      token: "",
+      bootstrapToken: "",
+      password: "",
+    },
+    subscribe: () => () => undefined,
+  } as unknown as ApplicationGateway;
+  return { gateway } as unknown as ApplicationContext;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("custodian route", () => {
+  it("keys and resolves route data from onboarding search", () => {
+    const context = {} as ApplicationContext;
+    expect(page.loaderDeps?.(context, location(""))).toBe("");
+    expect(loadRoute("")).toEqual({ onboarding: false });
+    expect(loadRoute("?onboarding=1")).toEqual({ onboarding: true });
+  });
+
+  it("shows Exit setup only in onboarding mode", async () => {
+    const provider = createApplicationContextProvider(createContext());
+    document.body.append(provider);
+
+    render(renderCustodianRoute({ onboarding: false }), provider);
+    const normalPage = provider.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+      "openclaw-custodian-page",
+    );
+    await normalPage?.updateComplete;
+    const normalExit = normalPage?.querySelector<HTMLButtonElement>(".custodian__header > .btn");
+    expect(normalPage?.className).toBe("custodian-route--normal");
+    expect(getComputedStyle(normalExit!).display).toBe("none");
+
+    render(renderCustodianRoute({ onboarding: true }), provider);
+    const onboardingPage = provider.querySelector<
+      HTMLElement & { updateComplete: Promise<boolean> }
+    >("openclaw-custodian-page");
+    await onboardingPage?.updateComplete;
+    const onboardingExit = onboardingPage?.querySelector<HTMLButtonElement>(
+      ".custodian__header > .btn",
+    );
+    expect(onboardingPage?.className).toBe("custodian-route--onboarding");
+    expect(getComputedStyle(onboardingExit!).display).not.toBe("none");
+  });
+});

--- a/ui/src/pages/custodian/route.ts
+++ b/ui/src/pages/custodian/route.ts
@@ -1,12 +1,24 @@
+import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
-import { html } from "lit";
+import type { ApplicationContext } from "../../app/context.ts";
+import { resolveOnboardingMode } from "../../app/onboarding-mode.ts";
+
+export type CustodianRouteData = {
+  onboarding: boolean;
+};
 
 export const page = definePage({
   id: "custodian",
   path: "/custodian",
+  loaderDeps: (_context: ApplicationContext, location: RouteLocation) => location.search,
+  loader: (_context: ApplicationContext, { location }): CustodianRouteData => ({
+    onboarding: resolveOnboardingMode(location.search),
+  }),
   component: () =>
-    import("./custodian-page.ts").then(() => ({
-      header: true,
-      render: () => html`<openclaw-custodian-page></openclaw-custodian-page>`,
-    })),
+    import("./custodian-page.ts").then(() =>
+      import("./route-view.ts").then(({ renderCustodianRoute }) => ({
+        header: true,
+        render: (data: CustodianRouteData | undefined) => renderCustodianRoute(data),
+      })),
+    ),
 });


### PR DESCRIPTION
## What Problem This Solves

Phase 6 PR1 of the custodian onboarding redesign (plan: `docs/start/onboarding-redesign.md`). After onboarding ends, OpenClaw (the system custodian) disappears: the `/custodian` conversation is reachable only by typing the URL, so the "stays reachable forever after as the system's caretaker" promise has no surface.

## Why This Change Was Made

The plan's phase 6 makes the custodian a permanent, findable presence: a pinned sidebar entry and a Settings entry point, both landing on the same conversation, with onboarding chrome reserved for onboarding.

## User Impact

- **Pinned sidebar entry "OpenClaw"**: `custodian` becomes a pinnable sidebar route, pinned by default for fresh profiles, removable through the existing customize menu. Existing users keep their saved pin sets untouched (deliberate: no silent pref mutation) — for them the entry is available under More/customize.
- **Settings entry "Ask OpenClaw"**: first entry of the Settings navigation, deep-linking to the same custodian conversation. The custodian route is excluded from the Settings takeover chrome — it opens as a normal workspace destination. (A true docked inline pane needs shared conversation-view extraction; noted as follow-up.)
- **Chrome modes**: `/custodian` renders in normal app chrome with no "Exit setup" control, driven by a typed `onboarding` property on the page (route loader keyed on `location.search`); `/custodian?onboarding=1` keeps the minimal onboarding chrome and Exit setup. No injected-style hacks.
- New i18n key `nav.askOpenClaw` (English + raw-copy baseline; translations post-merge by the locale workflow).

## Evidence

- Suites green: custodian page/route (20), app-navigation + groups, app-sidebar, settings-sidebar, settings persistence, sidebar-customization E2E, onboarding E2E. Full `ui/src` shard: 4389 tests green (one known unrelated flake, `chat-responsive.browser.test.ts`, passed isolated and on shard rerun; flaky-test card filed). `pnpm tsgo` + `pnpm tsgo:ui`, oxlint, i18n baseline/verify, `git diff --check` green.
- Live test on this Mac (isolated same-config gateway + vite dev UI from this branch, fresh localStorage): sidebar shows the pinned **OpenClaw** entry active on `/custodian` in normal chrome without Exit setup; Settings' first entry is **Ask OpenClaw**; `/custodian?onboarding=1` keeps minimal chrome, Exit setup, and the typed welcome option cards from #110242.
- Autoreview (Codex, branch mode, xhigh): clean, no actionable findings ("patch is correct", 0.91).
