### PR TITLE
feat(plugins): order Featured catalog by recency

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13017,6 +13017,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
     public let enabled: Bool
     public let state: AnyCodable
     public let featured: Bool?
+    public let featuredat: Int?
     public let order: Double?
     public let hasicon: Bool?
     public let install: PluginCatalogInstallAction?
@@ -13036,6 +13037,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         enabled: Bool,
         state: AnyCodable,
         featured: Bool? = nil,
+        featuredat: Int? = nil,
         order: Double? = nil,
         hasicon: Bool? = nil,
         install: PluginCatalogInstallAction? = nil,
@@ -13054,6 +13056,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         self.enabled = enabled
         self.state = state
         self.featured = featured
+        self.featuredat = featuredat
         self.order = order
         self.hasicon = hasicon
         self.install = install
@@ -13074,6 +13077,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         case enabled
         case state
         case featured
+        case featuredat = "featuredAt"
         case order
         case hasicon = "hasIcon"
         case install

--- a/packages/gateway-protocol/src/plugins-validators.test.ts
+++ b/packages/gateway-protocol/src/plugins-validators.test.ts
@@ -26,6 +26,7 @@ const installedPlugin = {
   enabled: false,
   state: "disabled",
   featured: true,
+  featuredAt: 1_784_280_000_000,
   order: 10,
   install: { source: "official", pluginId: "workboard" },
   category: "tool",

--- a/packages/gateway-protocol/src/schema/plugins.ts
+++ b/packages/gateway-protocol/src/schema/plugins.ts
@@ -107,6 +107,7 @@ export const PluginCatalogEntrySchema = closedObject({
     Type.Literal("error"),
   ]),
   featured: Type.Optional(Type.Boolean()),
+  featuredAt: Type.Optional(Type.Integer({ minimum: 0 })),
   order: Type.Optional(Type.Number()),
   /** True when the gateway can resolve a manifest or catalog icon for this plugin identity. */
   hasIcon: Type.Optional(Type.Boolean()),

--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -89,6 +89,7 @@ function hostedFeedEntry(params: {
   packageName: string;
   title: string;
   featured?: boolean;
+  featuredAt?: number;
   pluginId?: string;
   catalogFeatured?: boolean;
   order?: number;
@@ -102,6 +103,7 @@ function hostedFeedEntry(params: {
     ...(params.icon ? { icon: params.icon } : {}),
     state: "available",
     ...(params.featured === undefined ? {} : { featured: params.featured }),
+    ...(params.featuredAt === undefined ? {} : { featuredAt: params.featuredAt }),
     publisher: { id: "openclaw", trust: "official" },
     install: {
       candidates: [
@@ -244,6 +246,43 @@ describe("plugin management Featured authority", () => {
         install: { source: "official", pluginId: "@openclaw/new-tool" },
       }),
     ]);
+  });
+
+  it("orders live featured packages by when they were featured", async () => {
+    mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
+    mocks.officialCatalog.mockResolvedValue(
+      hostedCatalog([
+        hostedFeedEntry({
+          packageName: "@openclaw/older-popular",
+          title: "Older Popular",
+          featured: true,
+          featuredAt: 100,
+          order: 1,
+        }),
+        hostedFeedEntry({
+          packageName: "@openclaw/newest-featured",
+          title: "Newest Featured",
+          featured: true,
+          featuredAt: 200,
+          order: 99,
+        }),
+        hostedFeedEntry({
+          packageName: "@openclaw/legacy-featured",
+          title: "Legacy Featured",
+          featured: true,
+          order: 0,
+        }),
+      ]),
+    );
+
+    const catalog = await listManagedPlugins({ config: {}, env: {} });
+
+    expect(catalog.plugins.map((plugin) => plugin.id)).toEqual([
+      "@openclaw/newest-featured",
+      "@openclaw/older-popular",
+      "@openclaw/legacy-featured",
+    ]);
+    expect(catalog.plugins.map((plugin) => plugin.featuredAt)).toEqual([200, 100, undefined]);
   });
 
   it("clears stale embedded curation on an unmatched live official package", async () => {
@@ -395,6 +434,7 @@ describe("plugin management Featured authority", () => {
           packageName: "@openclaw/firecrawl-plugin",
           title: "FireCrawl",
           featured: true,
+          featuredAt: 1_784_280_000_000,
           pluginId: "firecrawl",
           description: "Crawl, scrape, search, and extract web content with FireCrawl.",
           icon: hostedIcon,
@@ -416,6 +456,7 @@ describe("plugin management Featured authority", () => {
         description: "Crawl, scrape, search, and extract web content with FireCrawl.",
         packageName: "@openclaw/firecrawl-plugin",
         featured: true,
+        featuredAt: 1_784_280_000_000,
         order: 10,
         hasIcon: true,
       }),

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -78,6 +78,7 @@ type ManagedPluginCatalogEntry = {
   enabled: boolean;
   state: "enabled" | "disabled" | "not-installed" | "error";
   featured?: boolean;
+  featuredAt?: number;
   order?: number;
   hasIcon?: boolean;
   install?: { source: "clawhub"; packageName: string } | { source: "official"; pluginId: string };
@@ -319,6 +320,10 @@ function normalizeCatalogMetadata(
       };
 }
 
+function normalizeFeaturedAt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
 function resolveCatalogInstallAction(params: {
   config: OpenClawConfig;
   entry: OfficialExternalPluginCatalogEntry;
@@ -388,6 +393,21 @@ function compareCatalogEntries(
   const featured = Number(Boolean(right.featured)) - Number(Boolean(left.featured));
   if (featured !== 0) {
     return featured;
+  }
+  if (left.featured && right.featured) {
+    const leftFeaturedAt = left.featuredAt;
+    const rightFeaturedAt = right.featuredAt;
+    if (leftFeaturedAt !== undefined || rightFeaturedAt !== undefined) {
+      if (leftFeaturedAt === undefined) {
+        return 1;
+      }
+      if (rightFeaturedAt === undefined) {
+        return -1;
+      }
+      if (leftFeaturedAt !== rightFeaturedAt) {
+        return rightFeaturedAt - leftFeaturedAt;
+      }
+    }
   }
   const order = (left.order ?? Number.MAX_SAFE_INTEGER) - (right.order ?? Number.MAX_SAFE_INTEGER);
   return order !== 0 ? order : left.name.localeCompare(right.name);
@@ -639,6 +659,10 @@ export async function listManagedPlugins(params: {
       manifest?.description ?? manifest?.channelCatalogMeta?.blurb ?? manifest?.packageDescription;
     const hostedListingAuthoritative =
       hasHostedOfficialIdentity && officialCatalog.hostedFeaturedAuthoritative;
+    const featuredAt =
+      hostedListingAuthoritative && catalog?.featured === true
+        ? normalizeFeaturedAt(officialEntry?.featuredAt)
+        : undefined;
     const name =
       (hostedListingAuthoritative ? normalizeOptionalString(officialEntry?.title) : undefined) ??
       localName;
@@ -660,6 +684,7 @@ export async function listManagedPlugins(params: {
       enabled: record.enabled,
       state: error ? "error" : record.enabled ? "enabled" : "disabled",
       ...(catalog?.featured !== undefined ? { featured: catalog.featured } : {}),
+      ...(featuredAt !== undefined ? { featuredAt } : {}),
       ...(catalog?.order !== undefined ? { order: catalog.order } : {}),
       ...(resolvePluginIconUrlFromCatalogFacts({
         metadata,
@@ -704,6 +729,8 @@ export async function listManagedPlugins(params: {
     const install = resolveCatalogInstallAction({ config: params.config, entry, pluginId });
     const description = normalizeOptionalString(entry.description);
     const version = normalizeOptionalString(entry.version);
+    const featuredAt =
+      catalog.featured === true ? normalizeFeaturedAt(entry.featuredAt) : undefined;
     plugins.push({
       id: pluginId,
       name: resolveOfficialExternalPluginLabel(entry),
@@ -715,6 +742,7 @@ export async function listManagedPlugins(params: {
       enabled: false,
       state: "not-installed",
       ...(catalog.featured !== undefined ? { featured: catalog.featured } : {}),
+      ...(featuredAt !== undefined ? { featuredAt } : {}),
       ...(catalog.order !== undefined ? { order: catalog.order } : {}),
       ...(resolveCatalogEntryIcon(entry) ? { hasIcon: true } : {}),
       ...(install ? { install } : {}),

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -111,6 +111,7 @@ export type OfficialExternalPluginCatalogEntry = {
   source?: string;
   kind?: string;
   featured?: boolean;
+  featuredAt?: number;
   install?: {
     candidates?: readonly OfficialExternalPluginCatalogInstallCandidate[];
   };

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -390,6 +390,41 @@ describe("renderPlugins", () => {
     });
   });
 
+  it("renders featured plugins newest-featured first", () => {
+    const plugins = [
+      createPlugin({
+        id: "not-featured",
+        name: "Not Featured",
+        featured: false,
+        origin: "official",
+        installed: false,
+        order: 0,
+      }),
+      createPlugin({
+        id: "older-popular",
+        name: "Older Popular",
+        featured: true,
+        featuredAt: 100,
+        order: 1,
+      }),
+      createPlugin({
+        id: "newest-featured",
+        name: "Newest Featured",
+        featured: true,
+        featuredAt: 200,
+        order: 99,
+      }),
+    ];
+
+    const container = mount(createProps({ activeTab: "discover", result: createResult(plugins) }));
+
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-plugin-id]")].map(
+        (row) => row.dataset.pluginId,
+      ),
+    ).toEqual(["newest-featured", "older-popular", "not-featured"]);
+  });
+
   it("adds MCP connectors and routes ClawHub connector searches", () => {
     const onAddConnector = vi.fn();
     const onSearchClawHub = vi.fn();

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -177,11 +177,31 @@ function matchesConnector(connector: ConnectorSuggestion, query: string): boolea
 }
 
 function sortCatalogPlugins(plugins: readonly PluginCatalogItem[]): PluginCatalogItem[] {
-  return plugins.toSorted(
-    (left, right) =>
+  return plugins.toSorted((left, right) => {
+    const featured = Number(Boolean(right.featured)) - Number(Boolean(left.featured));
+    if (featured !== 0) {
+      return featured;
+    }
+    if (left.featured && right.featured) {
+      const leftFeaturedAt = left.featuredAt;
+      const rightFeaturedAt = right.featuredAt;
+      if (leftFeaturedAt !== undefined || rightFeaturedAt !== undefined) {
+        if (leftFeaturedAt === undefined) {
+          return 1;
+        }
+        if (rightFeaturedAt === undefined) {
+          return -1;
+        }
+        if (leftFeaturedAt !== rightFeaturedAt) {
+          return rightFeaturedAt - leftFeaturedAt;
+        }
+      }
+    }
+    return (
       (left.order ?? Number.MAX_SAFE_INTEGER) - (right.order ?? Number.MAX_SAFE_INTEGER) ||
-      left.name.localeCompare(right.name),
-  );
+      left.name.localeCompare(right.name)
+    );
+  });
 }
 
 function installedPlugins(


### PR DESCRIPTION
## Summary
- parse optional `featuredAt` from the ClawHub schema-v1 feed
- carry the timestamp through trusted hosted catalog metadata and the Gateway protocol
- sort Featured Control entries newest-featured-first
- keep legacy Featured entries without timestamps after timestamped entries, then retain the existing order/name fallback
- preserve the Featured-first group in Control UI mixed lists

## Producer
Depends on ClawHub producer PR: https://github.com/openclaw/clawhub/pull/3168

Merge/deploy ClawHub first so the live feed begins supplying `featuredAt`; this consumer is backward-compatible when the field is absent.

## Validation
- focused protocol/management/UI tests: 45 passed
- local `tsgo:core`, `tsgo:core:test`, and `tsgo:ui` passed before the final disjoint upstream rebase
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29623293660 (three type lanes, targeted format/lint, 45 focused tests all passed)
- exact post-rebase focused tests: 45 passed
- targeted oxfmt/oxlint and `git diff --check` passed
- autoreview clean
- range-diff confirms the feature commit is patch-equivalent after rebasing onto current `main`

## Current main note
At PR creation, current `main` (`dc0285366ef`) independently fails `tsgo:core:test`: newly merged tests import missing `src/shared/deferred-event-buffer.ts` and `src/tools/protocol.ts`. This PR does not touch those files. The focused feature proof remains green.
