### PR TITLE
fix(ci): bound docs-sync publish repo git fetch with timeout

### DIFF
--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -122,7 +122,7 @@ jobs:
             exit 0
           fi
 
-          if git fetch origin main:refs/remotes/origin/main; then
+          if timeout --signal=TERM --kill-after=10s 120s git fetch origin main:refs/remotes/origin/main; then
             skip_stale_source
           fi
 
@@ -131,7 +131,7 @@ jobs:
           git add docs .openclaw-sync
           git commit -m "chore(sync): mirror docs from $GITHUB_REPOSITORY@$GITHUB_SHA"
           for attempt in 1 2 3 4 5; do
-            if git fetch origin main:refs/remotes/origin/main; then
+            if timeout --signal=TERM --kill-after=10s 120s git fetch origin main:refs/remotes/origin/main; then
               skip_stale_source
               if git rebase -X theirs origin/main && git push origin HEAD:main; then
                 exit 0

--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -118,7 +118,7 @@ jobs:
             exit 0
           fi
 
-          if git fetch origin main:refs/remotes/origin/main; then
+          if timeout --signal=TERM --kill-after=10s 120s git fetch origin main:refs/remotes/origin/main; then
             skip_stale_source
           fi
 
@@ -127,7 +127,7 @@ jobs:
           git add docs .openclaw-sync
           git commit -m "chore(sync): mirror docs from $GITHUB_REPOSITORY@$GITHUB_SHA"
           for attempt in 1 2 3 4 5; do
-            if git fetch origin main:refs/remotes/origin/main; then
+            if timeout --signal=TERM --kill-after=10s 120s git fetch origin main:refs/remotes/origin/main; then
               skip_stale_source
               if git rebase -X theirs origin/main && git push origin HEAD:main; then
                 exit 0

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5195,6 +5195,20 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     }
   });
 
+  it("bounds docs publish-repository Git transports", () => {
+    const source = readFileSync(".github/workflows/docs-sync-publish.yml", "utf8");
+    const transports = source
+      .split("\n")
+      .filter((line) => line.includes("git clone") || line.includes("git fetch origin main:"));
+
+    expect(transports).toHaveLength(3);
+    expect(
+      transports.every((line) =>
+        line.trimStart().startsWith("if timeout --signal=TERM --kill-after=10s 120s git"),
+      ),
+    ).toBe(true);
+  });
+
   it.each([
     [".github/workflows/mantis-discord-smoke.yml"],
     [".github/workflows/plugin-clawhub-release.yml"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a stalled Git fetch could leave the docs publication workflow running indefinitely after the publish repository was cloned.

## Why This Change Was Made

Both publish-repository fetches now use the same `timeout --signal=TERM --kill-after=10s 120s` wrapper already established for the workflow's clone and sibling docs automation. Existing stale-source handling, retry counts, refspecs, rebase behavior, and push behavior remain unchanged.

## User Impact

Docs publication now terminates or retries a stalled publish-repository fetch instead of hanging indefinitely.

## Evidence

Exact rewritten head: `92d7715c8ed2a47f9bce79f755f41082556fe7e5`.

- Current-main red proof: the new focused guard failed because two of the workflow's three publish-repository Git transports were unbounded.
- Exact-head green proof: `test/scripts/ci-workflow-guards.test.ts` passed 127 tests with 2 platform skips.
- Real stalled-transport proof: the wrapper returned exit 124 when the Git transport honored TERM and exit 137 when it required the KILL grace path.
- Public transport proof: a public-seeded clone of `openclaw/docs` plus both GitHub-backed bounded fetch shapes completed successfully at `cfb5aaddc47d`.
- `actionlint`, ShellCheck over the changed workflow shell block, targeted `oxfmt`, and `git diff --check` passed.
- Exact-head autoreview through P1 reported no findings with 0.98 confidence.
- `check-changed` passed conflict, attribution, deprecation, extension-boundary, duplicate-coverage, coercion, dependency-pin, formatting, patch, and temp-file guards. Its test-root type lane stopped on sparse-checkout omissions and the existing shared-install `pako` declaration gap; exact-head hosted CI is the clean-checkout authority for that lane.

Production LOC: +2/-2 (net 0) | Tests: +14/-0.

## Scope

Only the two existing publish-repository fetch commands and their focused workflow guard are changed. No retry, release, configuration, SDK, or publication-policy behavior changes.

Punchcard-Session: ember-lantern-harbor-24

