### PR TITLE
fix(ui): long chats retain generated image memory

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -25,6 +25,12 @@ const sessionAccessibilityProofDir = path.join(
   "control-ui-e2e",
   "session-accessibility",
 );
+const managedImageCacheProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "managed-image-cache",
+);
 
 let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
@@ -913,6 +919,227 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           ),
         )
         .toBe(1);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("evicts and refetches managed image Blob URLs after the cache reaches capacity", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+      const originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+      const proof = { created: [] as string[], revoked: [] as string[] };
+      Object.defineProperty(globalThis, "managedImageCacheProof", {
+        configurable: true,
+        value: proof,
+      });
+      Object.defineProperty(URL, "createObjectURL", {
+        configurable: true,
+        value: (blob: Blob) => {
+          const blobUrl = originalCreateObjectURL(blob);
+          proof.created.push(blobUrl);
+          return blobUrl;
+        },
+      });
+      Object.defineProperty(URL, "revokeObjectURL", {
+        configurable: true,
+        value: (blobUrl: string) => {
+          proof.revoked.push(blobUrl);
+          originalRevokeObjectURL(blobUrl);
+        },
+      });
+    });
+
+    const imageUrls = Array.from({ length: 65 }, (_, index) => {
+      const id = String(index + 1).padStart(12, "0");
+      return `/api/chat/media/outgoing/agent%3Amain%3Amain/00000000-0000-4000-8000-${id}/full`;
+    });
+    const fetchedMedia: Array<{
+      authorization: string | undefined;
+      pathname: string;
+      requesterSessionKey: string | undefined;
+    }> = [];
+    await page.route("**/api/chat/media/outgoing/**", async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      fetchedMedia.push({
+        authorization: request.headers().authorization,
+        pathname: url.pathname,
+        requesterSessionKey: request.headers()["x-openclaw-requester-session-key"],
+      });
+      await route.fulfill({
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="160" height="90"><rect width="160" height="90" rx="12" fill="#0f766e"/><text x="80" y="50" text-anchor="middle" fill="white" font-family="sans-serif" font-size="14">managed preview</text></svg>',
+        contentType: "image/svg+xml",
+      });
+    });
+
+    const historyFor = (indexes: number[], labelPrefix: string) => [
+      {
+        content: indexes.map((index) => ({
+          alt: `${labelPrefix} ${index + 1}`,
+          type: "image",
+          url: imageUrls[index],
+        })),
+        role: "assistant",
+        timestamp: Date.now(),
+      },
+    ];
+    const gateway = await installMockGateway(page, {
+      historyMessages: historyFor(
+        Array.from({ length: 64 }, (_, index) => index),
+        "Initial managed image",
+      ),
+    });
+    const readBlobProof = () =>
+      page.evaluate(() => {
+        const proof = (
+          globalThis as typeof globalThis & {
+            managedImageCacheProof: { created: string[]; revoked: string[] };
+          }
+        ).managedImageCacheProof;
+        return { created: [...proof.created], revoked: [...proof.revoked] };
+      });
+    let proofMessageSequence = 100;
+    const replaceHistory = async (messages: unknown[], visibleAlt: string) => {
+      const historyRequestsBefore = (await gateway.getRequests("chat.history")).length;
+      await gateway.setHistoryMessages(messages);
+      proofMessageSequence += 1;
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [],
+        hasActiveRun: false,
+        message: messages[0],
+        messageId: `managed-image-cache-proof-${proofMessageSequence}`,
+        messageSeq: proofMessageSequence,
+        session: {
+          activeRunIds: [],
+          hasActiveRun: false,
+          key: "main",
+          kind: "direct",
+          status: "done",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).length, {
+          timeout: 15_000,
+        })
+        .toBeGreaterThan(historyRequestsBefore);
+      await page.getByAltText(visibleAlt).waitFor({ state: "visible", timeout: 10_000 });
+    };
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await expect.poll(async () => (await readBlobProof()).created.length).toBe(64);
+      await expect
+        .poll(() =>
+          page
+            .locator("img.chat-message-image")
+            .evaluateAll(
+              (images) =>
+                images.filter(
+                  (image) =>
+                    image instanceof HTMLImageElement &&
+                    image.complete &&
+                    image.naturalWidth === 160,
+                ).length,
+            ),
+        )
+        .toBe(64);
+
+      await replaceHistory(
+        historyFor([0], "Recently viewed managed image"),
+        "Recently viewed managed image 1",
+      );
+      expect((await readBlobProof()).created).toHaveLength(64);
+
+      await replaceHistory(historyFor([64], "Overflow managed image"), "Overflow managed image 65");
+      await expect.poll(async () => (await readBlobProof()).created.length).toBe(65);
+      const overflowProof = await readBlobProof();
+      const retainedRecentBlobUrl = expectDefined(
+        overflowProof.created[0],
+        "recent managed image Blob URL",
+      );
+      const evictedBlobUrl = expectDefined(
+        overflowProof.created[1],
+        "evicted managed image Blob URL",
+      );
+      expect(overflowProof.revoked).toContain(evictedBlobUrl);
+      expect(overflowProof.revoked).not.toContain(retainedRecentBlobUrl);
+
+      const evictedPath = new URL(
+        expectDefined(imageUrls[1], "evicted managed image URL"),
+        server.baseUrl,
+      ).pathname;
+      const fetchesBeforeRevisit = fetchedMedia.filter(
+        (request) => request.pathname === evictedPath,
+      ).length;
+      await replaceHistory(historyFor([1], "Refetched managed image"), "Refetched managed image 2");
+      const revisitedImage = page.getByAltText("Refetched managed image 2");
+      await expect
+        .poll(() =>
+          revisitedImage.evaluate((image) =>
+            image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
+          ),
+        )
+        .toBe(160);
+      await expect.poll(async () => (await readBlobProof()).created.length).toBe(66);
+      const finalProof = await readBlobProof();
+      const evictedImageFetches = fetchedMedia.filter(
+        (request) => request.pathname === evictedPath,
+      ).length;
+      expect(evictedImageFetches).toBe(fetchesBeforeRevisit + 1);
+      expect(fetchedMedia).not.toHaveLength(0);
+      expect(
+        fetchedMedia.every((request) => request.authorization === "Bearer e2e-device-token"),
+      ).toBe(true);
+      expect(
+        fetchedMedia.every((request) => request.requesterSessionKey === "agent:main:main"),
+      ).toBe(true);
+
+      const proofSummary = {
+        cacheCapacity: 64,
+        createdBlobUrls: finalProof.created.length,
+        evictedBlobIndex: 1,
+        evictedImageFetches,
+        refetchedImageNaturalWidth: await revisitedImage.evaluate(
+          (image) => (image as HTMLImageElement).naturalWidth,
+        ),
+        retainedRecentBlobRevoked: finalProof.revoked.includes(retainedRecentBlobUrl),
+        revokedBlobUrls: finalProof.revoked.length,
+      };
+      if (captureUiProofEnabled) {
+        await mkdir(managedImageCacheProofDir, { recursive: true });
+        await page.evaluate((summary) => {
+          const panel = document.createElement("pre");
+          panel.setAttribute("data-managed-image-cache-proof", "true");
+          panel.style.cssText =
+            "position:fixed;right:16px;bottom:16px;z-index:99999;max-width:460px;padding:16px;border:2px solid #5eead4;border-radius:10px;background:#0f172a;color:#ccfbf1;font:14px/1.45 monospace;white-space:pre-wrap";
+          panel.textContent = `Managed image cache browser proof\n${JSON.stringify(summary, null, 2)}`;
+          document.body.append(panel);
+        }, proofSummary);
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(managedImageCacheProofDir, "after-refetch.png"),
+        });
+        await writeFile(
+          path.join(managedImageCacheProofDir, "after-refetch.json"),
+          `${JSON.stringify(proofSummary, null, 2)}\n`,
+          "utf8",
+        );
+      }
+      if (process.env.OPENCLAW_BEHAVIOR_PROOF === "1") {
+        process.stdout.write(
+          `${JSON.stringify({ proof: "managed-image-cache", ...proofSummary })}\n`,
+        );
+      }
     } finally {
       await closeBrowserContext(context);
     }

--- a/ui/src/lib/open-external-url.test.ts
+++ b/ui/src/lib/open-external-url.test.ts
@@ -1,6 +1,10 @@
 // Control UI tests cover open external url behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { openExternalUrlSafe, resolveSafeExternalUrl } from "./open-external-url.ts";
+import {
+  openExternalUrlSafe,
+  reserveExternalWindowForDeferredNavigation,
+  resolveSafeExternalUrl,
+} from "./open-external-url.ts";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -103,6 +107,23 @@ describe("openExternalUrlSafe", () => {
       "_blank",
       "noopener,noreferrer",
     );
+    expect(opened).toBe(openedLikeProxy);
+    expect(openedLikeProxy.opener).toBeNull();
+  });
+});
+
+describe("reserveExternalWindowForDeferredNavigation", () => {
+  it("opens an inert placeholder and detaches its opener", () => {
+    const openedLikeProxy = {
+      opener: { postMessage: () => void 0 },
+    } as unknown as WindowProxy;
+    const openMock = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => openedLikeProxy as unknown as Window);
+
+    const opened = reserveExternalWindowForDeferredNavigation();
+
+    expect(openMock).toHaveBeenCalledWith("about:blank", "_blank");
     expect(opened).toBe(openedLikeProxy);
     expect(openedLikeProxy.opener).toBeNull();
   });

--- a/ui/src/lib/open-external-url.ts
+++ b/ui/src/lib/open-external-url.ts
@@ -60,6 +60,16 @@ type OpenExternalUrlSafeOptions = ResolveSafeExternalUrlOptions & {
   baseHref?: string;
 };
 
+export function reserveExternalWindowForDeferredNavigation(): WindowProxy | null {
+  // Reserve while user activation is live, then detach the opener before any
+  // caller-controlled URL can be loaded into the new browsing context.
+  const opened = window.open("about:blank", "_blank");
+  if (opened) {
+    opened.opener = null;
+  }
+  return opened;
+}
+
 export function openExternalUrlSafe(
   rawUrl: string,
   opts: OpenExternalUrlSafeOptions = {},

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2674,6 +2674,24 @@ describe("grouped chat rendering", () => {
     await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(imageUrls.length));
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:managed-image-1");
     expect(revokeObjectURL).not.toHaveBeenCalledWith("blob:managed-image-0");
+
+    const replace = vi.fn();
+    const close = vi.fn();
+    const openedWindow = {
+      opener: window,
+      location: { replace },
+      close,
+    };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(openedWindow as unknown as Window);
+    const evictedImage = container.querySelector<HTMLImageElement>('img[alt="Generated image 2"]');
+    expect(evictedImage).toBeInstanceOf(HTMLImageElement);
+    evictedImage!.click();
+
+    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(openedWindow.opener).toBeNull();
+    await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(imageUrls.length + 1));
+    expect(replace).toHaveBeenCalledWith("blob:managed-image-65");
+    expect(close).not.toHaveBeenCalled();
   });
 
   it("bounds managed outgoing image miss retention", async () => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2623,6 +2623,90 @@ describe("grouped chat rendering", () => {
     expectSameOriginGet(fetchInit);
   });
 
+  it("bounds managed outgoing image blob URLs with least-recently-used eviction", async () => {
+    const imageUrls = Array.from(
+      { length: 65 },
+      () => `/api/chat/media/outgoing/agent%3Amain%3Amain/${crypto.randomUUID()}/full`,
+    );
+    let objectUrlIndex = 0;
+    const createObjectURL = vi.fn(() => `blob:managed-image-${objectUrlIndex++}`);
+    const revokeObjectURL = vi.fn();
+    const NativeUrl = URL;
+    vi.stubGlobal(
+      "URL",
+      class extends NativeUrl {
+        static override createObjectURL = createObjectURL;
+        static override revokeObjectURL = revokeObjectURL;
+      },
+    );
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["png"], { type: "image/png" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: imageUrls.slice(0, 64).map((url, index) => ({
+        type: "image",
+        url,
+        alt: `Generated image ${index + 1}`,
+      })),
+      timestamp: Date.now(),
+    });
+    await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(64));
+
+    const recentContainer = document.createElement("div");
+    renderAssistantMessage(recentContainer, {
+      role: "assistant",
+      content: [{ type: "image", url: imageUrls[0], alt: "Recently viewed image" }],
+      timestamp: Date.now(),
+    });
+    expect(createObjectURL).toHaveBeenCalledTimes(64);
+
+    const overflowContainer = document.createElement("div");
+    renderAssistantMessage(overflowContainer, {
+      role: "assistant",
+      content: [{ type: "image", url: imageUrls[64], alt: "Newest image" }],
+      timestamp: Date.now(),
+    });
+    await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(imageUrls.length));
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:managed-image-1");
+    expect(revokeObjectURL).not.toHaveBeenCalledWith("blob:managed-image-0");
+  });
+
+  it("bounds managed outgoing image miss retention", async () => {
+    const imageUrls = Array.from(
+      { length: 65 },
+      () => `/api/chat/media/outgoing/agent%3Amain%3Amain/${crypto.randomUUID()}/full`,
+    );
+    const fetchMock = vi.fn(async () => ({ ok: false }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const container = document.createElement("div");
+
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: imageUrls.map((url, index) => ({
+        type: "image",
+        url,
+        alt: `Missing image ${index + 1}`,
+      })),
+      timestamp: Date.now(),
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(imageUrls.length));
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    const retryContainer = document.createElement("div");
+    renderAssistantMessage(retryContainer, {
+      role: "assistant",
+      content: [{ type: "image", url: imageUrls[0], alt: "Oldest missing image" }],
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(imageUrls.length + 1));
+  });
+
   it("does not send auth to cross-origin managed-image-looking URLs", () => {
     const fetchMock = vi.fn(async () => {
       throw new Error("cross-origin image URL should not be fetched with Control UI auth");

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -47,7 +47,7 @@ import {
 } from "../../../lib/format.ts";
 import "../../../components/tooltip.ts";
 import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
-import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
+import { openExternalUrlSafe, resolveSafeExternalUrl } from "../../../lib/open-external-url.ts";
 import { stripThinkingTags } from "../../../lib/strip-thinking-tags.ts";
 import { detectTextDirection } from "../../../lib/text-direction.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
@@ -1364,8 +1364,37 @@ function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderO
     return nothing;
   }
 
-  const openImage = (url: string) => {
-    openExternalUrlSafe(url, { allowDataImage: true });
+  const openImage = (img: RenderableImageBlock, previewUrl: string) => {
+    if (
+      !isManagedOutgoingImageSource(img.displayUrl) ||
+      readManagedOutgoingImageBlobUrl(img.displayUrl, opts) === previewUrl
+    ) {
+      openExternalUrlSafe(previewUrl, { allowDataImage: true });
+      return;
+    }
+
+    // Reserve the tab during the click's user activation. An evicted Blob URL
+    // must be refetched before navigation, after popup permission has expired.
+    const pendingWindow = window.open("about:blank", "_blank");
+    if (pendingWindow) {
+      pendingWindow.opener = null;
+    }
+    void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts)
+      .then((freshUrl) => {
+        const safeUrl = freshUrl
+          ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
+          : null;
+        if (!safeUrl) {
+          pendingWindow?.close();
+          return;
+        }
+        if (pendingWindow) {
+          pendingWindow.location.replace(safeUrl);
+          return;
+        }
+        openExternalUrlSafe(safeUrl, { allowDataImage: true });
+      })
+      .catch(() => pendingWindow?.close());
   };
 
   const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => html`
@@ -1375,7 +1404,7 @@ function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderO
       class="chat-message-image"
       width=${img.width ?? nothing}
       height=${img.height ?? nothing}
-      @click=${() => openImage(previewUrl)}
+      @click=${() => openImage(img, previewUrl)}
     />
   `;
 
@@ -1605,13 +1634,29 @@ function buildManagedOutgoingImageFetchUrl(source: string, basePath?: string): s
   return `${normalizedBasePath}${source}`;
 }
 
+function resolveManagedOutgoingImageBlobUrlCacheKey(
+  source: string,
+  opts?: ImageRenderOptions,
+): string {
+  const authToken = opts?.authToken?.trim() ?? "";
+  const fetchUrl = buildManagedOutgoingImageFetchUrl(source, opts?.basePath);
+  return `${fetchUrl}::${authToken}`;
+}
+
+function readManagedOutgoingImageBlobUrl(
+  source: string,
+  opts?: ImageRenderOptions,
+): string | undefined {
+  return readManagedImageBlobUrl(resolveManagedOutgoingImageBlobUrlCacheKey(source, opts));
+}
+
 async function resolveManagedOutgoingImageBlobUrl(
   source: string,
   opts?: ImageRenderOptions,
 ): Promise<string | null> {
   const authToken = opts?.authToken?.trim() ?? "";
   const fetchUrl = buildManagedOutgoingImageFetchUrl(source, opts?.basePath);
-  const cacheKey = `${fetchUrl}::${authToken}`;
+  const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(source, opts);
   const cached = readManagedImageBlobUrl(cacheKey);
   if (cached) {
     return cached;

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -47,7 +47,11 @@ import {
 } from "../../../lib/format.ts";
 import "../../../components/tooltip.ts";
 import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
-import { openExternalUrlSafe, resolveSafeExternalUrl } from "../../../lib/open-external-url.ts";
+import {
+  openExternalUrlSafe,
+  reserveExternalWindowForDeferredNavigation,
+  resolveSafeExternalUrl,
+} from "../../../lib/open-external-url.ts";
 import { stripThinkingTags } from "../../../lib/strip-thinking-tags.ts";
 import { detectTextDirection } from "../../../lib/text-direction.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
@@ -1375,10 +1379,7 @@ function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderO
 
     // Reserve the tab during the click's user activation. An evicted Blob URL
     // must be refetched before navigation, after popup permission has expired.
-    const pendingWindow = window.open("about:blank", "_blank");
-    if (pendingWindow) {
-      pendingWindow.opener = null;
-    }
+    const pendingWindow = reserveExternalWindowForDeferredNavigation();
     void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts)
       .then((freshUrl) => {
         const safeUrl = freshUrl

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -260,7 +260,68 @@ type AttachmentItem = Extract<MessageContentItem, { type: "attachment" }>;
 const managedImageBlobUrlCache = new Map<string, Promise<string | null>>();
 const managedImageBlobUrlResolvedCache = new Map<string, string>();
 const managedImageBlobUrlMissCache = new Map<string, number>();
+const MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES = 64;
 const MANAGED_IMAGE_BLOB_URL_MISS_RETRY_MS = 5_000;
+
+function readManagedImageBlobUrl(cacheKey: string): string | undefined {
+  const cached = managedImageBlobUrlResolvedCache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+  managedImageBlobUrlResolvedCache.delete(cacheKey);
+  managedImageBlobUrlResolvedCache.set(cacheKey, cached);
+  return cached;
+}
+
+function cacheManagedImageBlobUrl(cacheKey: string, blobUrl: string) {
+  const previous = managedImageBlobUrlResolvedCache.get(cacheKey);
+  managedImageBlobUrlResolvedCache.delete(cacheKey);
+  managedImageBlobUrlResolvedCache.set(cacheKey, blobUrl);
+  managedImageBlobUrlMissCache.delete(cacheKey);
+  if (previous && previous !== blobUrl) {
+    URL.revokeObjectURL(previous);
+  }
+
+  // Blob URLs retain browser-managed image data. Keep recent previews reusable,
+  // but revoke evicted URLs so long-lived chat sessions cannot retain them forever.
+  while (managedImageBlobUrlResolvedCache.size > MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES) {
+    const oldest = managedImageBlobUrlResolvedCache.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    const evicted = managedImageBlobUrlResolvedCache.get(oldest.value);
+    managedImageBlobUrlResolvedCache.delete(oldest.value);
+    if (evicted) {
+      URL.revokeObjectURL(evicted);
+    }
+  }
+}
+
+function hasRecentManagedImageBlobUrlMiss(cacheKey: string): boolean {
+  const missAt = managedImageBlobUrlMissCache.get(cacheKey);
+  if (missAt === undefined) {
+    return false;
+  }
+  if (Date.now() - missAt >= MANAGED_IMAGE_BLOB_URL_MISS_RETRY_MS) {
+    managedImageBlobUrlMissCache.delete(cacheKey);
+    return false;
+  }
+  managedImageBlobUrlMissCache.delete(cacheKey);
+  managedImageBlobUrlMissCache.set(cacheKey, missAt);
+  return true;
+}
+
+function cacheManagedImageBlobUrlMiss(cacheKey: string) {
+  managedImageBlobUrlMissCache.delete(cacheKey);
+  managedImageBlobUrlMissCache.set(cacheKey, Date.now());
+  while (managedImageBlobUrlMissCache.size > MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES) {
+    const oldest = managedImageBlobUrlMissCache.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    managedImageBlobUrlMissCache.delete(oldest.value);
+  }
+}
 
 function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
   if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
@@ -1551,12 +1612,11 @@ async function resolveManagedOutgoingImageBlobUrl(
   const authToken = opts?.authToken?.trim() ?? "";
   const fetchUrl = buildManagedOutgoingImageFetchUrl(source, opts?.basePath);
   const cacheKey = `${fetchUrl}::${authToken}`;
-  const cached = managedImageBlobUrlResolvedCache.get(cacheKey);
+  const cached = readManagedImageBlobUrl(cacheKey);
   if (cached) {
     return cached;
   }
-  const missAt = managedImageBlobUrlMissCache.get(cacheKey);
-  if (missAt && Date.now() - missAt < MANAGED_IMAGE_BLOB_URL_MISS_RETRY_MS) {
+  if (hasRecentManagedImageBlobUrlMiss(cacheKey)) {
     return null;
   }
   let pending = managedImageBlobUrlCache.get(cacheKey);
@@ -1576,17 +1636,16 @@ async function resolveManagedOutgoingImageBlobUrl(
         credentials: "same-origin",
       });
       if (!res.ok) {
-        managedImageBlobUrlMissCache.set(cacheKey, Date.now());
+        cacheManagedImageBlobUrlMiss(cacheKey);
         return null;
       }
       const blob = await res.blob();
       if (!blob.type.startsWith("image/")) {
-        managedImageBlobUrlMissCache.set(cacheKey, Date.now());
+        cacheManagedImageBlobUrlMiss(cacheKey);
         return null;
       }
       const blobUrl = URL.createObjectURL(blob);
-      managedImageBlobUrlResolvedCache.set(cacheKey, blobUrl);
-      managedImageBlobUrlMissCache.delete(cacheKey);
+      cacheManagedImageBlobUrl(cacheKey, blobUrl);
       return blobUrl;
     })().finally(() => {
       managedImageBlobUrlCache.delete(cacheKey);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing many managed outgoing images in a long-lived Control UI session would retain every fetched image Blob URL and failed lookup key for the browser process lifetime. That state grew with each unique image or miss, and Blob URLs were never revoked.

## Why This Change Was Made

The managed-image success and miss caches now retain at most 64 recently used entries. Successful entries use least-recently-used ordering and revoke the evicted Blob URL; miss entries use the same bounded retention while preserving the existing 5-second retry window. In-flight request deduplication and image rendering behavior remain unchanged.

This is independent of #108116: that PR bounds stalled fetch duration, while this PR bounds process-lifetime retained cache state.

## User Impact

Long-running Control UI chat sessions no longer accumulate managed generated-image cache state without limit. Recently viewed previews remain cached, and an evicted preview is fetched again if revisited.

## Evidence

Exact proof head: `2296e25844fd7045084f7fd09dd3669e4676a018`.

### Real Chromium Control UI proof

The committed E2E starts the real Vite Control UI in Playwright Chromium, supplies 64 managed outgoing images through the mocked Gateway, intercepts their real browser HTTP fetches, and wraps the browser's native `URL.createObjectURL` / `URL.revokeObjectURL` calls for diagnostics. It then:

1. revisits image 1 to make it most-recently-used;
2. loads image 65 and verifies image 2's Blob URL was revoked while image 1's was retained;
3. revisits evicted image 2 and verifies a second HTTP fetch plus a successfully decoded 160px preview.

Command:

```text
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_BEHAVIOR_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.e2e.test.ts -t "evicts and refetches managed image Blob URLs after the cache reaches capacity"
```

Redacted browser diagnostic:

```json
{"proof":"managed-image-cache","cacheCapacity":64,"createdBlobUrls":66,"evictedBlobIndex":1,"evictedImageFetches":2,"refetchedImageNaturalWidth":160,"retainedRecentBlobRevoked":false,"revokedBlobUrls":2}
```

Result: 1 passed, 52 skipped. The proof command also writes the inspected browser screenshot and JSON diagnostics to `.artifacts/control-ui-e2e/managed-image-cache/after-refetch.{png,json}`. The screenshot contains only the synthetic managed preview and the redacted counters above.

### Regression and static validation

- Before the fix, `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts` failed both new regressions: no Blob URL was revoked, and the 65th miss left the oldest miss retained.
- Production regression head: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts` — 1 file, 94 tests passed.
- Proof head: `pnpm tsgo:test:ui` — passed.
- `pnpm tsgo:ui` — passed on the production change.
- `node scripts/run-oxlint.mjs ui/src/pages/chat/components/chat-message.ts ui/src/pages/chat/components/chat-message.test.ts` — passed on the production change.
- `node scripts/run-oxlint.mjs ui/src/e2e/chat-flow.e2e.test.ts` — passed on the proof change.
- `pnpm ui:build` — passed, including precompressed asset and Control UI performance checks.
- `git diff --check` — passed.
- The changed-check wrapper attempted to delegate the proof-head UI gate to Blacksmith Testbox, but the local `blacksmith` executable was unavailable; trusted-source validation fell back to the successful local focused Chromium run and `pnpm tsgo:test:ui`.
- Full GitHub CI passed on the production head; the proof-only head is rerunning CI.

Automated pre-submit review was attempted with both configured Codex models, but the review service returned no verdict; the installed Pi version was below the repository isolation minimum. The production diff and proof were manually reviewed after the exact-head checks above.

AI-assisted: yes. I inspected the implementation, browser artifact, and validation results.
