### PR TITLE
fix(agents): keep declared-output tools visible in the truncated code mode index

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -476,6 +476,35 @@ describe("Code Mode", () => {
     expect(description).not.toContain("additional OpenClaw/plugin tools omitted");
   });
 
+  it("keeps declared-output tools indexed when truncation drops unknown-output lines", () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    const pluginId = `fake-${"x".repeat(120)}`;
+    const catalogTools = Array.from({ length: 100 }, (_, index) =>
+      pluginTool(`fake_${index.toString().padStart(3, "0")}`, "Deferred", pluginId),
+    );
+    // Alphabetically last, but carries a declared output contract.
+    const contracted = pluginTool("zzz_contracted_tool", "Deferred", pluginId);
+    (contracted as { outputSchema?: unknown }).outputSchema = Type.Object(
+      { ok: Type.Boolean() },
+      { additionalProperties: false },
+    );
+    const compacted = applyCodeModeCatalog({
+      tools: [...tools, ...catalogTools, contracted],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const description = compacted.tools[0]?.description ?? "";
+    const indexStart = description.indexOf("OpenClaw/plugin tool quick index");
+    const index = indexStart >= 0 ? description.slice(indexStart) : "";
+    expect(index).toContain("additional OpenClaw/plugin tools omitted");
+    expect(index).toContain("zzz_contracted_tool");
+    expect(index).toContain("-> { ok: boolean }");
+  });
+
   it("bounds the model-visible native tool index", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
     const pluginId = `fake-${"x".repeat(120)}`;

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -1292,7 +1292,10 @@ function formatCodeModeCatalogIndex(catalog: readonly ToolSearchCatalogEntry[]):
   const lines = catalog
     .filter((entry) => entry.source === "openclaw")
     .map((entry) => compactToolSearchCatalogEntry(entry))
-    .toSorted((a, b) => a.id.localeCompare(b.id))
+    // Declared-output entries sort first so byte truncation drops `-> ?`
+    // lines, which stay fully discoverable through ALL_TOOLS, before it drops
+    // contracts the model can one-pass on. Deterministic within each tier.
+    .toSorted((a, b) => (a.output ? 0 : 1) - (b.output ? 0 : 1) || a.id.localeCompare(b.id))
     .map(
       (entry) =>
         `- ${JSON.stringify(entry.id)} ${entry.input ?? "unknown"} -> ${entry.output ?? "?"}`,


### PR DESCRIPTION
## What Problem This Solves

The Code Mode quick index is alphabetical and truncated at 8,000 chars. In a real gateway (44 built-ins plus plugins), truncation drops the alphabetical tail — which is exactly where the newly contracted tools sort (`sessions_search`, `spawn_task`, `terminal`, `web_fetch`). Live verification against a local gateway showed "12 additional OpenClaw/plugin tools omitted from this prompt index", so a model asked to fetch a page never saw `web_fetch`'s declared arrow, spent an exec searching for the tool, and then paid a raw-inspection exec on a shape that was already declared — the exact turns output contracts exist to eliminate.

## Why This Change Was Made

`formatCodeModeCatalogIndex` now sorts declared-output entries first (alphabetical within each tier, still fully deterministic for prompt caching). Byte truncation therefore drops `-> ?` lines — which lose nothing, since unknown-output tools remain fully discoverable through `ALL_TOOLS` and `tools.search` — before it drops contracts the model can one-pass on.

## User Impact

Code Mode agents on real, plugin-heavy catalogs keep every declared output contract visible in the prompt index, so contracted tools compose in one exec instead of paying search plus inspection turns.

## Evidence

- Live repro: local gateway (isolated state, code mode on), task "fetch docs page, return {title,length,truncated}" → transcript showed 2 execs (tool search, then raw-first fetch) with the truncation footer confirming the dropped tail.
- New regression test: 100 filler tools + an alphabetically-last contracted tool; index truncates yet retains the contracted line and its arrow (`src/agents/code-mode.test.ts`).
- Full `src/agents/code-mode.test.ts`: 75 tests green.
- Autoreview (Codex gpt-5.6-sol): clean, "patch is correct (0.98)".
