### PR TITLE
test(agents): isolate model-call listener state

### DIFF
--- a/src/agents/cli-runner/model-call-diagnostics.test.ts
+++ b/src/agents/cli-runner/model-call-diagnostics.test.ts
@@ -1,6 +1,6 @@
 // Verifies Claude CLI model diagnostics stay listener-gated and memory-bounded.
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   onTrustedInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -41,6 +41,10 @@ function createContext(): PreparedCliRunContext {
 }
 
 describe("Claude CLI model-call diagnostics", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
   afterEach(() => {
     resetDiagnosticEventsForTest();
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the new Claude CLI diagnostics test inherited a process-global diagnostic listener from an earlier test file, causing the full agents-support shard to fail deterministically even though the test passes in isolation.

## Why This Change Was Made

Reset diagnostic listener state before each test as well as after each test. The pre-test reset establishes the no-listener precondition for the first test in the file; the existing post-test reset still prevents this file from leaking state to later tests.

## User Impact

No product behavior changes. The full CI shard now tests listener-gating against an isolated diagnostic-event state.

## Evidence

- Exact-head CI failure reproduced twice on https://github.com/openclaw/openclaw/actions/runs/29624012640: `src/agents/cli-runner/model-call-diagnostics.test.ts:55` inherited an active listener.
- `node scripts/run-vitest.mjs src/agents/cli-runner/model-call-diagnostics.test.ts` — 1 file, 10 tests passed.
- `git diff --check` — passed.
- Codex autoreview — clean, no accepted or actionable findings.
- Hosted changed gate: https://github.com/openclaw/openclaw/actions/runs/29624564948 — formatting, guards, test types, and lint passed.

AI-assisted: yes. Maintainer CI-blocker repair.
