### PR TITLE
fix: accept compaction enabled config

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -615,6 +615,7 @@ Periodic heartbeat runs.
   agents: {
     defaults: {
       compaction: {
+        enabled: false, // disable automatic compaction entirely (default: true)
         mode: "safeguard", // default | safeguard
         provider: "my-provider", // id of a registered compaction provider plugin (optional)
         timeoutSeconds: 180,
@@ -646,6 +647,7 @@ Periodic heartbeat runs.
 }
 ```
 
+- `enabled`: master switch for automatic compaction. Set `false` to disable auto-compaction while keeping the rest of the compaction config for later reuse. Default: `true`.
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
 - `provider`: id of a registered compaction provider plugin. When set, the provider's `summarize()` is called instead of built-in LLM summarization. Falls back to built-in on failure. Setting a provider forces `mode: "safeguard"`. See [Compaction](/concepts/compaction).
 - `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `180`.

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -19,6 +19,7 @@ function materializeCompactionConfig(
 describe("config compaction settings", () => {
   it("preserves memory flush config values", () => {
     const compaction = materializeCompactionConfig({
+      enabled: false,
       mode: "safeguard",
       reserveTokensFloor: 12_345,
       identifierPolicy: "custom",
@@ -40,6 +41,7 @@ describe("config compaction settings", () => {
       maxActiveTranscriptBytes: "20mb",
     });
 
+    expect(compaction?.enabled).toBe(false);
     expect(compaction?.reserveTokensFloor).toBe(12_345);
     expect(compaction?.mode).toBe("safeguard");
     expect(compaction?.reserveTokens).toBeUndefined();

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -229,6 +229,20 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts agents.defaults.compaction.enabled", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts agents.defaults.compaction.truncateAfterCompaction", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -120,6 +120,8 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
   "agents.defaults.compaction":
     "Compaction tuning for when context nears token limits, including history share, reserve headroom, and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",
+  "agents.defaults.compaction.enabled":
+    "Master switch for automatic compaction in runtimes that honor OpenClaw compaction settings. Set false to disable auto-compaction entirely while leaving manual /compact and other compaction config values available for later reuse. Default: true.",
   "agents.defaults.compaction.mode":
     'Compaction strategy mode: "default" uses baseline behavior, while "safeguard" applies stricter guardrails to preserve recent context. Keep "default" unless you observe aggressive history loss near limit boundaries.',
   "agents.defaults.compaction.provider":

--- a/src/config/schema.help.quality.test-fixtures.ts
+++ b/src/config/schema.help.quality.test-fixtures.ts
@@ -405,6 +405,7 @@ export const TARGET_KEYS = [
   "agents.defaults",
   "agents.list",
   "agents.defaults.compaction",
+  "agents.defaults.compaction.enabled",
   "agents.defaults.compaction.mode",
   "agents.defaults.compaction.provider",
   "agents.defaults.compaction.reserveTokens",

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -433,6 +433,12 @@ describe("config help copy quality", () => {
   });
 
   it("documents agent compaction safeguards and memory flush behavior", () => {
+    const enabled = expectDefined(
+      FIELD_HELP["agents.defaults.compaction.enabled"],
+      'FIELD_HELP["agents.defaults.compaction.enabled"] test invariant',
+    );
+    expect(/disable|auto-compaction|default:\s*true/i.test(enabled)).toBe(true);
+
     const mode = expectDefined(
       FIELD_HELP["agents.defaults.compaction.mode"],
       'FIELD_HELP["agents.defaults.compaction.mode"] test invariant',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -720,6 +720,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
   "agents.defaults.cliBackends": "CLI Backends",
   "agents.defaults.compaction": "Compaction",
+  "agents.defaults.compaction.enabled": "Compaction Enabled",
   "agents.defaults.compaction.mode": "Compaction Mode",
   "agents.defaults.compaction.provider": "Compaction Provider",
   "agents.defaults.compaction.reserveTokens": "Compaction Reserve Tokens",

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -316,6 +316,15 @@ describe("agent defaults schema", () => {
     );
   });
 
+  it("accepts compaction.enabled", () => {
+    const result = AgentDefaultsSchema.parse({
+      compaction: {
+        enabled: false,
+      },
+    })!;
+    expect(result.compaction?.enabled).toBe(false);
+  });
+
   it("accepts compaction.truncateAfterCompaction", () => {
     const result = AgentDefaultsSchema.parse({
       compaction: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -158,6 +158,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
+        enabled: z.boolean().optional(),
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         provider: z.string().optional(),
         reserveTokens: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Summary
- accept `agents.defaults.compaction.enabled` in the validated config schema
- cover the new field in schema/materialization regressions
- document the config knob in the compaction help/docs surface

## Testing
- `./node_modules/.bin/vitest run src/config/zod-schema.agent-defaults.test.ts src/config/config.schema-regressions.test.ts src/config/config.compaction-settings.test.ts src/config/schema.help.quality.test.ts`

Fixes #110065