### PR TITLE
fix(ui): stopped realtime Talk relays no longer linger

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -356,6 +356,125 @@ describeControlUiE2e("Control UI browser Talk", () => {
     }
   });
 
+  it("closes a stale relay when stop and restart race its create response", async () => {
+    const context = await browser.newContext({ locale: "en-US", permissions: ["microphone"] });
+    const page = await context.newPage();
+    const currentRelaySessionId = "relay-current-e2e";
+    const staleRelaySessionId = "relay-stale-e2e";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "talk.client.create": {
+          provider: "openai",
+          transport: "gateway-relay",
+          relaySessionId: currentRelaySessionId,
+          audio: {
+            inputEncoding: "pcm16",
+            inputSampleRateHz: 16_000,
+            outputEncoding: "pcm16",
+            outputSampleRateHz: 24_000,
+          },
+        },
+        "talk.session.appendAudio": {},
+        "talk.session.close": {},
+      },
+    });
+    await installTalkBrowserFixtures(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.deferNext("talk.client.create");
+
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await expect
+        .poll(() => gateway.getRequests("talk.client.create").then((requests) => requests.length))
+        .toBe(1);
+      await page.getByRole("button", { name: "Stop voice input" }).click();
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await expect
+        .poll(() => gateway.getRequests("talk.client.create").then((requests) => requests.length))
+        .toBe(2);
+
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawTalkE2eState?: { constraints: unknown[] };
+                }
+              ).openclawTalkE2eState?.constraints.length,
+          ),
+        )
+        .toBe(1);
+      await gateway.emitGatewayEvent("talk.event", {
+        relaySessionId: currentRelaySessionId,
+        type: "ready",
+      });
+      await expect
+        .poll(() => page.locator('.agent-chat__voice-activity[data-status="listening"]').count())
+        .toBe(1);
+
+      await gateway.resolveDeferred("talk.client.create", {
+        provider: "openai",
+        transport: "gateway-relay",
+        relaySessionId: staleRelaySessionId,
+        audio: {
+          inputEncoding: "pcm16",
+          inputSampleRateHz: 16_000,
+          outputEncoding: "pcm16",
+          outputSampleRateHz: 24_000,
+        },
+      });
+      await expect
+        .poll(() => gateway.getRequests("talk.session.close"))
+        .toEqual([
+          expect.objectContaining({
+            params: { sessionId: staleRelaySessionId },
+          }),
+        ]);
+
+      await page.evaluate(() => {
+        const state = (
+          window as Window & {
+            openclawTalkE2eState?: {
+              inputProcessor?: {
+                onaudioprocess?: (event: {
+                  inputBuffer: { getChannelData: () => Float32Array };
+                }) => void;
+              };
+            };
+          }
+        ).openclawTalkE2eState;
+        state?.inputProcessor?.onaudioprocess?.({
+          inputBuffer: { getChannelData: () => new Float32Array(4096).fill(0.1) },
+        });
+      });
+      await expect
+        .poll(() => gateway.getRequests("talk.session.appendAudio"))
+        .toEqual([
+          expect.objectContaining({
+            params: expect.objectContaining({ sessionId: currentRelaySessionId }),
+          }),
+        ]);
+      await expect
+        .poll(() => page.getByRole("button", { name: "Stop voice input" }).isVisible())
+        .toBe(true);
+      await captureComposerProof(page, "05-relay-create-race-current-stays-active.png");
+      console.info("[browser-talk-e2e] relay_create_race=stale-closed,current-audio-appended");
+
+      await page.getByRole("button", { name: "Stop voice input" }).click();
+      await expect
+        .poll(() =>
+          gateway
+            .getRequests("talk.session.close")
+            .then((requests) => requests.map((request) => request.params)),
+        )
+        .toEqual([{ sessionId: staleRelaySessionId }, { sessionId: currentRelaySessionId }]);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps stop-voice and stop-run controls visually distinct while both are active", async () => {
     const context = await browser.newContext({ permissions: ["microphone"] });
     const page = await context.newPage();

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -163,6 +163,53 @@ describe("RealtimeTalkSession", () => {
     expect(webRtcCtor).not.toHaveBeenCalled();
   });
 
+  it("closes a stale Gateway relay that resolves after stop and restart", async () => {
+    const resolveRequests: Array<(value: unknown) => void> = [];
+    const request = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveRequests.push(resolve);
+        }),
+    );
+    const session = new RealtimeTalkSession({ request } as never, "main");
+
+    const firstStart = session.start();
+    await vi.waitFor(() => expect(resolveRequests).toHaveLength(1));
+    session.stop();
+    const secondStart = session.start();
+    await vi.waitFor(() => expect(resolveRequests).toHaveLength(2));
+    resolveRequests[1]!({
+      provider: "example",
+      transport: "gateway-relay",
+      relaySessionId: "relay-current",
+      audio: {
+        inputEncoding: "pcm16",
+        inputSampleRateHz: 24000,
+        outputEncoding: "pcm16",
+        outputSampleRateHz: 24000,
+      },
+    });
+    await secondStart;
+    resolveRequests[0]!({
+      provider: "example",
+      transport: "gateway-relay",
+      relaySessionId: "relay-stale",
+      audio: {
+        inputEncoding: "pcm16",
+        inputSampleRateHz: 24000,
+        outputEncoding: "pcm16",
+        outputSampleRateHz: 24000,
+      },
+    });
+    await firstStart;
+
+    expect(relayCtor).toHaveBeenCalledTimes(2);
+    expect(relayStart).toHaveBeenCalledTimes(1);
+    expect(relayStop).toHaveBeenCalledTimes(1);
+    expect(googleCtor).not.toHaveBeenCalled();
+    expect(webRtcCtor).not.toHaveBeenCalled();
+  });
+
   it("falls back to talk.session.create when gateway-relay is rejected by talk.client.create", async () => {
     const request = vi
       .fn()

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -101,6 +101,7 @@ function compactLaunchParams(
 export class RealtimeTalkSession {
   private transport: RealtimeTalkTransport | null = null;
   private closed = false;
+  private lifecycleGeneration = 0;
 
   constructor(
     private readonly client: GatewayBrowserClient,
@@ -111,26 +112,33 @@ export class RealtimeTalkSession {
   ) {}
 
   async start(): Promise<void> {
+    const generation = ++this.lifecycleGeneration;
     this.closed = false;
     this.callbacks.onStatus?.("connecting");
     const providerVideoCapable = await this.resolveVideoCapability();
-    if (this.closed) {
+    if (this.closed || generation !== this.lifecycleGeneration) {
       return;
     }
     const session = await this.createSession(
       providerVideoCapable ? { ...this.options, capabilities: ["camera-frame"] } : this.options,
     );
-    if (this.closed) {
-      return;
-    }
-    this.transport = createTransport(session, {
+    const transportContext = {
       client: this.client,
       sessionKey: this.sessionKey,
       callbacks: this.callbacks,
       inputDeviceId: this.localOptions.inputDeviceId,
       consultThinkingLevel: session.consultThinkingLevel,
       consultFastMode: session.consultFastMode,
-    });
+    };
+    if (this.closed || generation !== this.lifecycleGeneration) {
+      // Gateway relay creation allocates server state before returning. A late
+      // result still owns its close RPC after stop or a replacement start.
+      if (resolveTransport(session) === "gateway-relay") {
+        createTransport(session, transportContext).stop();
+      }
+      return;
+    }
+    this.transport = createTransport(session, transportContext);
     this.callbacks.onVideoCapability?.(
       providerVideoCapable && typeof this.transport.setVideoEnabled === "function",
     );
@@ -212,6 +220,7 @@ export class RealtimeTalkSession {
   }
 
   stop(): void {
+    this.lifecycleGeneration += 1;
     this.closed = true;
     this.callbacks.onStatus?.("idle");
     this.transport?.stop();


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Fixes an issue where stopping and quickly restarting browser realtime Talk could leave an older Gateway relay alive for up to its 30-minute TTL when session creation completed out of order.

## Why This Change Was Made

Each start attempt now carries a lifecycle generation. Results from stopped or superseded attempts cannot replace the active transport. If a stale `gateway-relay` result arrives after the Gateway has already allocated server state, the UI constructs its owning transport only to send `talk.session.close`; client-only late results remain local no-ops.

The generation check also covers the current `talk.catalog` video-capability preflight introduced on `main`, so an older start cannot resume after a replacement start while that preflight is pending.

## User Impact

Users can stop and immediately restart realtime Talk without a stale relay consuming the per-connection relay limit or disturbing the replacement session. The current relay remains usable, including the in-call camera capability added on current `main`.

## Evidence

Exact reviewed head: `42188942d2aa26a71e58fbc9c0964e30f90f9553`, rebased onto `347ee45895033b461649b1bcd2035b23fd221d5b`.

- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk.test.ts`: 17 tests passed on the exact head.
- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk.test.ts ui/src/pages/chat/chat-realtime.test.ts`: 29 tests passed after integrating the current voice/video Talk changes from `main`.
- Real browser/Gateway-protocol proof on the exact head: Playwright launched the Control UI in installed Microsoft Edge, deferred the first `talk.client.create`, stopped and immediately restarted Talk, allowed the replacement relay to reach `listening`, then delivered the stale response. The browser sent exactly one `talk.session.close` for the stale relay, continued sending `talk.session.appendAudio` only to the replacement relay, kept the Stop voice control active, and closed the replacement only after the final explicit stop.
- Focused browser command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/browser-talk-start-stop.e2e.test.ts -t "closes a stale relay when stop and restart race its create response"`: 1 passed on the exact head.
- The browser proof uses the repository's deterministic mocked Gateway and synthetic relay IDs; it emits no provider endpoint, IP address, or credential. The durable scenario is in `ui/src/e2e/browser-talk-start-stop.e2e.test.ts` and also captures the active replacement composer under the ignored Control UI proof artifact directory.
- Source-contract review: `GatewayRelayRealtimeTalkTransport.stop()` in `ui/src/pages/chat/realtime-talk-gateway-relay.ts` is valid before `start()` and sends `talk.session.close` exactly once because a newly constructed transport begins open.
- Gateway close ownership remains enforced in `src/gateway/server-methods/talk-session.ts`, which validates the owning connection, stops the realtime relay, forgets the unified session, and returns success.
- Targeted oxfmt and `git diff --check` pass.
- Final mandatory branch autoreview against the integrated patch passed with no actionable findings (0.93 confidence). A later unrelated `main` advance was rebased cleanly; the full PR patch hash remained byte-for-byte identical (`114cff37d05a5c21a2f87f4ccd0587fdd9f521e1`) before and after that rebase.