### PR TITLE
fix(gateway): reject malformed MCP sandbox policy

### DIFF
--- a/src/agents/mcp-app-sandbox.ts
+++ b/src/agents/mcp-app-sandbox.ts
@@ -98,12 +98,8 @@ export function decodeMcpAppSandboxCsp(value: string | null): McpAppCsp | undefi
   if (value.length > MCP_APP_SANDBOX_CSP_MAX_ENCODED_BYTES) {
     throw new Error("MCP App CSP metadata is too large");
   }
-  try {
-    const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
-    return normalizeMcpAppCsp(decoded);
-  } catch {
-    return undefined;
-  }
+  const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
+  return normalizeMcpAppCsp(decoded);
 }
 
 /** Trusted outer document. The untrusted app HTML is written only into its inner iframe. */

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -200,13 +200,11 @@ describe("MCP App UI resources", () => {
     expect(decodeMcpAppSandboxCsp(encodedCsp)).toStrictEqual(view?.csp);
   });
 
-  it("returns undefined when CSP metadata is not valid base64-encoded JSON", () => {
-    expect(decodeMcpAppSandboxCsp("bm90LWpzb24")).toBeUndefined();
-  });
-
-  it("returns undefined when base64-decoded CSP is not valid JSON", () => {
-    const invalid = Buffer.from("{not json}", "utf8").toString("base64url");
-    expect(decodeMcpAppSandboxCsp(invalid)).toBeUndefined();
+  it.each([
+    "bm90LWpzb24",
+    Buffer.from("{not json}", "utf8").toString("base64url"),
+  ])("rejects malformed encoded CSP metadata", (value) => {
+    expect(() => decodeMcpAppSandboxCsp(value)).toThrow();
   });
 
   it("builds proxy HTML", () => {

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -200,12 +200,12 @@ describe("MCP App UI resources", () => {
     expect(decodeMcpAppSandboxCsp(encodedCsp)).toStrictEqual(view?.csp);
   });
 
-  it.each([
-    "bm90LWpzb24",
-    Buffer.from("{not json}", "utf8").toString("base64url"),
-  ])("rejects malformed encoded CSP metadata", (value) => {
-    expect(() => decodeMcpAppSandboxCsp(value)).toThrow();
-  });
+  it.each(["bm90LWpzb24", Buffer.from("{not json}", "utf8").toString("base64url")])(
+    "rejects malformed encoded CSP metadata",
+    (value) => {
+      expect(() => decodeMcpAppSandboxCsp(value)).toThrow();
+    },
+  );
 
   it("builds proxy HTML", () => {
     const proxyHtml = buildMcpAppSandboxProxyHtml();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed MCP App sandbox policy metadata would be accepted as an omitted policy, so the dedicated sandbox listener returned HTTP 200 instead of rejecting the malformed request.

## Why This Change Was Made

The decoder again rejects malformed encoded JSON and leaves the HTTP listener as the owner that converts decoding failures into its existing HTTP 400 response. Missing metadata and well-formed metadata keep their existing behavior. This also preserves the decoder's existing throwing contract for oversized metadata.

## User Impact

Malformed MCP App sandbox policy URLs are rejected consistently instead of being served with a silently substituted policy.

## Evidence

- `node scripts/run-vitest.mjs src/agents/mcp-ui-resource.test.ts src/gateway/mcp-app-sandbox-http.test.ts` — 2 files, 16 tests passed.
- `git diff --check` — passed.
- Codex autoreview — clean, no accepted or actionable findings.
- Hosted changed gate: https://github.com/openclaw/openclaw/actions/runs/29623716123 — formatting, guards, SDK baseline, production/test types, lint, and architecture checks passed.

AI-assisted: yes. Maintainer-directed regression repair after exact-head CI exposed the new `main` failure.
