### PR TITLE
docs(providers): add Azure OpenAI setup page and directory entry

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,6 +53,10 @@
   },
   "redirects": [
     {
+      "source": "/providers/azure-openai-responses",
+      "destination": "/providers/azure-openai"
+    },
+    {
       "source": "/cli/crestodian",
       "destination": "/cli/openclaw"
     },
@@ -1490,6 +1494,7 @@
                   "providers/bedrock-mantle",
                   "providers/anthropic",
                   "providers/arcee",
+                  "providers/azure-openai",
                   "providers/azure-speech",
                   "providers/cerebras",
                   "providers/chutes",

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -1,0 +1,132 @@
+---
+summary: "Use an Azure OpenAI resource with OpenClaw for chat, Responses, and images"
+read_when:
+  - You have an Azure OpenAI resource and want to use it in OpenClaw
+  - You searched for "Azure OpenAI" and could not find setup steps
+title: "Azure OpenAI"
+---
+
+OpenClaw can run agents on your own Azure OpenAI resource. This page is the
+starting point if you have an Azure OpenAI deployment and want to use it for
+chat and Responses traffic.
+
+<Note>
+This is not [Azure Speech](/providers/azure-speech), which uses a separate
+Speech resource key for text-to-speech. If you have an Azure OpenAI key and
+want chat, Responses, or image models, you are in the right place.
+</Note>
+
+## Which route to use
+
+Azure OpenAI reaches OpenClaw through three routes depending on what you need:
+
+| Goal | Route | Auth |
+| --- | --- | --- |
+| Chat / Responses on a direct Azure OpenAI resource | `azure-openai-responses` custom provider (this page) | Azure OpenAI API key |
+| Chat / images through Microsoft or Azure AI Foundry | [Microsoft Foundry plugin](/plugins/reference/microsoft-foundry) | API key or Entra ID (`az login`) |
+| Image generation on the bundled `openai` provider | [OpenAI provider, Azure endpoints](/providers/openai#azure-openai-endpoints) | Azure OpenAI API key |
+
+If you want Entra ID (`az login`) auth or Foundry deployment discovery, use the
+Microsoft Foundry plugin instead. The rest of this page covers the direct
+API-key path.
+
+## Requirements
+
+- An Azure OpenAI resource with at least one model deployment.
+- An Azure OpenAI API key (not an OpenAI Platform key).
+- A deployment in a region that supports the Responses API. Older regions or
+  clients can return 404 for Responses.
+
+## Endpoint styles
+
+Azure exposes two endpoint shapes and OpenClaw handles both:
+
+- **v1 (recommended).** Point `baseUrl` at `.../openai/v1/`. OpenClaw talks to
+  it directly and no `api-version` is required.
+- **Classic.** Point `baseUrl` at the bare resource
+  (`https://<resource>.openai.azure.com`). OpenClaw adds the Azure
+  `api-version` automatically. The default is `preview`; override it with the
+  `AZURE_OPENAI_API_VERSION` environment variable.
+
+## Setup with onboarding
+
+`openclaw onboard` can configure this for you. Choose the custom-provider path
+and paste your Azure OpenAI endpoint. Onboarding recognizes
+`*.openai.azure.com` and `*.services.ai.azure.com` hosts, applies the Azure
+deployment path, and sets Azure-appropriate context and token defaults.
+
+## Setup with manual config
+
+Define a custom provider under `models.providers` with the
+`azure-openai-responses` adapter, then set it as your default model. The
+provider id you choose (here, `azure`) becomes the model ref prefix.
+
+```json5
+{
+  models: {
+    providers: {
+      azure: {
+        api: "azure-openai-responses",
+        baseUrl: "https://<your-resource>.openai.azure.com/openai/v1/",
+        apiKey: "<azure-openai-api-key>",
+        models: [{ id: "<your-deployment-name>" }],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "azure/<your-deployment-name>" },
+    },
+  },
+}
+```
+
+Prefer environment substitution for the key rather than inlining it.
+
+### Model names are deployment names
+
+Azure binds models to deployments, so the model `id` in OpenClaw must be your
+**Azure deployment name**, not the public OpenAI model id. If your deployment
+name differs from the model id you want to reference, remap it with the
+`AZURE_OPENAI_DEPLOYMENT_NAME_MAP` environment variable.
+
+### API version
+
+The classic endpoint uses `AZURE_OPENAI_API_VERSION`, which defaults to
+`preview`. The v1 endpoint does not require it. Pin a specific dated version
+when you need a particular GA or preview feature set:
+
+```bash
+export AZURE_OPENAI_API_VERSION="preview"
+```
+
+## Verify
+
+```bash
+openclaw models list --provider azure
+openclaw models status --probe --probe-provider azure
+```
+
+## Reported issues
+
+These are open, user-reported issues on the Azure Responses path that
+maintainers have not yet reproduced or confirmed. Treat them as things to watch
+for rather than confirmed platform behavior, and check the linked threads for
+current status before you rely on Responses in production:
+
+- Some resources are reported to return a synthetic zero-token refusal on every
+  Responses turn; the `openai-completions` adapter is the suggested workaround
+  ([#79570](https://github.com/openclaw/openclaw/issues/79570)).
+- Responses are reported to stall before the first event when memory tools are
+  exposed ([#80926](https://github.com/openclaw/openclaw/issues/80926)).
+- Some endpoints are reported to reject `prompt_cache_key` with a 400
+  ([#102907](https://github.com/openclaw/openclaw/issues/102907)).
+
+If chat fails on the Responses adapter, try the same deployment with an
+`openai-completions` custom provider as a fallback.
+
+## Related
+
+- [OpenAI provider](/providers/openai) — Azure image endpoints and shared config
+- [Microsoft Foundry plugin](/plugins/reference/microsoft-foundry) — Entra ID and Foundry deployments
+- [Model providers](/concepts/model-providers) — provider config reference

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -29,6 +29,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
+- [Azure OpenAI](/providers/azure-openai)
 - [Azure Speech](/providers/azure-speech)
 - [Baseten (Inkling + Model APIs)](/providers/baseten)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1020,9 +1020,9 @@ routes** accordion under [Advanced configuration](#advanced-configuration).
 
 For chat or Responses traffic on Azure (beyond image generation), use the
 onboarding flow or a dedicated Azure provider config; `openai.baseUrl` alone
-does not pick up the Azure API/auth shape. A separate
-`azure-openai-responses/*` provider exists; see the Server-side compaction
-accordion below.
+does not pick up the Azure API/auth shape. See the dedicated
+[Azure OpenAI](/providers/azure-openai) page for `azure-openai-responses`
+setup.
 </Note>
 
 ## Advanced configuration


### PR DESCRIPTION
## What Problem This Solves

Azure OpenAI chat/Responses is supported by the core `azure-openai-responses`
model API, but it is effectively undiscoverable in the docs. The provider
directory (`docs/providers/index.md`) only lists **Azure Speech**, so a new user
who has an Azure OpenAI key reasonably concludes chat/Responses is not
supported. The only mention of the setup path lived as a passing reference on
the OpenAI page that pointed readers into the unrelated "Server-side compaction"
accordion instead of a real walkthrough.

## Why This Change Was Made

Adds a dedicated **Azure OpenAI** provider page documenting the direct
API-key `azure-openai-responses` path (v1 vs classic endpoint, deployment name
as model id, `AZURE_OPENAI_API_VERSION` default, onboarding host recognition,
manual config, and verify commands). It also:

- adds Azure OpenAI to the provider directory (`docs/providers/index.md`),
- repoints the OpenAI page's Azure note to the new page instead of the
  compaction accordion,
- adds a nav entry and a `/providers/azure-openai-responses` -> `/providers/azure-openai`
  redirect in `docs.json`.

Non-goals: this page does not change any runtime behavior and does not duplicate
the existing OpenAI-page section on Azure **image** endpoints, nor the Microsoft
Foundry plugin (Entra ID / Foundry discovery) — it routes to both. Reported
reliability issues are listed as open, user-reported, and not maintainer-confirmed
so readers can weigh them without the docs asserting unverified behavior.

## User Impact

Users with an Azure OpenAI resource can now find a single page that walks them
through configuring chat/Responses, understand the v1 vs classic endpoint
choice, know that the model id must be the Azure deployment name, and see the
open reported caveats before relying on the path in production.

## Evidence

Documentation-only change (141 insertions across 4 files). Claims in the page
were derived from and cross-checked against current core source:

- Model API registered: `src/config/types.models.ts` (`azure-openai-responses`).
- Transport + defaults: `src/agents/openai-responses-transport.ts`
  (`DEFAULT_AZURE_OPENAI_API_VERSION = "preview"`, `AZURE_OPENAI_API_VERSION`,
  `AZURE_OPENAI_DEPLOYMENT_NAME_MAP`, v1 vs classic via
  `isOpenAICompatibleAzureResponsesBaseUrl`, deployment-name-as-model).
- Onboarding host recognition: `src/commands/onboard-custom-config.ts`
  (`*.openai.azure.com`, `*.services.ai.azure.com`).
- Verify commands: `--provider` / `--probe --probe-provider` in
  `src/cli/models-cli.ts`.
- Cross-link anchor `#azure-openai-endpoints` exists on the OpenAI page.

Links are root-relative with no `.md` suffix and the directory entry is
alphabetically ordered per the docs guide.

Related (open, user-reported): #79570, #80926, #102907
