### PR TITLE
fix(gateway): reject malformed MCP App sandbox policies

### DIFF
--- a/src/gateway/mcp-app-sandbox-http.ts
+++ b/src/gateway/mcp-app-sandbox-http.ts
@@ -30,9 +30,14 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
     return;
   }
 
+  const encodedCsp = url.searchParams.get("csp");
   let csp;
   try {
-    csp = decodeMcpAppSandboxCsp(url.searchParams.get("csp"));
+    csp = decodeMcpAppSandboxCsp(encodedCsp);
+    // The decoder also returns undefined for malformed input; only an absent query may use defaults.
+    if (encodedCsp !== null && !csp) {
+      throw new Error("invalid MCP App sandbox policy");
+    }
   } catch {
     res.statusCode = 400;
     res.setHeader("Content-Type", "text/plain; charset=utf-8");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where requests to the MCP App sandbox origin with a malformed CSP policy received a successful sandbox page instead of an HTTP 400 response.

## Why This Change Was Made

The CSP decoder intentionally returns `undefined` for both absent and malformed values. The HTTP boundary now distinguishes a missing query, which may use the restrictive default policy, from a present value that fails decoding, which must fail closed.

## User Impact

Malformed or non-canonical MCP App sandbox policy URLs are rejected instead of silently receiving the default page. Valid generated URLs and policy-free sandbox URLs behave unchanged.

## Evidence

Before: exact-head CI reproduced the existing regression twice in `src/gateway/mcp-app-sandbox-http.test.ts`, receiving 200 where 400 was required: https://github.com/openclaw/openclaw/actions/runs/29623666625

After:

```text
$ node scripts/run-vitest.mjs src/gateway/mcp-app-sandbox-http.test.ts src/agents/mcp-ui-resource.test.ts
Test Files  2 passed (2)
Tests       16 passed (16)
[test] passed 2 Vitest shards

$ ./node_modules/.bin/oxfmt --check src/gateway/mcp-app-sandbox-http.ts src/gateway/mcp-app-sandbox-http.test.ts
All matched files use the correct format.

$ node scripts/run-oxlint.mjs src/gateway/mcp-app-sandbox-http.ts src/gateway/mcp-app-sandbox-http.test.ts
exit 0

$ git diff --check origin/main...HEAD
exit 0
```

Changed-scope Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29624029355

Fresh branch autoreview: clean, no accepted or actionable findings.
