### PR TITLE
fix(android): Wear Talk replacement survives late audio errors

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -484,10 +484,13 @@ internal class WearRealtimeTalkController(
               "talk.session.appendAudio",
               params.toString(),
               8_000L,
-            ) { message -> fail(message) }
+            ) { message -> fail(message, expectedSessionId = activeSessionId) }
           } catch (err: Throwable) {
             if (err is CancellationException) throw err
-            fail(err.message ?: "Unable to send Watch audio")
+            fail(
+              err.message ?: "Unable to send Watch audio",
+              expectedSessionId = activeSessionId,
+            )
           }
         }
       }
@@ -567,9 +570,15 @@ internal class WearRealtimeTalkController(
     )
   }
 
-  private fun fail(message: String) {
+  private fun fail(
+    message: String,
+    expectedSessionId: String? = null,
+  ) {
     val (closingSession, closingNodeId) =
       synchronized(lifecycleStateLock) {
+        // Fire-and-forget append callbacks can outlive their relay. Only that
+        // relay may own teardown, or a late error can stop its replacement.
+        if (expectedSessionId != null && sessionId != expectedSessionId) return
         Log.w(TAG, message)
         val currentSession = sessionId
         val currentNodeId = ownerNodeId

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -409,7 +409,10 @@ internal class WearRealtimeTalkController(
             sendWatchFrame(nodeId, message.type, message.payload)
           } catch (err: Throwable) {
             if (err is CancellationException) throw err
-            fail("Unable to send audio to Watch")
+            fail(
+              "Unable to send audio to Watch",
+              expectedSessionId = activeSessionId,
+            )
             break
           }
           when (message.type) {
@@ -576,8 +579,8 @@ internal class WearRealtimeTalkController(
   ) {
     val (closingSession, closingNodeId) =
       synchronized(lifecycleStateLock) {
-        // Fire-and-forget append callbacks can outlive their relay. Only that
-        // relay may own teardown, or a late error can stop its replacement.
+        // Transport callbacks and non-cancellable I/O can outlive their relay.
+        // Only that relay may own teardown, or a late error can stop its replacement.
         if (expectedSessionId != null && sessionId != expectedSessionId) return
         Log.w(TAG, message)
         val currentSession = sessionId

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -180,6 +180,43 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
+  fun `late append error from a stopped session does not fail its replacement`() =
+    runTest {
+      var relaySequence = 0
+      var staleAppendError: ((String) -> Unit)? = null
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, _, _ ->
+            if (method == "talk.session.create") {
+              relaySequence += 1
+              """{"relaySessionId":"relay-$relaySequence"}"""
+            } else {
+              """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { _, _, _, onError ->
+            if (staleAppendError == null) staleAppendError = onError
+          },
+          sendWatchFrame = { _, _, _ -> },
+        )
+
+      assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
+      controller.appendAudio("watch-a", ByteArray(2))
+      runCurrent()
+      assertTrue(staleAppendError != null)
+
+      assertTrue(controller.stop("watch-a", "attempt-a"))
+      assertTrue(controller.start("watch-a", "session-b", "attempt-b", "de"))
+      staleAppendError?.invoke("request timeout")
+
+      assertEquals(WearRealtimeTalkStatus.LISTENING, controller.snapshot.value.status)
+      assertEquals("attempt-b", controller.snapshot.value.attemptId)
+      assertTrue(controller.stop("watch-a", "attempt-b"))
+    }
+
+  @Test
   fun `retries without language when an older gateway rejects only that field`() =
     runTest {
       val createParams = mutableListOf<String?>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -8,9 +8,11 @@ import ai.openclaw.wear.shared.WearRealtimeTalkStatus
 import android.util.Base64
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -210,6 +212,57 @@ class WearRealtimeTalkControllerTest {
       assertTrue(controller.stop("watch-a", "attempt-a"))
       assertTrue(controller.start("watch-a", "session-b", "attempt-b", "de"))
       staleAppendError?.invoke("request timeout")
+
+      assertEquals(WearRealtimeTalkStatus.LISTENING, controller.snapshot.value.status)
+      assertEquals("attempt-b", controller.snapshot.value.attemptId)
+      assertTrue(controller.stop("watch-a", "attempt-b"))
+    }
+
+  @Test
+  fun `late Watch output error from a stopped session does not fail its replacement`() =
+    runTest {
+      var relaySequence = 0
+      val outputStarted = CompletableDeferred<Unit>()
+      val releaseOutput = CompletableDeferred<Unit>()
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, _, _ ->
+            if (method == "talk.session.create") {
+              relaySequence += 1
+              """{"relaySessionId":"relay-$relaySequence"}"""
+            } else {
+              """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, _, _ ->
+            outputStarted.complete(Unit)
+            withContext(NonCancellable) {
+              releaseOutput.await()
+              error("wear link down")
+            }
+          },
+        )
+
+      assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
+      controller.handleGatewayEvent(
+        "talk.event",
+        """
+        {
+          "relaySessionId":"relay-1",
+          "type":"audio",
+          "audioBase64":"${Base64.encodeToString(ByteArray(16), Base64.NO_WRAP)}"
+        }
+        """.trimIndent(),
+      )
+      outputStarted.await()
+
+      assertTrue(controller.stop("watch-a", "attempt-a"))
+      assertTrue(controller.start("watch-a", "session-b", "attempt-b", "de"))
+      releaseOutput.complete(Unit)
+      runCurrent()
 
       assertEquals(WearRealtimeTalkStatus.LISTENING, controller.snapshot.value.status)
       assertEquals("attempt-b", controller.snapshot.value.attemptId)


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Fixes an issue where starting a new Wear realtime Talk session immediately after stopping the previous one could leave the replacement session in an error state when an older audio request completed late.

## Why This Change Was Made

Late append-audio failures are now tied to the relay session that issued the request. The controller ignores failures from superseded sessions while preserving the existing teardown behavior for the active session.

## User Impact

Wear users can stop and restart realtime Talk without an old request tearing down the new session.

## Evidence

- Added a focused regression test covering session A sending audio, session B replacing it, and session A's late error arriving afterward.
- GitHub CI passed, including `android-test-wear`, `android-build-wear`, `android-test-play`, `android-build-play`, Android ktlint, and the aggregate `openclaw/ci-gate`.
- `git diff --check` passes.
- Mandatory pre-commit autoreview reports no actionable findings (0.94 confidence).
- A local Gradle attempt was blocked because this host has no Android SDK; the focused Android test and build were subsequently exercised successfully by GitHub CI.
- No physical Wear device or emulator recording is available from this host; ClawSweeper may continue to require that separate real-behavior proof before merge.