### PR TITLE
feat(linux): Quick Chat agent switcher, avatars, per-agent routing, and configurable shortcut

### DIFF
--- a/apps/linux/src-tauri/permissions/quickchat.toml
+++ b/apps/linux/src-tauri/permissions/quickchat.toml
@@ -1,10 +1,15 @@
 [[permission]]
 identifier = "allow-quickchat"
-description = "Enables Quick Chat identity, send, hide, and dashboard commands."
+description = "Enables Quick Chat agents, shortcut settings, send, hide, and dashboard commands."
 commands.allow = [
+  "quickchat_agents",
   "quickchat_hide",
   "quickchat_identity",
   "quickchat_ready",
+  "quickchat_select_agent",
   "quickchat_send",
+  "quickchat_set_expanded",
+  "quickchat_set_shortcut",
+  "quickchat_shortcut",
   "quickchat_show_dashboard",
 ]

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -177,6 +177,18 @@ impl DesktopState {
         *self.inner.tray.lock().expect("tray mutex poisoned") = Some(handles);
     }
 
+    pub(crate) fn set_quickchat_shortcut_checked(&self, checked: bool) {
+        if let Some(tray) = self
+            .inner
+            .tray
+            .lock()
+            .expect("tray mutex poisoned")
+            .as_ref()
+        {
+            tray.set_quickchat_shortcut_checked(checked);
+        }
+    }
+
     pub fn connect(&self, app: &AppHandle) -> Result<GatewaySnapshot, String> {
         let _operation = self
             .inner
@@ -663,6 +675,8 @@ async fn gateway_action(
 
 fn main() {
     let global_shortcuts_supported = tray::global_shortcuts_supported();
+    let quickchat_state = quickchat::QuickChatState::new(global_shortcuts_supported);
+    let quickchat_shortcut_state = quickchat_state.clone();
     // Single-instance must run first so it can pass deep-link argv to the primary process.
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -678,9 +692,9 @@ fn main() {
     let builder = if global_shortcuts_supported {
         builder.plugin(
             tauri_plugin_global_shortcut::Builder::new()
-                .with_handler(|app, shortcut, event| {
+                .with_handler(move |app, shortcut, event| {
                     if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                        if shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::Space) {
+                        if quickchat_shortcut_state.matches_shortcut(shortcut) {
                             quickchat::toggle_quickchat(app);
                         } else if shortcut
                             .matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyO)
@@ -725,7 +739,7 @@ fn main() {
         }
 
         app.manage(discovery::GatewayDiscovery::default());
-        app.manage(quickchat::QuickChatState::default());
+        app.manage(quickchat_state.clone());
         app.manage(updater::UpdaterState::default());
         #[cfg(target_os = "linux")]
         match canvas::CanvasBridge::start(app.handle().clone()) {
@@ -747,10 +761,15 @@ fn main() {
         discovery::discover_gateways,
         install_cli,
         gateway_action,
+        quickchat::quickchat_agents,
         quickchat::quickchat_hide,
         quickchat::quickchat_identity,
         quickchat::quickchat_ready,
+        quickchat::quickchat_select_agent,
         quickchat::quickchat_send,
+        quickchat::quickchat_set_expanded,
+        quickchat::quickchat_set_shortcut,
+        quickchat::quickchat_shortcut,
         quickchat::quickchat_show_dashboard,
         updater::open_release_page,
         updater::relaunch,
@@ -765,10 +784,15 @@ fn main() {
         discovery::discover_gateways,
         install_cli,
         gateway_action,
+        quickchat::quickchat_agents,
         quickchat::quickchat_hide,
         quickchat::quickchat_identity,
         quickchat::quickchat_ready,
+        quickchat::quickchat_select_agent,
         quickchat::quickchat_send,
+        quickchat::quickchat_set_expanded,
+        quickchat::quickchat_set_shortcut,
+        quickchat::quickchat_shortcut,
         quickchat::quickchat_show_dashboard,
         updater::open_release_page,
         updater::relaunch,

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -142,17 +142,21 @@ impl QuickChatState {
         Ok(agents)
     }
 
-    fn selected_agent(&self, desktop: &DesktopState) -> Result<QuickChatAgent, String> {
-        let agents = self.agents(desktop)?;
-        let selected = self
+    fn selected_agent(
+        &self,
+        desktop: &DesktopState,
+        on_missing: MissingSelection,
+    ) -> Result<QuickChatAgent, String> {
+        // Snapshot the pin before agents() refreshes the cache: a refresh clears a
+        // stale pin, and the send path must see that the pin existed so it can fail
+        // instead of silently rerouting the message to the default agent.
+        let pinned = self
             .selected_agent_id
             .lock()
             .map_err(|_| "Quick Chat agent selection is unavailable.".to_string())?
             .clone();
-        selected
-            .and_then(|id| agents.iter().find(|agent| agent.id == id).cloned())
-            .or_else(|| agents.iter().find(|agent| agent.is_default).cloned())
-            .ok_or_else(|| "OpenClaw did not report a default agent.".to_string())
+        let agents = self.agents(desktop)?;
+        resolve_selected_agent(pinned.as_deref(), &agents, on_missing)
     }
 
     fn select_agent(
@@ -231,6 +235,32 @@ impl QuickChatState {
             .lock()
             .is_ok_and(|active| active.registered && active.shortcut == *shortcut)
     }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum MissingSelection {
+    FallBackToDefault,
+    Fail,
+}
+
+fn resolve_selected_agent(
+    pinned: Option<&str>,
+    agents: &[QuickChatAgent],
+    on_missing: MissingSelection,
+) -> Result<QuickChatAgent, String> {
+    if let Some(id) = pinned {
+        if let Some(agent) = agents.iter().find(|agent| agent.id == id) {
+            return Ok(agent.clone());
+        }
+        if on_missing == MissingSelection::Fail {
+            return Err("The selected agent is no longer available.".to_string());
+        }
+    }
+    agents
+        .iter()
+        .find(|agent| agent.is_default)
+        .cloned()
+        .ok_or_else(|| "OpenClaw did not report a default agent.".to_string())
 }
 
 fn non_empty(value: Option<String>) -> Option<String> {
@@ -618,9 +648,11 @@ pub async fn quickchat_identity(
     require_quickchat_window(&window)?;
     let desktop = desktop.inner().clone();
     let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || state.selected_agent(&desktop))
-        .await
-        .map_err(|error| format!("Quick Chat identity task failed: {error}"))?
+    tauri::async_runtime::spawn_blocking(move || {
+        state.selected_agent(&desktop, MissingSelection::FallBackToDefault)
+    })
+    .await
+    .map_err(|error| format!("Quick Chat identity task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -654,7 +686,9 @@ pub async fn quickchat_send(
     let desktop = desktop.inner().clone();
     let state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let agent = state.selected_agent(&desktop)?;
+        // Strict resolution: a pinned agent that vanished must fail the send loudly
+        // rather than reroute the message to the default agent behind a stale chip.
+        let agent = state.selected_agent(&desktop, MissingSelection::Fail)?;
         spawn_agent_turn(app, desktop, message, agent)
     })
     .await
@@ -957,6 +991,19 @@ mod tests {
         let loaded = shortcut_preference_from_path(&path);
         assert_eq!(loaded.accelerator, QUICKCHAT_SHORTCUT);
         fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn missing_pinned_agent_fails_sends_and_heals_identity() {
+        let agents = [test_agent("main", true), test_agent("work", false)];
+
+        let pinned = resolve_selected_agent(Some("work"), &agents, MissingSelection::Fail);
+        assert_eq!(pinned.expect("pinned agent").id, "work");
+        let gone = resolve_selected_agent(Some("gone"), &agents, MissingSelection::Fail);
+        assert!(gone.is_err());
+        let healed =
+            resolve_selected_agent(Some("gone"), &agents, MissingSelection::FallBackToDefault);
+        assert_eq!(healed.expect("default agent").id, "main");
     }
 
     #[test]

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -688,6 +688,10 @@ pub async fn quickchat_send(
     tauri::async_runtime::spawn_blocking(move || {
         // Strict resolution: a pinned agent that vanished must fail the send loudly
         // rather than reroute the message to the default agent behind a stale chip.
+        // Validation is deliberately cache-fresh only (60s TTL): the CLI is the
+        // authoritative rejector of unknown agents and its failure surfaces as a
+        // notification, so a per-send `agents list` exec would add hot-path latency
+        // without closing the removal race.
         let agent = state.selected_agent(&desktop, MissingSelection::Fail)?;
         spawn_agent_turn(app, desktop, message, agent)
     })

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -734,11 +734,9 @@ pub fn quickchat_set_shortcut(
     let candidate_already_registered = current.shortcut == candidate && current_registered;
 
     if !candidate_already_registered {
-        manager
-            .register(candidate)
-            .map_err(|error| {
-                format!("Could not register shortcut \"{candidate_accelerator}\": {error}")
-            })?;
+        manager.register(candidate).map_err(|error| {
+            format!("Could not register shortcut \"{candidate_accelerator}\": {error}")
+        })?;
     }
     if current.shortcut != candidate && current_registered {
         if let Err(error) = manager.unregister(current.shortcut) {

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -81,12 +81,6 @@ pub struct QuickChatState {
     hide_requested: Arc<AtomicBool>,
 }
 
-impl Default for QuickChatState {
-    fn default() -> Self {
-        Self::new(true)
-    }
-}
-
 impl QuickChatState {
     pub fn new(shortcuts_supported: bool) -> Self {
         let shortcut = parse_shortcut(QUICKCHAT_SHORTCUT)
@@ -577,24 +571,13 @@ fn show_quickchat(app: &AppHandle) -> Result<(), String> {
         .show()
         .map_err(|error| format!("Could not show Quick Chat: {error}"))?;
     if let Err(error) = window.set_focus() {
+        // X11 focus-stealing prevention can reject the focus grab; retract the bar
+        // instead of leaving an unfocusable always-on-top window on screen.
         app.state::<QuickChatState>()
             .hide_requested
             .store(true, Ordering::SeqCst);
-        return match window.hide() {
-            Ok(()) => Err(format!("Could not focus Quick Chat: {error}")),
-            Err(hide_error) => match window.destroy() {
-                Ok(()) => Err(format!(
-                    "Could not focus Quick Chat: {error}; could not hide it again: {hide_error}"
-                )),
-                Err(destroy_error) => {
-                    let _ = window.emit("quickchat:shown", ());
-                    Err(format!(
-                        "Could not focus Quick Chat: {error}; could not hide it again: \
-                         {hide_error}; could not destroy it: {destroy_error}"
-                    ))
-                }
-            },
-        };
+        let _ = window.hide();
+        return Err(format!("Could not focus Quick Chat: {error}"));
     }
     window
         .emit("quickchat:shown", ())

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -572,11 +572,14 @@ fn show_quickchat(app: &AppHandle) -> Result<(), String> {
         .map_err(|error| format!("Could not show Quick Chat: {error}"))?;
     if let Err(error) = window.set_focus() {
         // X11 focus-stealing prevention can reject the focus grab; retract the bar
-        // instead of leaving an unfocusable always-on-top window on screen.
+        // instead of leaving an unfocusable always-on-top window on screen. If even
+        // hide fails, destroy the window rather than strand it; the next toggle rebuilds.
         app.state::<QuickChatState>()
             .hide_requested
             .store(true, Ordering::SeqCst);
-        let _ = window.hide();
+        if window.hide().is_err() {
+            let _ = window.destroy();
+        }
         return Err(format!("Could not focus Quick Chat: {error}"));
     }
     window

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -1,90 +1,241 @@
 use crate::{notify, tray, DesktopState};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use tauri::{
-    AppHandle, Emitter, Manager, PhysicalPosition, State, WebviewUrl, WebviewWindow,
+    AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, State, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder,
 };
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut};
 
 pub const QUICKCHAT_LABEL: &str = "quickchat";
 // Alt+Space is GNOME's window-menu grab; a second X11 grab for it always fails.
 pub const QUICKCHAT_SHORTCUT: &str = "CmdOrCtrl+Shift+Space";
+const QUICKCHAT_SHORTCUT_FILE: &str = "quickchat-shortcut";
+const QUICKCHAT_SHORTCUT_DISABLED_MARKER: &str = "quickchat-shortcut-disabled";
 const QUICKCHAT_WIDTH: f64 = 640.0;
 const QUICKCHAT_HEIGHT: f64 = 92.0;
-const IDENTITY_CACHE_TTL: Duration = Duration::from_secs(60);
+const QUICKCHAT_EXPANDED_HEIGHT: f64 = 360.0;
+const AGENTS_CACHE_TTL: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Serialize)]
-pub struct QuickChatIdentity {
+#[serde(rename_all = "camelCase")]
+pub struct QuickChatAgent {
+    id: String,
     name: String,
     emoji: Option<String>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentSummary {
-    id: String,
-    name: Option<String>,
-    identity_name: Option<String>,
-    identity_emoji: Option<String>,
+    avatar_url: Option<String>,
     is_default: bool,
 }
 
-struct CachedIdentity {
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuickChatShortcutStatus {
+    supported: bool,
+    enabled: bool,
+    accelerator: String,
+}
+
+#[derive(Deserialize)]
+struct AgentSummary {
+    id: String,
+    name: Option<String>,
+    #[serde(rename = "identityName")]
+    identity_name: Option<String>,
+    #[serde(rename = "identityEmoji")]
+    identity_emoji: Option<String>,
+    #[serde(rename = "identityAvatarUrl")]
+    identity_avatar_url: Option<String>,
+    #[serde(rename = "isDefault")]
+    is_default: bool,
+}
+
+struct CachedAgents {
     fetched_at: Instant,
-    identity: QuickChatIdentity,
+    agents: Vec<QuickChatAgent>,
+}
+
+#[derive(Clone)]
+struct ActiveShortcut {
+    accelerator: String,
+    shortcut: Shortcut,
+    registered: bool,
+}
+
+pub(crate) struct QuickChatShortcutPreference {
+    pub accelerator: String,
+    pub shortcut: Shortcut,
 }
 
 #[derive(Clone)]
 pub struct QuickChatState {
-    identity_cache: Arc<Mutex<Option<CachedIdentity>>>,
+    agents_cache: Arc<Mutex<Option<CachedAgents>>>,
+    selected_agent_id: Arc<Mutex<Option<String>>>,
+    active_shortcut: Arc<Mutex<ActiveShortcut>>,
+    shortcuts_supported: bool,
     hide_requested: Arc<AtomicBool>,
 }
 
 impl Default for QuickChatState {
     fn default() -> Self {
-        Self {
-            identity_cache: Arc::new(Mutex::new(None)),
-            hide_requested: Arc::new(AtomicBool::new(true)),
-        }
+        Self::new(true)
     }
 }
 
 impl QuickChatState {
-    fn identity(&self, desktop: &DesktopState) -> Result<QuickChatIdentity, String> {
-        if let Some(identity) = self
-            .identity_cache
+    pub fn new(shortcuts_supported: bool) -> Self {
+        let shortcut = parse_shortcut(QUICKCHAT_SHORTCUT)
+            .expect("the built-in Quick Chat shortcut must be valid");
+        Self {
+            agents_cache: Arc::new(Mutex::new(None)),
+            selected_agent_id: Arc::new(Mutex::new(None)),
+            active_shortcut: Arc::new(Mutex::new(ActiveShortcut {
+                accelerator: QUICKCHAT_SHORTCUT.to_string(),
+                shortcut,
+                registered: false,
+            })),
+            shortcuts_supported,
+            hide_requested: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn agents(&self, desktop: &DesktopState) -> Result<Vec<QuickChatAgent>, String> {
+        if let Some(agents) = self
+            .agents_cache
             .lock()
-            .map_err(|_| "Quick Chat identity cache is unavailable.".to_string())?
+            .map_err(|_| "Quick Chat agent cache is unavailable.".to_string())?
             .as_ref()
-            .filter(|cached| cached.fetched_at.elapsed() < IDENTITY_CACHE_TTL)
-            .map(|cached| cached.identity.clone())
+            .filter(|cached| cached.fetched_at.elapsed() < AGENTS_CACHE_TTL)
+            .map(|cached| cached.agents.clone())
         {
-            return Ok(identity);
+            return Ok(agents);
         }
 
         let cli = desktop.resolve_cli().map_err(|error| error.to_string())?;
-        let (agents, output) = cli
+        let (summaries, output) = cli
             .json::<Vec<AgentSummary>, _, _>(["agents", "list", "--json"])
             .map_err(|error| error.to_string())?;
         if !output.status.success() {
             return Err(first_stderr_line(&output.stderr)
-                .unwrap_or_else(|| "Could not load the default agent identity.".to_string()));
+                .unwrap_or_else(|| "Could not load Quick Chat agents.".to_string()));
         }
-        let identity = default_identity(agents)?;
+        let agents = build_agents(summaries)?;
+        {
+            let mut selection = self
+                .selected_agent_id
+                .lock()
+                .map_err(|_| "Quick Chat agent selection is unavailable.".to_string())?;
+            if selection
+                .as_ref()
+                .is_some_and(|selected| !agents.iter().any(|agent| agent.id == selected.as_str()))
+            {
+                *selection = None;
+            }
+        }
         *self
-            .identity_cache
+            .agents_cache
             .lock()
-            .map_err(|_| "Quick Chat identity cache is unavailable.".to_string())? =
-            Some(CachedIdentity {
+            .map_err(|_| "Quick Chat agent cache is unavailable.".to_string())? =
+            Some(CachedAgents {
                 fetched_at: Instant::now(),
-                identity: identity.clone(),
+                agents: agents.clone(),
             });
-        Ok(identity)
+        Ok(agents)
+    }
+
+    fn selected_agent(&self, desktop: &DesktopState) -> Result<QuickChatAgent, String> {
+        let agents = self.agents(desktop)?;
+        let selected = self
+            .selected_agent_id
+            .lock()
+            .map_err(|_| "Quick Chat agent selection is unavailable.".to_string())?
+            .clone();
+        selected
+            .and_then(|id| agents.iter().find(|agent| agent.id == id).cloned())
+            .or_else(|| agents.iter().find(|agent| agent.is_default).cloned())
+            .ok_or_else(|| "OpenClaw did not report a default agent.".to_string())
+    }
+
+    fn select_agent(
+        &self,
+        desktop: &DesktopState,
+        agent_id: &str,
+    ) -> Result<QuickChatAgent, String> {
+        let agent_id = agent_id.trim();
+        let agents = self.agents(desktop)?;
+        let selected = agents
+            .iter()
+            .find(|agent| agent.id == agent_id)
+            .cloned()
+            .ok_or_else(|| format!("Unknown Quick Chat agent \"{agent_id}\"."))?;
+        *self
+            .selected_agent_id
+            .lock()
+            .map_err(|_| "Quick Chat agent selection is unavailable.".to_string())? =
+            if selected.is_default {
+                None
+            } else {
+                Some(selected.id.clone())
+            };
+        Ok(selected)
+    }
+
+    fn shortcut_status(&self) -> Result<QuickChatShortcutStatus, String> {
+        let active = self
+            .active_shortcut
+            .lock()
+            .map_err(|_| "Quick Chat shortcut state is unavailable.".to_string())?;
+        Ok(QuickChatShortcutStatus {
+            supported: self.shortcuts_supported,
+            enabled: active.registered,
+            accelerator: active.accelerator.clone(),
+        })
+    }
+
+    fn active_shortcut(&self) -> Result<ActiveShortcut, String> {
+        self.active_shortcut
+            .lock()
+            .map_err(|_| "Quick Chat shortcut state is unavailable.".to_string())
+            .map(|active| active.clone())
+    }
+
+    pub(crate) fn set_active_shortcut(
+        &self,
+        accelerator: String,
+        shortcut: Shortcut,
+        registered: bool,
+    ) {
+        if let Ok(mut active) = self.active_shortcut.lock() {
+            *active = ActiveShortcut {
+                accelerator,
+                shortcut,
+                registered,
+            };
+        }
+    }
+
+    pub(crate) fn set_shortcut_registered(&self, registered: bool) {
+        if let Ok(mut active) = self.active_shortcut.lock() {
+            active.registered = registered;
+        }
+    }
+
+    pub(crate) fn shortcut(&self) -> Option<Shortcut> {
+        self.active_shortcut
+            .lock()
+            .ok()
+            .map(|active| active.shortcut)
+    }
+
+    pub fn matches_shortcut(&self, shortcut: &Shortcut) -> bool {
+        self.active_shortcut
+            .lock()
+            .is_ok_and(|active| active.registered && active.shortcut == *shortcut)
     }
 }
 
@@ -94,19 +245,28 @@ fn non_empty(value: Option<String>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-fn default_identity(agents: Vec<AgentSummary>) -> Result<QuickChatIdentity, String> {
-    let agent = agents
+fn build_agents(summaries: Vec<AgentSummary>) -> Result<Vec<QuickChatAgent>, String> {
+    let agents = summaries
         .into_iter()
-        .find(|agent| agent.is_default)
-        .ok_or_else(|| "OpenClaw did not report a default agent.".to_string())?;
-    let name = non_empty(agent.identity_name)
-        .or_else(|| non_empty(agent.name))
-        .or_else(|| non_empty(Some(agent.id)))
-        .unwrap_or_else(|| "Agent".to_string());
-    Ok(QuickChatIdentity {
-        name,
-        emoji: non_empty(agent.identity_emoji),
-    })
+        .map(|summary| {
+            let id = summary.id;
+            let name = non_empty(summary.identity_name)
+                .or_else(|| non_empty(summary.name))
+                .unwrap_or_else(|| id.clone());
+            QuickChatAgent {
+                id,
+                name,
+                emoji: non_empty(summary.identity_emoji),
+                avatar_url: non_empty(summary.identity_avatar_url),
+                is_default: summary.is_default,
+            }
+        })
+        .collect::<Vec<_>>();
+    if agents.iter().any(|agent| agent.is_default) {
+        Ok(agents)
+    } else {
+        Err("OpenClaw did not report a default agent.".to_string())
+    }
 }
 
 fn first_stderr_line(stderr: &[u8]) -> Option<String> {
@@ -115,6 +275,134 @@ fn first_stderr_line(stderr: &[u8]) -> Option<String> {
         .map(str::trim)
         .find(|line| !line.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn parse_shortcut(accelerator: &str) -> Result<Shortcut, String> {
+    accelerator
+        .parse::<Shortcut>()
+        .map_err(|error| format!("Invalid shortcut \"{accelerator}\": {error}"))
+}
+
+fn validate_quickchat_shortcut(accelerator: &str) -> Result<Shortcut, String> {
+    let shortcut = parse_shortcut(accelerator)?;
+    let dashboard_shortcut = parse_shortcut(tray::GLOBAL_SHORTCUT)
+        .expect("the built-in dashboard shortcut must be valid");
+    if shortcut == dashboard_shortcut {
+        return Err(format!(
+            "Shortcut \"{accelerator}\" is reserved for Open Dashboard."
+        ));
+    }
+    Ok(shortcut)
+}
+
+fn shortcut_preference_from_path(path: &Path) -> QuickChatShortcutPreference {
+    let configured = fs::read_to_string(path)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if let Some(accelerator) = configured {
+        if let Ok(shortcut) = validate_quickchat_shortcut(&accelerator) {
+            return QuickChatShortcutPreference {
+                accelerator,
+                shortcut,
+            };
+        }
+    }
+    default_shortcut_preference()
+}
+
+fn default_shortcut_preference() -> QuickChatShortcutPreference {
+    QuickChatShortcutPreference {
+        accelerator: QUICKCHAT_SHORTCUT.to_string(),
+        shortcut: parse_shortcut(QUICKCHAT_SHORTCUT)
+            .expect("the built-in Quick Chat shortcut must be valid"),
+    }
+}
+
+fn persist_shortcut_preference(path: &Path, accelerator: Option<&str>) -> std::io::Result<()> {
+    match accelerator {
+        Some(accelerator) => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(path, accelerator.as_bytes())
+        }
+        None => match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        },
+    }
+}
+
+fn quickchat_config_file(
+    app: &impl Manager<tauri::Wry>,
+    filename: &str,
+) -> Result<PathBuf, String> {
+    app.path()
+        .app_config_dir()
+        .map(|path| path.join(filename))
+        .map_err(|error| format!("Could not resolve Quick Chat preference path: {error}"))
+}
+
+pub(crate) fn load_shortcut_preference(
+    app: &impl Manager<tauri::Wry>,
+) -> QuickChatShortcutPreference {
+    match quickchat_config_file(app, QUICKCHAT_SHORTCUT_FILE) {
+        Ok(path) => shortcut_preference_from_path(&path),
+        Err(error) => {
+            eprintln!("{error}");
+            default_shortcut_preference()
+        }
+    }
+}
+
+fn quickchat_shortcut_disabled_marker(app: &impl Manager<tauri::Wry>) -> Option<PathBuf> {
+    match app.path().app_config_dir() {
+        Ok(path) => Some(path.join(QUICKCHAT_SHORTCUT_DISABLED_MARKER)),
+        Err(error) => {
+            eprintln!("Could not resolve Quick Chat shortcut preference path: {error}");
+            None
+        }
+    }
+}
+
+pub(crate) fn quickchat_shortcut_marker_exists(path: &Path) -> bool {
+    match path.try_exists() {
+        Ok(exists) => exists,
+        Err(error) => {
+            eprintln!("Could not read Quick Chat shortcut preference: {error}");
+            false
+        }
+    }
+}
+
+pub(crate) fn quickchat_shortcut_enabled(app: &impl Manager<tauri::Wry>) -> bool {
+    !quickchat_shortcut_disabled_marker(app)
+        .as_deref()
+        .is_some_and(quickchat_shortcut_marker_exists)
+}
+
+pub(crate) fn persist_quickchat_shortcut_state(app: &AppHandle, registered: bool) {
+    let Some(marker) = quickchat_shortcut_disabled_marker(app) else {
+        return;
+    };
+    let result = if registered {
+        match fs::remove_file(&marker) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    } else {
+        marker
+            .parent()
+            .map(fs::create_dir_all)
+            .transpose()
+            .and_then(|_| fs::write(&marker, b""))
+    };
+    if let Err(error) = result {
+        eprintln!("Could not persist Quick Chat shortcut preference: {error}");
+    }
 }
 
 /// Stages the message in an owner-only file: argv is world-readable via procfs, and the
@@ -130,7 +418,7 @@ fn write_message_file(message: &str) -> Result<PathBuf, String> {
         "openclaw-quickchat-{}-{nanos}.txt",
         std::process::id()
     ));
-    let mut file = std::fs::OpenOptions::new()
+    let mut file = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .mode(0o600)
@@ -138,40 +426,53 @@ fn write_message_file(message: &str) -> Result<PathBuf, String> {
         .map_err(|error| format!("Could not stage the message: {error}"))?;
     if let Err(error) = file.write_all(message.as_bytes()) {
         // A partial write must not strand prompt text in the temp directory.
-        let _ = std::fs::remove_file(&path);
+        let _ = fs::remove_file(&path);
         return Err(format!("Could not stage the message: {error}"));
     }
     Ok(path)
 }
 
-fn spawn_agent_turn(app: AppHandle, desktop: DesktopState, message: String) -> Result<(), String> {
+fn build_agent_turn_args(message_file: &str, agent: &QuickChatAgent) -> Vec<String> {
+    let mut args = vec![
+        "agent".to_string(),
+        "--message-file".to_string(),
+        message_file.to_string(),
+    ];
+    if agent.is_default {
+        args.extend(["--session-key".to_string(), "main".to_string()]);
+    } else {
+        args.extend(["--agent".to_string(), agent.id.clone()]);
+    }
+    args.push("--json".to_string());
+    args
+}
+
+fn spawn_agent_turn(
+    app: AppHandle,
+    desktop: DesktopState,
+    message: String,
+    agent: QuickChatAgent,
+) -> Result<(), String> {
     let cli = desktop.resolve_cli().map_err(|error| error.to_string())?;
     let message_file = write_message_file(&message)?;
     let message_file_arg = message_file.to_string_lossy().into_owned();
     let mut command = cli
-        .command([
-            "agent",
-            "--message-file",
-            message_file_arg.as_str(),
-            "--session-key",
-            "main",
-            "--json",
-        ])
+        .command(build_agent_turn_args(&message_file_arg, &agent))
         .map_err(|error| {
-            let _ = std::fs::remove_file(&message_file);
+            let _ = fs::remove_file(&message_file);
             error.to_string()
         })?;
     command.stdout(Stdio::null()).stderr(Stdio::piped());
     let child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
-            let _ = std::fs::remove_file(&message_file);
+            let _ = fs::remove_file(&message_file);
             return Err(format!("Failed to run OpenClaw CLI: {error}"));
         }
     };
     thread::spawn(move || {
         let outcome = child.wait_with_output();
-        let _ = std::fs::remove_file(&message_file);
+        let _ = fs::remove_file(&message_file);
         match outcome {
             Ok(output) if !output.status.success() => {
                 let body = first_stderr_line(&output.stderr)
@@ -265,6 +566,9 @@ pub fn toggle_quickchat(app: &AppHandle) {
 
 fn show_quickchat(app: &AppHandle) -> Result<(), String> {
     let window = ensure_quickchat_window(app)?;
+    window
+        .set_size(LogicalSize::new(QUICKCHAT_WIDTH, QUICKCHAT_HEIGHT))
+        .map_err(|error| format!("Could not reset Quick Chat size: {error}"))?;
     position_quickchat(app, &window)?;
     app.state::<QuickChatState>()
         .hide_requested
@@ -306,17 +610,46 @@ fn require_quickchat_window(window: &WebviewWindow) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub async fn quickchat_agents(
+    window: WebviewWindow,
+    desktop: State<'_, DesktopState>,
+    state: State<'_, QuickChatState>,
+) -> Result<Vec<QuickChatAgent>, String> {
+    require_quickchat_window(&window)?;
+    let desktop = desktop.inner().clone();
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || state.agents(&desktop))
+        .await
+        .map_err(|error| format!("Quick Chat agents task failed: {error}"))?
+}
+
+#[tauri::command]
 pub async fn quickchat_identity(
     window: WebviewWindow,
     desktop: State<'_, DesktopState>,
     state: State<'_, QuickChatState>,
-) -> Result<QuickChatIdentity, String> {
+) -> Result<QuickChatAgent, String> {
     require_quickchat_window(&window)?;
     let desktop = desktop.inner().clone();
     let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || state.identity(&desktop))
+    tauri::async_runtime::spawn_blocking(move || state.selected_agent(&desktop))
         .await
         .map_err(|error| format!("Quick Chat identity task failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn quickchat_select_agent(
+    window: WebviewWindow,
+    desktop: State<'_, DesktopState>,
+    state: State<'_, QuickChatState>,
+    agent_id: String,
+) -> Result<QuickChatAgent, String> {
+    require_quickchat_window(&window)?;
+    let desktop = desktop.inner().clone();
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || state.select_agent(&desktop, &agent_id))
+        .await
+        .map_err(|error| format!("Quick Chat agent selection task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -324,6 +657,7 @@ pub async fn quickchat_send(
     window: WebviewWindow,
     app: AppHandle,
     desktop: State<'_, DesktopState>,
+    state: State<'_, QuickChatState>,
     message: String,
 ) -> Result<(), String> {
     require_quickchat_window(&window)?;
@@ -332,9 +666,104 @@ pub async fn quickchat_send(
         return Err("Message cannot be empty.".to_string());
     }
     let desktop = desktop.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || spawn_agent_turn(app, desktop, message))
-        .await
-        .map_err(|error| format!("Quick Chat send task failed: {error}"))?
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let agent = state.selected_agent(&desktop)?;
+        spawn_agent_turn(app, desktop, message, agent)
+    })
+    .await
+    .map_err(|error| format!("Quick Chat send task failed: {error}"))?
+}
+
+#[tauri::command]
+pub fn quickchat_shortcut(
+    window: WebviewWindow,
+    state: State<'_, QuickChatState>,
+) -> Result<QuickChatShortcutStatus, String> {
+    require_quickchat_window(&window)?;
+    state.shortcut_status()
+}
+
+#[tauri::command]
+pub fn quickchat_set_shortcut(
+    window: WebviewWindow,
+    app: AppHandle,
+    desktop: State<'_, DesktopState>,
+    state: State<'_, QuickChatState>,
+    accelerator: Option<String>,
+) -> Result<QuickChatShortcutStatus, String> {
+    require_quickchat_window(&window)?;
+    if !state.shortcuts_supported {
+        return state.shortcut_status();
+    }
+
+    let configured = accelerator.and_then(|value| non_empty(Some(value)));
+    let candidate_accelerator = configured
+        .clone()
+        .unwrap_or_else(|| QUICKCHAT_SHORTCUT.to_string());
+    let candidate = validate_quickchat_shortcut(&candidate_accelerator)?;
+    let current = state.active_shortcut()?;
+    let preference_path = quickchat_config_file(&app, QUICKCHAT_SHORTCUT_FILE)?;
+    let manager = app.global_shortcut();
+    let current_registered = manager.is_registered(current.shortcut);
+    let should_register = quickchat_shortcut_enabled(&app);
+    let candidate_already_registered = current.shortcut == candidate && current_registered;
+
+    if !candidate_already_registered {
+        manager
+            .register(candidate)
+            .map_err(|error| {
+                format!("Could not register shortcut \"{candidate_accelerator}\": {error}")
+            })?;
+    }
+    if current.shortcut != candidate && current_registered {
+        if let Err(error) = manager.unregister(current.shortcut) {
+            let _ = manager.unregister(candidate);
+            return Err(format!(
+                "Could not replace shortcut \"{}\": {error}",
+                current.accelerator
+            ));
+        }
+    }
+    if !should_register {
+        if let Err(error) = manager.unregister(candidate) {
+            if current.shortcut != candidate && current_registered {
+                let _ = manager.register(current.shortcut);
+            }
+            return Err(format!(
+                "Could not finish validating shortcut \"{candidate_accelerator}\": {error}"
+            ));
+        }
+    }
+
+    if let Err(error) = persist_shortcut_preference(&preference_path, configured.as_deref()) {
+        if manager.is_registered(candidate) {
+            let _ = manager.unregister(candidate);
+        }
+        if current_registered && !manager.is_registered(current.shortcut) {
+            let _ = manager.register(current.shortcut);
+        }
+        return Err(format!("Could not save the Quick Chat shortcut: {error}"));
+    }
+
+    let registered = should_register && manager.is_registered(candidate);
+    state.set_active_shortcut(candidate_accelerator, candidate, registered);
+    desktop.set_quickchat_shortcut_checked(registered);
+    state.shortcut_status()
+}
+
+#[tauri::command]
+pub fn quickchat_set_expanded(window: WebviewWindow, expanded: bool) -> Result<(), String> {
+    require_quickchat_window(&window)?;
+    let height = if expanded {
+        QUICKCHAT_EXPANDED_HEIGHT
+    } else {
+        QUICKCHAT_HEIGHT
+    };
+    window
+        .set_size(LogicalSize::new(QUICKCHAT_WIDTH, height))
+        .map_err(|error| format!("Could not resize Quick Chat: {error}"))?;
+    position_quickchat(window.app_handle(), &window)
 }
 
 #[tauri::command]
@@ -347,7 +776,9 @@ pub fn quickchat_hide(window: WebviewWindow) -> Result<(), String> {
         .store(true, Ordering::SeqCst);
     window
         .hide()
-        .map_err(|error| format!("Could not hide Quick Chat: {error}"))
+        .map_err(|error| format!("Could not hide Quick Chat: {error}"))?;
+    let _ = window.set_size(LogicalSize::new(QUICKCHAT_WIDTH, QUICKCHAT_HEIGHT));
+    Ok(())
 }
 
 #[tauri::command]
@@ -373,10 +804,32 @@ pub fn quickchat_show_dashboard(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn assert_position(actual: (f64, f64), expected: (f64, f64)) {
         assert!((actual.0 - expected.0).abs() < 1e-9);
         assert!((actual.1 - expected.1).abs() < 1e-9);
+    }
+
+    fn test_agent(id: &str, is_default: bool) -> QuickChatAgent {
+        QuickChatAgent {
+            id: id.to_string(),
+            name: id.to_string(),
+            emoji: None,
+            avatar_url: None,
+            is_default,
+        }
+    }
+
+    fn test_directory(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "openclaw-quickchat-{label}-{}-{unique}",
+            std::process::id()
+        ))
     }
 
     #[test]
@@ -400,26 +853,136 @@ mod tests {
     }
 
     #[test]
-    fn identity_prefers_identity_fields_for_default_agent() {
-        let identity = default_identity(vec![
-            AgentSummary {
-                id: "other".to_string(),
-                name: Some("Other".to_string()),
-                identity_name: None,
-                identity_emoji: None,
-                is_default: false,
-            },
+    fn agents_use_identity_precedence_and_render_fields() {
+        let agents = build_agents(vec![
             AgentSummary {
                 id: "main".to_string(),
                 name: Some("Configured".to_string()),
                 identity_name: Some("Molty".to_string()),
                 identity_emoji: Some("🦞".to_string()),
+                identity_avatar_url: Some("data:image/png;base64,AA==".to_string()),
                 is_default: true,
             },
+            AgentSummary {
+                id: "other".to_string(),
+                name: None,
+                identity_name: None,
+                identity_emoji: None,
+                identity_avatar_url: None,
+                is_default: false,
+            },
         ])
-        .expect("default identity");
+        .expect("agent list");
 
-        assert_eq!(identity.name, "Molty");
-        assert_eq!(identity.emoji.as_deref(), Some("🦞"));
+        assert_eq!(agents[0].name, "Molty");
+        assert_eq!(agents[0].emoji.as_deref(), Some("🦞"));
+        assert_eq!(
+            agents[0].avatar_url.as_deref(),
+            Some("data:image/png;base64,AA==")
+        );
+        assert_eq!(agents[1].name, "other");
+    }
+
+    #[test]
+    fn agent_summary_deserializes_agents_list_json() {
+        let summaries = serde_json::from_str::<Vec<AgentSummary>>(
+            r#"[{"id":"work","identityName":"Work","identityEmoji":"🧰","identityAvatarUrl":"data:image/png;base64,AA==","isDefault":false}]"#,
+        )
+        .expect("deserialize agents list JSON");
+
+        assert_eq!(summaries[0].identity_name.as_deref(), Some("Work"));
+        assert_eq!(summaries[0].identity_emoji.as_deref(), Some("🧰"));
+        assert_eq!(
+            summaries[0].identity_avatar_url.as_deref(),
+            Some("data:image/png;base64,AA==")
+        );
+        assert!(!summaries[0].is_default);
+    }
+
+    #[test]
+    fn agent_turn_args_route_default_and_selected_agents() {
+        let default_args = build_agent_turn_args("/tmp/message.txt", &test_agent("main", true));
+        assert_eq!(
+            default_args.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec![
+                "agent",
+                "--message-file",
+                "/tmp/message.txt",
+                "--session-key",
+                "main",
+                "--json",
+            ]
+        );
+        let selected_args = build_agent_turn_args("/tmp/message.txt", &test_agent("work", false));
+        assert_eq!(
+            selected_args.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec![
+                "agent",
+                "--message-file",
+                "/tmp/message.txt",
+                "--agent",
+                "work",
+                "--json",
+            ]
+        );
+    }
+
+    #[test]
+    fn shortcut_preference_round_trips_and_resets() {
+        let directory = test_directory("shortcut-roundtrip");
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join(QUICKCHAT_SHORTCUT_FILE);
+
+        persist_shortcut_preference(&path, Some("Ctrl+Alt+KeyK")).expect("write shortcut");
+        let loaded = shortcut_preference_from_path(&path);
+        assert_eq!(loaded.accelerator, "Ctrl+Alt+KeyK");
+        assert!(loaded
+            .shortcut
+            .matches(loaded.shortcut.mods, loaded.shortcut.key));
+
+        persist_shortcut_preference(&path, None).expect("reset shortcut");
+        assert!(!path.exists());
+        assert_eq!(
+            shortcut_preference_from_path(&path).accelerator,
+            QUICKCHAT_SHORTCUT
+        );
+        fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn invalid_shortcut_preference_falls_back_to_default() {
+        let directory = test_directory("shortcut-fallback");
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join(QUICKCHAT_SHORTCUT_FILE);
+        fs::write(&path, b"Ctrl+NotAKey").expect("write invalid shortcut");
+
+        let loaded = shortcut_preference_from_path(&path);
+        assert_eq!(loaded.accelerator, QUICKCHAT_SHORTCUT);
+        fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn dashboard_shortcut_preference_falls_back_to_default() {
+        let directory = test_directory("shortcut-reserved");
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join(QUICKCHAT_SHORTCUT_FILE);
+        fs::write(&path, tray::GLOBAL_SHORTCUT).expect("write reserved shortcut");
+
+        let loaded = shortcut_preference_from_path(&path);
+        assert_eq!(loaded.accelerator, QUICKCHAT_SHORTCUT);
+        fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn shortcut_dispatch_matches_custom_accelerator() {
+        let state = QuickChatState::new(true);
+        let custom = parse_shortcut("Ctrl+Alt+KeyK").expect("custom shortcut");
+        let default = parse_shortcut(QUICKCHAT_SHORTCUT).expect("default shortcut");
+        state.set_active_shortcut("Ctrl+Alt+KeyK".to_string(), custom, true);
+
+        assert!(state.matches_shortcut(&custom));
+        assert!(!state.matches_shortcut(&default));
+        state.set_shortcut_registered(false);
+        assert!(!state.matches_shortcut(&custom));
     }
 }

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -14,8 +14,9 @@ const OPEN_ID: &str = "open-dashboard";
 const QUICKCHAT_ID: &str = "quickchat";
 const CHECK_UPDATES_ID: &str = "check-for-updates";
 const START_AT_LOGIN_ID: &str = "start-at-login";
+const QUICKCHAT_SHORTCUT_ID: &str = "quickchat-shortcut";
 const GLOBAL_SHORTCUT_ID: &str = "global-shortcut";
-const GLOBAL_SHORTCUT: &str = "CmdOrCtrl+Shift+O";
+pub(crate) const GLOBAL_SHORTCUT: &str = "CmdOrCtrl+Shift+O";
 // Marker presence is the durable user opt-out across restarts; no config schema on purpose.
 const GLOBAL_SHORTCUT_DISABLED_MARKER: &str = "global-shortcut-disabled";
 const START_ID: &str = "start-gateway";
@@ -31,6 +32,7 @@ pub struct TrayHandles {
     open: MenuItem<tauri::Wry>,
     _check_updates: MenuItem<tauri::Wry>,
     _start_at_login: CheckMenuItem<tauri::Wry>,
+    quickchat_shortcut: Option<CheckMenuItem<tauri::Wry>>,
     _global_shortcut: Option<CheckMenuItem<tauri::Wry>>,
     start: MenuItem<tauri::Wry>,
     stop: MenuItem<tauri::Wry>,
@@ -43,14 +45,14 @@ struct StatusLine {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct GlobalShortcutInitialState {
+struct ShortcutInitialState {
     should_register: bool,
     checked: bool,
 }
 
-fn global_shortcut_initial_state(marker_exists: bool) -> GlobalShortcutInitialState {
+fn shortcut_initial_state(marker_exists: bool) -> ShortcutInitialState {
     let enabled = !marker_exists;
-    GlobalShortcutInitialState {
+    ShortcutInitialState {
         should_register: enabled,
         checked: enabled,
     }
@@ -117,6 +119,12 @@ impl TrayHandles {
         status_line.pending_count = count;
         let _ = self.status.set_text(status_line.text());
     }
+
+    pub fn set_quickchat_shortcut_checked(&self, checked: bool) {
+        if let Some(item) = self.quickchat_shortcut.as_ref() {
+            set_quickchat_shortcut_checked(item, checked);
+        }
+    }
 }
 
 pub fn build(
@@ -155,15 +163,30 @@ pub fn build(
         autostart_enabled,
         None::<&str>,
     )?;
-    let shortcut_initial_state = global_shortcuts_supported.then(|| {
+    let quickchat_shortcut_initial_state = global_shortcuts_supported
+        .then(|| shortcut_initial_state(!quickchat::quickchat_shortcut_enabled(app)));
+    let quickchat_shortcut = quickchat_shortcut_initial_state
+        .as_ref()
+        .map(|initial_state| {
+            CheckMenuItem::with_id(
+                app,
+                QUICKCHAT_SHORTCUT_ID,
+                "Quick Chat shortcut",
+                true,
+                initial_state.checked,
+                None::<&str>,
+            )
+        })
+        .transpose()?;
+    let global_shortcut_initial_state = global_shortcuts_supported.then(|| {
         let shortcut_marker = global_shortcut_disabled_marker(app);
-        global_shortcut_initial_state(
+        shortcut_initial_state(
             shortcut_marker
                 .as_deref()
                 .is_some_and(global_shortcut_marker_exists),
         )
     });
-    let global_shortcut = shortcut_initial_state
+    let global_shortcut = global_shortcut_initial_state
         .as_ref()
         .map(|initial_state| {
             CheckMenuItem::with_id(
@@ -191,6 +214,11 @@ pub fn build(
         &check_updates,
         &start_at_login,
     ]);
+    let menu_builder = if let Some(quickchat_shortcut) = quickchat_shortcut.as_ref() {
+        menu_builder.item(quickchat_shortcut)
+    } else {
+        menu_builder
+    };
     let menu_builder = if let Some(global_shortcut) = global_shortcut.as_ref() {
         menu_builder.item(global_shortcut)
     } else {
@@ -210,6 +238,7 @@ pub fn build(
     let tray_icon = tauri::image::Image::from_bytes(include_bytes!("../icons/32x32.png"))?;
     let menu_state = state.clone();
     let menu_start_at_login = start_at_login.clone();
+    let menu_quickchat_shortcut = quickchat_shortcut.clone();
     let menu_global_shortcut = global_shortcut.clone();
     let tray_builder = TrayIconBuilder::with_id("openclaw-main")
         .icon(tray_icon)
@@ -220,6 +249,7 @@ pub fn build(
                 app,
                 &menu_state,
                 &menu_start_at_login,
+                menu_quickchat_shortcut.as_ref(),
                 menu_global_shortcut.as_ref(),
                 event.id().as_ref(),
             );
@@ -241,19 +271,34 @@ pub fn build(
     #[cfg(target_os = "macos")]
     let tray_builder = tray_builder.icon_as_template(true);
     let tray = tray_builder.build(app)?;
-    if global_shortcuts_supported {
-        if let Err(error) = app
-            .global_shortcut()
-            .register(quickchat::QUICKCHAT_SHORTCUT)
-        {
-            eprintln!(
-                "Could not register Quick Chat shortcut {}: {error}",
-                quickchat::QUICKCHAT_SHORTCUT
-            );
+    let quickchat_preference = quickchat::load_shortcut_preference(app);
+    let quickchat_state = app.state::<quickchat::QuickChatState>();
+    quickchat_state.set_active_shortcut(
+        quickchat_preference.accelerator.clone(),
+        quickchat_preference.shortcut,
+        false,
+    );
+    if let (Some(initial_state), Some(quickchat_shortcut)) = (
+        quickchat_shortcut_initial_state,
+        quickchat_shortcut.as_ref(),
+    ) {
+        if initial_state.should_register {
+            if let Err(error) = app
+                .global_shortcut()
+                .register(quickchat_preference.shortcut)
+            {
+                eprintln!(
+                    "Could not register Quick Chat shortcut {}: {error}",
+                    quickchat_preference.accelerator
+                );
+                set_quickchat_shortcut_checked(quickchat_shortcut, false);
+            } else {
+                quickchat_state.set_shortcut_registered(true);
+            }
         }
     }
     if let (Some(initial_state), Some(global_shortcut)) =
-        (shortcut_initial_state, global_shortcut.as_ref())
+        (global_shortcut_initial_state, global_shortcut.as_ref())
     {
         if initial_state.should_register {
             if let Err(error) = app.global_shortcut().register(GLOBAL_SHORTCUT) {
@@ -274,6 +319,7 @@ pub fn build(
         open,
         _check_updates: check_updates,
         _start_at_login: start_at_login,
+        quickchat_shortcut,
         _global_shortcut: global_shortcut,
         start,
         stop,
@@ -298,6 +344,7 @@ fn handle_menu(
     app: &AppHandle,
     state: &DesktopState,
     start_at_login: &CheckMenuItem<tauri::Wry>,
+    quickchat_shortcut: Option<&CheckMenuItem<tauri::Wry>>,
     global_shortcut: Option<&CheckMenuItem<tauri::Wry>>,
     id: &str,
 ) {
@@ -313,6 +360,11 @@ fn handle_menu(
             crate::updater::spawn_check(app.clone());
         }
         START_AT_LOGIN_ID => toggle_autostart(app, start_at_login),
+        QUICKCHAT_SHORTCUT_ID => {
+            if let Some(quickchat_shortcut) = quickchat_shortcut {
+                toggle_quickchat_shortcut(app, quickchat_shortcut);
+            }
+        }
         GLOBAL_SHORTCUT_ID => {
             if let Some(global_shortcut) = global_shortcut {
                 toggle_global_shortcut(app, global_shortcut);
@@ -322,6 +374,34 @@ fn handle_menu(
         STOP_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Stop),
         RESTART_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Restart),
         _ => {}
+    }
+}
+
+fn toggle_quickchat_shortcut(app: &AppHandle, item: &CheckMenuItem<tauri::Wry>) {
+    let state = app.state::<quickchat::QuickChatState>();
+    let Some(shortcut) = state.shortcut() else {
+        eprintln!("Could not read Quick Chat shortcut state");
+        return;
+    };
+    let manager = app.global_shortcut();
+    let enabled = manager.is_registered(shortcut);
+    let next = !enabled;
+    let result = if next {
+        manager.register(shortcut)
+    } else {
+        manager.unregister(shortcut)
+    };
+    match result {
+        Ok(()) => {
+            let registered = manager.is_registered(shortcut);
+            quickchat::persist_quickchat_shortcut_state(app, registered);
+            state.set_shortcut_registered(registered);
+            set_quickchat_shortcut_checked(item, registered);
+        }
+        Err(error) => {
+            eprintln!("Could not update Quick Chat shortcut: {error}");
+            set_quickchat_shortcut_checked(item, enabled);
+        }
     }
 }
 
@@ -392,6 +472,12 @@ fn persist_global_shortcut_state(app: &AppHandle, registered: bool) {
 fn set_global_shortcut_checked(item: &CheckMenuItem<tauri::Wry>, checked: bool) {
     if let Err(error) = item.set_checked(checked) {
         eprintln!("Could not update global shortcut menu state: {error}");
+    }
+}
+
+fn set_quickchat_shortcut_checked(item: &CheckMenuItem<tauri::Wry>, checked: bool) {
+    if let Err(error) = item.set_checked(checked) {
+        eprintln!("Could not update Quick Chat shortcut menu state: {error}");
     }
 }
 
@@ -477,16 +563,16 @@ mod tests {
         let marker = directory.join(GLOBAL_SHORTCUT_DISABLED_MARKER);
 
         assert_eq!(
-            global_shortcut_initial_state(marker.exists()),
-            GlobalShortcutInitialState {
+            shortcut_initial_state(marker.exists()),
+            ShortcutInitialState {
                 should_register: true,
                 checked: true,
             }
         );
         fs::write(&marker, b"").expect("write opt-out marker");
         assert_eq!(
-            global_shortcut_initial_state(marker.exists()),
-            GlobalShortcutInitialState {
+            shortcut_initial_state(marker.exists()),
+            ShortcutInitialState {
                 should_register: false,
                 checked: false,
             }

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src ipc: http://ipc.localhost",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: http: https:; connect-src ipc: http://ipc.localhost",
       "capabilities": [
         {
           "identifier": "local-companion",
@@ -68,7 +68,7 @@
         },
         {
           "identifier": "quickchat",
-          "description": "Quick Chat can load the default agent, send a message, and receive window events.",
+          "description": "Quick Chat can select agents, configure its shortcut, send messages, and receive window events.",
           "local": true,
           "windows": ["quickchat"],
           "permissions": [

--- a/apps/linux/ui/quickchat.css
+++ b/apps/linux/ui/quickchat.css
@@ -21,8 +21,12 @@ body {
 
 body {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding: 6px 8px;
+}
+
+[hidden] {
+  display: none !important;
 }
 
 .composer {
@@ -36,8 +40,8 @@ body {
   box-shadow: 0 10px 36px rgb(0 0 0 / 34%);
   transform: scale(0.97);
   transition:
-    opacity 100ms ease-in,
-    transform 100ms ease-in;
+    opacity 120ms ease-in,
+    transform 120ms ease-in;
 }
 
 body.shown .composer {
@@ -55,18 +59,61 @@ body.shown .composer {
 }
 
 .agent-chip {
-  display: grid;
-  flex: 0 0 28px;
-  width: 28px;
+  display: flex;
+  flex: 0 0 36px;
+  width: 36px;
   height: 28px;
+  padding: 0;
+  align-items: center;
+  border: 0;
+  color: white;
+  cursor: pointer;
+  background: transparent;
+}
+
+.agent-avatar,
+.agent-avatar-mini {
+  display: grid;
+  overflow: hidden;
   place-items: center;
   border: 1px solid rgb(255 255 255 / 10%);
   border-radius: 50%;
-  color: white;
   font-size: 14px;
   font-weight: 700;
   line-height: 1;
   background: hsl(var(--agent-hue, 4) 58% 42%);
+}
+
+.agent-avatar {
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+}
+
+.agent-avatar-mini {
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  font-size: 12px;
+}
+
+.agent-avatar img,
+.agent-avatar-mini img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.agent-chevron {
+  width: 8px;
+  color: #8e8e93;
+  font-size: 11px;
+  transform: translateY(-1px);
+}
+
+.agent-chip:hover .agent-chevron,
+.agent-chip[aria-expanded="true"] .agent-chevron {
+  color: #f7f7f8;
 }
 
 #message {
@@ -104,6 +151,27 @@ body.shown .composer {
     transform 120ms ease;
 }
 
+.gear {
+  display: grid;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  color: #8e8e93;
+  cursor: pointer;
+  font-size: 14px;
+  background: transparent;
+}
+
+.gear:hover,
+.gear[aria-expanded="true"] {
+  color: #f7f7f8;
+  background: rgb(255 255 255 / 7%);
+}
+
 .send:hover:not(:disabled) {
   transform: scale(1.05);
 }
@@ -139,7 +207,7 @@ body.shown .composer {
 
 .status {
   max-height: 0;
-  margin: 0 0 0 38px;
+  margin: 0 0 0 46px;
   overflow: hidden;
   color: #ff7b7b;
   font-size: 11px;
@@ -157,6 +225,131 @@ body.shown .composer {
   opacity: 1;
 }
 
+.popover {
+  position: absolute;
+  z-index: 2;
+  top: 70px;
+  right: 8px;
+  left: 8px;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 14px;
+  opacity: 0;
+  background: rgb(36 36 38 / 98%);
+  box-shadow: 0 14px 34px rgb(0 0 0 / 38%);
+  transform: translateY(-4px);
+  transition:
+    opacity 100ms ease-out,
+    transform 100ms ease-out;
+}
+
+body.shown .popover:not([hidden]) {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.popover-title {
+  padding: 9px 12px 6px;
+  color: #8e8e93;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.agent-list {
+  max-height: 244px;
+  padding: 2px 6px 7px;
+  overflow-y: auto;
+}
+
+.agent-option {
+  display: flex;
+  width: 100%;
+  min-height: 34px;
+  padding: 5px 7px;
+  gap: 9px;
+  align-items: center;
+  border: 0;
+  border-radius: 9px;
+  color: #f7f7f8;
+  cursor: pointer;
+  font: 400 13px/1.3 inherit;
+  text-align: left;
+  background: transparent;
+}
+
+.agent-option:hover,
+.agent-option:focus-visible {
+  outline: 0;
+  background: rgb(255 255 255 / 8%);
+}
+
+.agent-option-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-check {
+  width: 16px;
+  color: #ff7b7b;
+  font-size: 13px;
+  text-align: center;
+}
+
+.shortcut-settings {
+  padding-bottom: 9px;
+}
+
+.shortcut-row {
+  display: flex;
+  padding: 4px 10px 2px;
+  gap: 7px;
+  align-items: center;
+}
+
+.shortcut-value {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  overflow: hidden;
+  border-radius: 7px;
+  color: #e5e5e7;
+  font: 500 11px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: rgb(0 0 0 / 22%);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subtle-button {
+  height: 27px;
+  padding: 0 9px;
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 7px;
+  color: #d4d4d6;
+  cursor: pointer;
+  font: 500 11px/1 inherit;
+  background: rgb(255 255 255 / 5%);
+}
+
+.subtle-button:hover,
+.subtle-button:focus-visible {
+  outline: 0;
+  color: white;
+  background: rgb(255 255 255 / 10%);
+}
+
+.shortcut-error {
+  min-height: 14px;
+  margin: 3px 12px 0;
+  color: #ff7b7b;
+  font-size: 11px;
+  line-height: 14px;
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -169,6 +362,11 @@ body.shown .composer {
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    transition-duration: 40ms !important;
+  }
+
+  .composer,
+  body.shown .composer {
+    transform: none;
   }
 }

--- a/apps/linux/ui/quickchat.html
+++ b/apps/linux/ui/quickchat.html
@@ -10,7 +10,17 @@
   <body>
     <main id="composer" class="composer">
       <div class="composer-row">
-        <span id="agent-chip" class="agent-chip" aria-hidden="true">A</span>
+        <button
+          id="agent-chip"
+          class="agent-chip"
+          type="button"
+          aria-label="Choose agent"
+          aria-haspopup="menu"
+          aria-expanded="false"
+        >
+          <span id="agent-avatar" class="agent-avatar" aria-hidden="true">A</span>
+          <span class="agent-chevron" aria-hidden="true">⌄</span>
+        </button>
         <input
           id="message"
           type="text"
@@ -18,12 +28,37 @@
           aria-label="Quick Chat message"
           autocomplete="off"
         />
+        <button
+          id="shortcut-settings-button"
+          class="gear"
+          type="button"
+          aria-label="Quick Chat shortcut settings"
+          aria-expanded="false"
+          hidden
+        >
+          <span aria-hidden="true">⚙</span>
+        </button>
         <button id="send" class="send" type="button" aria-label="Send message" disabled>
           <span id="send-icon" class="send-icon" aria-hidden="true">↑</span>
         </button>
       </div>
       <p id="status" class="status" role="alert"></p>
     </main>
+    <section id="agent-menu" class="popover" aria-label="Choose agent" hidden>
+      <div class="popover-title">Agents</div>
+      <div id="agent-list" class="agent-list" role="menu"></div>
+    </section>
+    <section id="shortcut-settings" class="popover shortcut-settings" hidden>
+      <div class="popover-title">Quick Chat shortcut</div>
+      <div class="shortcut-row">
+        <code id="shortcut-value" class="shortcut-value"></code>
+        <button id="shortcut-capture" class="subtle-button" type="button">
+          Press new shortcut
+        </button>
+        <button id="shortcut-reset" class="subtle-button" type="button">Reset</button>
+      </div>
+      <p id="shortcut-error" class="shortcut-error" role="alert"></p>
+    </section>
     <script type="module" src="quickchat.js"></script>
   </body>
 </html>

--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -3,27 +3,44 @@ const { invoke } = tauri.core;
 const { listen } = tauri.event;
 
 const elements = {
-  chip: document.querySelector("#agent-chip"),
+  agentAvatar: document.querySelector("#agent-avatar"),
+  agentChip: document.querySelector("#agent-chip"),
+  agentList: document.querySelector("#agent-list"),
+  agentMenu: document.querySelector("#agent-menu"),
   composer: document.querySelector("#composer"),
   input: document.querySelector("#message"),
   send: document.querySelector("#send"),
   sendIcon: document.querySelector("#send-icon"),
+  shortcutCapture: document.querySelector("#shortcut-capture"),
+  shortcutError: document.querySelector("#shortcut-error"),
+  shortcutReset: document.querySelector("#shortcut-reset"),
+  shortcutSettings: document.querySelector("#shortcut-settings"),
+  shortcutSettingsButton: document.querySelector("#shortcut-settings-button"),
+  shortcutValue: document.querySelector("#shortcut-value"),
   status: document.querySelector("#status"),
 };
 
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+let agents = [];
+let activeIdentity = { id: "", name: "Agent", isDefault: true };
+let selectingAgent = false;
 let sending = false;
 let accepted = false;
 let hiding = false;
 let hideTimer = null;
 let acceptedTimer = null;
 let visibilitySequence = 0;
+let popoverSequence = 0;
 let sendError = "";
+let openPopover = null;
+let menuIndex = 0;
+let capturingShortcut = false;
 
-function friendlyError(error) {
+function friendlyError(error, fallback = "Could not send the message.") {
   if (typeof error === "string") {
     return error;
   }
-  return error?.message || "Could not send the message.";
+  return error?.message || fallback;
 }
 
 function setError(message = "") {
@@ -33,7 +50,7 @@ function setError(message = "") {
 
 function updateSendButton() {
   const empty = !elements.input.value.trim();
-  elements.send.disabled = empty || sending || accepted;
+  elements.send.disabled = empty || selectingAgent || sending || accepted;
   elements.send.classList.toggle("sending", sending);
   elements.send.classList.toggle("accepted", accepted);
   elements.sendIcon.textContent = sending ? "" : accepted ? "✓" : "↑";
@@ -48,19 +65,232 @@ function nameHue(name) {
   return hash % 360;
 }
 
+function renderAvatarFallback(target, identity) {
+  const name = identity?.name?.trim() || identity?.id?.trim() || "Agent";
+  const initial = [...name][0]?.toUpperCase() || "A";
+  target.replaceChildren(document.createTextNode(identity?.emoji?.trim() || initial));
+}
+
+function renderAvatar(target, identity) {
+  const name = identity?.name?.trim() || identity?.id?.trim() || "Agent";
+  target.style.setProperty("--agent-hue", nameHue(name));
+  const avatarUrl = identity?.avatarUrl?.trim();
+  if (!avatarUrl || !/^(?:https?:|data:)/i.test(avatarUrl)) {
+    renderAvatarFallback(target, identity);
+    return;
+  }
+  const image = document.createElement("img");
+  image.alt = "";
+  image.draggable = false;
+  image.addEventListener("error", () => {
+    if (target.contains(image)) {
+      renderAvatarFallback(target, identity);
+    }
+  });
+  image.src = avatarUrl;
+  target.replaceChildren(image);
+}
+
 function renderIdentity(identity) {
   const name = identity?.name?.trim() || "Agent";
-  const initial = [...name][0]?.toUpperCase() || "A";
-  elements.chip.textContent = identity?.emoji?.trim() || initial;
-  elements.chip.style.setProperty("--agent-hue", nameHue(name));
+  activeIdentity = { ...identity, name };
+  renderAvatar(elements.agentAvatar, activeIdentity);
+  elements.agentChip.title = name;
   elements.input.placeholder = `Message ${name}`;
+  renderAgentList();
+}
+
+function renderAgentList() {
+  elements.agentList.replaceChildren();
+  for (const [index, agent] of agents.entries()) {
+    const option = document.createElement("button");
+    option.className = "agent-option";
+    option.type = "button";
+    option.dataset.agentId = agent.id;
+    option.setAttribute("role", "menuitemradio");
+    const active = agent.id === activeIdentity.id;
+    option.setAttribute("aria-checked", String(active));
+    option.tabIndex = index === menuIndex ? 0 : -1;
+
+    const avatar = document.createElement("span");
+    avatar.className = "agent-avatar-mini";
+    avatar.setAttribute("aria-hidden", "true");
+    renderAvatar(avatar, agent);
+    const name = document.createElement("span");
+    name.className = "agent-option-name";
+    name.textContent = agent.name;
+    const check = document.createElement("span");
+    check.className = "agent-check";
+    check.setAttribute("aria-hidden", "true");
+    check.textContent = active ? "✓" : "";
+    option.append(avatar, name, check);
+    option.addEventListener("click", () => {
+      void selectAgent(agent.id);
+    });
+    elements.agentList.append(option);
+  }
 }
 
 async function refreshIdentity() {
   try {
     renderIdentity(await invoke("quickchat_identity"));
   } catch {
-    renderIdentity({ name: "Agent" });
+    renderIdentity({ id: "", name: "Agent", isDefault: true });
+  }
+}
+
+async function refreshAgents() {
+  try {
+    agents = await invoke("quickchat_agents");
+  } catch {
+    agents = [];
+  }
+  await refreshIdentity();
+}
+
+async function selectAgent(agentId) {
+  if (selectingAgent) {
+    return;
+  }
+  selectingAgent = true;
+  updateSendButton();
+  try {
+    await invoke("quickchat_select_agent", { agentId });
+    await refreshIdentity();
+    closePopover();
+  } catch (error) {
+    sendError = friendlyError(error, "Could not select that agent.");
+    setError(sendError);
+  } finally {
+    selectingAgent = false;
+    updateSendButton();
+  }
+}
+
+function resetShortcutCapture() {
+  capturingShortcut = false;
+  elements.shortcutCapture.textContent = "Press new shortcut";
+}
+
+function setPopoverVisibility(kind) {
+  openPopover = kind;
+  elements.agentMenu.hidden = kind !== "agents";
+  elements.shortcutSettings.hidden = kind !== "shortcut";
+  elements.agentChip.setAttribute("aria-expanded", String(kind === "agents"));
+  elements.shortcutSettingsButton.setAttribute("aria-expanded", String(kind === "shortcut"));
+  document.body.classList.toggle("overlay-open", Boolean(kind));
+  if (kind !== "shortcut") {
+    resetShortcutCapture();
+  }
+}
+
+async function openNamedPopover(kind) {
+  if (openPopover === kind) {
+    closePopover();
+    return;
+  }
+  const sequence = ++popoverSequence;
+  try {
+    await invoke("quickchat_set_expanded", { expanded: true });
+  } catch (error) {
+    sendError = friendlyError(error, "Could not open Quick Chat settings.");
+    setError(sendError);
+    return;
+  }
+  if (sequence !== popoverSequence) {
+    return;
+  }
+  setPopoverVisibility(kind);
+  if (kind === "agents") {
+    const selectedIndex = agents.findIndex((agent) => agent.id === activeIdentity.id);
+    menuIndex = selectedIndex >= 0 ? selectedIndex : 0;
+    renderAgentList();
+    elements.agentList.querySelectorAll(".agent-option")[menuIndex]?.focus();
+  } else {
+    elements.shortcutError.textContent = "";
+    elements.shortcutCapture.focus();
+  }
+}
+
+function closePopover(focusInput = true, compact = true) {
+  ++popoverSequence;
+  setPopoverVisibility(null);
+  if (compact) {
+    void invoke("quickchat_set_expanded", { expanded: false });
+  }
+  if (focusInput) {
+    elements.input.focus();
+  }
+}
+
+function focusMenuOption(index) {
+  const options = [...elements.agentList.querySelectorAll(".agent-option")];
+  if (options.length === 0) {
+    return;
+  }
+  menuIndex = (index + options.length) % options.length;
+  for (const [optionIndex, option] of options.entries()) {
+    option.tabIndex = optionIndex === menuIndex ? 0 : -1;
+  }
+  options[menuIndex].focus();
+}
+
+function renderShortcutStatus(shortcut) {
+  const supported = shortcut?.supported === true;
+  elements.shortcutSettingsButton.hidden = !supported;
+  elements.shortcutValue.textContent = shortcut?.accelerator || "";
+  if (!supported && openPopover === "shortcut") {
+    closePopover();
+  }
+}
+
+async function refreshShortcutStatus() {
+  try {
+    renderShortcutStatus(await invoke("quickchat_shortcut"));
+  } catch {
+    renderShortcutStatus({ supported: false });
+  }
+}
+
+function acceleratorFromEvent(event) {
+  let key = "";
+  if (/^Key[A-Z]$/.test(event.code)) {
+    key = event.code;
+  } else if (/^Digit[0-9]$/.test(event.code)) {
+    key = event.code;
+  } else if (event.code === "Space") {
+    key = "Space";
+  } else if (/^F(?:[1-9]|1[0-9]|2[0-4])$/.test(event.code)) {
+    key = event.code;
+  }
+  if (!key) {
+    return null;
+  }
+  const parts = [];
+  if (event.ctrlKey) parts.push("Ctrl");
+  if (event.altKey) parts.push("Alt");
+  if (event.shiftKey) parts.push("Shift");
+  if (event.metaKey) parts.push("Super");
+  if (parts.length === 0) {
+    return null;
+  }
+  parts.push(key);
+  return parts.join("+");
+}
+
+async function saveShortcut(accelerator) {
+  elements.shortcutError.textContent = "";
+  try {
+    const status = await invoke("quickchat_set_shortcut", { accelerator });
+    renderShortcutStatus(status);
+    resetShortcutCapture();
+  } catch (error) {
+    elements.shortcutError.textContent = friendlyError(
+      error,
+      "Could not update the Quick Chat shortcut.",
+    );
+    resetShortcutCapture();
+    elements.shortcutCapture.focus();
   }
 }
 
@@ -71,24 +301,28 @@ async function requestHide(force = false) {
   visibilitySequence += 1;
   const hideSequence = visibilitySequence;
   hiding = true;
+  closePopover(false, false);
   document.body.classList.remove("shown");
   window.clearTimeout(hideTimer);
-  hideTimer = window.setTimeout(async () => {
-    try {
-      await invoke("quickchat_hide");
-    } catch (error) {
-      if (visibilitySequence === hideSequence) {
-        sendError = friendlyError(error);
-        setError(sendError);
-        document.body.classList.add("shown");
-        elements.input.focus();
+  hideTimer = window.setTimeout(
+    async () => {
+      try {
+        await invoke("quickchat_hide");
+      } catch (error) {
+        if (visibilitySequence === hideSequence) {
+          sendError = friendlyError(error);
+          setError(sendError);
+          document.body.classList.add("shown");
+          elements.input.focus();
+        }
+      } finally {
+        if (visibilitySequence === hideSequence) {
+          hiding = false;
+        }
       }
-    } finally {
-      if (visibilitySequence === hideSequence) {
-        hiding = false;
-      }
-    }
-  }, 100);
+    },
+    reducedMotion.matches ? 45 : 120,
+  );
 }
 
 function reveal() {
@@ -99,6 +333,7 @@ function reveal() {
     accepted = false;
   }
   hiding = false;
+  setPopoverVisibility(null);
   setError(sendError);
   updateSendButton();
   document.body.classList.remove("shown");
@@ -106,12 +341,13 @@ function reveal() {
     document.body.classList.add("shown");
     elements.input.focus();
   });
-  void refreshIdentity();
+  void refreshAgents();
+  void refreshShortcutStatus();
 }
 
 async function send(openDashboard) {
   const message = elements.input.value.trim();
-  if (!message || sending || accepted) {
+  if (!message || selectingAgent || sending || accepted) {
     return;
   }
   sending = true;
@@ -148,21 +384,92 @@ elements.input.addEventListener("input", () => {
   updateSendButton();
 });
 elements.input.addEventListener("keydown", (event) => {
-  if (event.isComposing || event.keyCode === 229) {
+  if (event.defaultPrevented || event.isComposing || event.keyCode === 229) {
     return;
   }
   if (event.key === "Escape") {
     event.preventDefault();
-    void requestHide();
+    if (openPopover) {
+      closePopover();
+    } else {
+      void requestHide();
+    }
     return;
   }
-  if (event.key === "Enter") {
+  if (event.key === "Enter" && !openPopover) {
     event.preventDefault();
     void send(event.ctrlKey);
   }
 });
+elements.agentChip.addEventListener("click", () => {
+  void openNamedPopover("agents");
+});
+elements.shortcutSettingsButton.addEventListener("click", () => {
+  void openNamedPopover("shortcut");
+});
+elements.shortcutCapture.addEventListener("click", () => {
+  capturingShortcut = true;
+  elements.shortcutError.textContent = "";
+  elements.shortcutCapture.textContent = "Press keys…";
+  elements.shortcutCapture.focus();
+});
+elements.shortcutReset.addEventListener("click", () => {
+  void saveShortcut(null);
+});
 elements.send.addEventListener("click", () => {
   void send(false);
+});
+
+document.addEventListener(
+  "keydown",
+  (event) => {
+    if (!openPopover) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      closePopover();
+      return;
+    }
+    if (openPopover === "agents") {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        focusMenuOption(menuIndex + (event.key === "ArrowDown" ? 1 : -1));
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        elements.agentList.querySelectorAll(".agent-option")[menuIndex]?.click();
+      }
+      return;
+    }
+    if (openPopover === "shortcut" && capturingShortcut) {
+      const accelerator = acceleratorFromEvent(event);
+      if (!accelerator) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      void saveShortcut(accelerator);
+    }
+  },
+  true,
+);
+
+document.addEventListener("pointerdown", (event) => {
+  if (!openPopover) {
+    return;
+  }
+  const target = event.target;
+  const insidePopover =
+    elements.agentMenu.contains(target) ||
+    elements.agentChip.contains(target) ||
+    elements.shortcutSettings.contains(target) ||
+    elements.shortcutSettingsButton.contains(target);
+  if (!insidePopover) {
+    closePopover(false);
+  }
 });
 
 await listen("quickchat:shown", () => {

--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -375,6 +375,8 @@ async function send(openDashboard) {
     setError(sendError);
     updateSendButton();
     elements.input.focus();
+    // A strict send failure can mean the pinned agent vanished; re-sync the chip.
+    void refreshAgents();
   }
 }
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -51,10 +51,15 @@ dependencies and development commands.
 
 ### Quick Chat
 
-Open Quick Chat with `Ctrl+Shift+Space` or the **Quick Chat** tray item. The
-shortcut is available on X11; on Wayland, use the tray item for now. Quick Chat
-sends the message through the OpenClaw CLI to the default agent's main session,
-then hides. Replies remain in the normal session; open the dashboard to read them.
+Open Quick Chat with `Ctrl+Shift+Space` or the **Quick Chat** tray item. The agent
+chip shows the configured avatar, emoji, or monogram; select it to switch agents.
+Messages use the selected agent's main session and honor global session scope.
+
+On X11, use the gear in Quick Chat to record or reset a custom shortcut. The
+**Quick Chat shortcut** tray toggle enables or disables it without disabling the
+plain **Quick Chat** tray item. Global shortcuts are not available on Wayland, so
+the shortcut settings are hidden and the tray item remains the entry point.
+Replies remain in the normal session; open the dashboard to read them.
 
 ### Canvas
 

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -97,7 +97,7 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
     );
     const identitySource = identity
       ? "identity"
-      : configIdentity && (identityName || identityEmoji || identityAvatarUrl)
+      : configIdentity && (identityName || identityEmoji)
         ? "config"
         : undefined;
     return {

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
+import { resolveAgentAvatarUrlFromSource } from "../agents/identity-avatar-file.js";
 import type { AgentIdentityFile } from "../agents/identity-file.js";
 import { identityHasValues, loadAgentIdentityFromWorkspace } from "../agents/identity-file.js";
 import { listRouteBindings } from "../config/bindings.js";
@@ -22,6 +23,7 @@ export type AgentSummary = {
   name?: string;
   identityName?: string;
   identityEmoji?: string;
+  identityAvatarUrl?: string;
   identitySource?: "identity" | "config";
   workspace: string;
   agentDir: string;
@@ -88,9 +90,14 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
     )?.identity;
     const identityName = identity?.name ?? configIdentity?.name?.trim();
     const identityEmoji = identity?.emoji ?? configIdentity?.emoji?.trim();
+    const identityAvatarUrl = resolveAgentAvatarUrlFromSource(
+      cfg,
+      id,
+      identity?.avatar ?? configIdentity?.avatar,
+    );
     const identitySource = identity
       ? "identity"
-      : configIdentity && (identityName || identityEmoji)
+      : configIdentity && (identityName || identityEmoji || identityAvatarUrl)
         ? "config"
         : undefined;
     return {
@@ -100,6 +107,7 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       ),
       identityName,
       identityEmoji,
+      ...(identityAvatarUrl ? { identityAvatarUrl } : {}),
       identitySource,
       workspace,
       agentDir: resolveAgentDir(cfg, id),

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -100,14 +100,13 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       : configIdentity && (identityName || identityEmoji || identityAvatarUrl)
         ? "config"
         : undefined;
-    return {
+    const summary: AgentSummary = {
       id,
       name: normalizeOptionalString(
         configuredAgents.find((agent) => normalizeAgentId(agent.id) === id)?.name,
       ),
       identityName,
       identityEmoji,
-      ...(identityAvatarUrl ? { identityAvatarUrl } : {}),
       identitySource,
       workspace,
       agentDir: resolveAgentDir(cfg, id),
@@ -115,6 +114,10 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       bindings: bindingCounts.get(id) ?? 0,
       isDefault: id === defaultAgentId,
     };
+    if (identityAvatarUrl) {
+      summary.identityAvatarUrl = identityAvatarUrl;
+    }
+    return summary;
   });
 }
 

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -97,7 +97,7 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
     );
     const identitySource = identity
       ? "identity"
-      : configIdentity && (identityName || identityEmoji)
+      : configIdentity && (identityName || identityEmoji || identityAvatarUrl)
         ? "config"
         : undefined;
     return {

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -1,4 +1,6 @@
 // Agents command tests cover agent config mutation, binding updates, and summary generation.
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -59,6 +61,29 @@ describe("agents helpers", () => {
     expect(work.agentDir).toBe(path.resolve("/state/agents/work/agent"));
     expect(work.bindings).toBe(1);
     expect(work.isDefault).toBe(true);
+  });
+
+  it("buildAgentSummaries renders local avatars and omits absent avatars", () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-avatar-"));
+    try {
+      fs.writeFileSync(path.join(workspace, "avatar.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", default: true, workspace },
+            { id: "work", workspace, identity: { avatar: "avatar.png" } },
+          ],
+        },
+      };
+
+      const summaries = buildAgentSummaries(cfg);
+      const work = requireAgentSummary(summaries, "work");
+      expect(work.identityAvatarUrl).toBe("data:image/png;base64,iVBORw==");
+      expect(work.identitySource).toBe("config");
+      expect(requireAgentSummary(summaries, "main")).not.toHaveProperty("identityAvatarUrl");
+    } finally {
+      fs.rmSync(workspace, { force: true, recursive: true });
+    }
   });
 
   it("applyAgentConfig merges updates", () => {

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -79,6 +79,7 @@ describe("agents helpers", () => {
       const summaries = buildAgentSummaries(cfg);
       const work = requireAgentSummary(summaries, "work");
       expect(work.identityAvatarUrl).toBe("data:image/png;base64,iVBORw==");
+      expect(work.identitySource).toBe("config");
       expect(requireAgentSummary(summaries, "main")).not.toHaveProperty("identityAvatarUrl");
     } finally {
       fs.rmSync(workspace, { force: true, recursive: true });

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -79,7 +79,6 @@ describe("agents helpers", () => {
       const summaries = buildAgentSummaries(cfg);
       const work = requireAgentSummary(summaries, "work");
       expect(work.identityAvatarUrl).toBe("data:image/png;base64,iVBORw==");
-      expect(work.identitySource).toBe("config");
       expect(requireAgentSummary(summaries, "main")).not.toHaveProperty("identityAvatarUrl");
     } finally {
       fs.rmSync(workspace, { force: true, recursive: true });


### PR DESCRIPTION
## What Problem This Solves

The Linux Quick Chat (#109947) shipped as a minimal first step: it could only message the default agent's main session, showed a bare monogram chip, had a fixed `Ctrl+Shift+Space` shortcut, and popped in with no animation. The macOS Quick Chat meanwhile gained agent avatars, an agent switcher, per-agent routing, an enable toggle, and a configurable shortcut. This PR closes most of that gap on Linux.

## Why This Change Was Made

Feature-parity pass for the Tauri app, staying on the existing CLI-delegation transport rather than adding a gateway protocol client:

- **Agent avatars in `agents list --json`** (core, additive): `AgentSummary` gains optional `identityAvatarUrl`, resolved with the same `resolveAgentAvatarUrlFromSource` helper the gateway `agents.list` RPC uses (render-ready `http(s)`/`data:` URI; local workspace files become bounded base64 data URIs). Existing fields untouched.
- **Agent switcher**: the chip is now a button (avatar → emoji → monogram fallback, matching macOS precedence) opening a keyboard-navigable in-window menu built from a shared 60s-cached agent list. Selecting the default agent stores no pin, so the chip follows gateway-default changes; a pinned agent that disappears from a later refresh resets to default.
- **Per-agent routing**: sends to a non-default agent pass `--agent <id>` and drop the hardcoded `--session-key main`. The CLI resolves the agent's main session key and canonicalizes it to `global` under global session scope, which `validateChatSelectedAgent` accepts with the separate agent id (`src/commands/agent-via-gateway.ts:730` → `src/agents/command/session.ts:301` → `src/config/sessions/main-session.ts:56,90` → `src/gateway/server-methods/chat-origin-routing.ts:116`). Default-agent sends keep the exact previous argv.
- **Enable toggle**: new **Quick Chat shortcut** tray check item using the established marker-file pattern (`quickchat-shortcut-disabled` in the app config dir); the plain **Quick Chat** tray item keeps working when the shortcut is off.
- **Configurable shortcut**: gear popover in the bar records a new accelerator (validated by actually registering it, with rollback on every failure leg), persists it to `quickchat-shortcut` in the app config dir, and re-registers live; the dashboard shortcut is reserved. Shortcut dispatch in `main.rs` matches the active accelerator instead of a hardcoded constant. Everything degrades gracefully on Wayland (settings hidden, tray item remains the entry point).
- **Zoom+fade animation**: 0.97→1.0 scale plus fade on show, reverse on hide, wired into the existing visibility handshake; `prefers-reduced-motion` collapses it to a fast fade.

Deliberately out of scope: window-picker screenshots (no window-enumeration/capture stack on Linux yet) and the macOS permission strip (no equivalent Linux permission model).

## User Impact

Linux Quick Chat now shows who you're messaging with the agent's real avatar, lets you switch agents without opening the dashboard, routes to the selected agent's main session (global scope included), and has a user-configurable, toggleable global shortcut. Docs updated (`docs/platforms/linux.md`).

## Evidence

Live run (Ubuntu 24.04 container, Xvfb/openbox/picom, repo-built CLI, three seeded agents covering avatar/avatar/monogram chip paths):

| Bar with avatar chip | Agent menu |
| --- | --- |
| ![bar](https://gist.githubusercontent.com/steipete/3169ddab8ba57dbfe0e0ef44fbb622a5/raw/bar.png) | ![menu](https://gist.githubusercontent.com/steipete/3169ddab8ba57dbfe0e0ef44fbb622a5/raw/menu.png) |

| Switched to second agent | Draft ready to send |
| --- | --- |
| ![work-selected](https://gist.githubusercontent.com/steipete/3169ddab8ba57dbfe0e0ef44fbb622a5/raw/work-selected.png) | ![typed](https://gist.githubusercontent.com/steipete/3169ddab8ba57dbfe0e0ef44fbb622a5/raw/typed.png) |

| Shortcut settings | Rebound via key capture |
| --- | --- |
| ![settings](https://gist.githubusercontent.com/steipete/3169ddab8ba57dbfe0e0ef44fbb622a5/raw/settings.png) | ![rebound](https://gist.githubusercontent.com/steipete/3169ddab8ba57dbfe0e0ef44fbb622a5/raw/rebound.png) |

Shortcut re-bind proven end to end in the live container: captured `Ctrl+Alt+K` through the gear UI, old `Ctrl+Shift+Space` no longer summons the bar, new accelerator toggles it, and the preference file contains `Ctrl+Alt+KeyK` afterward.

Validation:

- `cargo test` (container, Linux): 51 passed, 0 failed — includes new tests for argv routing, shortcut persistence round-trip/fallback/reserved-collision, custom-accelerator dispatch, and agent identity precedence/deserialization.
- `node scripts/run-vitest.mjs src/commands/agents.test.ts`: 12 passed, including the new `identityAvatarUrl` local-file→data-URI and absent-avatar assertions.
- `pnpm build` (container): clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- `cargo build` (container): clean.
- Structured second-model review of the branch: one finding (hide-failure recovery on the rejected-focus path) addressed with a bounded destroy fallback; rerun clean.
