### PR TITLE
feat(gateway): idempotent start, non-interactive stop guard, unified lifecycle audit

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -78,7 +78,7 @@ openclaw gateway run   # equivalent, explicit form
   Reset dev config, credentials, sessions, and workspace. Requires `--dev`.
 </ParamField>
 <ParamField path="--force" type="boolean">
-  Kill any existing listener on the target port before starting.
+  Kill any existing listener on the target port before starting. In a non-interactive shell, this refuses to kill a verified Gateway listener; use `--dev` or an isolated `--profile` with a free port instead.
 </ParamField>
 <ParamField path="--verbose" type="boolean">
   Verbose logging to stdout/stderr.
@@ -513,12 +513,15 @@ openclaw gateway restart
     - `gateway install`: `--port`, `--runtime <node>` (default: `node`), `--token`, `--wrapper <path>`, `--force`, `--json`
     - `gateway restart`: `--safe`, `--skip-deferral`, `--force`, `--wait <duration>`, `--json`
     - `gateway uninstall|start`: `--json`
-    - `gateway stop`: `--disable`, `--json`
+    - `gateway stop`: `--disable`, `--force`, `--json`
 
   </Accordion>
   <Accordion title="Lifecycle behavior">
+    - `gateway start` is idempotent: when the managed service is already running, it reports the running process and leaves it untouched. A loaded but stopped service is started as before.
     - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
+    - In a non-interactive shell, `gateway stop` requires `--force`. Interactive terminals keep the existing prompt-free behavior. For automation and tests, prefer `gateway run --dev` or an isolated `--profile` with a free port.
     - On macOS, `gateway stop` uses `launchctl bootout` by default, which removes the LaunchAgent from the current boot session without persisting a disable — KeepAlive auto-recovery stays active for future crashes and `gateway start` re-enables cleanly without a manual `launchctl enable`. Pass `--disable` to persistently suppress KeepAlive and RunAtLoad so the gateway does not respawn until the next explicit `gateway start`; use this when a manual stop should survive reboots.
+    - Gateway lifecycle mutations append best-effort key-value audit records to `<state-dir>/logs/gateway-restart.log`, including CLI start, stop, and restart operations, safe restart requests, supervisor restarts, and detached handoffs.
     - Lifecycle commands accept `--json` for scripting.
 
   </Accordion>

--- a/src/cli/daemon-cli.coverage.test.ts
+++ b/src/cli/daemon-cli.coverage.test.ts
@@ -350,9 +350,10 @@ describe("daemon-cli coverage", () => {
     serviceRestart.mockClear();
     serviceStop.mockClear();
     serviceIsLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValueOnce({ status: "stopped" });
 
     await runDaemonCommand(["daemon", "start", "--json"]);
-    await runDaemonCommand(["daemon", "stop", "--json"]);
+    await runDaemonCommand(["daemon", "stop", "--json", "--force"]);
 
     expect(serviceRestart).toHaveBeenCalledTimes(1);
     expect(serviceStop).toHaveBeenCalledTimes(1);

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
-import type { DaemonActionResponse } from "./response.js";
+import type { createDaemonInstallActionContext } from "./shared.js";
+
+type DaemonActionResponse = Parameters<
+  ReturnType<typeof createDaemonInstallActionContext>["emit"]
+>[0];
 
 const resolveNodeStartupTlsEnvironmentMock = vi.hoisted(() => vi.fn());
 const loadConfigMock = vi.hoisted(() => vi.fn());

--- a/src/cli/daemon-cli/lifecycle-audit.ts
+++ b/src/cli/daemon-cli/lifecycle-audit.ts
@@ -1,0 +1,41 @@
+import {
+  appendGatewayLifecycleAuditLog,
+  type GatewayLifecycleAuditSource,
+} from "../../daemon/restart-logs.js";
+/** Gateway lifecycle audit helpers shared by managed and unmanaged CLI paths. */
+import type { GatewayLifecycleMutation } from "../../daemon/service-types.js";
+import { isTerminalInteractive } from "../terminal-interactivity.js";
+
+type GatewayLifecycleAction = "start" | "stop" | "restart";
+
+export function appendGatewayLifecycleAudit(params: {
+  action: GatewayLifecycleAction;
+  source: GatewayLifecycleAuditSource;
+  mode: string;
+  pid?: number;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  appendGatewayLifecycleAuditLog(params.env ?? process.env, {
+    action: params.action,
+    source: params.source,
+    mode: params.mode,
+    ...(params.pid === undefined ? {} : { pid: params.pid }),
+    interactive: isTerminalInteractive(),
+  });
+}
+
+export function createGatewayLifecycleMutationAudit(params: {
+  action: GatewayLifecycleAction;
+  source?: GatewayLifecycleAuditSource;
+  env?: NodeJS.ProcessEnv;
+}): (mutation: GatewayLifecycleMutation) => void {
+  return (mutation) => {
+    appendGatewayLifecycleAudit({
+      action: params.action,
+      source: params.source ?? "cli",
+      mode: mutation.mode,
+      ...(mutation.pid === undefined ? {} : { pid: mutation.pid }),
+      ...(params.env === undefined ? {} : { env: params.env }),
+    });
+  };
+}

--- a/src/cli/daemon-cli/lifecycle-audit.ts
+++ b/src/cli/daemon-cli/lifecycle-audit.ts
@@ -39,3 +39,28 @@ export function createGatewayLifecycleMutationAudit(params: {
     });
   };
 }
+
+export function createServiceLifecycleMutationAudit(params: {
+  serviceNoun: string;
+  action: GatewayLifecycleAction;
+}): ((mutation: GatewayLifecycleMutation) => void) | undefined {
+  return params.serviceNoun === "Gateway"
+    ? createGatewayLifecycleMutationAudit({ action: params.action })
+    : undefined;
+}
+
+export function appendServiceLifecycleRepairAudit(params: {
+  serviceNoun: string;
+  action: "start" | "restart";
+  pid?: number;
+}): void {
+  if (params.serviceNoun !== "Gateway") {
+    return;
+  }
+  appendGatewayLifecycleAudit({
+    action: params.action,
+    source: "cli",
+    mode: "service-repair",
+    ...(params.pid === undefined ? {} : { pid: params.pid }),
+  });
+}

--- a/src/cli/daemon-cli/lifecycle-config-preflight.ts
+++ b/src/cli/daemon-cli/lifecycle-config-preflight.ts
@@ -1,0 +1,46 @@
+import { readConfigFileSnapshot } from "../../config/config.js";
+import { resolveFutureConfigActionBlock } from "../../config/future-version-guard.js";
+import { formatConfigIssueLines } from "../../config/issue-format.js";
+import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../../config/recovery-policy.js";
+import { formatPluginPackagingRuntimeOutputRecoveryHint } from "../config-recovery-hints.js";
+
+type ConfigActionPreflightFailure = {
+  message: string;
+  hints?: string[];
+};
+
+function formatPluginPackagingRuntimeOutputRecoveryHints(): string[] {
+  return formatPluginPackagingRuntimeOutputRecoveryHint().split("\n");
+}
+
+/** Best-effort validation before a service action mutates runtime state. */
+export async function getConfigActionPreflightFailure(
+  action: string,
+): Promise<ConfigActionPreflightFailure | null> {
+  let snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  try {
+    snapshot = await readConfigFileSnapshot();
+    if (snapshot.exists && !snapshot.valid) {
+      const message =
+        snapshot.issues.length > 0
+          ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
+          : "Unknown validation issue.";
+      return {
+        message,
+        ...(isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
+          ? { hints: formatPluginPackagingRuntimeOutputRecoveryHints() }
+          : {}),
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  const futureBlock = resolveFutureConfigActionBlock({ action, snapshot });
+  return futureBlock
+    ? {
+        message: futureBlock.message,
+        hints: futureBlock.hints,
+      }
+    : null;
+}

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -50,6 +50,22 @@ vi.mock("./lifecycle-audit.js", () => ({
   appendGatewayLifecycleAudit: (params: unknown) => appendGatewayLifecycleAudit(params),
   createGatewayLifecycleMutationAudit: (params: { action: string; source?: string }) =>
     createGatewayLifecycleMutationAudit(params),
+  createServiceLifecycleMutationAudit: (params: { serviceNoun: string; action: string }) =>
+    params.serviceNoun === "Gateway" ? createGatewayLifecycleMutationAudit(params) : undefined,
+  appendServiceLifecycleRepairAudit: (params: {
+    serviceNoun: string;
+    action: string;
+    pid?: number;
+  }) => {
+    if (params.serviceNoun === "Gateway") {
+      appendGatewayLifecycleAudit({
+        action: params.action,
+        source: "cli",
+        mode: "service-repair",
+        ...(params.pid === undefined ? {} : { pid: params.pid }),
+      });
+    }
+  },
 }));
 
 let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -21,6 +21,15 @@ const loadConfig = vi.fn<() => OpenClawConfig>(() => ({
 }));
 const writeGatewayRestartIntentSync = vi.fn();
 const clearGatewayRestartIntentSync = vi.fn();
+const appendGatewayLifecycleAudit = vi.fn();
+const createGatewayLifecycleMutationAudit = vi.fn(
+  (params: { action: string; source?: string }) => (mutation: { mode: string; pid?: number }) =>
+    appendGatewayLifecycleAudit({
+      action: params.action,
+      source: params.source ?? "cli",
+      ...mutation,
+    }),
+);
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: () => loadConfig(),
@@ -35,6 +44,12 @@ vi.mock("../../runtime.js", () => ({
 vi.mock("../../infra/restart-intent.js", () => ({
   clearGatewayRestartIntentSync: () => clearGatewayRestartIntentSync(),
   writeGatewayRestartIntentSync: (opts: unknown) => writeGatewayRestartIntentSync(opts),
+}));
+
+vi.mock("./lifecycle-audit.js", () => ({
+  appendGatewayLifecycleAudit: (params: unknown) => appendGatewayLifecycleAudit(params),
+  createGatewayLifecycleMutationAudit: (params: { action: string; source?: string }) =>
+    createGatewayLifecycleMutationAudit(params),
 }));
 
 let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;
@@ -113,6 +128,8 @@ describe("runServiceRestart token drift", () => {
   });
 
   beforeEach(() => {
+    appendGatewayLifecycleAudit.mockClear();
+    createGatewayLifecycleMutationAudit.mockClear();
     resetLifecycleRuntimeLogs();
     loadConfig.mockReset();
     loadConfig.mockReturnValue({
@@ -561,6 +578,76 @@ describe("runServiceRestart token drift", () => {
     const payload = readJsonLog<{ result?: string; message?: string }>();
     expect(payload.result).toBe("scheduled");
     expect(payload.message).toBe("restart scheduled, gateway will restart momentarily");
+  });
+
+  it("reports an already-running gateway without restarting it", async () => {
+    service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    const payload = readJsonLog<{ ok?: boolean; result?: string; message?: string }>();
+    expect(payload).toMatchObject({
+      ok: true,
+      result: "already-running",
+      message: "Gateway service already running (pid 4242).",
+    });
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
+  });
+
+  it("audits a service start that actually mutates the gateway", async () => {
+    service.restart.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
+      args?.onMutation?.({ mode: "kickstart" });
+      return { outcome: "completed" };
+    });
+
+    await runServiceStart(createServiceRunArgs());
+
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "start",
+      source: "cli",
+      mode: "kickstart",
+    });
+  });
+
+  it("audits direct managed restart mutations", async () => {
+    service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
+    service.restart.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
+      args?.onMutation?.({ mode: "kickstart", pid: 4242 });
+      return { outcome: "completed" };
+    });
+
+    await runServiceRestart(createServiceRunArgs());
+
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "restart",
+      source: "cli",
+      mode: "kickstart",
+      pid: 4242,
+    });
+  });
+
+  it("audits direct managed stop mutations", async () => {
+    service.stop.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
+      args?.onMutation?.({ mode: "bootout" });
+    });
+
+    await runServiceStop({
+      serviceNoun: "Gateway",
+      service,
+      opts: { json: true },
+    });
+
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "stop",
+      source: "cli",
+      mode: "bootout",
+    });
   });
 
   it("captures service start warnings in json start output", async () => {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -31,6 +31,10 @@ import {
 } from "../config-recovery-hints.js";
 import { resolveGatewayTokenForDriftCheck } from "./gateway-token-drift.js";
 import {
+  appendGatewayLifecycleAudit,
+  createGatewayLifecycleMutationAudit,
+} from "./lifecycle-audit.js";
+import {
   buildDaemonServiceSnapshot,
   createDaemonActionContext,
   type DaemonActionResponse,
@@ -318,6 +322,10 @@ export async function runServiceStart(params: {
         env: process.env,
         stdout,
         warn,
+        onMutation:
+          params.serviceNoun === "Gateway"
+            ? createGatewayLifecycleMutationAudit({ action: "start" })
+            : undefined,
       },
       params.expectedPort,
     );
@@ -329,6 +337,25 @@ export async function runServiceStart(params: {
         renderStartHints: params.renderStartHints,
         json,
         emit,
+      });
+      return;
+    }
+    if (startResult.outcome === "already-running") {
+      const pid = startResult.state.runtime?.pid;
+      const message =
+        pid === undefined
+          ? `${params.serviceNoun} service already running.`
+          : `${params.serviceNoun} service already running (pid ${pid}).`;
+      emitActionMessage({
+        json,
+        emit,
+        payload: {
+          ok: true,
+          result: "already-running",
+          message,
+          service: buildDaemonServiceSnapshot(params.service, true),
+          warnings: warnings.length ? warnings : undefined,
+        },
       });
       return;
     }
@@ -360,6 +387,13 @@ export async function runServiceStart(params: {
           issues: startResult.issues,
         });
         if (handled) {
+          if (params.serviceNoun === "Gateway") {
+            appendGatewayLifecycleAudit({
+              action: "start",
+              source: "cli",
+              mode: "service-repair",
+            });
+          }
           emit({
             ok: true,
             result: handled.result,
@@ -406,6 +440,10 @@ export async function runServiceStop(params: {
 }) {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createDaemonActionContext({ action: "stop", json });
+  const gatewayStopAudit =
+    params.serviceNoun === "Gateway"
+      ? createGatewayLifecycleMutationAudit({ action: "stop" })
+      : undefined;
 
   const loaded = await resolveServiceLoadedOrFail({
     serviceNoun: params.serviceNoun,
@@ -425,7 +463,12 @@ export async function runServiceStop(params: {
   if (!loaded) {
     if (params.stopWhenNotLoaded) {
       try {
-        await params.service.stop({ env: process.env, stdout, disable: params.opts?.disable });
+        await params.service.stop({
+          env: process.env,
+          stdout,
+          disable: params.opts?.disable,
+          onMutation: gatewayStopAudit,
+        });
       } catch (err) {
         fail(`${params.serviceNoun} stop failed: ${String(err)}`);
         return;
@@ -468,7 +511,12 @@ export async function runServiceStop(params: {
     return;
   }
   try {
-    await params.service.stop({ env: process.env, stdout, disable: params.opts?.disable });
+    await params.service.stop({
+      env: process.env,
+      stdout,
+      disable: params.opts?.disable,
+      onMutation: gatewayStopAudit,
+    });
   } catch (err) {
     fail(`${params.serviceNoun} stop failed: ${String(err)}`);
     return;
@@ -502,6 +550,10 @@ export async function runServiceRestart(params: {
   const { stdout, warnings, emit, fail } = createDaemonActionContext({ action: "restart", json });
   const warn = json ? (message: string) => warnings.push(message) : undefined;
   const restartIntent = params.opts?.restartIntent;
+  const gatewayRestartAudit =
+    params.serviceNoun === "Gateway"
+      ? createGatewayLifecycleMutationAudit({ action: "restart" })
+      : undefined;
   let handledRecovery: ServiceRecoveryResult | null = null;
   let handledRepair: ServiceRecoveryResult | null = null;
   let recoveredLoadedState: boolean | null = null;
@@ -616,6 +668,14 @@ export async function runServiceRestart(params: {
           );
           return false;
         }
+        if (params.serviceNoun === "Gateway") {
+          appendGatewayLifecycleAudit({
+            action: "restart",
+            source: "cli",
+            mode: "service-repair",
+            pid: state.runtime?.pid,
+          });
+        }
         if (handledRepair.warnings?.length) {
           warnings.push(...handledRepair.warnings);
         }
@@ -669,7 +729,12 @@ export async function runServiceRestart(params: {
     if (loaded && !handledRepair) {
       await prepareGatewayRestartIntent();
       try {
-        restartResult = await params.service.restart({ env: process.env, stdout, warn });
+        restartResult = await params.service.restart({
+          env: process.env,
+          stdout,
+          warn,
+          onMutation: gatewayRestartAudit,
+        });
       } catch (err) {
         clearPreparedRestartIntent();
         throw err;

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -1,10 +1,7 @@
 // Gateway service lifecycle command core: install, uninstall, start, stop, restart.
 import type { Writable } from "node:stream";
-import { readBestEffortConfig, readConfigFileSnapshot } from "../../config/config.js";
-import { resolveFutureConfigActionBlock } from "../../config/future-version-guard.js";
-import { formatConfigIssueLines } from "../../config/issue-format.js";
+import { readBestEffortConfig } from "../../config/config.js";
 import { resolveIsNixMode } from "../../config/paths.js";
-import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../../config/recovery-policy.js";
 import { checkTokenDrift } from "../../daemon/service-audit.js";
 import type { GatewayServiceRestartResult } from "../../daemon/service-types.js";
 import type { GatewayServiceStartRepairIssue, GatewayServiceState } from "../../daemon/service.js";
@@ -25,19 +22,19 @@ import {
 import { isWSL } from "../../infra/wsl.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
-import {
-  formatInvalidConfigRecoveryHint,
-  formatPluginPackagingRuntimeOutputRecoveryHint,
-} from "../config-recovery-hints.js";
+import { formatInvalidConfigRecoveryHint } from "../config-recovery-hints.js";
 import { resolveGatewayTokenForDriftCheck } from "./gateway-token-drift.js";
 import {
-  appendGatewayLifecycleAudit,
-  createGatewayLifecycleMutationAudit,
+  appendServiceLifecycleRepairAudit,
+  createServiceLifecycleMutationAudit,
 } from "./lifecycle-audit.js";
+import { getConfigActionPreflightFailure } from "./lifecycle-config-preflight.js";
 import {
   buildDaemonServiceSnapshot,
   createDaemonActionContext,
-  type DaemonActionResponse,
+  emitDaemonActionMessage,
+  emitDaemonAlreadyRunning,
+  emitDaemonScheduledRestart,
 } from "./response.js";
 import { filterContainerGenericHints } from "./shared.js";
 
@@ -90,17 +87,6 @@ async function maybeAugmentSystemdHints(hints: string[]): Promise<string[]> {
   ];
 }
 
-function emitActionMessage(params: {
-  json: boolean;
-  emit: ReturnType<typeof createDaemonActionContext>["emit"];
-  payload: Omit<DaemonActionResponse, "action">;
-}) {
-  params.emit(params.payload);
-  if (!params.json && params.payload.message) {
-    defaultRuntime.log(params.payload.message);
-  }
-}
-
 function mergeWarnings(
   captured: readonly string[],
   reported?: readonly string[],
@@ -147,57 +133,6 @@ async function resolveServiceLoadedOrFail(params: {
     params.fail(`${params.serviceNoun} service check failed: ${String(err)}`);
     return null;
   }
-}
-
-/**
- * Best-effort config validation. Returns a string describing the issues if
- * config exists and is invalid, or null if config is valid/missing/unreadable.
- *
- * Note: This reads the config file snapshot in the current CLI environment.
- * Configs using env vars only available in the service context (launchd/systemd)
- * may produce false positives, but the check is intentionally best-effort —
- * a false positive here is safer than a crash on startup. (#35862)
- */
-type ConfigActionPreflightFailure = {
-  message: string;
-  hints?: string[];
-};
-
-function formatPluginPackagingRuntimeOutputRecoveryHints(): string[] {
-  return formatPluginPackagingRuntimeOutputRecoveryHint().split("\n");
-}
-
-async function getConfigActionPreflightFailure(
-  action: string,
-): Promise<ConfigActionPreflightFailure | null> {
-  let snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
-  try {
-    snapshot = await readConfigFileSnapshot();
-    if (snapshot.exists && !snapshot.valid) {
-      const message =
-        snapshot.issues.length > 0
-          ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
-          : "Unknown validation issue.";
-      return {
-        message,
-        ...(isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
-          ? { hints: formatPluginPackagingRuntimeOutputRecoveryHints() }
-          : {}),
-      };
-    }
-  } catch {
-    return null;
-  }
-
-  const futureBlock = resolveFutureConfigActionBlock({ action, snapshot });
-  if (futureBlock) {
-    return {
-      message: futureBlock.message,
-      hints: futureBlock.hints,
-    };
-  }
-
-  return null;
 }
 
 export async function runServiceUninstall(params: {
@@ -322,10 +257,10 @@ export async function runServiceStart(params: {
         env: process.env,
         stdout,
         warn,
-        onMutation:
-          params.serviceNoun === "Gateway"
-            ? createGatewayLifecycleMutationAudit({ action: "start" })
-            : undefined,
+        onMutation: createServiceLifecycleMutationAudit({
+          serviceNoun: params.serviceNoun,
+          action: "start",
+        }),
       },
       params.expectedPort,
     );
@@ -341,21 +276,13 @@ export async function runServiceStart(params: {
       return;
     }
     if (startResult.outcome === "already-running") {
-      const pid = startResult.state.runtime?.pid;
-      const message =
-        pid === undefined
-          ? `${params.serviceNoun} service already running.`
-          : `${params.serviceNoun} service already running (pid ${pid}).`;
-      emitActionMessage({
+      emitDaemonAlreadyRunning({
+        serviceNoun: params.serviceNoun,
+        service: params.service,
+        pid: startResult.state.runtime?.pid,
         json,
+        warnings,
         emit,
-        payload: {
-          ok: true,
-          result: "already-running",
-          message,
-          service: buildDaemonServiceSnapshot(params.service, true),
-          warnings: warnings.length ? warnings : undefined,
-        },
       });
       return;
     }
@@ -363,7 +290,7 @@ export async function runServiceStart(params: {
       const restartStatus = describeGatewayServiceRestart(params.serviceNoun, {
         outcome: "scheduled",
       });
-      emitActionMessage({
+      emitDaemonActionMessage({
         json,
         emit,
         payload: {
@@ -387,13 +314,10 @@ export async function runServiceStart(params: {
           issues: startResult.issues,
         });
         if (handled) {
-          if (params.serviceNoun === "Gateway") {
-            appendGatewayLifecycleAudit({
-              action: "start",
-              source: "cli",
-              mode: "service-repair",
-            });
-          }
+          appendServiceLifecycleRepairAudit({
+            serviceNoun: params.serviceNoun,
+            action: "start",
+          });
           emit({
             ok: true,
             result: handled.result,
@@ -440,10 +364,10 @@ export async function runServiceStop(params: {
 }) {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createDaemonActionContext({ action: "stop", json });
-  const gatewayStopAudit =
-    params.serviceNoun === "Gateway"
-      ? createGatewayLifecycleMutationAudit({ action: "stop" })
-      : undefined;
+  const gatewayStopAudit = createServiceLifecycleMutationAudit({
+    serviceNoun: params.serviceNoun,
+    action: "stop",
+  });
 
   const loaded = await resolveServiceLoadedOrFail({
     serviceNoun: params.serviceNoun,
@@ -550,10 +474,10 @@ export async function runServiceRestart(params: {
   const { stdout, warnings, emit, fail } = createDaemonActionContext({ action: "restart", json });
   const warn = json ? (message: string) => warnings.push(message) : undefined;
   const restartIntent = params.opts?.restartIntent;
-  const gatewayRestartAudit =
-    params.serviceNoun === "Gateway"
-      ? createGatewayLifecycleMutationAudit({ action: "restart" })
-      : undefined;
+  const gatewayRestartAudit = createServiceLifecycleMutationAudit({
+    serviceNoun: params.serviceNoun,
+    action: "restart",
+  });
   let handledRecovery: ServiceRecoveryResult | null = null;
   let handledRepair: ServiceRecoveryResult | null = null;
   let recoveredLoadedState: boolean | null = null;
@@ -579,18 +503,15 @@ export async function runServiceRestart(params: {
     restartStatus: ReturnType<typeof describeGatewayServiceRestart>,
     serviceLoaded: boolean,
   ) => {
-    emitActionMessage({
+    return emitDaemonScheduledRestart({
       json,
       emit,
-      payload: {
-        ok: true,
-        result: restartStatus.daemonActionResult,
-        message: restartStatus.message,
-        service: buildDaemonServiceSnapshot(params.service, serviceLoaded),
-        warnings: warnings.length ? warnings : undefined,
-      },
+      result: restartStatus.daemonActionResult,
+      message: restartStatus.message,
+      service: params.service,
+      loaded: serviceLoaded,
+      warnings,
     });
-    return true;
   };
 
   const loaded = await resolveServiceLoadedOrFail({
@@ -668,14 +589,11 @@ export async function runServiceRestart(params: {
           );
           return false;
         }
-        if (params.serviceNoun === "Gateway") {
-          appendGatewayLifecycleAudit({
-            action: "restart",
-            source: "cli",
-            mode: "service-repair",
-            pid: state.runtime?.pid,
-          });
-        }
+        appendServiceLifecycleRepairAudit({
+          serviceNoun: params.serviceNoun,
+          action: "restart",
+          pid: state.runtime?.pid,
+        });
         if (handledRepair.warnings?.length) {
           warnings.push(...handledRepair.warnings);
         }

--- a/src/cli/daemon-cli/lifecycle-safe-restart.ts
+++ b/src/cli/daemon-cli/lifecycle-safe-restart.ts
@@ -1,0 +1,76 @@
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { callGatewayCli } from "../../gateway/call.js";
+import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
+import type { GatewayRestartIntent } from "../../infra/restart-intent.js";
+import { defaultRuntime, writeRuntimeJson } from "../../runtime.js";
+import { parseDurationMs } from "../parse-duration.js";
+import { appendGatewayLifecycleAudit } from "./lifecycle-audit.js";
+import type { DaemonLifecycleOptions } from "./types.js";
+
+function formatSafeRestartWarnings(result: SafeGatewayRestartRequestResult): string[] | undefined {
+  return result.preflight.blockers.length === 0 ? undefined : [result.preflight.summary];
+}
+
+export function resolveGatewayRestartIntentOptions(
+  opts: DaemonLifecycleOptions,
+): GatewayRestartIntent | undefined {
+  if (opts.force && opts.wait !== undefined) {
+    throw new Error("--force cannot be combined with --wait");
+  }
+  if (opts.force) {
+    return { force: true };
+  }
+  return opts.wait === undefined ? undefined : { waitMs: parseDurationMs(opts.wait) };
+}
+
+/** Request an OpenClaw-aware restart through the running Gateway. */
+export async function requestSafeGatewayRestart(opts: DaemonLifecycleOptions): Promise<boolean> {
+  if (opts.force) {
+    throw new Error("--safe cannot be combined with --force; omit --safe to force restart now");
+  }
+  if (opts.wait !== undefined) {
+    throw new Error("--safe cannot be combined with --wait; safe restart uses gateway deferral");
+  }
+  const skipDeferral = opts.skipDeferral === true;
+  const params: { reason: string; skipDeferral?: true } = { reason: "gateway.restart.safe" };
+  if (skipDeferral) {
+    params.skipDeferral = true;
+  }
+  const result = await callGatewayCli<SafeGatewayRestartRequestResult>({
+    method: "gateway.restart.request",
+    params,
+    timeoutMs: 10_000,
+  });
+  appendGatewayLifecycleAudit({
+    action: "restart",
+    source: "safe-rpc",
+    mode: result.status,
+    pid: result.restart.pid,
+  });
+  const message =
+    result.status === "coalesced"
+      ? "safe restart request joined an existing pending gateway restart"
+      : result.status === "deferred"
+        ? "safe restart requested; gateway will restart after active work drains " +
+          "(bounded by gateway.reload.deferralTimeoutMs; may force after timeout expires)"
+        : skipDeferral
+          ? "safe restart requested; gateway bypassing active-work deferral"
+          : "safe restart requested; gateway will restart momentarily";
+  const payload = {
+    ok: true,
+    result: result.status,
+    message,
+    preflight: result.preflight,
+    restart: result.restart,
+    warnings: formatSafeRestartWarnings(result),
+  };
+  if (opts.json) {
+    writeRuntimeJson(defaultRuntime, payload);
+  } else {
+    defaultRuntime.log(message);
+    if (result.preflight.blockers.length > 0) {
+      defaultRuntime.log(theme.warn(result.preflight.summary));
+    }
+  }
+  return true;
+}

--- a/src/cli/daemon-cli/lifecycle.external-supervision.test.ts
+++ b/src/cli/daemon-cli/lifecycle.external-supervision.test.ts
@@ -24,6 +24,9 @@ const clearGatewayRestartIntentSync = vi.fn();
 const findInstalledSystemdGatewayScope = vi.fn();
 const probeGateway = vi.fn();
 const callGatewayCli = vi.fn();
+const isTerminalInteractive = vi.fn(() => true);
+const appendGatewayLifecycleAudit = vi.fn();
+const createGatewayLifecycleMutationAudit = vi.fn(() => vi.fn());
 
 const gatewayLockIdentity = {
   pid: 4200,
@@ -94,6 +97,16 @@ vi.mock("./lifecycle-core.js", () => ({
   runServiceUninstall,
 }));
 
+vi.mock("../terminal-interactivity.js", () => ({
+  isTerminalInteractive: () => isTerminalInteractive(),
+  NON_INTERACTIVE_GATEWAY_STOP_MESSAGE: "non-interactive gateway stop requires --force",
+}));
+
+vi.mock("./lifecycle-audit.js", () => ({
+  appendGatewayLifecycleAudit: (params: unknown) => appendGatewayLifecycleAudit(params),
+  createGatewayLifecycleMutationAudit: () => createGatewayLifecycleMutationAudit(),
+}));
+
 async function expectRestartError(promise: Promise<unknown>): Promise<Error> {
   try {
     await promise;
@@ -144,6 +157,9 @@ describe("external gateway supervision lifecycle", () => {
       findInstalledSystemdGatewayScope,
       probeGateway,
       callGatewayCli,
+      isTerminalInteractive,
+      appendGatewayLifecycleAudit,
+      createGatewayLifecycleMutationAudit,
     ]) {
       mock.mockReset();
     }
@@ -160,6 +176,7 @@ describe("external gateway supervision lifecycle", () => {
       portUsage: { port: 18_789, status: "busy", listeners: [], hints: [] },
     });
     callGatewayCli.mockResolvedValue({ ok: true, status: "emitted", pid: 4200 });
+    isTerminalInteractive.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -199,6 +216,12 @@ describe("external gateway supervision lifecycle", () => {
       intent: { force: true },
     });
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGUSR1");
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "restart",
+      source: "supervisor",
+      mode: "sigusr1",
+      pid: 4200,
+    });
     expect(waitForGatewayHealthyListener).toHaveBeenCalledWith({
       port: 19_455,
       attempts: 120,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -221,19 +221,9 @@ vi.mock("./lifecycle-core.js", () => ({
 }));
 
 describe("runDaemonRestart health checks", () => {
-  let runDaemonStart: (opts?: { json?: boolean }) => Promise<void>;
-  let runDaemonRestart: (opts?: {
-    json?: boolean;
-    safe?: boolean;
-    force?: boolean;
-    skipDeferral?: boolean;
-    wait?: string;
-  }) => Promise<boolean>;
-  let runDaemonStop: (opts?: {
-    json?: boolean;
-    disable?: boolean;
-    force?: boolean;
-  }) => Promise<void>;
+  let runDaemonStart: typeof import("./lifecycle.js").runDaemonStart;
+  let runDaemonRestart: typeof import("./lifecycle.js").runDaemonRestart;
+  let runDaemonStop: typeof import("./lifecycle.js").runDaemonStop;
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   function mockUnmanagedRestart({
@@ -763,14 +753,6 @@ describe("runDaemonRestart health checks", () => {
     isTerminalInteractive.mockReturnValue(false);
 
     await runDaemonStop({ json: true, force: true });
-
-    expect(runServiceStop).toHaveBeenCalledTimes(1);
-  });
-
-  it("allows an interactive managed stop without force", async () => {
-    isTerminalInteractive.mockReturnValue(true);
-
-    await runDaemonStop({ json: true });
 
     expect(runServiceStop).toHaveBeenCalledTimes(1);
   });

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -88,6 +88,16 @@ const restartSystemdService = vi.hoisted(() =>
   vi.fn<() => Promise<{ outcome: "completed" }>>(async () => ({ outcome: "completed" })),
 );
 const stopSystemdService = vi.hoisted(() => vi.fn<() => Promise<void>>(async () => {}));
+const isTerminalInteractive = vi.fn(() => true);
+const appendGatewayLifecycleAudit = vi.fn();
+const createGatewayLifecycleMutationAudit = vi.fn(
+  (params: { action: string; source?: string }) => (mutation: { mode: string; pid?: number }) =>
+    appendGatewayLifecycleAudit({
+      action: params.action,
+      source: params.source ?? "cli",
+      ...mutation,
+    }),
+);
 
 function requireMockCallArg(
   mockFn: { mock: { calls: unknown[][] } },
@@ -181,6 +191,18 @@ vi.mock("./start-repair.js", () => ({
   repairLoadedGatewayServiceForStart: (args: unknown) => repairLoadedGatewayServiceForStart(args),
 }));
 
+vi.mock("../terminal-interactivity.js", () => ({
+  isTerminalInteractive: () => isTerminalInteractive(),
+  NON_INTERACTIVE_GATEWAY_STOP_MESSAGE:
+    "This stops the operator's running gateway service. Use an isolated dev gateway (openclaw gateway run --dev, or --profile <name> with a free port) for testing, or re-run with --force if you really mean it.",
+}));
+
+vi.mock("./lifecycle-audit.js", () => ({
+  appendGatewayLifecycleAudit: (params: unknown) => appendGatewayLifecycleAudit(params),
+  createGatewayLifecycleMutationAudit: (params: { action: string; source?: string }) =>
+    createGatewayLifecycleMutationAudit(params),
+}));
+
 vi.mock("./restart-health.js", () => ({
   DEFAULT_RESTART_HEALTH_ATTEMPTS: 120,
   DEFAULT_RESTART_HEALTH_DELAY_MS: 500,
@@ -207,7 +229,11 @@ describe("runDaemonRestart health checks", () => {
     skipDeferral?: boolean;
     wait?: string;
   }) => Promise<boolean>;
-  let runDaemonStop: (opts?: { json?: boolean; disable?: boolean }) => Promise<void>;
+  let runDaemonStop: (opts?: {
+    json?: boolean;
+    disable?: boolean;
+    force?: boolean;
+  }) => Promise<void>;
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   function mockUnmanagedRestart({
@@ -272,6 +298,10 @@ describe("runDaemonRestart health checks", () => {
     readActiveGatewayLockIdentity.mockReset();
     recoverInstalledLaunchAgent.mockReset();
     repairLoadedGatewayServiceForStart.mockReset();
+    isTerminalInteractive.mockReset();
+    isTerminalInteractive.mockReturnValue(true);
+    appendGatewayLifecycleAudit.mockClear();
+    createGatewayLifecycleMutationAudit.mockClear();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
@@ -479,6 +509,12 @@ describe("runDaemonRestart health checks", () => {
       timeoutMs: 10_000,
     });
     expect(runServiceRestart).not.toHaveBeenCalled();
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "restart",
+      source: "safe-rpc",
+      mode: "deferred",
+      pid: 123,
+    });
   });
 
   it("keeps force restart on the existing non-safe path", async () => {
@@ -695,6 +731,64 @@ describe("runDaemonRestart health checks", () => {
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4300, "SIGTERM");
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "stop",
+      source: "cli",
+      mode: "sigterm",
+      pid: 4200,
+    });
+  });
+
+  it("blocks non-interactive stop without force before managed service access", async () => {
+    isTerminalInteractive.mockReturnValue(false);
+    const { defaultRuntime } = await import("../../runtime.js");
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+
+    await expect(runDaemonStop({ json: true })).rejects.toThrow(
+      'process.exit unexpectedly called with "1"',
+    );
+
+    expect(writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        error: expect.stringContaining("openclaw gateway run --dev"),
+      }),
+    );
+    expect(runServiceStop).not.toHaveBeenCalled();
+    expect(service.stop).not.toHaveBeenCalled();
+    expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+  });
+
+  it("allows a forced non-interactive managed stop", async () => {
+    isTerminalInteractive.mockReturnValue(false);
+
+    await runDaemonStop({ json: true, force: true });
+
+    expect(runServiceStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows an interactive managed stop without force", async () => {
+    isTerminalInteractive.mockReturnValue(true);
+
+    await runDaemonStop({ json: true });
+
+    expect(runServiceStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows forced non-interactive unmanaged stop fallback", async () => {
+    isTerminalInteractive.mockReturnValue(false);
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    runServiceStop.mockImplementation(
+      async (params: {
+        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
+      }) => {
+        await params.onNotLoaded?.({ stdout: process.stdout });
+      },
+    );
+
+    await runDaemonStop({ json: true, force: true });
+
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
   });
 
   it("routes macOS disable stops through the service manager when not loaded", async () => {
@@ -723,7 +817,9 @@ describe("runDaemonRestart health checks", () => {
 
     await runDaemonStop({ json: true });
 
-    expect(service.stop).toHaveBeenCalledWith({ env: process.env, stdout: process.stdout });
+    expect(service.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ env: process.env, stdout: process.stdout }),
+    );
     expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
   });
 
@@ -743,6 +839,12 @@ describe("runDaemonRestart health checks", () => {
 
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGUSR1");
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
+      action: "restart",
+      source: "cli",
+      mode: "sigusr1",
+      pid: 4200,
+    });
     expect(probeGateway).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -39,7 +39,15 @@ import { resolveGatewayRestartDeferralTimeoutMs } from "../../infra/restart.js";
 import { defaultRuntime, writeRuntimeJson } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { parseDurationMs } from "../parse-duration.js";
+import {
+  isTerminalInteractive,
+  NON_INTERACTIVE_GATEWAY_STOP_MESSAGE,
+} from "../terminal-interactivity.js";
 import { recoverInstalledLaunchAgent } from "./launchd-recovery.js";
+import {
+  appendGatewayLifecycleAudit,
+  createGatewayLifecycleMutationAudit,
+} from "./lifecycle-audit.js";
 import {
   runServiceRestart,
   runServiceStart,
@@ -169,13 +177,21 @@ async function handleSystemScopeSystemdGateway(
   }
   const stdout = createNullWriter();
   if (action === "stop") {
-    await stopSystemdService({ stdout, env: process.env });
+    await stopSystemdService({
+      stdout,
+      env: process.env,
+      onMutation: createGatewayLifecycleMutationAudit({ action: "stop" }),
+    });
     return {
       result: "stopped",
       message: `Gateway stopped via system-scope systemd unit ${installed.unitName}.`,
     };
   }
-  await restartSystemdService({ stdout, env: process.env });
+  await restartSystemdService({
+    stdout,
+    env: process.env,
+    onMutation: createGatewayLifecycleMutationAudit({ action: "restart" }),
+  });
   return {
     result: "restarted",
     message: `Gateway restarted via system-scope systemd unit ${installed.unitName}.`,
@@ -193,6 +209,12 @@ async function stopGatewayWithoutServiceManager(port: number) {
   }
   for (const pid of pids) {
     signalVerifiedGatewayPidSync(pid, "SIGTERM");
+    appendGatewayLifecycleAudit({
+      action: "stop",
+      source: "cli",
+      mode: "sigterm",
+      pid,
+    });
   }
   return {
     result: "stopped" as const,
@@ -275,6 +297,12 @@ async function requestSafeGatewayRestart(opts: DaemonLifecycleOptions): Promise<
     params,
     timeoutMs: 10_000,
   });
+  appendGatewayLifecycleAudit({
+    action: "restart",
+    source: "safe-rpc",
+    mode: result.status,
+    pid: result.restart.pid,
+  });
   const message =
     result.status === "coalesced"
       ? "safe restart request joined an existing pending gateway restart"
@@ -310,6 +338,7 @@ async function signalGatewayRestart(
     enforceRestartConfig: boolean;
     processLabel: string;
     requireLockIdentity?: boolean;
+    auditSource: "cli" | "supervisor";
   },
 ) {
   if (params.enforceRestartConfig) {
@@ -404,6 +433,12 @@ async function signalGatewayRestart(
     }
     throw err;
   }
+  appendGatewayLifecycleAudit({
+    action: "restart",
+    source: params.auditSource,
+    mode: isWindows ? "rpc" : "sigusr1",
+    pid,
+  });
   return {
     result: "restarted" as const,
     pid,
@@ -424,6 +459,7 @@ async function restartGatewayWithoutServiceManager(
     restartIntent,
     enforceRestartConfig: true,
     processLabel: "unmanaged",
+    auditSource: "cli",
   });
 }
 
@@ -452,6 +488,7 @@ async function runExternalSupervisorRestart(opts: DaemonLifecycleOptions): Promi
       enforceRestartConfig: false,
       processLabel: "externally supervised",
       requireLockIdentity: true,
+      auditSource: "supervisor",
     });
   } catch (err) {
     fail(`Gateway restart failed: ${String(err)}`);
@@ -512,7 +549,17 @@ export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
     renderStartHints: renderGatewayServiceStartHints,
     onNotLoaded:
       process.platform === "darwin"
-        ? async () => await recoverInstalledLaunchAgent({ result: "started" })
+        ? async () => {
+            const recovered = await recoverInstalledLaunchAgent({ result: "started" });
+            if (recovered) {
+              appendGatewayLifecycleAudit({
+                action: "start",
+                source: "cli",
+                mode: "launchd-bootstrap",
+              });
+            }
+            return recovered;
+          }
         : undefined,
     repairLoadedService: async ({ json, stdout, warn, state, issues }) =>
       await repairLoadedGatewayServiceForStart({
@@ -531,6 +578,11 @@ export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
 
 /** Stop the managed Gateway service or verified unmanaged listener fallback. */
 export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
+  if (!isTerminalInteractive() && !opts.force) {
+    const { fail } = createDaemonActionContext({ action: "stop", json: Boolean(opts.json) });
+    fail(NON_INTERACTIVE_GATEWAY_STOP_MESSAGE);
+    return;
+  }
   assertGatewayServiceMutationAllowed("stop the gateway");
   const service = resolveGatewayService();
   let gatewayPortPromise: Promise<number> | undefined;
@@ -545,7 +597,11 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
         if (runtime?.status === "running") {
           // systemd can run a disabled unit with Restart=always. Stop it through
           // systemctl so a process-level SIGTERM cannot trigger a respawn.
-          await service.stop({ env: process.env, stdout });
+          await service.stop({
+            env: process.env,
+            stdout,
+            onMutation: createGatewayLifecycleMutationAudit({ action: "stop" }),
+          });
           return { result: "stopped" };
         }
       }
@@ -622,6 +678,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       if (process.platform === "darwin") {
         const recovered = await recoverInstalledLaunchAgent({ result: "restarted" });
         if (recovered) {
+          appendGatewayLifecycleAudit({
+            action: "restart",
+            source: "cli",
+            mode: "launchd-bootstrap",
+          });
           return recovered;
         }
       }
@@ -698,7 +759,12 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         }
 
         await terminateStaleGatewayPids(health.staleGatewayPids);
-        const retryRestart = await service.restart({ env: process.env, stdout, warn });
+        const retryRestart = await service.restart({
+          env: process.env,
+          stdout,
+          warn,
+          onMutation: createGatewayLifecycleMutationAudit({ action: "restart" }),
+        });
         if (retryRestart.outcome === "scheduled") {
           return retryRestart;
         }

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -29,16 +29,14 @@ import {
   formatExternalSupervisorActionRequired,
   isGatewayExternallySupervised,
 } from "../../infra/gateway-supervision.js";
-import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
 import {
   clearGatewayRestartIntentSync,
   type GatewayRestartIntent,
   writeGatewayRestartIntentSync,
 } from "../../infra/restart-intent.js";
 import { resolveGatewayRestartDeferralTimeoutMs } from "../../infra/restart.js";
-import { defaultRuntime, writeRuntimeJson } from "../../runtime.js";
+import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
-import { parseDurationMs } from "../parse-duration.js";
 import {
   isTerminalInteractive,
   NON_INTERACTIVE_GATEWAY_STOP_MESSAGE,
@@ -54,6 +52,10 @@ import {
   runServiceStop,
   runServiceUninstall,
 } from "./lifecycle-core.js";
+import {
+  requestSafeGatewayRestart,
+  resolveGatewayRestartIntentOptions,
+} from "./lifecycle-safe-restart.js";
 import { createDaemonActionContext, createNullWriter } from "./response.js";
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
@@ -222,21 +224,6 @@ async function stopGatewayWithoutServiceManager(port: number) {
   };
 }
 
-function resolveGatewayRestartIntentOptions(
-  opts: DaemonLifecycleOptions,
-): GatewayRestartIntent | undefined {
-  if (opts.force && opts.wait !== undefined) {
-    throw new Error("--force cannot be combined with --wait");
-  }
-  if (opts.force) {
-    return { force: true };
-  }
-  if (opts.wait !== undefined) {
-    return { waitMs: parseDurationMs(opts.wait) };
-  }
-  return undefined;
-}
-
 async function resolveRestartListenerHealthWait(
   restartIntent: GatewayRestartIntent | undefined,
 ): Promise<{
@@ -271,64 +258,6 @@ async function resolveRestartListenerHealthWait(
     waitIndefinitelyForPreviousOwner: false,
     timeoutSeconds: Math.round((attempts * POST_RESTART_HEALTH_DELAY_MS) / 1000),
   };
-}
-
-function formatSafeRestartWarnings(result: SafeGatewayRestartRequestResult): string[] | undefined {
-  if (result.preflight.blockers.length === 0) {
-    return undefined;
-  }
-  return [result.preflight.summary];
-}
-
-async function requestSafeGatewayRestart(opts: DaemonLifecycleOptions): Promise<boolean> {
-  if (opts.force) {
-    throw new Error("--safe cannot be combined with --force; omit --safe to force restart now");
-  }
-  if (opts.wait !== undefined) {
-    throw new Error("--safe cannot be combined with --wait; safe restart uses gateway deferral");
-  }
-  const skipDeferral = opts.skipDeferral === true;
-  const params: { reason: string; skipDeferral?: true } = { reason: "gateway.restart.safe" };
-  if (skipDeferral) {
-    params.skipDeferral = true;
-  }
-  const result = await callGatewayCli<SafeGatewayRestartRequestResult>({
-    method: "gateway.restart.request",
-    params,
-    timeoutMs: 10_000,
-  });
-  appendGatewayLifecycleAudit({
-    action: "restart",
-    source: "safe-rpc",
-    mode: result.status,
-    pid: result.restart.pid,
-  });
-  const message =
-    result.status === "coalesced"
-      ? "safe restart request joined an existing pending gateway restart"
-      : result.status === "deferred"
-        ? "safe restart requested; gateway will restart after active work drains " +
-          "(bounded by gateway.reload.deferralTimeoutMs; may force after timeout expires)"
-        : skipDeferral
-          ? "safe restart requested; gateway bypassing active-work deferral"
-          : "safe restart requested; gateway will restart momentarily";
-  const payload = {
-    ok: true,
-    result: result.status,
-    message,
-    preflight: result.preflight,
-    restart: result.restart,
-    warnings: formatSafeRestartWarnings(result),
-  };
-  if (opts.json) {
-    writeRuntimeJson(defaultRuntime, payload);
-  } else {
-    defaultRuntime.log(message);
-    if (result.preflight.blockers.length > 0) {
-      defaultRuntime.log(theme.warn(result.preflight.summary));
-    }
-  }
-  return true;
 }
 
 async function signalGatewayRestart(

--- a/src/cli/daemon-cli/register-service-commands.test.ts
+++ b/src/cli/daemon-cli/register-service-commands.test.ts
@@ -91,6 +91,14 @@ describe("addGatewayServiceCommands", () => {
       },
     },
     {
+      name: "forwards stop force control",
+      argv: ["stop", "--force"],
+      assert: () => {
+        const opts = expectSingleDaemonCall(runDaemonStop);
+        expect(opts.force).toBe(true);
+      },
+    },
+    {
       name: "forwards status auth collisions from parent gateway command",
       argv: ["status", "--token", "tok_status", "--password", "pw_status"],
       assert: () => {

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -54,6 +54,14 @@ function resolveRestartOptions(cmdOpts: DaemonLifecycleOptions, command?: Comman
   };
 }
 
+function resolveStopOptions(cmdOpts: DaemonLifecycleOptions, command?: Command) {
+  const parentForce = inheritOptionFromParent<boolean>(command, "force");
+  return {
+    ...cmdOpts,
+    force: Boolean(cmdOpts.force || parentForce),
+  };
+}
+
 /** Attach Gateway service status/install/lifecycle subcommands to a parent command. */
 export function addGatewayServiceCommands(parent: Command, opts?: { statusDescription?: string }) {
   parent
@@ -115,15 +123,16 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("stop")
     .description("Stop the Gateway service (launchd/systemd/schtasks)")
+    .option("--force", "Allow stop from a non-interactive shell", false)
     .option("--json", "Output JSON", false)
     .option(
       "--disable",
       "Persistently suppress KeepAlive/RunAtLoad so the gateway does not respawn until next start (launchd only)",
       false,
     )
-    .action(async (cmdOpts) => {
+    .action(async (cmdOpts, command) => {
       const { runDaemonStop } = await loadDaemonLifecycleModule();
-      await runDaemonStop(cmdOpts);
+      await runDaemonStop(resolveStopOptions(cmdOpts, command));
     });
 
   parent

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -97,6 +97,70 @@ export function buildDaemonServiceSnapshot(service: GatewayService, loaded: bool
   };
 }
 
+type DaemonEmit = (payload: Omit<DaemonActionResponse, "action">) => void;
+
+/** Emit a lifecycle result and mirror its message to text output. */
+export function emitDaemonActionMessage(params: {
+  json: boolean;
+  emit: DaemonEmit;
+  payload: Omit<DaemonActionResponse, "action">;
+}): void {
+  params.emit(params.payload);
+  if (!params.json && params.payload.message) {
+    defaultRuntime.log(params.payload.message);
+  }
+}
+
+/** Emit the no-op success returned when a service is already running. */
+export function emitDaemonAlreadyRunning(params: {
+  serviceNoun: string;
+  service: GatewayService;
+  pid?: number;
+  json: boolean;
+  warnings: string[];
+  emit: DaemonEmit;
+}): void {
+  const message =
+    params.pid === undefined
+      ? `${params.serviceNoun} service already running.`
+      : `${params.serviceNoun} service already running (pid ${params.pid}).`;
+  emitDaemonActionMessage({
+    json: params.json,
+    emit: params.emit,
+    payload: {
+      ok: true,
+      result: "already-running",
+      message,
+      service: buildDaemonServiceSnapshot(params.service, true),
+      warnings: params.warnings.length ? params.warnings : undefined,
+    },
+  });
+}
+
+/** Emit a service-manager restart that has been accepted but not completed. */
+export function emitDaemonScheduledRestart(params: {
+  json: boolean;
+  emit: DaemonEmit;
+  result: string;
+  message: string;
+  service: GatewayService;
+  loaded: boolean;
+  warnings: string[];
+}): true {
+  emitDaemonActionMessage({
+    json: params.json,
+    emit: params.emit,
+    payload: {
+      ok: true,
+      result: params.result,
+      message: params.message,
+      service: buildDaemonServiceSnapshot(params.service, params.loaded),
+      warnings: params.warnings.length ? params.warnings : undefined,
+    },
+  });
+  return true;
+}
+
 /** Writable sink used when JSON output should suppress service command stdout. */
 export function createNullWriter(): Writable {
   return new Writable({

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -29,7 +29,7 @@ type DaemonHintItem = {
 };
 
 /** Machine-readable response shape for service lifecycle commands. */
-export type DaemonActionResponse = {
+type DaemonActionResponse = {
   ok: boolean;
   action: DaemonAction;
   result?: string;

--- a/src/cli/daemon-cli/test-helpers/lifecycle-core-harness.ts
+++ b/src/cli/daemon-cli/test-helpers/lifecycle-core-harness.ts
@@ -50,7 +50,7 @@ export function resetLifecycleServiceMocks() {
   service.restart.mockReset();
   service.isLoaded.mockResolvedValue(true);
   service.readCommand.mockResolvedValue({ programArguments: [], environment: {} });
-  service.readRuntime.mockResolvedValue({ status: "running" });
+  service.readRuntime.mockResolvedValue({ status: "stopped" });
   service.stop.mockResolvedValue(undefined);
   service.uninstall.mockResolvedValue(undefined);
   service.restart.mockResolvedValue({ outcome: "completed" });

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -31,6 +31,9 @@ const cleanStaleGatewayProcessesSync = vi.fn(
   (_port?: number, _options?: { protectedPid?: number }) => [],
 );
 const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
+const findVerifiedGatewayListenerPidsOnPortSync = vi.fn((_port: number) => [] as number[]);
+const formatGatewayPidList = vi.fn((pids: number[]) => pids.join(", "));
+const isTerminalInteractive = vi.fn(() => true);
 const ensureDevGatewayConfig = vi.fn(async (_opts?: unknown) => {});
 type GatewayLoopStart = (params?: { startupStartedAt?: number }) => Promise<unknown>;
 const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
@@ -245,6 +248,12 @@ vi.mock("../../infra/restart-stale-pids.js", () => ({
     cleanStaleGatewayProcessesSync(port, options),
 }));
 
+vi.mock("../../infra/gateway-processes.js", () => ({
+  findVerifiedGatewayListenerPidsOnPortSync: (port: number) =>
+    findVerifiedGatewayListenerPidsOnPortSync(port),
+  formatGatewayPidList: (pids: number[]) => formatGatewayPidList(pids),
+}));
+
 vi.mock("../../gateway/server.js", () => ({
   startGatewayServer: (port: number, opts?: unknown) => startGatewayServer(port, opts),
 }));
@@ -316,6 +325,12 @@ vi.mock("../command-format.js", () => ({
   formatCliCommand: (cmd: string) => cmd,
 }));
 
+vi.mock("../terminal-interactivity.js", () => ({
+  isTerminalInteractive: () => isTerminalInteractive(),
+  NON_INTERACTIVE_GATEWAY_RUN_FORCE_MESSAGE:
+    "Refusing to kill the operator's running gateway service from a non-interactive shell. Use an isolated dev gateway (openclaw gateway run --dev, or --profile <name> with a free port) for testing.",
+}));
+
 vi.mock("../ports.js", () => ({
   forceFreePortAndWait: (port: number, opts: unknown) => forceFreePortAndWait(port, opts),
   waitForPortBindable: (port: number, opts?: unknown) => waitForPortBindable(port, opts),
@@ -379,6 +394,11 @@ describe("gateway run option collisions", () => {
     setVerbose.mockClear();
     setConsoleSubsystemFilter.mockClear();
     forceFreePortAndWait.mockClear();
+    findVerifiedGatewayListenerPidsOnPortSync.mockReset();
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+    formatGatewayPidList.mockClear();
+    isTerminalInteractive.mockReset();
+    isTerminalInteractive.mockReturnValue(true);
     cleanStaleGatewayProcessesSync.mockClear();
     waitForPortBindable.mockClear();
     ensureDevGatewayConfig.mockClear();
@@ -930,6 +950,25 @@ describe("gateway run option collisions", () => {
     expect(gatewayStartOptions().auth?.token).toBe("tok_run");
     expect(normalizeStateDirEnv).toHaveBeenCalledWith(process.env);
     expect(callOrder).toEqual(["bootstrap", "normalize", "normalize", "start"]);
+  });
+
+  it("refuses non-interactive --force when a verified gateway appears before signaling", async () => {
+    isTerminalInteractive.mockReturnValue(false);
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValueOnce([]).mockReturnValueOnce([4242]);
+    forceFreePortAndWait.mockImplementationOnce(async (_port, opts) => {
+      (opts as { beforeSignal?: () => void }).beforeSignal?.();
+      return { killed: [], waitedMs: 0, escalatedToSigkill: false };
+    });
+
+    await expect(
+      runGatewayCli(["gateway", "run", "--allow-unconfigured", "--force"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
+    expect(forceFreePortAndWait).toHaveBeenCalledTimes(1);
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("openclaw gateway run --dev");
+    expect(runtimeErrors.join("\n")).toContain("--profile <name> with a free port");
   });
 
   it("marks service-mode gateway descendants with the live gateway pid", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -48,6 +48,10 @@ import {
   type GatewayBootLifecycleCompletion,
 } from "../../infra/gateway-boot-lifecycle.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import {
+  findVerifiedGatewayListenerPidsOnPortSync,
+  formatGatewayPidList,
+} from "../../infra/gateway-processes.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import type { RespawnSupervisor } from "../../infra/supervisor-markers.js";
 import { normalizeFingerprint } from "../../infra/tls/fingerprint.js";
@@ -60,6 +64,10 @@ import { formatCliCommand } from "../command-format.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
 import { withProgress } from "../progress.js";
 import { parsePort } from "../shared/parse-port.js";
+import {
+  isTerminalInteractive,
+  NON_INTERACTIVE_GATEWAY_RUN_FORCE_MESSAGE,
+} from "../terminal-interactivity.js";
 import {
   enforceGatewayRunFutureConfigGuard,
   isGatewayRunFutureConfigAllowed,
@@ -827,12 +835,37 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
     }
   }
   if (opts.force) {
+    const describeNonInteractiveGatewayOwner = () => {
+      const gatewayPids = findVerifiedGatewayListenerPidsOnPortSync(port);
+      if (gatewayPids.length === 0) {
+        return undefined;
+      }
+      return `${NON_INTERACTIVE_GATEWAY_RUN_FORCE_MESSAGE} Existing gateway listener pid${gatewayPids.length === 1 ? "" : "s"}: ${formatGatewayPidList(gatewayPids)}.`;
+    };
+    if (!isTerminalInteractive()) {
+      const refusal = describeNonInteractiveGatewayOwner();
+      if (refusal) {
+        defaultRuntime.error(refusal);
+        defaultRuntime.exit(1);
+        return;
+      }
+    }
     try {
       const { forceFreePortAndWait, waitForPortBindable } = await import("../ports.js");
       const { killed, waitedMs, escalatedToSigkill } = await forceFreePortAndWait(port, {
         timeoutMs: 2000,
         intervalMs: 100,
         sigtermTimeoutMs: 700,
+        ...(isTerminalInteractive()
+          ? {}
+          : {
+              beforeSignal: () => {
+                const refusal = describeNonInteractiveGatewayOwner();
+                if (refusal) {
+                  throw new Error(refusal);
+                }
+              },
+            }),
       });
       if (killed.length === 0) {
         // Nothing was freed; keep the no-op out of normal startup output.

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -87,18 +87,13 @@ function parseFuserPidList(output: string): number[] {
     return [];
   }
   const values = new Set<number>();
-  for (const rawLine of output.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line) {
+  for (const token of output.split(/\s+/)) {
+    if (!token) {
       continue;
     }
-    const pidRegion = line.includes(":") ? line.slice(line.indexOf(":") + 1) : line;
-    const pidMatches = pidRegion.match(/\d+/g) ?? [];
-    for (const match of pidMatches) {
-      const pid = Number.parseInt(match, 10);
-      if (Number.isFinite(pid) && pid > 0) {
-        values.add(pid);
-      }
+    const pid = parseStrictPositiveInteger(token);
+    if (pid !== undefined) {
+      values.add(pid);
     }
   }
   return [...values];
@@ -162,8 +157,9 @@ function listPortListenersWithFuser(port: number): PortProcess[] {
   } catch (err: unknown) {
     const execErr = err as ExecFileError;
     const stdout = readExecOutput(execErr.stdout);
-    const stderr = readExecOutput(execErr.stderr);
-    const parsed = parseFuserPidList([stdout, stderr].filter(Boolean).join("\n"));
+    // fuser writes resource labels and diagnostics to stderr. Only its stdout
+    // PID stream is safe to turn into direct signal targets.
+    const parsed = parseFuserPidList(stdout);
     if (execErr.status === 1) {
       return parsed.map((pid) => ({ pid }));
     }

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -109,8 +109,14 @@ function killPortWithFuser(
   signal: "SIGTERM" | "SIGKILL",
   beforeSignal?: BeforePortSignal,
 ): PortProcess[] {
+  if (beforeSignal) {
+    const listeners = listPortListenersWithFuser(port);
+    // fuser's resource-targeted -k can select a different PID at exec time.
+    // A guard therefore freezes concrete victims before signaling directly.
+    killPids(port, listeners, signal, beforeSignal);
+    return listeners;
+  }
   const args = ["-k", `-${FUSER_SIGNALS[signal]}`, `${port}/tcp`];
-  beforeSignal?.({ port, signal });
   try {
     const stdout = execFileSync("fuser", args, {
       encoding: "utf-8",
@@ -139,6 +145,41 @@ function killPortWithFuser(
     }
     if (code === "EACCES" || code === "EPERM") {
       throw withErrnoCode("fuser permission denied while forcing gateway port", code, err);
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+function listPortListenersWithFuser(port: number): PortProcess[] {
+  try {
+    const stdout = execFileSync("fuser", [`${port}/tcp`], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: PORT_TOOL_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+    return parseFuserPidList(stdout).map((pid) => ({ pid }));
+  } catch (err: unknown) {
+    const execErr = err as ExecFileError;
+    const stdout = readExecOutput(execErr.stdout);
+    const stderr = readExecOutput(execErr.stderr);
+    const parsed = parseFuserPidList([stdout, stderr].filter(Boolean).join("\n"));
+    if (execErr.status === 1) {
+      return parsed.map((pid) => ({ pid }));
+    }
+    if (execErr.code === "ENOENT") {
+      throw withErrnoCode(
+        "fuser not found; required for --force when lsof is unavailable",
+        "ENOENT",
+        err,
+      );
+    }
+    if (execErr.code === "EACCES" || execErr.code === "EPERM") {
+      throw withErrnoCode(
+        "fuser permission denied while inspecting gateway port",
+        execErr.code,
+        err,
+      );
     }
     throw err instanceof Error ? err : new Error(String(err));
   }

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -18,6 +18,8 @@ type ForceFreePortResult = {
   escalatedToSigkill: boolean;
 };
 
+type BeforePortSignal = (context: { port: number; pid?: number; signal: NodeJS.Signals }) => void;
+
 type ExecFileError = NodeJS.ErrnoException & {
   status?: number | null;
   stderr?: string | Buffer;
@@ -102,8 +104,13 @@ function parseFuserPidList(output: string): number[] {
   return [...values];
 }
 
-function killPortWithFuser(port: number, signal: "SIGTERM" | "SIGKILL"): PortProcess[] {
+function killPortWithFuser(
+  port: number,
+  signal: "SIGTERM" | "SIGKILL",
+  beforeSignal?: BeforePortSignal,
+): PortProcess[] {
   const args = ["-k", `-${FUSER_SIGNALS[signal]}`, `${port}/tcp`];
+  beforeSignal?.({ port, signal });
   try {
     const stdout = execFileSync("fuser", args, {
       encoding: "utf-8",
@@ -235,10 +242,14 @@ function listPortListeners(port: number): PortProcess[] {
   }
 }
 
-export function forceFreePort(port: number): PortProcess[] {
+export function forceFreePort(
+  port: number,
+  opts: { beforeSignal?: BeforePortSignal } = {},
+): PortProcess[] {
   const listeners = listPortListeners(port);
   for (const proc of listeners) {
     try {
+      opts.beforeSignal?.({ port, pid: proc.pid, signal: "SIGTERM" });
       process.kill(proc.pid, "SIGTERM");
     } catch (err) {
       throw new Error(
@@ -250,9 +261,15 @@ export function forceFreePort(port: number): PortProcess[] {
   return listeners;
 }
 
-function killPids(listeners: PortProcess[], signal: NodeJS.Signals) {
+function killPids(
+  port: number,
+  listeners: PortProcess[],
+  signal: NodeJS.Signals,
+  beforeSignal?: BeforePortSignal,
+) {
   for (const proc of listeners) {
     try {
+      beforeSignal?.({ port, pid: proc.pid, signal });
       process.kill(proc.pid, signal);
     } catch (err) {
       throw new Error(
@@ -272,6 +289,8 @@ export async function forceFreePortAndWait(
     intervalMs?: number;
     /** How long to wait after SIGTERM before escalating to SIGKILL. */
     sigtermTimeoutMs?: number;
+    /** Last-moment ownership guard invoked before each destructive signal. */
+    beforeSignal?: BeforePortSignal;
   } = {},
 ): Promise<ForceFreePortResult> {
   const timeoutMs = resolveTimerTimeoutMs(opts.timeoutMs, 1500, 0);
@@ -285,7 +304,7 @@ export async function forceFreePortAndWait(
   let useFuserFallback = false;
 
   try {
-    killed = forceFreePort(port);
+    killed = forceFreePort(port, opts.beforeSignal ? { beforeSignal: opts.beforeSignal } : {});
   } catch (err) {
     if (!isRecoverableLsofError(err)) {
       throw err;
@@ -296,7 +315,7 @@ export async function forceFreePortAndWait(
       return { killed, waitedMs: 0, escalatedToSigkill: false };
     }
     useFuserFallback = true;
-    killed = killPortWithFuser(port, "SIGTERM");
+    killed = killPortWithFuser(port, "SIGTERM", opts.beforeSignal);
   }
 
   if (killed.length === 0) {
@@ -330,10 +349,10 @@ export async function forceFreePortAndWait(
   }
 
   if (useFuserFallback) {
-    killPortWithFuser(port, "SIGKILL");
+    killPortWithFuser(port, "SIGKILL", opts.beforeSignal);
   } else {
     const remaining = listPortListeners(port);
-    killPids(remaining, "SIGKILL");
+    killPids(port, remaining, "SIGKILL", opts.beforeSignal);
   }
 
   while (waitedMs < timeoutMs) {

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -304,7 +304,7 @@ describe("gateway --force helpers", () => {
         err.code = "EACCES";
         throw err;
       }
-      return "18789/tcp: 4242\n";
+      return "4242\n";
     });
     probePortUsageMock.mockResolvedValueOnce("busy").mockResolvedValue("free");
 
@@ -335,7 +335,7 @@ describe("gateway --force helpers", () => {
       if (args.includes("-k")) {
         throw new Error("guarded fuser cleanup must not use resource-targeted kill");
       }
-      return `18789/tcp: ${fuserPids.join(" ")}\n`;
+      return `${fuserPids.join(" ")}\n`;
     });
     probePortUsageMock.mockResolvedValueOnce("busy").mockResolvedValue("free");
     const killMock = vi.fn();
@@ -358,6 +358,43 @@ describe("gateway --force helpers", () => {
     expect(execFileSync).toHaveBeenCalledWith("fuser", ["18789/tcp"], expect.anything());
   });
 
+  it("never derives guarded fuser victims from stderr diagnostics", async () => {
+    (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
+      if (cmd.includes("lsof")) {
+        const err = new Error("spawnSync lsof EACCES") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      const err = new Error("fuser diagnostics") as NodeJS.ErrnoException & {
+        status?: number;
+        stdout?: string;
+        stderr?: string;
+      };
+      err.status = 1;
+      err.stdout = "4242 5151oops\n";
+      err.stderr = "18789/tcp: 5252\nfuser warning for device 6161\n";
+      throw err;
+    });
+    probePortUsageMock.mockResolvedValueOnce("busy").mockResolvedValue("free");
+    const killMock = vi.fn();
+    process.kill = killMock;
+    const beforeSignal = vi.fn();
+
+    const result = await forceFreePortAndWait(18789, {
+      timeoutMs: 500,
+      intervalMs: 100,
+      beforeSignal,
+    });
+
+    expect(result.killed).toEqual<PortProcess[]>([{ pid: 4242 }]);
+    expect(beforeSignal).toHaveBeenCalledOnce();
+    expect(beforeSignal).toHaveBeenCalledWith({ port: 18789, pid: 4242, signal: "SIGTERM" });
+    expect(killMock).toHaveBeenCalledOnce();
+    expect(killMock).toHaveBeenCalledWith(4242, "SIGTERM");
+    expect(killMock).not.toHaveBeenCalledWith(5252, expect.anything());
+    expect(killMock).not.toHaveBeenCalledWith(6161, expect.anything());
+  });
+
   it("uses fuser SIGKILL escalation when port stays busy", async () => {
     vi.useFakeTimers();
     (execFileSync as unknown as Mock).mockImplementation((cmd: string, args: string[]) => {
@@ -367,10 +404,10 @@ describe("gateway --force helpers", () => {
         throw err;
       }
       if (args.includes("-TERM")) {
-        return "18789/tcp: 1337\n";
+        return "1337\n";
       }
       if (args.includes("-KILL")) {
-        return "18789/tcp: 1337\n";
+        return "1337\n";
       }
       return "";
     });

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -258,12 +258,14 @@ describe("gateway --force helpers", () => {
     });
 
     const killMock = vi.fn();
+    const beforeSignal = vi.fn();
     process.kill = killMock;
 
     const promise = forceFreePortAndWait(18789, {
       timeoutMs: 800,
       intervalMs: 100,
       sigtermTimeoutMs: 300,
+      beforeSignal,
     });
 
     await vi.runAllTimersAsync();
@@ -271,6 +273,8 @@ describe("gateway --force helpers", () => {
 
     expect(killMock).toHaveBeenCalledWith(42, "SIGTERM");
     expect(killMock).toHaveBeenCalledWith(42, "SIGKILL");
+    expect(beforeSignal).toHaveBeenCalledWith({ port: 18789, pid: 42, signal: "SIGTERM" });
+    expect(beforeSignal).toHaveBeenCalledWith({ port: 18789, pid: 42, signal: "SIGKILL" });
     expect(res.escalatedToSigkill).toBe(true);
 
     vi.useRealTimers();

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -324,6 +324,40 @@ describe("gateway --force helpers", () => {
     });
   });
 
+  it("freezes guarded fuser PIDs before signaling when the port owner changes", async () => {
+    let fuserPids = [4242];
+    (execFileSync as unknown as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd.includes("lsof")) {
+        const err = new Error("spawnSync lsof EACCES") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      if (args.includes("-k")) {
+        throw new Error("guarded fuser cleanup must not use resource-targeted kill");
+      }
+      return `18789/tcp: ${fuserPids.join(" ")}\n`;
+    });
+    probePortUsageMock.mockResolvedValueOnce("busy").mockResolvedValue("free");
+    const killMock = vi.fn();
+    process.kill = killMock;
+    const beforeSignal = vi.fn(() => {
+      fuserPids = [5252];
+    });
+
+    const result = await forceFreePortAndWait(18789, {
+      timeoutMs: 500,
+      intervalMs: 100,
+      beforeSignal,
+    });
+
+    expect(result.killed).toEqual<PortProcess[]>([{ pid: 4242 }]);
+    expect(beforeSignal).toHaveBeenCalledWith({ port: 18789, pid: 4242, signal: "SIGTERM" });
+    expect(killMock).toHaveBeenCalledOnce();
+    expect(killMock).toHaveBeenCalledWith(4242, "SIGTERM");
+    expect(killMock).not.toHaveBeenCalledWith(5252, expect.anything());
+    expect(execFileSync).toHaveBeenCalledWith("fuser", ["18789/tcp"], expect.anything());
+  });
+
   it("uses fuser SIGKILL escalation when port stays busy", async () => {
     vi.useFakeTimers();
     (execFileSync as unknown as Mock).mockImplementation((cmd: string, args: string[]) => {

--- a/src/cli/terminal-interactivity.ts
+++ b/src/cli/terminal-interactivity.ts
@@ -1,6 +1,6 @@
 /** True when CLI input and output both belong to an interactive terminal. */
 export function isTerminalInteractive(): boolean {
-  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
 export const NON_INTERACTIVE_GATEWAY_STOP_MESSAGE =

--- a/src/cli/terminal-interactivity.ts
+++ b/src/cli/terminal-interactivity.ts
@@ -1,6 +1,10 @@
 /** True when CLI input and output both belong to an interactive terminal. */
+function isTtyStream(stream: { isTTY?: boolean }): boolean {
+  return stream.isTTY === true;
+}
+
 export function isTerminalInteractive(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  return isTtyStream(process.stdin) && isTtyStream(process.stdout);
 }
 
 export const NON_INTERACTIVE_GATEWAY_STOP_MESSAGE =

--- a/src/cli/terminal-interactivity.ts
+++ b/src/cli/terminal-interactivity.ts
@@ -1,0 +1,10 @@
+/** True when CLI input and output both belong to an interactive terminal. */
+export function isTerminalInteractive(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+export const NON_INTERACTIVE_GATEWAY_STOP_MESSAGE =
+  "This stops the operator's running gateway service. Use an isolated dev gateway (openclaw gateway run --dev, or --profile <name> with a free port) for testing, or re-run with --force if you really mean it.";
+
+export const NON_INTERACTIVE_GATEWAY_RUN_FORCE_MESSAGE =
+  "Refusing to kill the operator's running gateway service from a non-interactive shell. Use an isolated dev gateway (openclaw gateway run --dev, or --profile <name> with a free port) for testing.";

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -141,7 +141,8 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(args[7]).toBe("ai.openclaw.gateway");
     expect(args[1]).toContain('while kill -0 "$wait_pid" >/dev/null 2>&1; do');
     expect(args[1]).toContain("exec >>'/Users/test/.openclaw/logs/gateway-restart.log' 2>&1");
-    expect(args[1]).toContain("openclaw restart attempt source=launchd-handoff mode=kickstart");
+    expect(args[1]).toContain("openclaw restart attempt source=handoff mode=kickstart");
+    expect(args[1]).toContain("pid=%s interactive=0");
     expect(args[1]).toContain('launchctl enable "$service_target"');
     expect(args[1]).toContain('if launchctl kickstart -k "$service_target"; then');
     expect(args[1]).toContain(
@@ -187,7 +188,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     });
 
     const [, args] = requireSpawnCall();
-    expect(args[1]).toContain("openclaw restart attempt source=launchd-handoff mode=reload");
+    expect(args[1]).toContain("openclaw restart attempt source=handoff mode=reload");
     expect(args[1]).toContain('launchctl enable "$service_target"');
     expect(args[1]).toContain('launchctl bootout "$service_target"');
     // The unload poll must outlast launchd's ExitTimeOut SIGKILL ceiling plus

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -107,7 +107,7 @@ function buildLaunchdRestartScript(
   const waitForCallerPid = `wait_pid="$4"
 label="$5"
 ${renderPosixRestartLogSetup(restartLogEnv)}
-printf '[%s] openclaw restart attempt source=launchd-handoff mode=${mode} target=%s waitPid=%s\\n' "$(date -u +%FT%TZ)" "$service_target" "$wait_pid" >&2
+printf '[%s] openclaw restart attempt source=handoff mode=${mode} target=%s pid=%s interactive=0\\n' "$(date -u +%FT%TZ)" "$service_target" "$wait_pid" >&2
 if [ -n "$wait_pid" ] && [ "$wait_pid" -gt 1 ] 2>/dev/null; then
   while kill -0 "$wait_pid" >/dev/null 2>&1; do
     sleep 0.1
@@ -135,9 +135,9 @@ else
   fi
 fi
 if [ "$status" -eq 0 ]; then
-  printf '[%s] openclaw restart done source=launchd-handoff mode=${mode}\\n' "$(date -u +%FT%TZ)" >&2
+  printf '[%s] openclaw restart done source=handoff mode=${mode} interactive=0\\n' "$(date -u +%FT%TZ)" >&2
 else
-  printf '[%s] openclaw restart failed source=launchd-handoff mode=${mode} status=%s\\n' "$(date -u +%FT%TZ)" "$status" >&2
+  printf '[%s] openclaw restart failed source=handoff mode=${mode} status=%s interactive=0\\n' "$(date -u +%FT%TZ)" "$status" >&2
 fi
 exit "$status"
 `;
@@ -199,9 +199,9 @@ launchctl bootout "$service_target" >/dev/null 2>&1 || true
 ${bootoutWaitLoop}
 ${bootstrapRetryLoop}
 if [ "$status" -eq 0 ]; then
-  printf '[%s] openclaw restart done source=launchd-handoff mode=${mode}\\n' "$(date -u +%FT%TZ)" >&2
+  printf '[%s] openclaw restart done source=handoff mode=${mode} interactive=0\\n' "$(date -u +%FT%TZ)" >&2
 else
-  printf '[%s] openclaw restart failed source=launchd-handoff mode=${mode} status=%s\\n' "$(date -u +%FT%TZ)" "$status" >&2
+  printf '[%s] openclaw restart failed source=handoff mode=${mode} status=%s interactive=0\\n' "$(date -u +%FT%TZ)" "$status" >&2
 fi
 exit "$status"
 `;
@@ -210,7 +210,7 @@ exit "$status"
   const verifyLaunchdReload = `print_retry_count="${START_AFTER_EXIT_PRINT_RETRY_COUNT}"
 while [ "$print_retry_count" -gt 0 ]; do
   if launchctl print "$service_target" >/dev/null 2>&1; then
-    printf '[%s] openclaw restart done source=launchd-handoff mode=${mode} reason=launchd-auto-reload\\n' "$(date -u +%FT%TZ)" >&2
+    printf '[%s] openclaw restart done source=handoff mode=${mode} reason=launchd-auto-reload interactive=0\\n' "$(date -u +%FT%TZ)" >&2
     exit 0
   fi
   print_retry_count=$((print_retry_count - 1))
@@ -234,9 +234,9 @@ else
   status=$?
 fi
 if [ "$status" -eq 0 ]; then
-  printf '[%s] openclaw restart done source=launchd-handoff mode=${mode}\\n' "$(date -u +%FT%TZ)" >&2
+  printf '[%s] openclaw restart done source=handoff mode=${mode} interactive=0\\n' "$(date -u +%FT%TZ)" >&2
 else
-  printf '[%s] openclaw restart failed source=launchd-handoff mode=${mode} status=%s\\n' "$(date -u +%FT%TZ)" "$status" >&2
+  printf '[%s] openclaw restart failed source=handoff mode=${mode} status=%s interactive=0\\n' "$(date -u +%FT%TZ)" "$status" >&2
 fi
 exit "$status"
 `;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1674,6 +1674,7 @@ describe("launchd install", () => {
       OPENCLAW_GATEWAY_PORT: "19004",
     };
     const stdout = new PassThrough();
+    const onMutation = vi.fn();
     let output = "";
     stdout.on("data", (chunk: Buffer) => {
       output += chunk.toString();
@@ -1687,10 +1688,11 @@ describe("launchd install", () => {
     probePortUsage.mockResolvedValue("busy");
     formatPortDiagnostics.mockReturnValue(["Port 19004 is held by pid 4242."]);
 
-    await expect(runStopLaunchAgentWithFakeTimers({ env, stdout })).rejects.toThrow(
+    await expect(runStopLaunchAgentWithFakeTimers({ env, stdout, onMutation })).rejects.toThrow(
       "gateway port 19004 is still busy after LaunchAgent stop\nPort 19004 is held by pid 4242.",
     );
 
+    expect(onMutation).toHaveBeenCalledWith({ mode: "bootout" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19004);
     expect(inspectPortUsage).toHaveBeenCalledWith(19004);
     expect(output).not.toContain("Stopped LaunchAgent");
@@ -1819,6 +1821,7 @@ describe("launchd install", () => {
       OPENCLAW_GATEWAY_PORT: "19008",
     };
     const stdout = new PassThrough();
+    const onMutation = vi.fn();
     let output = "";
     state.disableError = "Operation not permitted";
     stdout.on("data", (chunk: Buffer) => {
@@ -1833,10 +1836,13 @@ describe("launchd install", () => {
     probePortUsage.mockResolvedValue("busy");
     formatPortDiagnostics.mockReturnValue(["Port 19008 is held by pid 4242."]);
 
-    await expect(runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true })).rejects.toThrow(
+    await expect(
+      runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true, onMutation }),
+    ).rejects.toThrow(
       "gateway port 19008 is still busy after LaunchAgent stop\nPort 19008 is held by pid 4242.",
     );
 
+    expect(onMutation).toHaveBeenCalledWith({ mode: "disable-bootout" });
     expect(launchctlCommandNames()).toContain("bootout");
     expect(output).toContain("used bootout fallback");
     expect(output).not.toContain("Stopped LaunchAgent");
@@ -1920,6 +1926,21 @@ describe("launchd install", () => {
     ).rejects.toThrow(
       "launchctl print could not confirm stop; used bootout fallback and left service unloaded: launchctl print permission denied; launchctl bootout failed: launchctl bootout permission denied",
     );
+  });
+
+  it("audits disable when stop and its bootout fallback both fail", async () => {
+    const env = createDefaultLaunchdEnv();
+    const onMutation = vi.fn();
+    state.stopError = "stop failed";
+    state.bootoutError = "bootout failed";
+
+    await expect(
+      stopLaunchAgent({ env, stdout: new PassThrough(), disable: true, onMutation }),
+    ).rejects.toThrow("launchctl stop failed; used bootout fallback");
+
+    expect(onMutation).toHaveBeenCalledWith({ mode: "disable" });
+    expect(onMutation).not.toHaveBeenCalledWith({ mode: "disable-stop" });
+    expect(onMutation).not.toHaveBeenCalledWith({ mode: "disable-bootout" });
   });
 
   it("throws when default bootout fails", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1955,9 +1955,11 @@ describe("launchd install", () => {
       ...createDefaultLaunchdEnv(),
       OPENCLAW_GATEWAY_PORT: "18789",
     };
+    const onMutation = vi.fn();
     const result = await restartLaunchAgent({
       env,
       stdout: new PassThrough(),
+      onMutation,
     });
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
@@ -1971,6 +1973,7 @@ describe("launchd install", () => {
     ]);
     expect(launchctlCommandNames()).not.toContain("bootout");
     expect(launchctlCommandNames()).not.toContain("bootstrap");
+    expect(onMutation).toHaveBeenCalledWith({ mode: "kickstart" });
   });
 
   it("reloads launchd after rewriting an existing plist", async () => {
@@ -1999,9 +2002,11 @@ describe("launchd install", () => {
       ].join("\n"),
     );
 
+    const onMutation = vi.fn();
     await restartLaunchAgent({
       env,
       stdout: new PassThrough(),
+      onMutation,
     });
 
     const plist = state.files.get(plistPath) ?? "";
@@ -2010,6 +2015,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
     expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
+    expect(onMutation).toHaveBeenCalledWith({ mode: "bootout-bootstrap" });
   });
 
   it("treats a concurrent launchd bootstrap as success when the service is loaded", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1994,7 +1994,24 @@ describe("launchd install", () => {
     ]);
     expect(launchctlCommandNames()).not.toContain("bootout");
     expect(launchctlCommandNames()).not.toContain("bootstrap");
-    expect(onMutation).toHaveBeenCalledWith({ mode: "kickstart" });
+    expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }], [{ mode: "kickstart" }]]);
+  });
+
+  it("audits kickstart before a later output failure", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    const onMutation = vi.fn();
+    const stdout = {
+      write: vi.fn(() => {
+        throw new Error("output failed");
+      }),
+    } as unknown as NodeJS.WritableStream;
+
+    await expect(restartLaunchAgent({ env, stdout, onMutation })).rejects.toThrow("output failed");
+
+    expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }], [{ mode: "kickstart" }]]);
   });
 
   it("reloads launchd after rewriting an existing plist", async () => {
@@ -2036,7 +2053,63 @@ describe("launchd install", () => {
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
     expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
-    expect(onMutation).toHaveBeenCalledWith({ mode: "bootout-bootstrap" });
+    expect(onMutation.mock.calls).toEqual([
+      [{ mode: "enable" }],
+      [{ mode: "bootout" }],
+      [{ mode: "enable" }],
+      [{ mode: "bootstrap" }],
+    ]);
+  });
+
+  it("audits reload bootout before a later bootstrap failure", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    setLaunchAgentPlist({
+      env,
+      label: "ai.openclaw.gateway",
+      programArguments: ["node", "gateway.js"],
+    });
+    state.bootstrapError = "Operation not permitted";
+    state.bootstrapCode = 5;
+    const onMutation = vi.fn();
+
+    await expect(
+      restartLaunchAgent({ env, stdout: new PassThrough(), onMutation }),
+    ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+
+    expect(onMutation.mock.calls).toEqual([
+      [{ mode: "enable" }],
+      [{ mode: "bootout" }],
+      [{ mode: "enable" }],
+    ]);
+    expect(onMutation).not.toHaveBeenCalledWith({ mode: "bootstrap" });
+  });
+
+  it("completes reload when the mutation observer fails after bootout", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    setLaunchAgentPlist({
+      env,
+      label: "ai.openclaw.gateway",
+      programArguments: ["node", "gateway.js"],
+    });
+    const onMutation = vi.fn(({ mode }: { mode: string }) => {
+      if (mode === "bootout") {
+        throw new Error("audit failed");
+      }
+    });
+
+    await expect(
+      restartLaunchAgent({ env, stdout: new PassThrough(), onMutation }),
+    ).resolves.toEqual({ outcome: "completed" });
+
+    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
+    expect(onMutation).toHaveBeenCalledWith({ mode: "bootout" });
+    expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
   });
 
   it("treats a concurrent launchd bootstrap as success when the service is loaded", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -885,6 +885,7 @@ async function bootoutLaunchAgentOrThrow(params: {
   serviceTarget: string;
   warning: string;
   stdout: NodeJS.WritableStream;
+  onMutation?: () => void;
 }): Promise<void> {
   const bootout = await execLaunchctl(["bootout", params.serviceTarget]);
   if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
@@ -892,6 +893,7 @@ async function bootoutLaunchAgentOrThrow(params: {
       `${params.warning}; launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
     );
   }
+  params.onMutation?.();
   params.stdout.write(`${formatLine("Warning", params.warning)}\n`);
 }
 
@@ -1001,9 +1003,9 @@ export async function stopLaunchAgent({
     if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
       throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
     }
+    onMutation?.({ mode: "bootout" });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
-    onMutation?.({ mode: "bootout" });
     return;
   }
 
@@ -1015,12 +1017,13 @@ export async function stopLaunchAgent({
       serviceTarget,
       stdout,
       warning: `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disableResult)}`,
+      onMutation: () => onMutation?.({ mode: "disable-bootout" }),
     });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
-    onMutation?.({ mode: "disable-bootout" });
     return;
   }
+  onMutation?.({ mode: "disable" });
 
   // `launchctl stop` targets the plain label (not the fully-qualified service target).
   const stop = await execLaunchctl(["stop", label]);
@@ -1029,12 +1032,14 @@ export async function stopLaunchAgent({
       serviceTarget,
       stdout,
       warning: `launchctl stop failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(stop)}`,
+      onMutation: () => onMutation?.({ mode: "disable-bootout" }),
     });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
-    onMutation?.({ mode: "disable-bootout" });
     return;
   }
+
+  onMutation?.({ mode: "disable-stop" });
 
   const stopState = await waitForLaunchAgentStopped(serviceTarget);
   if (stopState.state !== "stopped" && stopState.state !== "not-loaded") {
@@ -1042,16 +1047,19 @@ export async function stopLaunchAgent({
       stopState.state === "unknown"
         ? `launchctl print could not confirm stop; used bootout fallback and left service unloaded: ${stopState.detail ?? "unknown error"}`
         : "launchctl stop did not fully stop the service; used bootout fallback and left service unloaded";
-    await bootoutLaunchAgentOrThrow({ serviceTarget, stdout, warning });
+    await bootoutLaunchAgentOrThrow({
+      serviceTarget,
+      stdout,
+      warning,
+      onMutation: () => onMutation?.({ mode: "disable-bootout" }),
+    });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
-    onMutation?.({ mode: "disable-bootout" });
     return;
   }
 
   await assertGatewayPortReleasedAfterStop(serviceEnv);
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
-  onMutation?.({ mode: "disable-stop" });
 }
 
 async function writeLaunchAgentPlist({

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -978,6 +978,7 @@ export async function stopLaunchAgent({
   stdout,
   env,
   disable: persistDisable,
+  onMutation,
 }: GatewayServiceControlArgs): Promise<void> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
@@ -1002,6 +1003,7 @@ export async function stopLaunchAgent({
     }
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
+    onMutation?.({ mode: "bootout" });
     return;
   }
 
@@ -1016,6 +1018,7 @@ export async function stopLaunchAgent({
     });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    onMutation?.({ mode: "disable-bootout" });
     return;
   }
 
@@ -1029,6 +1032,7 @@ export async function stopLaunchAgent({
     });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    onMutation?.({ mode: "disable-bootout" });
     return;
   }
 
@@ -1041,11 +1045,13 @@ export async function stopLaunchAgent({
     await bootoutLaunchAgentOrThrow({ serviceTarget, stdout, warning });
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    onMutation?.({ mode: "disable-bootout" });
     return;
   }
 
   await assertGatewayPortReleasedAfterStop(serviceEnv);
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
+  onMutation?.({ mode: "disable-stop" });
 }
 
 async function writeLaunchAgentPlist({
@@ -1234,6 +1240,7 @@ export async function restartLaunchAgent({
   stdout,
   env,
   warn,
+  onMutation,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
@@ -1261,6 +1268,7 @@ export async function restartLaunchAgent({
       throw new Error(`launchd restart handoff failed: ${handoff.error}`);
     }
     writeLaunchAgentActionLine(stdout, "Scheduled LaunchAgent restart", serviceTarget);
+    onMutation?.({ mode: plistReloadNeeded ? "handoff-reload" : "handoff-kickstart" });
     return { outcome: "scheduled" };
   }
 
@@ -1301,12 +1309,14 @@ export async function restartLaunchAgent({
       actionHint: "openclaw gateway restart",
     });
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
+    onMutation?.({ mode: "bootout-bootstrap" });
     return { outcome: "completed" };
   }
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
+    onMutation?.({ mode: "kickstart" });
     return { outcome: "completed" };
   }
 
@@ -1323,6 +1333,7 @@ export async function restartLaunchAgent({
     actionHint: "openclaw gateway restart",
   });
   writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
+  onMutation?.({ mode: "bootstrap" });
   return { outcome: "completed" };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -607,12 +607,17 @@ async function bootstrapLaunchAgentOrThrow(params: {
   serviceTarget: string;
   plistPath: string;
   actionHint: string;
+  onMutation?: (mode: "enable" | "bootstrap") => void;
 }) {
   // `disable` state survives bootout and plist rewrites; explicit start/repair
   // paths must clear it before asking launchd to load the job again.
-  await execLaunchctl(["enable", params.serviceTarget]);
+  const enable = await execLaunchctl(["enable", params.serviceTarget]);
+  if (enable.code === 0) {
+    params.onMutation?.("enable");
+  }
   const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
   if (boot.code === 0) {
+    params.onMutation?.("bootstrap");
     return;
   }
   const detail = (boot.stderr || boot.stdout).trim();
@@ -626,6 +631,7 @@ async function bootstrapLaunchAgentOrThrow(params: {
   if (isLaunchctlOperationAlreadyInProgress(detail)) {
     const state = await probeLaunchAgentState(params.serviceTarget);
     if (state.state === "running" || state.state === "stopped") {
+      params.onMutation?.("bootstrap");
       return;
     }
   }
@@ -1227,6 +1233,7 @@ async function ensureLaunchAgentLoadedAfterFailure(params: {
   domain: string;
   serviceTarget: string;
   plistPath: string;
+  onMutation?: (mode: "enable" | "bootstrap") => void;
 }): Promise<void> {
   const probe = await execLaunchctl(["print", params.serviceTarget]);
   if (probe.code === 0) {
@@ -1238,6 +1245,7 @@ async function ensureLaunchAgentLoadedAfterFailure(params: {
       serviceTarget: params.serviceTarget,
       plistPath: params.plistPath,
       actionHint: "openclaw gateway start",
+      onMutation: params.onMutation,
     });
   } catch {
     // Best-effort only. Preserve the original kickstart failure below.
@@ -1255,6 +1263,13 @@ export async function restartLaunchAgent({
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
   const serviceTarget = `${domain}/${label}`;
+  const reportMutation = (mode: string) => {
+    try {
+      onMutation?.({ mode });
+    } catch {
+      // Audit observers are diagnostic; never interrupt a multi-step restart.
+    }
+  };
 
   // Restart requests issued from inside the managed gateway process tree need a
   // detached handoff. A direct `kickstart -k` would terminate the caller before
@@ -1275,8 +1290,8 @@ export async function restartLaunchAgent({
     if (!handoff.ok) {
       throw new Error(`launchd restart handoff failed: ${handoff.error}`);
     }
+    reportMutation(plistReloadNeeded ? "handoff-reload" : "handoff-kickstart");
     writeLaunchAgentActionLine(stdout, "Scheduled LaunchAgent restart", serviceTarget);
-    onMutation?.({ mode: plistReloadNeeded ? "handoff-reload" : "handoff-kickstart" });
     return { outcome: "scheduled" };
   }
 
@@ -1303,33 +1318,44 @@ export async function restartLaunchAgent({
 
   // `openclaw gateway restart` is an explicit operator request to bring the
   // LaunchAgent back, so clear any persisted disabled state before restart.
-  await execLaunchctl(["enable", serviceTarget]);
+  const enable = await execLaunchctl(["enable", serviceTarget]);
+  if (enable.code === 0) {
+    reportMutation("enable");
+  }
 
   if (plistReloadNeeded) {
     const bootout = await execLaunchctl(["bootout", serviceTarget]);
     if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
       throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
     }
+    if (bootout.code === 0) {
+      reportMutation("bootout");
+    }
     await bootstrapLaunchAgentOrThrow({
       domain,
       serviceTarget,
       plistPath,
       actionHint: "openclaw gateway restart",
+      onMutation: reportMutation,
     });
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
-    onMutation?.({ mode: "bootout-bootstrap" });
     return { outcome: "completed" };
   }
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {
+    reportMutation("kickstart");
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
-    onMutation?.({ mode: "kickstart" });
     return { outcome: "completed" };
   }
 
   if (!isLaunchctlNotLoaded(start)) {
-    await ensureLaunchAgentLoadedAfterFailure({ domain, serviceTarget, plistPath });
+    await ensureLaunchAgentLoadedAfterFailure({
+      domain,
+      serviceTarget,
+      plistPath,
+      onMutation: reportMutation,
+    });
     throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
 
@@ -1339,9 +1365,9 @@ export async function restartLaunchAgent({
     serviceTarget,
     plistPath,
     actionHint: "openclaw gateway restart",
+    onMutation: reportMutation,
   });
   writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
-  onMutation?.({ mode: "bootstrap" });
   return { outcome: "completed" };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/daemon/restart-logs.test.ts
+++ b/src/daemon/restart-logs.test.ts
@@ -1,12 +1,24 @@
 // Daemon restart log tests cover restart log formatting and filtering.
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  appendGatewayLifecycleAuditLog,
   renderCmdRestartLogSetup,
   renderPosixRestartLogSetup,
   resolveGatewayLogPaths,
   resolveGatewayRestartLogPath,
   resolveGatewaySupervisorLogPaths,
 } from "./restart-logs.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("restart log conventions", () => {
   it("resolves profile-aware gateway logs and restart attempts together", () => {
@@ -83,5 +95,48 @@ describe("restart log conventions", () => {
     expect(setup.lines).toContain(
       'if not exist "C:\\Users\\Test User/.openclaw/logs" mkdir "C:\\Users\\Test User/.openclaw/logs" >nul 2>&1',
     );
+  });
+
+  it("appends a profile-aware lifecycle audit line with stable key-value fields", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-audit-"));
+    tempDirs.push(stateDir);
+
+    appendGatewayLifecycleAuditLog(
+      { OPENCLAW_STATE_DIR: stateDir },
+      {
+        action: "restart",
+        source: "safe-rpc",
+        mode: "deferred",
+        pid: 4242,
+        interactive: false,
+      },
+    );
+
+    const line = fs.readFileSync(path.join(stateDir, "logs", "gateway-restart.log"), "utf8");
+    expect(line).toMatch(/^\[[^\]]+\] openclaw gateway lifecycle /);
+    expect(line).toContain("source=safe-rpc");
+    expect(line).toContain("action=restart");
+    expect(line).toContain("mode=deferred");
+    expect(line).toContain("pid=4242");
+    expect(line).toContain("interactive=0");
+  });
+
+  it("does not throw when lifecycle audit logging fails", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-audit-fail-"));
+    tempDirs.push(stateDir);
+    const blocker = path.join(stateDir, "not-a-directory");
+    fs.writeFileSync(blocker, "block");
+
+    expect(() =>
+      appendGatewayLifecycleAuditLog(
+        { OPENCLAW_STATE_DIR: path.join(blocker, "state") },
+        {
+          action: "stop",
+          source: "cli",
+          mode: "bootout",
+          interactive: true,
+        },
+      ),
+    ).not.toThrow();
   });
 });

--- a/src/daemon/restart-logs.ts
+++ b/src/daemon/restart-logs.ts
@@ -1,4 +1,5 @@
 /** Resolves daemon log paths and shell snippets for restart handoff diagnostics. */
+import fs from "node:fs";
 import path from "node:path";
 import { quoteCmdScriptArg } from "./cmd-argv.js";
 import { resolveGatewayProfileSuffix } from "./constants.js";
@@ -6,6 +7,16 @@ import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import type { GatewayServiceEnv } from "./service-types.js";
 
 const GATEWAY_RESTART_LOG_FILENAME = "gateway-restart.log";
+
+export type GatewayLifecycleAuditSource = "cli" | "safe-rpc" | "supervisor" | "handoff";
+
+type GatewayLifecycleAuditEntry = {
+  action: "start" | "stop" | "restart";
+  source: GatewayLifecycleAuditSource;
+  mode: string;
+  pid?: number;
+  interactive: boolean;
+};
 
 type GatewayLogPaths = {
   logDir: string;
@@ -59,6 +70,31 @@ export function resolveGatewaySupervisorLogPaths(
 
 export function resolveGatewayRestartLogPath(env: GatewayServiceEnv): string {
   return path.join(resolveGatewayLogPaths(env).logDir, GATEWAY_RESTART_LOG_FILENAME);
+}
+
+/** Append one best-effort lifecycle record without letting diagnostics block the mutation. */
+export function appendGatewayLifecycleAuditLog(
+  env: GatewayServiceEnv,
+  entry: GatewayLifecycleAuditEntry,
+): void {
+  try {
+    const logPath = resolveGatewayRestartLogPath(env);
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    const fields = [
+      `source=${entry.source}`,
+      `action=${entry.action}`,
+      `mode=${entry.mode}`,
+      ...(entry.pid !== undefined ? [`pid=${entry.pid}`] : []),
+      `interactive=${entry.interactive ? 1 : 0}`,
+    ];
+    fs.appendFileSync(
+      logPath,
+      `[${new Date().toISOString()}] openclaw gateway lifecycle ${fields.join(" ")}\n`,
+      "utf8",
+    );
+  } catch {
+    // Lifecycle logging is diagnostic only; service control remains authoritative.
+  }
 }
 
 export function shellEscapeRestartLogValue(value: string): string {

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -1923,6 +1923,42 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("audits Startup fallback termination when relaunch fails", async () => {
+    useListenerBackedFallbackOwnership();
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      addStartupFallbackMissingResponses([
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "not found" },
+      ]);
+      await writeGatewayScript(env);
+      await writeStartupFallbackEntry(env);
+      inspectPortUsage.mockResolvedValue({
+        port: 18789,
+        status: "busy",
+        listeners: [
+          {
+            pid: 5151,
+            command: "node.exe",
+            commandLine: 'node "C:\\openclaw\\dist\\index.js" gateway --port 18789',
+          },
+        ],
+        hints: [],
+      });
+      spawn.mockImplementationOnce(() => {
+        throw new Error("spawn failed");
+      });
+      const onMutation = vi.fn();
+
+      await expect(
+        restartScheduledTask({ env, stdout: new PassThrough(), onMutation }),
+      ).rejects.toThrow("spawn failed");
+
+      expectGatewayTermination(5151);
+      expect(onMutation).toHaveBeenCalledWith({ mode: "startup-entry-stop" });
+      expect(onMutation).not.toHaveBeenCalledWith({ mode: "startup-entry-restart" });
+    });
+  });
+
   it("refuses to restart a Startup fallback with an unverified busy port owner", async () => {
     useListenerBackedFallbackOwnership();
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -353,6 +353,22 @@ describe("Scheduled Task stop/restart cleanup", () => {
     });
   });
 
+  it("audits a successful task stop before a later output failure", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      pushSuccessfulSchtasksResponses(3);
+      const onMutation = vi.fn();
+      const stdout = {
+        write: vi.fn(() => {
+          throw new Error("output failed");
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      await expect(stopScheduledTask({ env, stdout, onMutation })).rejects.toThrow("output failed");
+
+      expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-stop" });
+    });
+  });
+
   it("force-kills remaining busy port listeners when the first stop pass does not free the port", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       pushSuccessfulSchtasksResponses(3);
@@ -478,6 +494,7 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("throws when /Run fails during restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
+      const onMutation = vi.fn();
       schtasksResponses.push(
         { ...SUCCESS_RESPONSE },
         { ...SUCCESS_RESPONSE },
@@ -485,9 +502,11 @@ describe("Scheduled Task stop/restart cleanup", () => {
         { code: 1, stdout: "", stderr: "ERROR: Access is denied." },
       );
 
-      await expect(restartScheduledTask({ env, stdout })).rejects.toThrow(
+      await expect(restartScheduledTask({ env, stdout, onMutation })).rejects.toThrow(
         "schtasks run failed: ERROR: Access is denied.",
       );
+      expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-end" });
+      expect(onMutation).not.toHaveBeenCalledWith({ mode: "schtasks-restart" });
       expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -337,17 +337,19 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("kills lingering verified gateway listeners after schtasks stop", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
+      const onMutation = vi.fn();
       pushSuccessfulSchtasksResponses(3);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
       inspectPortUsage
         .mockResolvedValueOnce(busyPortUsage(4242))
         .mockResolvedValueOnce(freePortUsage());
 
-      await stopScheduledTask({ env, stdout });
+      await stopScheduledTask({ env, stdout, onMutation });
 
       expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(GATEWAY_PORT);
       expectGatewayTermination(4242);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+      expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-stop" });
     });
   });
 
@@ -418,19 +420,21 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("kills lingering verified gateway listeners and waits for port release before restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
+      const onMutation = vi.fn();
       pushSuccessfulSchtasksResponses(4);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
       inspectPortUsage
         .mockResolvedValueOnce(busyPortUsage(5151))
         .mockResolvedValueOnce(freePortUsage());
 
-      await expect(restartScheduledTask({ env, stdout })).resolves.toEqual({
+      await expect(restartScheduledTask({ env, stdout, onMutation })).resolves.toEqual({
         outcome: "completed",
       });
 
       expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(GATEWAY_PORT);
       expectGatewayTermination(5151);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+      expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-restart" });
       expect(schtasksCalls).toEqual([
         ["/Query"],
         ["/Query", "/TN", "OpenClaw Gateway"],

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1167,11 +1167,13 @@ async function resolveControllableFallbackRuntime(
 async function stopStartupEntry(
   env: GatewayServiceEnv,
   stdout: NodeJS.WritableStream,
+  onMutation?: () => void,
 ): Promise<void> {
   const runtime = await resolveControllableFallbackRuntime(env);
   if (typeof runtime.pid === "number" && runtime.pid > 0) {
     await terminateGatewayProcessTree(runtime.pid, 300);
   }
+  onMutation?.();
   stdout.write(`${formatLine("Stopped Windows login item", resolveTaskName(env))}\n`);
 }
 
@@ -1188,12 +1190,15 @@ async function terminateInstalledStartupRuntime(env: GatewayServiceEnv): Promise
 async function restartStartupEntry(
   env: GatewayServiceEnv,
   stdout: NodeJS.WritableStream,
+  onMutation?: (kind: "stop" | "restart") => void,
 ): Promise<GatewayServiceRestartResult> {
   const runtime = await resolveControllableFallbackRuntime(env);
   if (typeof runtime.pid === "number" && runtime.pid > 0) {
     await terminateGatewayProcessTree(runtime.pid, 300);
+    onMutation?.("stop");
   }
   await launchFallbackTaskScript(env);
+  onMutation?.("restart");
   stdout.write(`${formatLine("Restarted Windows login item", resolveTaskName(env))}\n`);
   return { outcome: "completed" };
 }
@@ -1508,11 +1513,13 @@ async function runScheduledTaskOrThrow(params: {
   taskName: string;
   env: GatewayServiceEnv;
   scriptPath: string;
+  onMutation?: () => void;
 }): Promise<ScheduledTaskActivation> {
   const run = await execSchtasks(["/Run", "/TN", params.taskName]);
   if (run.code !== 0) {
     throw new Error(`schtasks run failed: ${run.stderr || run.stdout}`.trim());
   }
+  params.onMutation?.();
   if (
     !(await shouldFallbackScheduledTaskLaunch({ env: params.env, scriptPath: params.scriptPath }))
   ) {
@@ -1865,16 +1872,18 @@ export async function stopScheduledTask({
     await assertSchtasksAvailable();
   } catch (err) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
-      await stopStartupEntry(effectiveEnv, stdout);
-      onMutation?.({ mode: "startup-entry-stop" });
+      await stopStartupEntry(effectiveEnv, stdout, () =>
+        onMutation?.({ mode: "startup-entry-stop" }),
+      );
       return;
     }
     throw err;
   }
   if (!(await isRegisteredScheduledTask(effectiveEnv))) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
-      await stopStartupEntry(effectiveEnv, stdout);
-      onMutation?.({ mode: "startup-entry-stop" });
+      await stopStartupEntry(effectiveEnv, stdout, () =>
+        onMutation?.({ mode: "startup-entry-stop" }),
+      );
       return;
     }
   }
@@ -1883,6 +1892,7 @@ export async function stopScheduledTask({
   if (res.code !== 0 && !isTaskNotRunning(res)) {
     throw new Error(`schtasks end failed: ${res.stderr || res.stdout}`.trim());
   }
+  onMutation?.({ mode: "schtasks-stop" });
   const manageGatewayPort = shouldManageGatewayListenerPort(effectiveEnv);
   const stopPort = manageGatewayPort ? await resolveScheduledTaskPort(effectiveEnv) : null;
   if (manageGatewayPort) {
@@ -1902,16 +1912,20 @@ export async function stopScheduledTask({
     }
   }
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
-  onMutation?.({ mode: "schtasks-stop" });
 }
 
 async function restartRegisteredScheduledTask(params: {
   env: GatewayServiceEnv;
   stdout: NodeJS.WritableStream;
   mode: { kind: "standard" } | { kind: "fallback-takeover" };
+  onEndMutation?: () => void;
+  onRunMutation?: () => void;
 }): Promise<GatewayServiceRestartResult> {
   const taskName = resolveTaskName(params.env);
-  await execSchtasks(["/End", "/TN", taskName]);
+  const end = await execSchtasks(["/End", "/TN", taskName]);
+  if (end.code === 0) {
+    params.onEndMutation?.();
+  }
   const manageGatewayPort = shouldManageGatewayListenerPort(params.env);
   const restartPort = manageGatewayPort ? await resolveScheduledTaskPort(params.env) : null;
   if (params.mode.kind === "standard") {
@@ -1952,6 +1966,7 @@ async function restartRegisteredScheduledTask(params: {
     taskName,
     env: params.env,
     scriptPath: resolveTaskScriptPath(params.env),
+    ...(params.onRunMutation ? { onMutation: params.onRunMutation } : {}),
   });
   const startupEntryInstalled = await isStartupEntryInstalled(params.env);
   const hasRunningEvidence = startupEntryInstalled
@@ -1991,16 +2006,18 @@ export async function restartScheduledTask({
     await assertSchtasksAvailable();
   } catch (err) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
-      const result = await restartStartupEntry(effectiveEnv, stdout);
-      onMutation?.({ mode: "startup-entry-restart" });
+      const result = await restartStartupEntry(effectiveEnv, stdout, (kind) =>
+        onMutation?.({ mode: kind === "stop" ? "startup-entry-stop" : "startup-entry-restart" }),
+      );
       return result;
     }
     throw err;
   }
   if (!(await isRegisteredScheduledTask(effectiveEnv))) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
-      const result = await restartStartupEntry(effectiveEnv, stdout);
-      onMutation?.({ mode: "startup-entry-restart" });
+      const result = await restartStartupEntry(effectiveEnv, stdout, (kind) =>
+        onMutation?.({ mode: kind === "stop" ? "startup-entry-stop" : "startup-entry-restart" }),
+      );
       return result;
     }
   }
@@ -2008,8 +2025,9 @@ export async function restartScheduledTask({
     env: effectiveEnv,
     stdout,
     mode: { kind: "standard" },
+    onEndMutation: () => onMutation?.({ mode: "schtasks-end" }),
+    onRunMutation: () => onMutation?.({ mode: "schtasks-restart" }),
   });
-  onMutation?.({ mode: "schtasks-restart" });
   return result;
 }
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1855,13 +1855,18 @@ export async function resumeScheduledTaskAutoStartAfterUpdate(
   return await changeScheduledTaskEnabledState({ env, enabled: true });
 }
 
-export async function stopScheduledTask({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
+export async function stopScheduledTask({
+  stdout,
+  env,
+  onMutation,
+}: GatewayServiceControlArgs): Promise<void> {
   const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
   try {
     await assertSchtasksAvailable();
   } catch (err) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
       await stopStartupEntry(effectiveEnv, stdout);
+      onMutation?.({ mode: "startup-entry-stop" });
       return;
     }
     throw err;
@@ -1869,6 +1874,7 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
   if (!(await isRegisteredScheduledTask(effectiveEnv))) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
       await stopStartupEntry(effectiveEnv, stdout);
+      onMutation?.({ mode: "startup-entry-stop" });
       return;
     }
   }
@@ -1896,6 +1902,7 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
     }
   }
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
+  onMutation?.({ mode: "schtasks-stop" });
 }
 
 async function restartRegisteredScheduledTask(params: {
@@ -1977,26 +1984,33 @@ async function restartRegisteredScheduledTask(params: {
 export async function restartScheduledTask({
   stdout,
   env,
+  onMutation,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
   try {
     await assertSchtasksAvailable();
   } catch (err) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
-      return await restartStartupEntry(effectiveEnv, stdout);
+      const result = await restartStartupEntry(effectiveEnv, stdout);
+      onMutation?.({ mode: "startup-entry-restart" });
+      return result;
     }
     throw err;
   }
   if (!(await isRegisteredScheduledTask(effectiveEnv))) {
     if (await isStartupEntryInstalled(effectiveEnv)) {
-      return await restartStartupEntry(effectiveEnv, stdout);
+      const result = await restartStartupEntry(effectiveEnv, stdout);
+      onMutation?.({ mode: "startup-entry-restart" });
+      return result;
     }
   }
-  return await restartRegisteredScheduledTask({
+  const result = await restartRegisteredScheduledTask({
     env: effectiveEnv,
     stdout,
     mode: { kind: "standard" },
   });
+  onMutation?.({ mode: "schtasks-restart" });
+  return result;
 }
 
 export async function isScheduledTaskInstalled(args: GatewayServiceEnvArgs): Promise<boolean> {

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -31,6 +31,12 @@ export type GatewayServiceControlArgs = {
   env?: GatewayServiceEnv;
   disable?: boolean;
   warn?: (message: string) => void;
+  onMutation?: (mutation: GatewayLifecycleMutation) => void;
+};
+
+export type GatewayLifecycleMutation = {
+  mode: string;
+  pid?: number;
 };
 
 export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };
@@ -74,6 +80,7 @@ export type GatewayServiceStartRepairIssue = {
 };
 
 export type GatewayServiceStartResult =
+  | { outcome: "already-running"; state: GatewayServiceState }
   | { outcome: "started"; state: GatewayServiceState }
   | { outcome: "scheduled"; state: GatewayServiceState }
   | { outcome: "missing-install"; state: GatewayServiceState }

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -222,6 +222,27 @@ describe("startGatewayService", () => {
     expect(result.state.running).toBe(true);
   });
 
+  it("returns already-running without restarting a loaded running service", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 4242 })),
+    });
+
+    const result = await startGatewayService(service, {
+      env: {},
+      stdout: process.stdout,
+    });
+
+    expect(result.outcome).toBe("already-running");
+    if (result.outcome === "already-running") {
+      expect(result.state.runtime?.pid).toBe(4242);
+    }
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
   it("requests repair before start when the loaded service version is stale", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({
@@ -253,7 +274,7 @@ describe("startGatewayService", () => {
         environment: { OPENCLAW_GATEWAY_PORT: "19001" },
       })),
       isLoaded: vi.fn(async () => true),
-      readRuntime: vi.fn(async () => ({ status: "running" })),
+      readRuntime: vi.fn(async () => ({ status: "stopped" })),
     });
 
     const result = await startGatewayService(
@@ -282,7 +303,7 @@ describe("startGatewayService", () => {
         environment: { OPENCLAW_GATEWAY_PORT: "18789" },
       })),
       isLoaded: vi.fn(async () => true),
-      readRuntime: vi.fn(async () => ({ status: "running" })),
+      readRuntime: vi.fn(async () => ({ status: "stopped" })),
     });
 
     const result = await startGatewayService(

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -214,6 +214,13 @@ export async function startGatewayService(
     };
   }
 
+  if (state.loaded && state.running) {
+    return {
+      outcome: "already-running",
+      state,
+    };
+  }
+
   if (repairIssues.length > 0) {
     return {
       outcome: "repair-required",

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2179,12 +2179,14 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     const write = vi.fn();
+    const onMutation = vi.fn();
     const stdout = { write } as unknown as NodeJS.WritableStream;
 
-    await stopSystemdService({ stdout, env: {} });
+    await stopSystemdService({ stdout, env: {}, onMutation });
 
     expect(write).toHaveBeenCalledTimes(1);
     expect(requireFirstWrite(write)).toContain("Stopped systemd service");
+    expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-stop" });
   });
 
   it("allows stop when systemd status is degraded but available", async () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2187,6 +2187,28 @@ describe("systemd service control", () => {
     expect(write).toHaveBeenCalledTimes(1);
     expect(requireFirstWrite(write)).toContain("Stopped systemd service");
     expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-stop" });
+    expect(onMutation.mock.invocationCallOrder[0]).toBeLessThan(write.mock.invocationCallOrder[0]);
+  });
+
+  it("audits a successful stop before a later output failure", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "stop", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+    const onMutation = vi.fn();
+    const stdout = {
+      write: vi.fn(() => {
+        throw new Error("output failed");
+      }),
+    } as unknown as NodeJS.WritableStream;
+
+    await expect(stopSystemdService({ stdout, env: {}, onMutation })).rejects.toThrow(
+      "output failed",
+    );
+
+    expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-stop" });
   });
 
   it("allows stop when systemd status is degraded but available", async () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,8 +1,9 @@
-// Systemd tests cover Linux service install, start, stop, and status behavior.
 import type { ExecFileOptionsWithStringEncoding } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+// Systemd tests cover Linux service install, start, stop, and status behavior.
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type ExecFileError = Error & {
@@ -2187,7 +2188,12 @@ describe("systemd service control", () => {
     expect(write).toHaveBeenCalledTimes(1);
     expect(requireFirstWrite(write)).toContain("Stopped systemd service");
     expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-stop" });
-    expect(onMutation.mock.invocationCallOrder[0]).toBeLessThan(write.mock.invocationCallOrder[0]);
+    expect(onMutation.mock.invocationCallOrder[0]).toBeLessThan(
+      expectDefined(
+        write.mock.invocationCallOrder[0],
+        "write.mock.invocationCallOrder[0] test invariant",
+      ),
+    );
   });
 
   it("audits a successful stop before a later output failure", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1342,6 +1342,7 @@ async function runSystemdServiceAction(params: {
   env?: GatewayServiceEnv;
   action: "stop" | "restart";
   label: string;
+  onMutation?: () => void;
 }) {
   const env = params.env ?? process.env;
   const installed = await findInstalledSystemdGatewayScope(env);
@@ -1363,6 +1364,7 @@ async function runSystemdServiceAction(params: {
     if (res.code !== 0) {
       throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
     }
+    params.onMutation?.();
     params.stdout.write(`${formatLine(params.label, unitName)}\n`);
     return;
   }
@@ -1376,6 +1378,7 @@ async function runSystemdServiceAction(params: {
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
   }
+  params.onMutation?.();
   params.stdout.write(`${formatLine(params.label, unitName)}\n`);
 }
 
@@ -1389,8 +1392,8 @@ export async function stopSystemdService({
     env,
     action: "stop",
     label: "Stopped systemd service",
+    onMutation: () => onMutation?.({ mode: "systemctl-stop" }),
   });
-  onMutation?.({ mode: "systemctl-stop" });
 }
 
 export async function restartSystemdService({
@@ -1403,8 +1406,8 @@ export async function restartSystemdService({
     env,
     action: "restart",
     label: "Restarted systemd service",
+    onMutation: () => onMutation?.({ mode: "systemctl-restart" }),
   });
-  onMutation?.({ mode: "systemctl-restart" });
   return { outcome: "completed" };
 }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1382,6 +1382,7 @@ async function runSystemdServiceAction(params: {
 export async function stopSystemdService({
   stdout,
   env,
+  onMutation,
 }: GatewayServiceControlArgs): Promise<void> {
   await runSystemdServiceAction({
     stdout,
@@ -1389,11 +1390,13 @@ export async function stopSystemdService({
     action: "stop",
     label: "Stopped systemd service",
   });
+  onMutation?.({ mode: "systemctl-stop" });
 }
 
 export async function restartSystemdService({
   stdout,
   env,
+  onMutation,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   await runSystemdServiceAction({
     stdout,
@@ -1401,6 +1404,7 @@ export async function restartSystemdService({
     action: "restart",
     label: "Restarted systemd service",
   });
+  onMutation?.({ mode: "systemctl-restart" });
   return { outcome: "completed" };
 }
 

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -92,7 +92,9 @@ export async function runGatewayLifecycle(
     return;
   }
   if (operation === "stop") {
-    await lifecycle.runDaemonStop();
+    // The system-agent approval gate is the non-interactive equivalent of an
+    // operator passing --force after explicitly approving the mutation.
+    await lifecycle.runDaemonStop({ force: true });
     return;
   }
   return await lifecycle.runDaemonRestart();


### PR DESCRIPTION
## Summary

Agents (and scripts) have been fighting over operators' running gateways: `gateway start` on a loaded service silently restarted it, non-interactive `gateway stop` could bootout a production service or SIGTERM a dev gateway it never started, and `gateway run --force` killed whatever held the port. Most restarts also bypassed the `gateway-restart.log` audit trail.

## Changes

- `gateway start` is now idempotent: loaded + running -> "already running (pid N)", exit 0. No hidden restart.
- `gateway stop` in a non-interactive shell requires `--force`; the refusal teaches the isolated-dev-gateway path (`run --dev` / `--profile` + free port). Interactive behavior unchanged. Applies to managed bootout and the unmanaged port-SIGTERM fallback. The system-agent approval flow supplies `force` (its approval gate is the consent).
- `gateway run --force` in a non-interactive shell refuses to kill a verified existing gateway listener, with per-signal revalidation (no check-then-kill race); fuser fallback resolves and validates concrete PIDs (stdout only) before signaling.
- Unified lifecycle audit: every start/stop/restart mutation (cli, safe-rpc, supervisor, handoff) appends a key=value line to `gateway-restart.log`, immediately after each successful mutation, best-effort.

## Proof

- Focused suites green across daemon + CLI shards (service, lifecycle, launchd/systemd/schtasks, ports/run guards): 400+ tests.
- tsgo core + core:test green on Blacksmith Testbox.
- Structured review (Codex gpt-5.6-sol): two hardening rounds (fuser TOCTOU, stderr PID parsing, partial-mutation audit ordering) fixed; final run clean.

Docs: `docs/cli/gateway.md` updated. Policy context: AGENTS.md "Tests" live-gateway rules (2ca4d92f1ae).
