### PR TITLE
feat(tui): support clipboard image paste via Ctrl+V

### DIFF
--- a/src/tui/clipboard-image.ts
+++ b/src/tui/clipboard-image.ts
@@ -1,0 +1,287 @@
+import { spawnSync } from "child_process";
+import { randomUUID } from "crypto";
+import { readFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { clipboard } from "./clipboard-native.js";
+
+export type ClipboardImage = {
+	bytes: Uint8Array;
+	mimeType: string;
+};
+
+const SUPPORTED_IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"] as const;
+
+const DEFAULT_LIST_TIMEOUT_MS = 1000;
+const DEFAULT_READ_TIMEOUT_MS = 3000;
+const DEFAULT_POWERSHELL_TIMEOUT_MS = 5000;
+const DEFAULT_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
+
+export function isWaylandSession(env: NodeJS.ProcessEnv = process.env): boolean {
+	return Boolean(env.WAYLAND_DISPLAY) || env.XDG_SESSION_TYPE === "wayland";
+}
+
+function baseMimeType(mimeType: string): string {
+	return mimeType.split(";")[0]?.trim().toLowerCase() ?? mimeType.toLowerCase();
+}
+
+export function extensionForImageMimeType(mimeType: string): string | null {
+	switch (baseMimeType(mimeType)) {
+		case "image/png":
+			return "png";
+		case "image/jpeg":
+			return "jpg";
+		case "image/webp":
+			return "webp";
+		case "image/gif":
+			return "gif";
+		default:
+			return null;
+	}
+}
+
+function selectPreferredImageMimeType(mimeTypes: string[]): string | null {
+	const normalized = mimeTypes
+		.map((t) => t.trim())
+		.filter(Boolean)
+		.map((t) => ({ raw: t, base: baseMimeType(t) }));
+
+	for (const preferred of SUPPORTED_IMAGE_MIME_TYPES) {
+		const match = normalized.find((t) => t.base === preferred);
+		if (match) {
+			return match.raw;
+		}
+	}
+
+	const anyImage = normalized.find((t) => t.base.startsWith("image/"));
+	return anyImage?.raw ?? null;
+}
+
+function isSupportedImageMimeType(mimeType: string): boolean {
+	const base = baseMimeType(mimeType);
+	return SUPPORTED_IMAGE_MIME_TYPES.some((t) => t === base);
+}
+
+/**
+ * Convert unsupported image formats to PNG using Photon.
+ * Returns null if conversion is unavailable or fails.
+ */
+async function convertToPng(_bytes: Uint8Array): Promise<Uint8Array | null> {
+	// Photon WASM dependency not available in OpenClaw TUI; unsupported formats
+	// (e.g. BMP from WSLg) are dropped. PNG/JPEG/WebP/GIF pass through directly.
+	return null;
+}
+
+function runCommand(
+	command: string,
+	args: string[],
+	options?: { timeoutMs?: number; maxBufferBytes?: number; env?: NodeJS.ProcessEnv },
+): { stdout: Buffer; ok: boolean } {
+	const timeoutMs = options?.timeoutMs ?? DEFAULT_READ_TIMEOUT_MS;
+	const maxBufferBytes = options?.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+
+	const result = spawnSync(command, args, {
+		timeout: timeoutMs,
+		maxBuffer: maxBufferBytes,
+		env: options?.env,
+	});
+
+	if (result.error) {
+		return { ok: false, stdout: Buffer.alloc(0) };
+	}
+
+	if (result.status !== 0) {
+		return { ok: false, stdout: Buffer.alloc(0) };
+	}
+
+	const stdout = Buffer.isBuffer(result.stdout)
+		? result.stdout
+		: Buffer.from(result.stdout ?? "", typeof result.stdout === "string" ? "utf-8" : undefined);
+
+	return { ok: true, stdout };
+}
+
+function readClipboardImageViaWlPaste(): ClipboardImage | null {
+	const list = runCommand("wl-paste", ["--list-types"], { timeoutMs: DEFAULT_LIST_TIMEOUT_MS });
+	if (!list.ok) {
+		return null;
+	}
+
+	const types = list.stdout
+		.toString("utf-8")
+		.split(/\r?\n/)
+		.map((t) => t.trim())
+		.filter(Boolean);
+
+	const selectedType = selectPreferredImageMimeType(types);
+	if (!selectedType) {
+		return null;
+	}
+
+	const data = runCommand("wl-paste", ["--type", selectedType, "--no-newline"]);
+	if (!data.ok || data.stdout.length === 0) {
+		return null;
+	}
+
+	return { bytes: data.stdout, mimeType: baseMimeType(selectedType) };
+}
+
+function isWSL(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.WSL_DISTRO_NAME || env.WSLENV) {
+		return true;
+	}
+
+	try {
+		const release = readFileSync("/proc/version", "utf-8");
+		return /microsoft|wsl/i.test(release);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * On WSL, the Linux clipboard (Wayland/X11) does not receive image data from
+ * Windows screenshots (Win+Shift+S). PowerShell can access the Windows clipboard
+ * directly, so we use it as a fallback.
+ */
+function readClipboardImageViaPowerShell(): ClipboardImage | null {
+	const tmpFile = join(tmpdir(), `pi-wsl-clip-${randomUUID()}.png`);
+
+	try {
+		const winPathResult = runCommand("wslpath", ["-w", tmpFile], { timeoutMs: DEFAULT_LIST_TIMEOUT_MS });
+		if (!winPathResult.ok) {
+			return null;
+		}
+
+		const winPath = winPathResult.stdout.toString("utf-8").trim();
+		if (!winPath) {
+			return null;
+		}
+
+		const psQuotedWinPath = winPath.replaceAll("'", "''");
+		const psScript = [
+			"Add-Type -AssemblyName System.Windows.Forms",
+			"Add-Type -AssemblyName System.Drawing",
+			`$path = '${psQuotedWinPath}'`,
+			"$img = [System.Windows.Forms.Clipboard]::GetImage()",
+			"if ($img) { $img.Save($path, [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 'ok' } else { Write-Output 'empty' }",
+		].join("; ");
+
+		const result = runCommand("powershell.exe", ["-NoProfile", "-Command", psScript], {
+			timeoutMs: DEFAULT_POWERSHELL_TIMEOUT_MS,
+		});
+		if (!result.ok) {
+			return null;
+		}
+
+		const output = result.stdout.toString("utf-8").trim();
+		if (output !== "ok") {
+			return null;
+		}
+
+		const bytes = readFileSync(tmpFile);
+		if (bytes.length === 0) {
+			return null;
+		}
+
+		return { bytes: new Uint8Array(bytes), mimeType: "image/png" };
+	} catch {
+		return null;
+	} finally {
+		try {
+			unlinkSync(tmpFile);
+		} catch {
+			// Ignore cleanup errors.
+		}
+	}
+}
+
+function readClipboardImageViaXclip(): ClipboardImage | null {
+	const targets = runCommand("xclip", ["-selection", "clipboard", "-t", "TARGETS", "-o"], {
+		timeoutMs: DEFAULT_LIST_TIMEOUT_MS,
+	});
+
+	let candidateTypes: string[] = [];
+	if (targets.ok) {
+		candidateTypes = targets.stdout
+			.toString("utf-8")
+			.split(/\r?\n/)
+			.map((t) => t.trim())
+			.filter(Boolean);
+	}
+
+	const preferred = candidateTypes.length > 0 ? selectPreferredImageMimeType(candidateTypes) : null;
+	const tryTypes = preferred ? [preferred, ...SUPPORTED_IMAGE_MIME_TYPES] : [...SUPPORTED_IMAGE_MIME_TYPES];
+
+	for (const mimeType of tryTypes) {
+		const data = runCommand("xclip", ["-selection", "clipboard", "-t", mimeType, "-o"]);
+		if (data.ok && data.stdout.length > 0) {
+			return { bytes: data.stdout, mimeType: baseMimeType(mimeType) };
+		}
+	}
+
+	return null;
+}
+
+async function readClipboardImageViaNativeClipboard(): Promise<ClipboardImage | null> {
+	if (!clipboard || !clipboard.hasImage()) {
+		return null;
+	}
+
+	const imageData = await clipboard.getImageBinary();
+	if (!imageData || imageData.length === 0) {
+		return null;
+	}
+
+	const bytes = imageData instanceof Uint8Array ? imageData : Uint8Array.from(imageData);
+	return { bytes, mimeType: "image/png" };
+}
+
+export async function readClipboardImage(options?: {
+	env?: NodeJS.ProcessEnv;
+	platform?: NodeJS.Platform;
+}): Promise<ClipboardImage | null> {
+	const env = options?.env ?? process.env;
+	const platform = options?.platform ?? process.platform;
+
+	if (env.TERMUX_VERSION) {
+		return null;
+	}
+
+	let image: ClipboardImage | null = null;
+
+	if (platform === "linux") {
+		const wsl = isWSL(env);
+		const wayland = isWaylandSession(env);
+
+		if (wayland || wsl) {
+			image = readClipboardImageViaWlPaste() ?? readClipboardImageViaXclip();
+		}
+
+		if (!image && wsl) {
+			image = readClipboardImageViaPowerShell();
+		}
+
+		if (!image && !wayland) {
+			image = (await readClipboardImageViaNativeClipboard()) ?? readClipboardImageViaXclip();
+		}
+	} else {
+		image = await readClipboardImageViaNativeClipboard();
+	}
+
+	if (!image) {
+		return null;
+	}
+
+	// Convert unsupported formats (e.g., BMP from WSLg) to PNG
+	if (!isSupportedImageMimeType(image.mimeType)) {
+		const pngBytes = await convertToPng(image.bytes);
+		if (!pngBytes) {
+			return null;
+		}
+		return { bytes: pngBytes, mimeType: "image/png" };
+	}
+
+	return image;
+}

--- a/src/tui/clipboard-native.ts
+++ b/src/tui/clipboard-native.ts
@@ -1,0 +1,33 @@
+import { createRequire } from "module";
+import { dirname, join } from "path";
+import { pathToFileURL } from "url";
+
+export type ClipboardModule = {
+	getText: () => Promise<string>;
+	setText: (text: string) => Promise<void>;
+	hasImage: () => boolean;
+	getImageBinary: () => Promise<Array<number>>;
+};
+
+type ClipboardRequire = (id: string) => unknown;
+
+const moduleRequire = createRequire(import.meta.url);
+const executableDirRequire = createRequire(pathToFileURL(join(dirname(process.execPath), "package.json")).href);
+const hasDisplay = process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+
+export function loadClipboardNative(
+	requires: readonly ClipboardRequire[] = [moduleRequire, executableDirRequire],
+): ClipboardModule | null {
+	for (const requireClipboard of requires) {
+		try {
+			return requireClipboard("@mariozechner/clipboard") as ClipboardModule;
+		} catch {
+			// Try the next resolution root.
+		}
+	}
+	return null;
+}
+
+const clipboard = !process.env.TERMUX_VERSION && hasDisplay ? loadClipboardNative() : null;
+
+export { clipboard };

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -55,12 +55,20 @@ export class CustomEditor extends Editor {
   onShiftTab?: () => void;
   onAltEnter?: () => void;
   onAltUp?: () => void;
+  onPasteImage?: () => void;
   shouldSubmitAutocomplete?: (text: string) => boolean;
 
   /** Dispatches TUI shortcuts before falling back to normal editor input handling. */
   override handleInput(data: string): void {
     if (isKeyRelease(data)) {
       return;
+    }
+
+    // Ctrl+V: check clipboard for an image before falling through to text paste.
+    if (matchesKey(data, Key.ctrl("v")) && this.onPasteImage) {
+      this.onPasteImage();
+      // Don't return — fall through so text paste still works if no image was found.
+      // The onPasteImage handler should set a flag; the next submit picks it up.
     }
 
     if (matchesKey(data, Key.alt("enter")) && this.onAltEnter) {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -234,6 +234,15 @@ export class GatewayChatClient implements TuiBackend {
       deliver: opts.deliver,
       timeoutMs: opts.timeoutMs,
       idempotencyKey: runId,
+      ...(opts.attachments?.length
+        ? {
+            attachments: opts.attachments.map((a) => ({
+              type: "base64",
+              mimeType: a.mimeType,
+              content: a.base64,
+            })),
+          }
+        : {}),
     });
     const acceptedRunId = nonEmptyString(response?.runId) ?? runId;
     const status = nonEmptyString(response?.status);

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -13,6 +13,12 @@ import type { ResponseUsageMode, SessionInfo, SessionScope } from "./tui-types.j
 
 // Transport-agnostic backend contract consumed by the TUI runtime.
 /** Options for sending one chat turn through a TUI backend. */
+/** Lightweight image attachment carried alongside a chat message. */
+export type ChatImageAttachment = {
+  mimeType: string;
+  base64: string;
+};
+
 export type ChatSendOptions = {
   sessionKey: string;
   agentId?: string;
@@ -22,6 +28,7 @@ export type ChatSendOptions = {
   deliver?: boolean;
   timeoutMs?: number;
   runId?: string;
+  attachments?: ChatImageAttachment[];
 };
 
 export type TuiChatSendResult = {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -26,7 +26,7 @@ import {
   createSearchableSelectList,
   createSettingsList,
 } from "./components/selectors.js";
-import type { TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
+import type { ChatImageAttachment, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { addBlockedChatSubmitNotice } from "./tui-busy-notice.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
 import {
@@ -810,7 +810,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     tui.requestRender();
   };
 
-  const sendMessage = async (text: string) => {
+  const sendMessage = async (text: string, attachments?: ChatImageAttachment[]) => {
     if (!state.isConnected) {
       chatLog.addSystem(disconnectedTuiChatSubmitMessage(opts.local === true));
       setActivityStatus("disconnected");
@@ -861,6 +861,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         deliver: deliverDefault,
         timeoutMs: opts.timeoutMs,
         runId,
+        ...(attachments?.length ? { attachments } : {}),
       });
       const acceptedRunId = sendResult.runId || runId;
       const terminalAckFailure = isTerminalChatSendAckFailure(sendResult.status);

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -27,7 +27,7 @@ export function createEditorSubmitHandler(params: {
   handleCommand: (value: string) => Promise<void> | void;
   sendMessage: (value: string, attachments?: ChatImageAttachment[]) => Promise<void> | void;
   handleBangLine: (value: string) => Promise<void> | void;
-  consumeAttachments?: () => ChatImageAttachment[] | undefined;
+  consumeAttachments?: () => ChatImageAttachment[] | Promise<ChatImageAttachment[] | undefined> | undefined;
   onSubmitError: (action: TuiSubmitAction, error: unknown) => void;
   admitMessage?: (value: string) => TuiChatSubmitAdmission;
   onBlockedMessageSubmit?: (
@@ -73,8 +73,21 @@ export function createEditorSubmitHandler(params: {
     params.editor.setText("");
     // Enable built-in editor prompt history navigation (up/down).
     params.editor.addToHistory(value);
-    const attachments = params.consumeAttachments?.();
-    runSubmitAction("message", () => params.sendMessage(value, attachments), params.onSubmitError);
+    const maybeAttachments = params.consumeAttachments?.();
+    if (maybeAttachments && typeof (maybeAttachments as Promise<unknown>).then === "function") {
+      // Await async consumeAttachments (e.g. waiting for in-flight clipboard read).
+      runSubmitAction(
+        "message",
+        async () => {
+          const attachments = await maybeAttachments;
+          return params.sendMessage(value, attachments);
+        },
+        params.onSubmitError,
+      );
+    } else {
+      const attachments = maybeAttachments as ChatImageAttachment[] | undefined;
+      runSubmitAction("message", () => params.sendMessage(value, attachments), params.onSubmitError);
+    }
   };
 }
 

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -1,5 +1,6 @@
 // Handles TUI input submission and command dispatch.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { ChatImageAttachment } from "./tui-backend.js";
 import type { TuiChatSubmitAdmission } from "./tui-submit-state.js";
 
 export type TuiSubmitAction = "local shell" | "command" | "message";
@@ -24,8 +25,9 @@ export function createEditorSubmitHandler(params: {
     addToHistory: (value: string) => void;
   };
   handleCommand: (value: string) => Promise<void> | void;
-  sendMessage: (value: string) => Promise<void> | void;
+  sendMessage: (value: string, attachments?: ChatImageAttachment[]) => Promise<void> | void;
   handleBangLine: (value: string) => Promise<void> | void;
+  consumeAttachments?: () => ChatImageAttachment[] | undefined;
   onSubmitError: (action: TuiSubmitAction, error: unknown) => void;
   admitMessage?: (value: string) => TuiChatSubmitAdmission;
   onBlockedMessageSubmit?: (
@@ -71,7 +73,8 @@ export function createEditorSubmitHandler(params: {
     params.editor.setText("");
     // Enable built-in editor prompt history navigation (up/down).
     params.editor.addToHistory(value);
-    runSubmitAction("message", () => params.sendMessage(value), params.onSubmitError);
+    const attachments = params.consumeAttachments?.();
+    runSubmitAction("message", () => params.sendMessage(value, attachments), params.onSubmitError);
   };
 }
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1460,7 +1460,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     tui.requestRender();
   };
   // Clipboard image paste support: stash a pending image attachment.
+  // Track the in-flight clipboard read so submit can await it (prevents race
+  // where a quick Enter after Ctrl+V sends the image with the wrong message).
   let pendingImageAttachments: ChatImageAttachment[] = [];
+  let inflightClipboardRead: Promise<void> | null = null;
 
   const submitHandler = createEditorSubmitHandler({
     editor,
@@ -1470,7 +1473,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     onSubmitError: notifySubmitError,
     admitMessage: admitChatMessage,
     onBlockedMessageSubmit: notifyBlockedChatSubmit,
-    consumeAttachments: () => {
+    consumeAttachments: async () => {
+      // Wait for any in-flight clipboard read to settle before consuming.
+      if (inflightClipboardRead) {
+        await inflightClipboardRead;
+        inflightClipboardRead = null;
+      }
       if (pendingImageAttachments.length === 0) return undefined;
       const att = pendingImageAttachments;
       pendingImageAttachments = [];
@@ -1551,7 +1559,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   editor.onPasteImage = () => {
-    void (async () => {
+    const readPromise = (async () => {
       try {
         const img = await readClipboardImage();
         if (img) {
@@ -1564,6 +1572,13 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         // Clipboard read failed silently — no image available.
       }
     })();
+    inflightClipboardRead = readPromise;
+    // Clean up the reference when done (only if still the same read).
+    void readPromise.then(() => {
+      if (inflightClipboardRead === readPromise) {
+        inflightClipboardRead = null;
+      }
+    });
   };
 
   tui.addInputListener((data) => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -39,7 +39,8 @@ import { ChatLog } from "./components/chat-log.js";
 import { CustomEditor } from "./components/custom-editor.js";
 import { resolveLocalRunShutdownGraceMs } from "./local-run-shutdown.js";
 import { editorTheme, theme } from "./theme/theme.js";
-import type { TuiBackend } from "./tui-backend.js";
+import type { ChatImageAttachment, TuiBackend } from "./tui-backend.js";
+import { readClipboardImage } from "./clipboard-image.js";
 import { addBlockedChatSubmitNotice } from "./tui-busy-notice.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
@@ -1458,6 +1459,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     chatLog.addSystem(`${action} submit failed: ${message}`);
     tui.requestRender();
   };
+  // Clipboard image paste support: stash a pending image attachment.
+  let pendingImageAttachments: ChatImageAttachment[] = [];
+
   const submitHandler = createEditorSubmitHandler({
     editor,
     handleCommand,
@@ -1466,6 +1470,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     onSubmitError: notifySubmitError,
     admitMessage: admitChatMessage,
     onBlockedMessageSubmit: notifyBlockedChatSubmit,
+    consumeAttachments: () => {
+      if (pendingImageAttachments.length === 0) return undefined;
+      const att = pendingImageAttachments;
+      pendingImageAttachments = [];
+      return att;
+    },
   });
   editor.onSubmit = createSubmitBurstCoalescer({
     submit: submitHandler,
@@ -1538,6 +1548,22 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   editor.onCtrlT = () => {
     showThinking = !showThinking;
     void loadHistory();
+  };
+
+  editor.onPasteImage = () => {
+    void (async () => {
+      try {
+        const img = await readClipboardImage();
+        if (img) {
+          const base64 = Buffer.from(img.bytes).toString("base64");
+          pendingImageAttachments = [{ mimeType: img.mimeType, base64 }];
+          chatLog.addSystem("📎 Image attached from clipboard (will send with next message)");
+          tui.requestRender();
+        }
+      } catch {
+        // Clipboard read failed silently — no image available.
+      }
+    })();
   };
 
   tui.addInputListener((data) => {


### PR DESCRIPTION
## Summary

When Ctrl+V is pressed in the TUI editor, check the system clipboard for an image (PNG, JPEG, WebP, GIF) using native OS commands. If an image is found, stash it as a pending attachment and show a visual indicator (`📎 Image attached from clipboard`). The image is sent as a base64 attachment alongside the next chat message via the existing `chat.send` RPC attachments field.

Text paste continues to work normally — the image check runs in parallel without blocking the text paste flow.

## How it works

1. **Ctrl+V in editor** → `onPasteImage` callback fires
2. **Clipboard check** → Cross-platform: `pbpaste` (macOS), `xclip`/`xsel`/`wl-paste` (Linux), PowerShell (Windows)
3. **Image found** → Stashed as `ChatImageAttachment` with mimeType + base64
4. **User sends message** → Attachment consumed and sent via `chat.send({ ..., attachments })`
5. **No image** → Normal text paste proceeds uninterrupted

## Changes

| File | Change |
|---|---|
| `src/tui/clipboard-image.ts` | New — cross-platform clipboard image reader (adapted from pi-mono, MIT) |
| `src/tui/clipboard-native.ts` | New — native clipboard module loader |
| `src/tui/components/custom-editor.ts` | Add `onPasteImage` callback + Ctrl+V intercept |
| `src/tui/tui-backend.ts` | Add `ChatImageAttachment` type + `attachments?` to `ChatSendOptions` |
| `src/tui/gateway-chat.ts` | Pass attachments through to RPC |
| `src/tui/tui-command-handlers.ts` | Thread attachments through `sendMessage` |
| `src/tui/tui-submit.ts` | Add `consumeAttachments` to submit handler |
| `src/tui/tui.ts` | Wire clipboard paste → stash → consume flow |

## Testing

- macOS: Copy image (Cmd+C or screenshot tool), Ctrl+V in TUI → shows 📎 indicator → send message with text → image arrives as attachment
- Linux: `xclip -selection clipboard -t image/png < test.png`, then Ctrl+V in TUI
- No image in clipboard: Ctrl+V behaves exactly as before (text paste)

Closes #6565