### PR TITLE
refactor(test): centralize declaration guard temp cleanup

### DIFF
--- a/test/scripts/check-script-declarations.test.ts
+++ b/test/scripts/check-script-declarations.test.ts
@@ -1,22 +1,15 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { verifyScriptDeclarationContracts } from "../../scripts/check-script-declarations.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("script declaration contracts", () => {
-  const tempDirs: string[] = [];
-
-  afterEach(() => {
-    for (const tempDir of tempDirs.splice(0)) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
   it("fails deliberate export drift and passes after regenerating the declaration", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.mkdirSync(path.join(root, "test"), { recursive: true });
     fs.writeFileSync(
@@ -47,8 +40,7 @@ describe("script declaration contracts", () => {
   });
 
   it("requires declarations for scripts imported by typed sources", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.mkdirSync(path.join(root, "test"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "missing.mjs"), "export const value = 1;\n");
@@ -69,8 +61,7 @@ describe("script declaration contracts", () => {
   });
 
   it("rejects declaration sidecars whose runtime script is missing", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.mkdirSync(path.join(root, "test"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "orphan.d.mts"), "export const value: 1;\n");
@@ -91,8 +82,7 @@ describe("script declaration contracts", () => {
   });
 
   it("ignores tracked declaration pairs deleted from the working tree", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     execFileSync("git", ["init", "-q"], { cwd: root });
     const runtimePath = path.join(root, "scripts", "removed.mjs");
@@ -107,8 +97,7 @@ describe("script declaration contracts", () => {
   });
 
   it("applies ESM default and ambiguity rules to star re-exports", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(
       path.join(root, "scripts", "left.mjs"),
@@ -143,8 +132,7 @@ describe("script declaration contracts", () => {
   });
 
   it("propagates ambiguity through nested star re-exports", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "left.mjs"), "export const shared = 1;\n");
     fs.writeFileSync(path.join(root, "scripts", "right.mjs"), "export const shared = 2;\n");
@@ -173,8 +161,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed on cyclic star graphs", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "a.mjs"), 'export * from "./b.mjs";\n');
     fs.writeFileSync(
@@ -194,8 +181,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed on explicit re-exports of ambiguous bindings", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "left.mjs"), "export const shared = 1;\n");
     fs.writeFileSync(path.join(root, "scripts", "right.mjs"), "export const shared = 2;\n");
@@ -227,8 +213,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed when a star re-export cannot be resolved", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "barrel.mjs"), 'export * from "package";\n');
     fs.writeFileSync(path.join(root, "scripts", "barrel.d.mts"), "export {};\n");
@@ -245,8 +230,7 @@ describe("script declaration contracts", () => {
   });
 
   it("resolves declaration stars to declarations before runtime modules", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.mkdirSync(path.join(root, "lib"), { recursive: true });
     fs.writeFileSync(
@@ -275,8 +259,7 @@ describe("script declaration contracts", () => {
   });
 
   it("does not count type-only named or default declaration exports", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(
       path.join(root, "scripts", "types.mjs"),
@@ -299,8 +282,7 @@ describe("script declaration contracts", () => {
   });
 
   it("preserves local binding identity through renamed star paths", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(
       path.join(root, "scripts", "origin.mjs"),
@@ -335,8 +317,7 @@ describe("script declaration contracts", () => {
   });
 
   it("preserves statically named exports from external modules", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(
       path.join(root, "scripts", "external.mjs"),
@@ -356,8 +337,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed on external declaration re-exports with unknown value provenance", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "external.mjs"), "export const Foo = 1;\n");
     fs.writeFileSync(
@@ -379,8 +359,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed on re-exported external declaration imports", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "external.mjs"), "export const Foo = 1;\n");
     fs.writeFileSync(
@@ -402,8 +381,7 @@ describe("script declaration contracts", () => {
   });
 
   it("accepts statically value-bearing external namespace declaration imports", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(
       path.join(root, "scripts", "external.mjs"),
@@ -423,8 +401,7 @@ describe("script declaration contracts", () => {
   });
 
   it("retains runtime exports imported from opaque local modules", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "config.json"), '{"enabled":true}\n');
     fs.writeFileSync(
@@ -445,8 +422,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed on missing exports from analyzable local modules", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "origin.mjs"), "export const value = 1;\n");
     fs.writeFileSync(
@@ -467,8 +443,7 @@ describe("script declaration contracts", () => {
   });
 
   it("fails closed on named JSON imports", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "config.json"), '{"enabled":true}\n');
     fs.writeFileSync(
@@ -492,8 +467,7 @@ describe("script declaration contracts", () => {
   });
 
   it("resolves CommonJS imports to adjacent declaration sidecars", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(root, "scripts", "helper.cjs"), "exports.value = 1;\n");
     fs.writeFileSync(path.join(root, "scripts", "helper.d.cts"), "export const value: 1;\n");
@@ -520,8 +494,7 @@ describe("script declaration contracts", () => {
   });
 
   it("distinguishes namespace objects from named external bindings", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-script-declarations-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-script-declarations-");
     fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
     fs.writeFileSync(
       path.join(root, "scripts", "namespace.mjs"),


### PR DESCRIPTION
## What Problem This Solves

Removes 21 repeated raw temporary-directory allocations and the file-local cleanup loop from the script declaration guard tests. The changed-file gate flagged every allocation for migration to the shared test helper.

## Why This Change Was Made

Uses `useAutoCleanupTempDirTracker(afterEach)`, the repository-standard test helper, for every fixture root. This deletes duplicate cleanup state and keeps teardown behavior centralized.

AI-assisted. The change passed the repository `autoreview` workflow with no actionable findings.

## User Impact

No product behavior change. Test cleanup is simpler and the temp-directory migration guard is warning-free.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/check-script-declarations.test.ts` — 21 passed.
- `node scripts/check-changed.mjs -- test/scripts/check-script-declarations.test.ts` — formatting, test typecheck, script lint, declaration guard, and temp-directory migration report passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29626157179
- Net diff: 24 additions, 51 deletions.
