### PR TITLE
refactor(feishu): use shared cache pruning helper

### DIFF
--- a/extensions/feishu/src/bot-name.ts
+++ b/extensions/feishu/src/bot-name.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements bot sender name resolution.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { createFeishuClient } from "./client.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -49,13 +50,7 @@ function readCache(key: string): CacheEntry | undefined {
 function writeCache(key: string, entry: CacheEntry): void {
   cache.delete(key);
   cache.set(key, entry);
-  while (cache.size > MAX_CACHE_ENTRIES) {
-    const oldest = cache.keys().next().value;
-    if (oldest === undefined) {
-      break;
-    }
-    cache.delete(oldest);
-  }
+  pruneMapToMaxSize(cache, MAX_CACHE_ENTRIES);
 }
 
 function isBreakerOpen(accountId: string): boolean {


### PR DESCRIPTION
Related: #103513

## What Problem This Solves

Feishu bot-name caching maintained a second insertion-order pruning loop beside the shared plugin SDK cache helper. Keeping duplicate eviction code makes sibling cache behavior easier to drift.

## Why This Change Was Made

Use the existing `pruneMapToMaxSize` plugin SDK helper after the cache's existing LRU touch. The 5,000-entry limit and oldest-entry eviction semantics stay unchanged. AI-assisted maintainer follow-up requested during #103513 review.

## User Impact

No user-visible behavior change. Feishu bot-name cache pruning now shares the same bounded-cache implementation as the sender-name cache and other plugins.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu/src/bot-name.test.ts` — 4/4 passed after the final rebase.
- `node scripts/check-changed.mjs -- extensions/feishu/src/bot-name.ts` — passed formatting, SDK baseline, plugin boundaries, extension and extension-test typechecks, lint, and static guards on Testbox.
- Testbox: https://github.com/openclaw/openclaw/actions/runs/29627084343
- Autoreview: clean, 0.99 confidence.
