### PR TITLE
fix(diagnostics): prevent listener leaks across worker resets

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -111,48 +111,51 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) =>
       diagnosticEvents.push(event),
     );
-    const params = createParams(
-      path.join(tempDir, "session.jsonl"),
-      path.join(tempDir, "workspace"),
-    );
-    params.onAgentEvent = onRunAgentEvent;
-    params.onExecutionPhase = onExecutionPhase;
+    try {
+      const params = createParams(
+        path.join(tempDir, "session.jsonl"),
+        path.join(tempDir, "workspace"),
+      );
+      params.onAgentEvent = onRunAgentEvent;
+      params.onExecutionPhase = onExecutionPhase;
 
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("thread/start");
-    await vi.waitFor(() =>
-      expect(onExecutionPhase).toHaveBeenCalledWith(
-        expect.objectContaining({ phase: "turn_accepted" }),
-      ),
-    );
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("thread/start");
+      await vi.waitFor(() =>
+        expect(onExecutionPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ phase: "turn_accepted" }),
+        ),
+      );
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "lookup",
-        arguments: {
-          action: "search",
-          token: "plain-secret-value-12345",
-          text: "hello",
+      const toolResult = (await harness.handleServerRequest({
+        id: "request-tool-1",
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: null,
+          tool: "lookup",
+          arguments: {
+            action: "search",
+            token: "plain-secret-value-12345",
+            text: "hello",
+          },
         },
-      },
-    })) as {
-      contentItems?: Array<{ text?: string; type?: string }>;
-      success?: boolean;
-    };
-    expect(toolResult.success).toBe(false);
-    expect(toolResult.contentItems?.[0]?.type).toBe("inputText");
-    expect(toolResult.contentItems?.[0]?.text).toMatch(/^Unknown OpenClaw tool: lookup$/u);
+      })) as {
+        contentItems?: Array<{ text?: string; type?: string }>;
+        success?: boolean;
+      };
+      expect(toolResult.success).toBe(false);
+      expect(toolResult.contentItems?.[0]?.type).toBe("inputText");
+      expect(toolResult.contentItems?.[0]?.text).toMatch(/^Unknown OpenClaw tool: lookup$/u);
 
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
-    await flushDiagnosticEvents();
-    unsubscribeDiagnostics();
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+      await flushDiagnosticEvents();
+    } finally {
+      unsubscribeDiagnostics();
+    }
 
     const agentEvents = onRunAgentEvent.mock.calls.map(([event]) => event) as Array<{
       data?: {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -3316,9 +3316,12 @@ describe("runCodexAppServerAttempt turn watches", () => {
     }).finally(() => {
       settled = true;
     });
-    await harness.waitForMethod("turn/start");
-    await vi.waitFor(() => expect(turnStartProgressEvents).toHaveLength(2), { interval: 1 });
-    stopDiagnostics();
+    try {
+      await harness.waitForMethod("turn/start");
+      await vi.waitFor(() => expect(turnStartProgressEvents).toHaveLength(2), { interval: 1 });
+    } finally {
+      stopDiagnostics();
+    }
 
     const blockedProjection = harness.notify({
       method: "item/reasoning/textDelta",

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -25,6 +25,7 @@ import {
 import {
   getDiagnosticSessionActivitySnapshot,
   resetDiagnosticRunActivityForTest,
+  startDiagnosticRunActivityTracking,
 } from "../logging/diagnostic-run-activity.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit } from "../process/supervisor/types.js";
@@ -96,6 +97,7 @@ beforeEach(() => {
   setDiagnosticsEnabledForProcess(true);
   resetAgentEventsForTest();
   resetDiagnosticRunActivityForTest();
+  startDiagnosticRunActivityTracking();
   resetClaudeLiveSessionsForTest();
   replyRunTesting.resetReplyRunRegistry();
   restoreCliRunnerPrepareTestDeps();

--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -8,6 +8,7 @@ import {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
   resetDiagnosticRunActivityForTest,
+  startDiagnosticRunActivityTracking,
 } from "../../logging/diagnostic-run-activity.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
 import {
@@ -31,6 +32,7 @@ type SupervisorSpawnFn = ProcessSupervisor["spawn"];
 beforeEach(() => {
   setDiagnosticsEnabledForProcess(true);
   resetDiagnosticRunActivityForTest();
+  startDiagnosticRunActivityTracking();
   resetClaudeLiveSessionsForTest();
   restoreCliRunnerPrepareTestDeps();
   setCliRunnerExecuteTestDeps({ writeCliSystemPromptFile });

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -17,6 +17,7 @@ import { createDiagnosticTraceContext } from "../../../infra/diagnostic-trace-co
 import {
   getDiagnosticSessionActivitySnapshot,
   resetDiagnosticRunActivityForTest,
+  startDiagnosticRunActivityTracking,
 } from "../../../logging/diagnostic-run-activity.js";
 import {
   initializeGlobalHookRunner,
@@ -140,6 +141,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
     resetDiagnosticRunActivityForTest();
+    startDiagnosticRunActivityTracking();
     resetGlobalHookRunner();
   });
 

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -1,10 +1,80 @@
 // Unit tests for shared run-staleness threshold policy.
-import { describe, expect, it } from "vitest";
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, describe, expect, it } from "vitest";
+import { hasInternalDiagnosticEventListeners } from "../infra/diagnostic-event-listener-presence.js";
+import {
+  emitTrustedDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
 import {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticEmbeddedRunStarted,
   resolveRunStaleThresholdMs,
   RUN_STALE_TAKEOVER_MS,
+  startDiagnosticRunActivityTracking,
+  stopDiagnosticRunActivityTracking,
 } from "./diagnostic-run-activity.js";
+
+afterEach(() => {
+  stopDiagnosticRunActivityTracking();
+  resetDiagnosticEventsForTest();
+});
+
+describe("diagnostic run activity listener lifecycle", () => {
+  it("does not register a listener when the module is imported", async () => {
+    stopDiagnosticRunActivityTracking();
+    resetDiagnosticEventsForTest();
+
+    await importFreshModule<typeof import("./diagnostic-run-activity.js")>(
+      import.meta.url,
+      "./diagnostic-run-activity.js?scope=no-import-listener",
+    );
+
+    expect(hasInternalDiagnosticEventListeners()).toBe(false);
+  });
+
+  it("registers and unregisters through the explicit lifecycle", () => {
+    resetDiagnosticEventsForTest();
+
+    startDiagnosticRunActivityTracking();
+    expect(hasInternalDiagnosticEventListeners()).toBe(true);
+    markDiagnosticEmbeddedRunStarted({ sessionId: "run-before-stop" });
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId: "run-before-stop" })).toMatchObject({
+      activeWorkKind: "embedded_run",
+    });
+
+    stopDiagnosticRunActivityTracking();
+    expect(hasInternalDiagnosticEventListeners()).toBe(false);
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId: "run-before-stop" })).toEqual({});
+  });
+
+  it("ignores diagnostic events queued before tracking restarts", async () => {
+    resetDiagnosticEventsForTest();
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.started",
+      sessionId: "stale-run",
+      toolName: "stale-tool",
+    });
+
+    startDiagnosticRunActivityTracking();
+    await waitForDiagnosticEventsDrained();
+
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId: "stale-run" })).toEqual({});
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.started",
+      sessionId: "current-run",
+      toolName: "current-tool",
+    });
+    await waitForDiagnosticEventsDrained();
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId: "current-run" })).toMatchObject({
+      activeWorkKind: "tool_call",
+      activeToolName: "current-tool",
+    });
+  });
+});
 
 describe("resolveRunStaleThresholdMs", () => {
   it.each([

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -1,5 +1,6 @@
 // Diagnostic run activity helpers summarize run lifecycle activity for diagnostics.
 import {
+  getInternalDiagnosticEventSequence,
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
   type DiagnosticSessionActiveWorkKind,
@@ -646,21 +647,22 @@ function markDiagnosticModelStartedForTest(params: DiagnosticModelStartedActivit
 }
 
 export function resetDiagnosticRunActivityForTest(): void {
-  activityByRef.clear();
-  activityByRunId.clear();
-  embeddedRunSequence = 0;
-  unregisterDiagnosticRunActivityListener?.();
-  unregisterDiagnosticRunActivityListener = undefined;
-  registerDiagnosticRunActivityListener();
+  stopDiagnosticRunActivityTracking();
 }
 
 let unregisterDiagnosticRunActivityListener: (() => void) | undefined;
 
-function registerDiagnosticRunActivityListener(): void {
+export function startDiagnosticRunActivityTracking(): void {
   if (unregisterDiagnosticRunActivityListener) {
     return;
   }
+  const startAfterEventSequence = getInternalDiagnosticEventSequence();
   unregisterDiagnosticRunActivityListener = onInternalDiagnosticEvent((event) => {
+    // A prior lifecycle can leave already-sequenced events in the async queue.
+    // Ignore them so a restart cannot recreate activity that stop cleared.
+    if (event.seq <= startAfterEventSequence) {
+      return;
+    }
     switch (event.type) {
       case "tool.execution.started":
         recordToolStarted(event);
@@ -688,7 +690,13 @@ function registerDiagnosticRunActivityListener(): void {
   });
 }
 
-registerDiagnosticRunActivityListener();
+export function stopDiagnosticRunActivityTracking(): void {
+  unregisterDiagnosticRunActivityListener?.();
+  unregisterDiagnosticRunActivityListener = undefined;
+  activityByRef.clear();
+  activityByRunId.clear();
+  embeddedRunSequence = 0;
+}
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -15,6 +15,7 @@ import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
   resetDiagnosticRunActivityForTest,
+  startDiagnosticRunActivityTracking,
 } from "./diagnostic-run-activity.js";
 import {
   markDiagnosticModelStartedForTest,
@@ -2732,6 +2733,7 @@ describe("stuck session recovery activity reconciliation", () => {
     setDiagnosticsEnabledForProcess(true);
     resetDiagnosticSessionStateForTest();
     resetDiagnosticRunActivityForTest();
+    startDiagnosticRunActivityTracking();
     resetDiagnosticSessionRecoveryCoordinatorForTest();
   });
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -22,6 +22,8 @@ import {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
   resetDiagnosticRunActivityForTest,
+  startDiagnosticRunActivityTracking,
+  stopDiagnosticRunActivityTracking,
   type DiagnosticSessionActivitySnapshot,
 } from "./diagnostic-run-activity.js";
 import {
@@ -1214,6 +1216,9 @@ export function startDiagnosticHeartbeat(
   if (!areDiagnosticsEnabledForProcess() || !isDiagnosticsEnabled(config)) {
     return;
   }
+  // The heartbeat owns run-activity event tracking for its full lifecycle.
+  // Importing diagnostic helpers must not seed process-global listeners.
+  startDiagnosticRunActivityTracking();
   startDiagnosticStabilityRecorder();
   installDiagnosticStabilityFatalHook();
   if (heartbeatInterval) {
@@ -1374,6 +1379,7 @@ export function stopDiagnosticHeartbeat() {
     heartbeatInterval = null;
   }
   lastDiagnosticHeartbeatTickAt = undefined;
+  stopDiagnosticRunActivityTracking();
   stopDiagnosticLivenessSampler();
   stopDiagnosticStabilityRecorder();
   uninstallDiagnosticStabilityFatalHook();
@@ -1384,6 +1390,7 @@ export function getDiagnosticSessionStateCountForTest(): number {
 }
 
 export function resetDiagnosticStateForTest(): void {
+  stopDiagnosticHeartbeat();
   resetDiagnosticSessionRecoveryCoordinatorForTest();
   resetDiagnosticSessionStateForTest();
   resetDiagnosticActivityForTest();
@@ -1392,7 +1399,6 @@ export function resetDiagnosticStateForTest(): void {
   webhookStats.processed = 0;
   webhookStats.errors = 0;
   webhookStats.lastReceived = 0;
-  stopDiagnosticHeartbeat();
   resetDiagnosticMemoryForTest();
   resetDiagnosticPhasesForTest();
   resetDiagnosticStabilityRecorderForTest();


### PR DESCRIPTION
Related: #110267
Related: #110288

## What Problem This Solves

Fixes an issue where non-isolated test workers could retain an internal diagnostic listener after their module registry reset, leaving stale listener-presence counts and making later tests order-dependent.

## Why This Change Was Made

Diagnostic heartbeat startup now explicitly starts run-activity tracking, and heartbeat shutdown unregisters the listener and clears tracked activity. A sequence watermark prevents diagnostic events queued before a restart from repopulating cleared state. Importing the run-activity module no longer mutates global listener state.

The two Codex app-server listener tests also now unsubscribe in `finally`, so a failed assertion or awaited request cannot leak their listeners.

## User Impact

No product-facing behavior change. Diagnostic tracking keeps the same gateway and standalone webhook lifetime, while test workers and runtime restarts no longer retain stale listener state.

## Evidence

- Blacksmith Testbox `tbx_01kxsfh4dpng4mxq018hpegzny`: 325 focused tests passed across diagnostic activity, heartbeat, agent runner, Claude live session, and Codex app-server listener coverage.
- Full `pnpm check:changed` passed on head `69919ff5cefc716e000e51ee06af64250e2f745b`: format, typecheck, lint, import-cycle, boundary, and repository guards.
- `git diff --check` passed.
- Fresh branch autoreview: clean, no accepted/actionable findings; correctness confidence 0.93.

AI assistance used: yes.
