### PR TITLE
fix(android): polish Wear light and dark surfaces

### DIFF
--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -84,8 +83,6 @@ private const val CONTROLS_PAGE = 4
 private const val VOICE_MODE_COUNT = 2
 private const val VOICE_HOME_MODE = 0
 private const val VOICE_THREAD_MODE = 1
-private val DictateBlue = Color(0xFF0A84FF)
-private val LiveCyan = Color(0xFF10DCC2)
 
 @Composable
 internal fun OpenClawWearScreens(
@@ -529,22 +526,22 @@ private fun VoiceHomeMode(
     }
   val accent =
     when {
-      dictatePreview || state == RealtimeVoiceButtonState.IDLE -> DictateBlue
+      dictatePreview || state == RealtimeVoiceButtonState.IDLE -> colors.voiceAccent
       state == RealtimeVoiceButtonState.ERROR -> colors.danger
-      else -> DictateBlue
+      else -> colors.voiceAccent
     }
   val containerColor =
     when {
       dictatePreview || state == RealtimeVoiceButtonState.IDLE -> colors.surfaceRaised
       state == RealtimeVoiceButtonState.ERROR -> colors.danger.copy(alpha = 0.28f)
-      else -> lerp(colors.surfaceRaised, DictateBlue, 0.18f)
+      else -> colors.voiceAccentSoft
     }
   val contentColor =
     when {
-      dictatePreview -> DictateBlue
+      dictatePreview -> colors.voiceAccent
       state == RealtimeVoiceButtonState.IDLE -> colors.text
       state == RealtimeVoiceButtonState.ERROR -> colors.danger
-      else -> DictateBlue
+      else -> colors.voiceAccent
     }
   Box(
     modifier =
@@ -563,7 +560,7 @@ private fun VoiceHomeMode(
       VoiceGestureLabel(
         title = stringResource(R.string.hold),
         detail = stringResource(R.string.dictate),
-        accent = DictateBlue,
+        accent = colors.voiceAccent,
         onClick = if (dictateEnabled) startDictate else null,
         modifier =
           Modifier
@@ -578,7 +575,7 @@ private fun VoiceHomeMode(
         VoiceGestureLabel(
           title = stringResource(R.string.double_tap),
           detail = stringResource(R.string.thread),
-          accent = DictateBlue,
+          accent = colors.voiceAccent,
           verticalPadding = 0.dp,
           modifier =
             Modifier
@@ -608,7 +605,7 @@ private fun VoiceHomeMode(
             state == RealtimeVoiceButtonState.SPEAKING
           ) {
             LiveWaveform(
-              color = DictateBlue,
+              color = colors.voiceAccent,
               active = true,
             )
           } else {
@@ -638,7 +635,7 @@ private fun VoiceHomeMode(
       VoiceGestureLabel(
         title = stringResource(R.string.tap),
         detail = stringResource(R.string.live),
-        accent = DictateBlue,
+        accent = colors.voiceAccent,
         onClick = if (liveEnabled) toggleLive else null,
         modifier =
           Modifier
@@ -778,11 +775,11 @@ private fun ThreadVoiceMode(
           Modifier
             .size(36.dp)
             .background(
-              color = if (realtimeActive) LiveCyan else colors.surfaceRaised,
+              color = if (realtimeActive) colors.voiceAccent else colors.surfaceRaised,
               shape = CircleShape,
             ).border(
               width = 1.dp,
-              color = if (realtimeActive) LiveCyan else DictateBlue,
+              color = colors.voiceAccent,
               shape = CircleShape,
             ).clickable(
               enabled = realtimeActive || (inputEnabled && !actionBusy),
@@ -792,7 +789,7 @@ private fun ThreadVoiceMode(
         contentAlignment = Alignment.Center,
       ) {
         MicrophoneGlyph(
-          color = if (realtimeActive) colors.canvas else colors.text,
+          color = if (realtimeActive) colors.onVoiceAccent else colors.text,
           modifier = Modifier.size(18.dp),
         )
       }
@@ -973,8 +970,8 @@ private enum class RealtimeVoiceButtonState {
 private fun RealtimeTalkBubble(entry: WearRealtimeTalkEntry) {
   val colors = OpenClawWearTheme.colors
   val isUser = entry.role == WearRealtimeTalkRole.USER
-  val background = if (isUser) colors.primary else colors.surfaceRaised
-  val foreground = if (isUser) colors.primaryText else colors.text
+  val background = if (isUser) colors.surfacePressed else colors.surfaceRaised
+  val foreground = colors.text
   Column(
     modifier =
       Modifier
@@ -984,11 +981,11 @@ private fun RealtimeTalkBubble(entry: WearRealtimeTalkEntry) {
           end = if (isUser) 12.dp else 28.dp,
         ).background(background, RoundedCornerShape(14.dp))
         .then(
-          if (isUser) {
-            Modifier
-          } else {
-            Modifier.border(1.dp, colors.borderStrong, RoundedCornerShape(14.dp))
-          },
+          Modifier.border(
+            width = 1.dp,
+            color = colors.borderStrong,
+            shape = RoundedCornerShape(14.dp),
+          ),
         ).padding(horizontal = 12.dp, vertical = 9.dp),
   ) {
     Text(
@@ -1406,11 +1403,11 @@ private fun MessageBubble(message: WearChatMessage) {
   val isUser = message.chatRole == WearChatRole.USER
   val background =
     when (message.chatRole) {
-      WearChatRole.USER -> colors.primary
+      WearChatRole.USER -> colors.surfacePressed
       WearChatRole.ASSISTANT -> colors.surfaceRaised
       WearChatRole.SYSTEM -> colors.surface
     }
-  val foreground = if (isUser) colors.primaryText else colors.text
+  val foreground = colors.text
   Column(
     modifier =
       Modifier
@@ -1420,11 +1417,11 @@ private fun MessageBubble(message: WearChatMessage) {
           end = if (isUser) 12.dp else 28.dp,
         ).background(background, RoundedCornerShape(14.dp))
         .then(
-          if (isUser) {
-            Modifier
-          } else {
-            Modifier.border(1.dp, colors.borderStrong, RoundedCornerShape(14.dp))
-          },
+          Modifier.border(
+            width = 1.dp,
+            color = colors.borderStrong,
+            shape = RoundedCornerShape(14.dp),
+          ),
         ).padding(horizontal = 12.dp, vertical = 9.dp),
   ) {
     Text(
@@ -1655,7 +1652,7 @@ private fun SelectionButton(
         containerColor = if (selected) colors.primary else colors.surfaceRaised,
         contentColor = if (selected) colors.primaryText else colors.text,
         disabledContainerColor =
-          if (selected) colors.primary else colors.surfaceRaised,
+          if (selected) colors.primary else colors.surface,
         disabledContentColor =
           if (selected) colors.primaryText else colors.textMuted,
       ),
@@ -1665,7 +1662,12 @@ private fun SelectionButton(
         .padding(horizontal = 12.dp)
         .border(
           width = 1.dp,
-          color = colors.borderStrong,
+          color =
+            when {
+              selected -> colors.primary
+              enabled -> colors.borderStrong
+              else -> colors.border
+            },
           shape = RoundedCornerShape(26.dp),
         ),
     label = {
@@ -1703,6 +1705,8 @@ private fun ActionButton(
       ButtonDefaults.buttonColors(
         containerColor = colors.primary,
         contentColor = colors.primaryText,
+        disabledContainerColor = colors.surface,
+        disabledContentColor = colors.textMuted,
       ),
     modifier = modifier,
     label = {
@@ -1737,7 +1741,7 @@ private fun CompactVoiceButton(
     modifier =
       modifier.border(
         width = 1.dp,
-        color = colors.borderStrong,
+        color = if (enabled) colors.borderStrong else colors.border,
         shape = RoundedCornerShape(24.dp),
       ),
     label = {
@@ -1767,11 +1771,18 @@ private fun SecondaryButton(
       ButtonDefaults.buttonColors(
         containerColor = colors.surfaceRaised,
         contentColor = colors.text,
+        disabledContainerColor = colors.surface,
+        disabledContentColor = colors.textMuted,
       ),
     modifier =
       Modifier
         .fillMaxWidth()
-        .padding(horizontal = 12.dp),
+        .padding(horizontal = 12.dp)
+        .border(
+          width = 1.dp,
+          color = if (enabled) colors.borderStrong else colors.border,
+          shape = RoundedCornerShape(26.dp),
+        ),
     label = {
       Text(
         text = label,

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearTheme.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearTheme.kt
@@ -72,28 +72,39 @@ internal data class WearColors(
   val canvas: Color,
   val surface: Color,
   val surfaceRaised: Color,
+  val surfacePressed: Color,
   val border: Color,
   val borderStrong: Color,
   val text: Color,
   val textMuted: Color,
   val primary: Color,
   val primaryText: Color,
+  val voiceAccent: Color,
+  val voiceAccentSoft: Color,
+  val onVoiceAccent: Color,
   val success: Color,
   val warning: Color,
   val danger: Color,
 )
 
+// Keep the companion surfaces aligned with the canonical Phone ClawTheme.
+// Voice blue comes from the Phone MobileUiTokens and is intentionally not the
+// general control or panel color.
 private val DarkWearColors =
   WearColors(
     canvas = Color(0xFF030303),
     surface = Color(0xFF0A0A0A),
     surfaceRaised = Color(0xFF111111),
+    surfacePressed = Color(0xFF1A1A1A),
     border = Color(0xFF242424),
-    borderStrong = Color(0xFF3B3B3B),
+    borderStrong = Color(0xFF3A3A3A),
     text = Color(0xFFF8F8F8),
     textMuted = Color(0xFFA8A8A8),
     primary = Color(0xFFFFFFFF),
     primaryText = Color(0xFF050505),
+    voiceAccent = Color(0xFF6EA8FF),
+    voiceAccentSoft = Color(0xFF1A2A44),
+    onVoiceAccent = Color(0xFF050505),
     success = Color(0xFF3EDB82),
     warning = Color(0xFFE6B956),
     danger = Color(0xFFFF6B6B),
@@ -104,16 +115,26 @@ private val LightWearColors =
     canvas = Color(0xFFFAFBFC),
     surface = Color(0xFFFFFEFB),
     surfaceRaised = Color(0xFFFFFFFF),
-    border = Color(0xFFC9D1DC),
-    borderStrong = Color(0xFFAEB8C5),
+    surfacePressed = Color(0xFFE9EDF3),
+    border = Color(0xFFDDE3EC),
+    borderStrong = Color(0xFFC7D0DC),
     text = Color(0xFF111318),
     textMuted = Color(0xFF505865),
     primary = Color(0xFF111827),
     primaryText = Color(0xFFFFFFFF),
+    voiceAccent = Color(0xFF1B5ACB),
+    voiceAccentSoft = Color(0xFFEAF2FF),
+    onVoiceAccent = Color(0xFFFFFFFF),
     success = Color(0xFF217747),
     warning = Color(0xFFA56F17),
     danger = Color(0xFFB82929),
   )
+
+internal fun wearColorsFor(themeMode: WearThemeMode): WearColors =
+  when (themeMode) {
+    WearThemeMode.Dark -> DarkWearColors
+    WearThemeMode.Light -> LightWearColors
+  }
 
 private val LocalWearColors = staticCompositionLocalOf { DarkWearColors }
 
@@ -129,11 +150,7 @@ internal fun OpenClawWearTheme(
   themeMode: WearThemeMode,
   content: @Composable () -> Unit,
 ) {
-  val colors =
-    when (themeMode) {
-      WearThemeMode.Dark -> DarkWearColors
-      WearThemeMode.Light -> LightWearColors
-    }
+  val colors = wearColorsFor(themeMode)
   val colorScheme =
     MaterialTheme.colorScheme.copy(
       primary = colors.primary,

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearThemeTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearThemeTest.kt
@@ -1,0 +1,115 @@
+package ai.openclaw.wear
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+
+class WearThemeTest {
+  @Test
+  fun `wear palettes mirror the canonical phone surfaces and voice accents`() {
+    val dark = wearColorsFor(WearThemeMode.Dark)
+    assertEquals(Color(0xFF030303), dark.canvas)
+    assertEquals(Color(0xFF0A0A0A), dark.surface)
+    assertEquals(Color(0xFF111111), dark.surfaceRaised)
+    assertEquals(Color(0xFF1A1A1A), dark.surfacePressed)
+    assertEquals(Color(0xFF242424), dark.border)
+    assertEquals(Color(0xFF3A3A3A), dark.borderStrong)
+    assertEquals(Color(0xFFF8F8F8), dark.text)
+    assertEquals(Color(0xFFA8A8A8), dark.textMuted)
+    assertEquals(Color(0xFFFFFFFF), dark.primary)
+    assertEquals(Color(0xFF050505), dark.primaryText)
+    assertEquals(Color(0xFF6EA8FF), dark.voiceAccent)
+    assertEquals(Color(0xFF1A2A44), dark.voiceAccentSoft)
+
+    val light = wearColorsFor(WearThemeMode.Light)
+    assertEquals(Color(0xFFFAFBFC), light.canvas)
+    assertEquals(Color(0xFFFFFEFB), light.surface)
+    assertEquals(Color(0xFFFFFFFF), light.surfaceRaised)
+    assertEquals(Color(0xFFE9EDF3), light.surfacePressed)
+    assertEquals(Color(0xFFDDE3EC), light.border)
+    assertEquals(Color(0xFFC7D0DC), light.borderStrong)
+    assertEquals(Color(0xFF111318), light.text)
+    assertEquals(Color(0xFF505865), light.textMuted)
+    assertEquals(Color(0xFF111827), light.primary)
+    assertEquals(Color(0xFFFFFFFF), light.primaryText)
+    assertEquals(Color(0xFF1B5ACB), light.voiceAccent)
+    assertEquals(Color(0xFFEAF2FF), light.voiceAccentSoft)
+  }
+
+  @Test
+  fun `dark and light palettes keep panels distinct from the canvas`() {
+    WearThemeMode.entries.forEach { mode ->
+      val colors = wearColorsFor(mode)
+
+      assertNotEquals("$mode canvas and panel must differ", colors.canvas, colors.surfaceRaised)
+      assertTrue(
+        "$mode panel outline must remain visible",
+        contrastRatio(colors.borderStrong, colors.surfaceRaised) >= MIN_OUTLINE_CONTRAST,
+      )
+    }
+  }
+
+  @Test
+  fun `dark and light palettes keep text readable on panels`() {
+    WearThemeMode.entries.forEach { mode ->
+      val colors = wearColorsFor(mode)
+
+      assertTrue(
+        "$mode text must remain readable",
+        contrastRatio(colors.text, colors.surfaceRaised) >= MIN_TEXT_CONTRAST,
+      )
+      assertTrue(
+        "$mode muted text must remain readable",
+        contrastRatio(colors.textMuted, colors.surfaceRaised) >= MIN_TEXT_CONTRAST,
+      )
+    }
+  }
+
+  @Test
+  fun `dark and light primary and voice accents keep their content readable`() {
+    WearThemeMode.entries.forEach { mode ->
+      val colors = wearColorsFor(mode)
+
+      assertTrue(
+        "$mode primary content must remain readable",
+        contrastRatio(colors.primaryText, colors.primary) >= MIN_TEXT_CONTRAST,
+      )
+      assertTrue(
+        "$mode voice accent content must remain readable",
+        contrastRatio(colors.onVoiceAccent, colors.voiceAccent) >= MIN_TEXT_CONTRAST,
+      )
+    }
+  }
+
+  private fun contrastRatio(
+    foreground: Color,
+    background: Color,
+  ): Double {
+    val foregroundLuminance = relativeLuminance(foreground)
+    val backgroundLuminance = relativeLuminance(background)
+    return (max(foregroundLuminance, backgroundLuminance) + 0.05) /
+      (min(foregroundLuminance, backgroundLuminance) + 0.05)
+  }
+
+  private fun relativeLuminance(color: Color): Double =
+    0.2126 * linearize(color.red.toDouble()) +
+      0.7152 * linearize(color.green.toDouble()) +
+      0.0722 * linearize(color.blue.toDouble())
+
+  private fun linearize(channel: Double): Double =
+    if (channel <= 0.03928) {
+      channel / 12.92
+    } else {
+      ((channel + 0.055) / 1.055).pow(2.4)
+    }
+
+  private companion object {
+    const val MIN_OUTLINE_CONTRAST = 1.5
+    const val MIN_TEXT_CONTRAST = 4.5
+  }
+}


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

Fixes an issue where Wear OS users switching between Dark and Light mode could see inconsistent panel fills, outlines, selection states, and voice accents that did not match the Phone app.

## Why This Change Was Made

Aligns the Wear canvas, surfaces, pressed states, outlines, text, and status colors with the canonical Phone `ClawTheme`. The Phone blue accent remains reserved for voice gestures and active voice states, while layout, protocol, Gateway, session, and voice behavior remain unchanged.

## User Impact

Panels, chat bubbles, and controls remain distinct and readable in both themes. Light mode keeps visible outlines, Dark mode keeps coherent surface depth, and disabled or selected controls now follow the same visual hierarchy as the Phone app.

## Evidence

> [!NOTE]
> ### Validation
>
> - [x] `./gradlew :wear:testDebugUnitTest` — PASS after the final `origin/main` refresh; 59 tests, 0 failures, 0 errors, 0 skipped
> - [x] `./gradlew :wear:ktlintCheck :wear:lintDebug :wear:assembleDebug` — PASS after the final `origin/main` refresh
> - [x] `git diff --check` — PASS
> - [x] Final `origin/main` commit `3d1b77103511004fad59362805180024eabc1c12` is the parent of exact PR head `b55183f25e61fad5d779bc8eb1eefef336f29c21`; the refresh changed no Android files, and the Wear patch remains limited to two source files and one focused theme test

> [!TIP]
> ### Real Behavior Proof
>
> The Phone-aligned Wear surfaces were exercised across the physical companion UI in both Dark and Light mode.
>
> - [x] **Environment:** Physical Phone and Watch running matching `ai.openclaw.app` debug builds, replace-installed without clearing app data.
> - [x] **Security boundary:** The Phone remained the sole Gateway, authentication, credential, and transport boundary; this patch adds no Watch credential or direct Gateway path.
> - [x] **Precondition:** The complete merged Wear companion baseline was installed, the Phone and Watch builds matched, and theme changes were made through the existing Watch UI.
> - [x] **Before result:** The operator-attested baseline capture shows the prior Wear surface and outline treatment.
> - [x] **After result:** The operator-attested final capture shows Phone-aligned panels, outlines, chat bubbles, controls, and voice accents while navigating the companion UI in Dark and Light mode.
> - [x] **Automated result:** Focused palette and contrast assertions pass together with all 59 Wear unit tests, Ktlint, Android Lint, and the Wear debug build.
> - [x] **Proof ownership:** The physical Before and After captures and interaction results were supplied and attested by the maintainer; automated validation was run locally on the final refreshed tree.
> - [x] **Remaining proof gap:** The final main refresh changed no Android files, so the physical capture remains representative of the exact Android diff; CI remains the independent repository-wide gate.

### Before

https://github.com/user-attachments/assets/4e1dd597-91d0-43f4-9ac0-dcce8caeabce

### After

https://github.com/user-attachments/assets/d3b125fd-e9d0-4ee8-80b2-c27fe44a75f7
