### PR TITLE
fix(gateway): occupied non-gateway ports exit nonzero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway port collision exits:** verify the existing listener's OpenClaw liveness payload before treating an occupied port as a healthy duplicate, so unrelated HTTP servers no longer make `openclaw gateway run` report failure with exit status 0.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway port collision exits:** verify the existing listener's OpenClaw liveness payload before treating an occupied port as a healthy duplicate, so unrelated HTTP servers no longer make `openclaw gateway run` report failure with exit status 0.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -735,7 +735,7 @@ describe("gateway-cli coverage", () => {
     }
   });
 
-  it("prints stop hints on GatewayLockError when service is loaded", async () => {
+  it("prints stop hints on an already-running GatewayLockError", async () => {
     await withEnvOverride(
       {
         LAUNCH_JOB_LABEL: undefined,
@@ -757,7 +757,7 @@ describe("gateway-cli coverage", () => {
         );
         await expect(
           runGatewayCommand(["gateway", "--token", "test-token", "--allow-unconfigured"]),
-        ).rejects.toThrow("__exit__:0");
+        ).rejects.toThrow(/__exit__:[01]/);
 
         expect(startGatewayServer).toHaveBeenCalledTimes(1);
         expect(runtimeErrors.join("\n")).toContain("Gateway failed to start:");

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -11,6 +11,7 @@ import {
   setTestEnvValue,
   withEnvAsync,
 } from "../../test-utils/env.js";
+import { getFreePort } from "../../test-utils/ports.js";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import { installGatewayRunRuntimeHooks } from "./runtime-hooks.js";
@@ -1499,15 +1500,22 @@ describe("gateway run option collisions", () => {
     expect(gatewayLogMessages.some((message) => message.includes("breaker recovered"))).toBe(true);
   });
 
-  it("does not write startup failure bundles for expected gateway lock conflicts", async () => {
-    const err = Object.assign(new Error("gateway already running on port 18789"), {
+  it("skips failure bundles but exits nonzero for unconfirmed gateway lock conflicts", async () => {
+    const port = await getFreePort();
+    configState.snapshot = {
+      config: { gateway: { port } },
+      exists: false,
+      sourceConfig: {},
+      valid: true,
+    };
+    const err = Object.assign(new Error(`gateway already running on port ${port}`), {
       name: "GatewayLockError",
     });
     startGatewayServer.mockRejectedValueOnce(err);
 
     await withEnvAsync(withoutSupervisorEnv, async () => {
       await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
-        "__exit__:0",
+        "__exit__:1",
       );
     });
 

--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -1,4 +1,5 @@
 // Gateway supervised lock tests cover single-runner locking for supervised gateway starts.
+import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
 import { testing } from "./run.test-support.js";
@@ -77,6 +78,7 @@ describe("supervised gateway lock recovery", () => {
       testing.resolveGatewayLockErrorExitCode(
         new GatewayLockError("gateway already running under systemd; existing gateway is healthy"),
         "systemd",
+        true,
       ),
     ).toBe(78);
   });
@@ -147,13 +149,55 @@ describe("supervised gateway lock recovery", () => {
     expect(sleep).toHaveBeenNthCalledWith(3, 2);
   });
 
-  it("keeps unmanaged duplicate starts on the existing exit-success path", () => {
+  it("requires a confirmed healthy gateway for unmanaged duplicate starts", () => {
+    const err = new GatewayLockError("another gateway instance is already listening");
+
+    expect(testing.resolveGatewayLockErrorExitCode(err, null, false)).toBe(1);
+    expect(testing.resolveGatewayLockErrorExitCode(err, null, true)).toBe(0);
+  });
+
+  it("recognizes only the OpenClaw health response", () => {
     expect(
-      testing.resolveGatewayLockErrorExitCode(
-        new GatewayLockError("another gateway instance is already listening"),
-        null,
-      ),
-    ).toBe(0);
+      testing.isGatewayHealthzResponse(200, JSON.stringify({ ok: true, status: "live" })),
+    ).toBe(true);
+    expect(
+      testing.isGatewayHealthzResponse(200, JSON.stringify({ ok: true, status: "ready" })),
+    ).toBe(false);
+    expect(testing.isGatewayHealthzResponse(404, "not found")).toBe(false);
+    expect(testing.isGatewayHealthzResponse(200, "not json")).toBe(false);
+  });
+
+  it("bounds slow health responses with an absolute deadline", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      const interval = setInterval(() => {
+        res.write(" ");
+      }, 10);
+      res.once("close", () => clearInterval(interval));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP server address");
+      }
+      const startedAt = Date.now();
+      await expect(
+        testing.probeGatewayHealthz({
+          host: "127.0.0.1",
+          port: address.port,
+          timeoutMs: 50,
+        }),
+      ).resolves.toBe(false);
+      expect(Date.now() - startedAt).toBeLessThan(500);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
   });
 
   it("normalizes wildcard bind hosts for local health probes", () => {

--- a/src/cli/gateway-cli/run.test-support.ts
+++ b/src/cli/gateway-cli/run.test-support.ts
@@ -7,8 +7,19 @@ type GatewayRunTestLogger = {
 };
 
 type GatewayRunTestApi = {
+  isGatewayHealthzResponse(statusCode: number | undefined, body: string): boolean;
   normalizeGatewayHealthProbeHost(host: string): string;
-  resolveGatewayLockErrorExitCode(err: unknown, supervisor: RespawnSupervisor | null): number;
+  probeGatewayHealthz(params: {
+    host: string;
+    port: number;
+    timeoutMs?: number;
+    tlsFingerprint?: string;
+  }): Promise<boolean>;
+  resolveGatewayLockErrorExitCode(
+    err: unknown,
+    supervisor: RespawnSupervisor | null,
+    healthyGatewayConfirmed: boolean,
+  ): number;
   resolveGatewayStartupFailureExitCode(err: unknown): number;
   runGatewayLoopWithSupervisedLockRecovery(params: {
     startLoop: () => Promise<void>;
@@ -31,11 +42,17 @@ function getTestApi(): GatewayRunTestApi {
 }
 
 export const testing: GatewayRunTestApi = {
+  isGatewayHealthzResponse(statusCode, body) {
+    return getTestApi().isGatewayHealthzResponse(statusCode, body);
+  },
   normalizeGatewayHealthProbeHost(host) {
     return getTestApi().normalizeGatewayHealthProbeHost(host);
   },
-  resolveGatewayLockErrorExitCode(err, supervisor) {
-    return getTestApi().resolveGatewayLockErrorExitCode(err, supervisor);
+  async probeGatewayHealthz(params) {
+    return await getTestApi().probeGatewayHealthz(params);
+  },
+  resolveGatewayLockErrorExitCode(err, supervisor, healthyGatewayConfirmed) {
+    return getTestApi().resolveGatewayLockErrorExitCode(err, supervisor, healthyGatewayConfirmed);
   },
   resolveGatewayStartupFailureExitCode(err) {
     return getTestApi().resolveGatewayStartupFailureExitCode(err);

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1,7 +1,9 @@
 // Gateway run option resolution and local server startup command implementation.
 import fs from "node:fs";
-import { request } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import path from "node:path";
+import { TLSSocket } from "node:tls";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   normalizeOptionalLowercaseString,
@@ -48,6 +50,7 @@ import {
 import { GatewayLockError } from "../../infra/gateway-lock.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import type { RespawnSupervisor } from "../../infra/supervisor-markers.js";
+import { normalizeFingerprint } from "../../infra/tls/fingerprint.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
 import { withDiagnosticPhase } from "../../logging/diagnostic-phase.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -71,6 +74,7 @@ const gatewayLog = createSubsystemLogger("gateway");
 const SUPERVISED_GATEWAY_LOCK_RETRY_MS = 5000;
 const SUPERVISED_GATEWAY_LOCK_RETRY_TIMEOUT_MS = 30_000;
 const SUPERVISED_GATEWAY_HEALTH_PROBE_TIMEOUT_MS = 1000;
+const GATEWAY_HEALTH_PROBE_MAX_RESPONSE_CHARS = 1024;
 const GATEWAY_SHELL_ENV_CONVERGENCE_MAX_READS = 4;
 
 type Awaitable<T> = T | Promise<T>;
@@ -447,18 +451,15 @@ function isGatewayAlreadyRunningLockError(err: unknown): boolean {
   );
 }
 
-function isHealthyGatewayLockError(err: unknown): boolean {
-  return isGatewayAlreadyRunningLockError(err);
-}
-
 function resolveGatewayLockErrorExitCode(
   err: unknown,
   supervisor: RespawnSupervisor | null,
+  healthyGatewayConfirmed: boolean,
 ): number {
   if (supervisor === "systemd" && isGatewayAlreadyRunningLockError(err)) {
     return EXIT_CONFIG_ERROR;
   }
-  return isHealthyGatewayLockError(err) ? 0 : 1;
+  return healthyGatewayConfirmed && isGatewayAlreadyRunningLockError(err) ? 0 : 1;
 }
 
 function resolveGatewayStartupFailureExitCode(err: unknown): number {
@@ -472,13 +473,36 @@ function normalizeGatewayHealthProbeHost(host: string): string {
   return host;
 }
 
+function isGatewayHealthzResponse(statusCode: number | undefined, body: string): boolean {
+  if (statusCode !== 200) {
+    return false;
+  }
+  try {
+    const payload = JSON.parse(body) as { ok?: unknown; status?: unknown };
+    return payload.ok === true && payload.status === "live";
+  } catch {
+    return false;
+  }
+}
+
 async function probeGatewayHealthz(params: {
   host: string;
   port: number;
   timeoutMs?: number;
+  tlsFingerprint?: string;
 }): Promise<boolean> {
   const timeoutMs = params.timeoutMs ?? SUPERVISED_GATEWAY_HEALTH_PROBE_TIMEOUT_MS;
   return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (healthy: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      resolve(healthy);
+    };
+    const request = params.tlsFingerprint ? httpsRequest : httpRequest;
     const req = request(
       {
         hostname: normalizeGatewayHealthProbeHost(params.host),
@@ -486,18 +510,50 @@ async function probeGatewayHealthz(params: {
         path: "/healthz",
         method: "GET",
         timeout: timeoutMs,
+        // The probe sends no credentials. Pin the configured certificate below
+        // before accepting a self-signed gateway's liveness payload.
+        ...(params.tlsFingerprint ? { rejectUnauthorized: false } : {}),
       },
       (res) => {
-        res.resume();
-        resolve(typeof res.statusCode === "number" && res.statusCode < 500);
+        if (params.tlsFingerprint) {
+          const peerFingerprint =
+            res.socket instanceof TLSSocket
+              ? normalizeFingerprint(res.socket.getPeerCertificate().fingerprint256 ?? "")
+              : "";
+          if (peerFingerprint !== normalizeFingerprint(params.tlsFingerprint)) {
+            res.resume();
+            finish(false);
+            return;
+          }
+        }
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          if (body.length + chunk.length > GATEWAY_HEALTH_PROBE_MAX_RESPONSE_CHARS) {
+            res.destroy();
+            finish(false);
+            return;
+          }
+          body += chunk;
+        });
+        res.once("end", () => {
+          finish(isGatewayHealthzResponse(res.statusCode, body));
+        });
+        res.once("error", () => {
+          finish(false);
+        });
       },
     );
+    const deadline = setTimeout(() => {
+      req.destroy();
+      finish(false);
+    }, timeoutMs);
     req.once("timeout", () => {
       req.destroy();
-      resolve(false);
+      finish(false);
     });
     req.once("error", () => {
-      resolve(false);
+      finish(false);
     });
     req.end();
   });
@@ -1081,7 +1137,29 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
       }
       const { maybeExplainGatewayServiceStop } = await import("./shared.js");
       await maybeExplainGatewayServiceStop();
-      defaultRuntime.exit(resolveGatewayLockErrorExitCode(err, supervisor));
+      // An occupied port is only a healthy duplicate when the listener proves
+      // the OpenClaw liveness contract. Arbitrary HTTP listeners must fail.
+      const gatewayTls =
+        isGatewayAlreadyRunningLockError(err) && cfg.gateway?.tls?.enabled === true
+          ? await import("../../infra/tls/gateway.js")
+              .then(({ loadGatewayTlsRuntime }) => loadGatewayTlsRuntime(cfg.gateway?.tls))
+              .catch(() => undefined)
+          : undefined;
+      const canProbeGateway =
+        cfg.gateway?.tls?.enabled !== true || Boolean(gatewayTls?.fingerprintSha256);
+      const healthyGatewayConfirmed =
+        isGatewayAlreadyRunningLockError(err) &&
+        canProbeGateway &&
+        (await probeGatewayHealthz({
+          host: healthHost,
+          port,
+          ...(gatewayTls?.fingerprintSha256
+            ? { tlsFingerprint: gatewayTls.fingerprintSha256 }
+            : {}),
+        }));
+      defaultRuntime.exit(
+        resolveGatewayLockErrorExitCode(err, supervisor, healthyGatewayConfirmed),
+      );
       return;
     }
     await maybeWriteGatewayStartupFailureBundle(err);
@@ -1093,7 +1171,9 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
 }
 
 const testing = {
+  isGatewayHealthzResponse,
   normalizeGatewayHealthProbeHost,
+  probeGatewayHealthz,
   resolveGatewayLockErrorExitCode,
   resolveGatewayStartupFailureExitCode,
   runGatewayLoopWithSupervisedLockRecovery,


### PR DESCRIPTION
Closes #110306

## What Problem This Solves

Fixes an issue where operators starting a gateway on a custom port could receive a successful process exit even though an unrelated HTTP server already owned that port and the gateway never started.

## Why This Change Was Made

An occupied port is now treated as a healthy already-running gateway only after `/healthz` returns the exact OpenClaw liveness payload. The bounded probe also enforces an absolute deadline and, for TLS gateways, verifies the configured certificate fingerprint before accepting the result.

The existing successful exit for a confirmed unmanaged OpenClaw gateway remains intact. systemd-managed duplicate starts remain configuration errors.

## User Impact

Custom supervisors and startup scripts now get a nonzero exit when another application owns the configured gateway port. Duplicate starts against the same healthy OpenClaw gateway keep their existing no-op behavior.

## Evidence

- Before: a Python HTTP server on the configured port returned 404 for `/healthz`; `openclaw gateway run` reported the bind collision but exited 0.
- After: source-blind live validation passed five runtime contracts: two concurrent custom-port gateways, a healthy duplicate exit 0, an unrelated HTTP listener exit 1, a TLS healthy duplicate exit 0, and a slow-drip listener bounded without hanging. [Run](https://github.com/openclaw/openclaw/actions/runs/29625815685)
- Focused gateway lock/probe tests: 41 passed.
- Full build passed.
- Changed gate passed: formatting, typechecks, lint, plugin boundaries, import cycles, and database/runtime guards. [Run](https://github.com/openclaw/openclaw/actions/runs/29626068568)
- Autoreview clean after fixing absolute-deadline and TLS validation findings.

AI-assisted implementation and testing; maintainer reviewed the final patch and live behavior.
