### PR TITLE
fix(ui): chat popover layout test flakes under parallel load

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -447,6 +447,17 @@ async function closeBrowserPage(page: Page): Promise<void> {
   await page.close().catch(() => {});
 }
 
+async function waitForLayoutSettled(page: Page): Promise<void> {
+  // Raw DOM mutations skip Playwright's actionability wait. Allow style invalidation
+  // to land, then observe one stable frame before measuring viewport bounds.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
 async function getRect(page: Page, selector: string) {
   const rect = await page.locator(selector).evaluate((node) => {
     const bounds = (node as HTMLElement).getBoundingClientRect();
@@ -1837,6 +1848,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await page.locator(".chat-view-menu").evaluate((node) => {
           node.setAttribute("open", "");
         });
+        await waitForLayoutSettled(page);
 
         const settingsMenu = await getRect(page, ".chat-view-menu[open]");
         expect(settingsMenu.left).toBeGreaterThanOrEqual(0);
@@ -1861,6 +1873,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await page.locator(".chat-view-menu").evaluate((node) => {
           node.setAttribute("open", "");
         });
+        await waitForLayoutSettled(page);
 
         const settingsMenu = await getRect(page, ".chat-view-menu[open]");
         expect(settingsMenu.left).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI browser shard could intermittently fail the desktop chat settings-popover viewport assertion at 1024x768 under concurrent browser-test load.

## Why This Change Was Made

The test opened the settings menu with a raw DOM attribute mutation and measured its bounds immediately. Raw DOM mutations bypass Playwright's actionability and layout waits, so both mobile and desktop settings-popover checks now allow style invalidation to land and observe one stable frame before measuring.

## User Impact

No runtime behavior changes. Maintainers get deterministic chat-responsive browser coverage under parallel UI test load.

## Evidence

- Reported macOS full-shard failure on 2026-07-17: one 1024x768 desktop-settings assertion failure; isolation 62/62 and shard rerun passed.
- Pre-fix bounded reproduction: 5 neighboring-browser loops and 2 full UI shards passed, confirming the failure is rare/order-dependent.
- Post-fix neighboring-browser loop: 10/10 passed; 970 tests passed total, with 20 expected skips.
- Post-fix full UI shard loop: 2/2 passed; 8,768 tests passed total, with 22 expected skips.
- Changed-file gate passed: conflict checks, formatting, i18n verification, core-test typecheck, and lint.
- Fresh autoreview: no accepted or actionable findings; overall confidence 0.94.

AI-assisted: yes. I reviewed the synchronization boundary and proof results.
