### PR TITLE
fix: isolate macOS sessions.send follow-up test

### DIFF
--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -8,7 +8,7 @@ import { expectSubagentFollowupReactivation } from "./subagent-followup.test-hel
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 const loadSessionEntryMock = vi.fn();
-const readSessionMessagesMock = vi.fn();
+const readSessionMessageCountAsyncMock = vi.fn();
 const loadGatewaySessionRowMock = vi.fn();
 const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
 const replaceSubagentRunAfterSteerMock = vi.fn();
@@ -19,8 +19,18 @@ vi.mock("../session-utils.js", async () => {
   return {
     ...actual,
     loadSessionEntry: (...args: unknown[]) => loadSessionEntryMock(...args),
-    readSessionMessages: (...args: unknown[]) => readSessionMessagesMock(...args),
     loadGatewaySessionRow: (...args: unknown[]) => loadGatewaySessionRowMock(...args),
+  };
+});
+
+vi.mock("../session-transcript-readers.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-transcript-readers.js")>(
+    "../session-transcript-readers.js",
+  );
+  return {
+    ...actual,
+    readSessionMessageCountAsync: (...args: unknown[]) =>
+      readSessionMessageCountAsyncMock(...args),
   };
 });
 
@@ -50,7 +60,7 @@ import { sessionsHandlers } from "./sessions.js";
 describe("sessions.send completed subagent follow-up status", () => {
   beforeEach(() => {
     loadSessionEntryMock.mockReset();
-    readSessionMessagesMock.mockReset();
+    readSessionMessageCountAsyncMock.mockReset().mockResolvedValue(0);
     loadGatewaySessionRowMock.mockReset();
     getLatestSubagentRunByChildSessionKeyMock.mockReset();
     replaceSubagentRunAfterSteerMock.mockReset();
@@ -79,7 +89,6 @@ describe("sessions.send completed subagent follow-up status", () => {
       storePath: "/tmp/sessions.json",
       entry: { sessionId: "sess-followup" },
     });
-    readSessionMessagesMock.mockReturnValue([]);
     getLatestSubagentRunByChildSessionKeyMock.mockReturnValue(completedRun);
     replaceSubagentRunAfterSteerMock.mockReturnValue(true);
     loadGatewaySessionRowMock.mockReturnValue({
@@ -145,7 +154,6 @@ describe("sessions.send completed subagent follow-up status", () => {
         storePath: "/tmp/work/sessions.json",
         entry: { sessionId: "sess-work-global" },
       });
-      readSessionMessagesMock.mockReturnValue([]);
       loadGatewaySessionRowMock.mockReturnValue(null);
       chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
         respond(true, { runId: "run-work", status: "started" }, undefined, undefined);

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -29,8 +29,7 @@ vi.mock("../session-transcript-readers.js", async () => {
   );
   return {
     ...actual,
-    readSessionMessageCountAsync: (...args: unknown[]) =>
-      readSessionMessageCountAsyncMock(...args),
+    readSessionMessageCountAsync: (...args: unknown[]) => readSessionMessageCountAsyncMock(...args),
   };
 });
 


### PR DESCRIPTION
Regression source: #75552

## What Problem This Solves

Fixes an issue where maintainers running the focused `sessions.send` follow-up status test on macOS could get a deterministic failure because the test read host session state instead of its mocked fixture.

## Why This Change Was Made

The handler now counts messages through `session-transcript-readers`, but this test still mocked the obsolete synchronous reader on `session-utils`. Mock the current asynchronous count seam and return a deterministic empty-transcript count. Runtime code is unchanged.

## User Impact

No product behavior change. macOS maintainers get the same isolated test behavior as clean Linux CI runners.

## Evidence

- macOS focused proof: `node scripts/run-vitest.mjs src/gateway/server-methods/sessions.send-followup-status.test.ts` — 3 passed.
- Linux changed gate: Blacksmith Testbox `tbx_01kxsbwz3sygxkky66dxhv27at` — passed; https://github.com/openclaw/openclaw/actions/runs/29624381837
- `git diff --check` — passed.
- Autoreview (`gpt-5.6-sol`, xhigh) — clean; no accepted/actionable findings.

AI-assisted: Codex diagnosed, patched, and validated this change. Maintainer reviewed the exact diff and evidence.
