### PR TITLE
fix: restore iMessage and WhatsApp channel test coverage

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
+import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import type { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,11 +21,6 @@ import {
 } from "./private-api-status.js";
 import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 
-type DispatchInboundMessageParams = {
-  ctx: MsgContext;
-  replyOptions?: GetReplyOptions;
-};
-
 function expireCachedPrivateApiStatus(): void {
   setCachedIMessagePrivateApiStatus(
     "imsg",
@@ -38,11 +35,11 @@ const waitForTransportReadyMock = vi.hoisted(() =>
 );
 const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
 const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
-const dispatchInboundMessageMock = vi.hoisted(() =>
-  vi.fn(
-    async (_params: DispatchInboundMessageParams) =>
-      ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }) as const,
-  ),
+const dispatchReplyWithBufferedBlockDispatcherMock = vi.hoisted(() =>
+  vi.fn<typeof dispatchReplyWithBufferedBlockDispatcher>(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
 );
 const debouncerControl = vi.hoisted(() => ({
   holdEntries: false,
@@ -105,14 +102,6 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
-  return {
-    ...actual,
-    dispatchInboundMessage: dispatchInboundMessageMock,
-  };
-});
-
 vi.mock("./client.js", () => ({
   createIMessageRpcClient: createIMessageRpcClientMock,
 }));
@@ -121,21 +110,52 @@ vi.mock("./monitor/abort-handler.js", () => ({
   attachIMessageMonitorAbortHandler: vi.fn(() => () => {}),
 }));
 
+type RunChannelInboundEventParams = Parameters<typeof channelInbound.runChannelInboundEvent>[0];
+const runChannelInboundEventActual = channelInbound.runChannelInboundEvent;
+
+async function runChannelInboundEventForLastRouteTest(params: RunChannelInboundEventParams) {
+  return await runChannelInboundEventActual({
+    ...params,
+    adapter: {
+      ...params.adapter,
+      resolveTurn: async (input, eventClass, preflight) => {
+        const turn = await params.adapter.resolveTurn(input, eventClass, preflight);
+        if (!("route" in turn) || !("delivery" in turn)) {
+          throw new Error("expected assembled iMessage channel turn plan");
+        }
+        const { route, ...resolvedTurn } = turn;
+        return {
+          ...resolvedTurn,
+          agentId: route.agentId,
+          routeSessionKey: route.sessionKey,
+          storePath: resolveStorePath(turn.cfg.session?.store, { agentId: route.agentId }),
+          recordInboundSession,
+          dispatchReplyWithBufferedBlockDispatcher: dispatchReplyWithBufferedBlockDispatcherMock,
+        };
+      },
+    },
+  });
+}
+
 describe("iMessage monitor last-route updates", () => {
   const tempDirs: string[] = [];
 
   beforeEach(() => {
+    vi.spyOn(channelInbound, "runChannelInboundEvent").mockImplementation(
+      runChannelInboundEventForLastRouteTest as typeof channelInbound.runChannelInboundEvent,
+    );
     installIMessageStateRuntimeForTest();
     waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
     createIMessageRpcClientMock.mockReset();
     readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    dispatchInboundMessageMock.mockClear();
+    dispatchReplyWithBufferedBlockDispatcherMock.mockClear();
     createChannelInboundDebouncerMock.mockClear();
     debouncerControl.reset();
     expireCachedPrivateApiStatus();
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
     vi.unstubAllEnvs();
     for (const dir of tempDirs.splice(0)) {
@@ -150,25 +170,30 @@ describe("iMessage monitor last-route updates", () => {
       selectors: {},
       rpcMethods: ["watch.subscribe", "send", "typing"],
     });
-    dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
       expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
       expect(params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
+      const onReplyStart =
+        params.dispatcherOptions.onReplyStart ??
+        params.dispatcherOptions.typingCallbacks?.onReplyStart;
+      const onTypingCleanup =
+        params.dispatcherOptions.onCleanup ?? params.dispatcherOptions.typingCallbacks?.onCleanup;
       let active = false;
       let runComplete = false;
       let dispatchIdle = false;
       const stopIfSettled = () => {
         if (active && runComplete && dispatchIdle) {
           active = false;
-          params.replyOptions?.onTypingCleanup?.();
+          onTypingCleanup?.();
         }
       };
       const typingController = {
         onReplyStart: async () => {
-          await params.replyOptions?.onReplyStart?.();
+          await onReplyStart?.();
         },
         startTypingLoop: async () => {
           active = true;
-          await params.replyOptions?.onReplyStart?.();
+          await onReplyStart?.();
         },
         startTypingOnText: async () => {},
         refreshTypingTtl: () => {},
@@ -183,7 +208,7 @@ describe("iMessage monitor last-route updates", () => {
         },
         cleanup: () => {
           active = false;
-          params.replyOptions?.onTypingCleanup?.();
+          onTypingCleanup?.();
         },
       };
       params.replyOptions?.onTypingController?.(typingController);
@@ -271,7 +296,7 @@ describe("iMessage monitor last-route updates", () => {
       selectors: {},
       rpcMethods: ["watch.subscribe", "send", "read"],
     });
-    dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
       expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
       expect(params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
       expect(params.replyOptions?.onToolStart).toBeUndefined();
@@ -333,7 +358,7 @@ describe("iMessage monitor last-route updates", () => {
     });
 
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
     expect(client.request).not.toHaveBeenCalledWith(
       "typing",
@@ -391,7 +416,7 @@ describe("iMessage monitor last-route updates", () => {
             expect.objectContaining({ typing: true, to: "+15550001111" }),
             expect.any(Object),
           );
-          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+          expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
         });
       }),
       stop: vi.fn(async () => {}),
@@ -403,7 +428,7 @@ describe("iMessage monitor last-route updates", () => {
       }
       return earlyTypingClient as never;
     });
-    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async () => {
       expect(earlyTypingClient.request).toHaveBeenCalledWith(
         "typing",
         expect.objectContaining({ typing: true, to: "+15550001111" }),
@@ -450,7 +475,7 @@ describe("iMessage monitor last-route updates", () => {
         selectors: {},
         rpcMethods: ["watch.subscribe", "send", "typing"],
       });
-      dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
         expect(
           params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed,
@@ -514,7 +539,7 @@ describe("iMessage monitor last-route updates", () => {
       });
 
       await vi.waitFor(() => {
-        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
       });
       expect(client.request).not.toHaveBeenCalledWith(
         "typing",
@@ -531,7 +556,7 @@ describe("iMessage monitor last-route updates", () => {
       selectors: {},
       rpcMethods: ["watch.subscribe", "send", "typing"],
     });
-    dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
       expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
       expect(
         params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed,
@@ -596,7 +621,7 @@ describe("iMessage monitor last-route updates", () => {
     });
 
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
     expect(client.request).not.toHaveBeenCalledWith(
       "typing",
@@ -646,7 +671,7 @@ describe("iMessage monitor last-route updates", () => {
           },
         });
         await vi.waitFor(() => {
-          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+          expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
         });
       }),
       stop: vi.fn(async () => {}),
@@ -683,7 +708,7 @@ describe("iMessage monitor last-route updates", () => {
       expect.anything(),
       expect.anything(),
     );
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -701,7 +726,7 @@ describe("iMessage monitor last-route updates", () => {
   ] as const)(
     "passes iMessage block streaming config ($label) through to reply dispatch",
     async ({ imessagePatch, expectedDisable }) => {
-      dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.disableBlockStreaming).toBe(expectedDisable);
         return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
       });
@@ -759,7 +784,7 @@ describe("iMessage monitor last-route updates", () => {
       });
 
       await vi.waitFor(() => {
-        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
       });
     },
   );
@@ -780,7 +805,7 @@ describe("iMessage monitor last-route updates", () => {
   ] as const)(
     "preserves account-level block streaming opt-outs when inheriting channel streaming ($label)",
     async ({ channelBlockEnabled, accountBlockEnabled, expectedDisable }) => {
-      dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.disableBlockStreaming).toBe(expectedDisable);
         return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
       });
@@ -844,7 +869,7 @@ describe("iMessage monitor last-route updates", () => {
       });
 
       await vi.waitFor(() => {
-        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
       });
     },
   );
@@ -861,7 +886,7 @@ describe("iMessage monitor last-route updates", () => {
   ] as const)(
     "preserves channel-level nested block streaming when an account overrides $label",
     async ({ accountStreaming }) => {
-      dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.disableBlockStreaming).toBe(false);
         return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
       });
@@ -925,7 +950,7 @@ describe("iMessage monitor last-route updates", () => {
       });
 
       await vi.waitFor(() => {
-        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
       });
     },
   );
@@ -1073,7 +1098,7 @@ describe("iMessage monitor last-route updates", () => {
     );
     // Only the fresh row dispatches; the stale backlog row is suppressed.
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1295,7 +1320,7 @@ describe("iMessage monitor last-route updates", () => {
     );
     // The recovery replay row dispatches; the live old row is suppressed.
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1361,7 +1386,7 @@ describe("iMessage monitor last-route updates", () => {
     );
     await Promise.resolve();
     await Promise.resolve();
-    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).not.toHaveBeenCalled();
   });
 
   it("records a suppressed live row so a later replay of the same row is deduped, not delivered", async () => {
@@ -1440,7 +1465,7 @@ describe("iMessage monitor last-route updates", () => {
 
     await Promise.resolve();
     await Promise.resolve();
-    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).not.toHaveBeenCalled();
   });
 
   it("does not advance the recovery cursor past a failed replay row", async () => {
@@ -1462,7 +1487,7 @@ describe("iMessage monitor last-route updates", () => {
       database.close();
     }
     const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
-    dispatchInboundMessageMock
+    dispatchReplyWithBufferedBlockDispatcherMock
       .mockRejectedValueOnce(new Error("dispatch failed"))
       .mockResolvedValue({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
 
@@ -1517,7 +1542,7 @@ describe("iMessage monitor last-route updates", () => {
     });
     await debouncerControl.flushEach?.();
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
     });
     expect(
       loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
@@ -1591,7 +1616,7 @@ describe("iMessage monitor last-route updates", () => {
     debouncerControl.entries.reverse();
     await debouncerControl.flushEach?.();
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
     });
     expect(
       loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
@@ -1685,9 +1710,9 @@ describe("iMessage monitor last-route updates", () => {
     });
 
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
-    const dispatchParams = dispatchInboundMessageMock.mock.calls.at(0)?.[0];
+    const dispatchParams = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.at(0)?.[0];
     expect(dispatchParams?.ctx.To).toBe("chat_id:349");
     expect(dispatchParams?.ctx.From).toBe("imessage:group:349");
     expect(dispatchParams?.ctx.ChatType).toBe("group");
@@ -1772,9 +1797,9 @@ describe("iMessage monitor last-route updates", () => {
     });
 
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
-    const dispatchParams = dispatchInboundMessageMock.mock.calls.at(0)?.[0];
+    const dispatchParams = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.at(0)?.[0];
     expect(dispatchParams?.ctx.To).toBe("imessage:+15550000002");
     expect(dispatchParams?.ctx.To).not.toBe("imessage:+15550000001");
 
@@ -1868,7 +1893,7 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(runtime.error).toHaveBeenCalled();
     });
-    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).not.toHaveBeenCalled();
     expect(runtime.error.mock.calls.at(-1)?.[0]).toContain(
       "recovered authoritative row is from-me",
     );
@@ -1878,7 +1903,7 @@ describe("iMessage monitor last-route updates", () => {
         "[L3 proof #104136] scenario: authoritative from-me row suppressed before dispatch",
         `[L3 proof #104136] notification is_from_me: ${anchorlessNotification.is_from_me}`,
         `[L3 proof #104136] history is_from_me: ${authoritativeHistory.is_from_me}`,
-        `[L3 proof #104136] monitor dispatch count: ${dispatchInboundMessageMock.mock.calls.length}`,
+        `[L3 proof #104136] monitor dispatch count: ${dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.length}`,
         `[L3 proof #104136] runtime error: ${runtime.error.mock.calls.at(-1)?.[0]}`,
       ].join("\n"),
     );
@@ -1964,8 +1989,9 @@ describe("iMessage monitor last-route updates", () => {
       | { debounceMsOverride?: number }
       | undefined;
     expect(debouncerOptions?.debounceMsOverride).toBe(7000);
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
-    const mergedBody = dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.Body ?? "";
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
+    const mergedBody =
+      dispatchReplyWithBufferedBlockDispatcherMock.mock.calls[0]?.[0].ctx.Body ?? "";
     expect(mergedBody).toContain("summarize");
     expect(mergedBody).toContain("https://example.com/article");
   });
@@ -2047,8 +2073,10 @@ describe("iMessage monitor last-route updates", () => {
       runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
     });
 
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(3);
-    const bodies = dispatchInboundMessageMock.mock.calls.map((call) => call[0].ctx.Body ?? "");
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(3);
+    const bodies = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.map(
+      (call) => call[0].ctx.Body ?? "",
+    );
     expect(bodies.some((body) => body.includes("handwriting"))).toBe(true);
     expect(bodies.some((body) => body.includes("first thought"))).toBe(true);
     expect(bodies.some((body) => body.includes("second thought"))).toBe(true);
@@ -2132,8 +2160,10 @@ describe("iMessage monitor last-route updates", () => {
       runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
     });
 
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    const bodies = dispatchInboundMessageMock.mock.calls.map((call) => call[0].ctx.Body ?? "");
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
+    const bodies = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.map(
+      (call) => call[0].ctx.Body ?? "",
+    );
     expect(bodies.some((body) => body.includes("old handwriting"))).toBe(false);
     expect(bodies.some((body) => body.includes("first fresh thought"))).toBe(true);
     expect(bodies.some((body) => body.includes("second fresh thought"))).toBe(true);
@@ -2216,8 +2246,10 @@ describe("iMessage monitor last-route updates", () => {
       runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
     });
 
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    const bodies = dispatchInboundMessageMock.mock.calls.map((call) => call[0].ctx.Body ?? "");
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
+    const bodies = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.map(
+      (call) => call[0].ctx.Body ?? "",
+    );
     expect(bodies[0]).toContain("unrelated thought");
     expect(bodies[0]).not.toContain("summarize");
     expect(bodies[1]).toContain("summarize");
@@ -2296,8 +2328,10 @@ describe("iMessage monitor last-route updates", () => {
       runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
     });
 
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    const bodies = dispatchInboundMessageMock.mock.calls.map((call) => call[0].ctx.Body ?? "");
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
+    const bodies = dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.map(
+      (call) => call[0].ctx.Body ?? "",
+    );
     expect(bodies[0]).toContain("unrelated thought");
     expect(bodies[0]).not.toContain("summarize");
     expect(bodies[1]).toContain("summarize");

--- a/extensions/imessage/src/monitor.media-policy.test.ts
+++ b/extensions/imessage/src/monitor.media-policy.test.ts
@@ -1,7 +1,8 @@
 // Imessage tests cover monitor.media policy plugin behavior.
-import type { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
+import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
+import type { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import type { stageIMessageAttachments } from "./monitor/media-staging.js";
@@ -13,8 +14,8 @@ const waitForTransportReadyMock = vi.hoisted(() =>
 const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
 const stageIMessageAttachmentsMock = vi.hoisted(() => vi.fn<typeof stageIMessageAttachments>());
 const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
-const dispatchInboundMessageMock = vi.hoisted(() =>
-  vi.fn<typeof dispatchInboundMessage>(async () => ({
+const dispatchReplyWithBufferedBlockDispatcherMock = vi.hoisted(() =>
+  vi.fn<typeof dispatchReplyWithBufferedBlockDispatcher>(async () => ({
     queuedFinal: false,
     counts: { tool: 0, block: 0, final: 0 },
   })),
@@ -47,14 +48,6 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
-  return {
-    ...actual,
-    dispatchInboundMessage: dispatchInboundMessageMock,
-  };
-});
-
 vi.mock("./client.js", () => ({
   createIMessageRpcClient: createIMessageRpcClientMock,
 }));
@@ -67,13 +60,86 @@ vi.mock("./monitor/media-staging.js", () => ({
   stageIMessageAttachments: stageIMessageAttachmentsMock,
 }));
 
+type RunChannelInboundEventParams = Parameters<typeof channelInbound.runChannelInboundEvent>[0];
+
+async function runChannelInboundEventForMediaPolicyTest(params: RunChannelInboundEventParams) {
+  const input = await params.adapter.ingest(params.raw);
+  if (!input) {
+    return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
+  }
+  const eventClass = (await params.adapter.classify?.(input)) ?? {
+    kind: "message" as const,
+    canStartAgentTurn: true,
+  };
+  if (!eventClass.canStartAgentTurn) {
+    return {
+      admission: { kind: "handled" as const, reason: `event:${eventClass.kind}` },
+      dispatched: false,
+    };
+  }
+  const rawPreflight = await params.adapter.preflight?.(input, eventClass);
+  const preflight =
+    rawPreflight && "kind" in rawPreflight ? { admission: rawPreflight } : rawPreflight;
+  const preflightFacts = preflight ?? {};
+  const preflightAdmission = preflightFacts.admission;
+  if (
+    preflightAdmission &&
+    preflightAdmission.kind !== "dispatch" &&
+    preflightAdmission.kind !== "observeOnly"
+  ) {
+    return { admission: preflightAdmission, dispatched: false };
+  }
+  const turn = await params.adapter.resolveTurn(input, eventClass, preflightFacts);
+  if (!("route" in turn) || !("delivery" in turn)) {
+    throw new Error("expected assembled iMessage channel turn plan");
+  }
+  const admission = turn.admission ?? preflightAdmission ?? { kind: "dispatch" as const };
+  if (admission.kind === "handled" || admission.kind === "drop") {
+    const result = {
+      admission,
+      dispatched: false as const,
+      ctxPayload: turn.ctxPayload,
+      routeSessionKey: turn.route.sessionKey,
+    };
+    await params.adapter.onFinalize?.(result);
+    return result;
+  }
+  const result = {
+    admission,
+    dispatched: true as const,
+    ctxPayload: turn.ctxPayload,
+    routeSessionKey: turn.route.sessionKey,
+    dispatchResult: await dispatchReplyWithBufferedBlockDispatcherMock({
+      ctx: turn.ctxPayload,
+      cfg: turn.cfg,
+      dispatcherOptions: {
+        ...turn.dispatcherOptions,
+        deliver: turn.delivery.deliver,
+        onError: turn.delivery.onError,
+      },
+      toolsAllow: turn.toolsAllow,
+      replyOptions: turn.replyOptions,
+      replyResolver: turn.replyResolver,
+    }),
+  };
+  await params.adapter.onFinalize?.(result);
+  return result;
+}
+
 describe("iMessage monitor attachment policy", () => {
   beforeEach(() => {
+    vi.spyOn(channelInbound, "runChannelInboundEvent").mockImplementation(
+      runChannelInboundEventForMediaPolicyTest as typeof channelInbound.runChannelInboundEvent,
+    );
     installIMessageStateRuntimeForTest();
     createIMessageRpcClientMock.mockReset();
     stageIMessageAttachmentsMock.mockReset();
     readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    dispatchInboundMessageMock.mockClear();
+    dispatchReplyWithBufferedBlockDispatcherMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("does not stage local attachments for messages dropped by inbound policy", async () => {
@@ -235,7 +301,11 @@ describe("iMessage monitor attachment policy", () => {
 
     expect(runtime.error).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(stageIMessageAttachmentsMock).toHaveBeenCalledTimes(1));
-    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
-    expect(dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.BodyForAgent).toBe(expectedBody);
+    await vi.waitFor(() =>
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1),
+    );
+    expect(dispatchReplyWithBufferedBlockDispatcherMock.mock.calls[0]?.[0].ctx.BodyForAgent).toBe(
+      expectedBody,
+    );
   });
 });

--- a/extensions/imessage/src/monitor.media-policy.test.ts
+++ b/extensions/imessage/src/monitor.media-policy.test.ts
@@ -93,17 +93,9 @@ async function runChannelInboundEventForMediaPolicyTest(params: RunChannelInboun
   if (!("route" in turn) || !("delivery" in turn)) {
     throw new Error("expected assembled iMessage channel turn plan");
   }
+  // Terminal admissions returned at preflight above; an assembled plan only
+  // carries dispatch/observeOnly, so no handled/drop branch exists here.
   const admission = turn.admission ?? preflightAdmission ?? { kind: "dispatch" as const };
-  if (admission.kind === "handled" || admission.kind === "drop") {
-    const result = {
-      admission,
-      dispatched: false as const,
-      ctxPayload: turn.ctxPayload,
-      routeSessionKey: turn.route.sessionKey,
-    };
-    await params.adapter.onFinalize?.(result);
-    return result;
-  }
   const result = {
     admission,
     dispatched: true as const,

--- a/extensions/whatsapp/src/auto-reply.broadcast-groups.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.broadcast-groups.test-harness.ts
@@ -1,4 +1,5 @@
 // Whatsapp plugin module implements auto reply.broadcast groups harness behavior.
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
 import {
   createWebInboundDeliverySpies,
@@ -7,6 +8,39 @@ import {
 } from "./auto-reply.test-harness.js";
 import { monitorWebChannel } from "./auto-reply/monitor.js";
 import type { WebInboundMessageInput } from "./inbound.js";
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  return {
+    ...actual,
+    runChannelInboundEvent: (params: RunParams) => {
+      const runtime = createPluginRuntimeMock({
+        channel: {
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher: async (dispatchParams) => {
+              const resolver = dispatchParams.replyResolver;
+              if (!resolver) {
+                throw new Error("Missing broadcast reply resolver");
+              }
+              const reply = await resolver(
+                dispatchParams.ctx,
+                dispatchParams.replyOptions,
+                dispatchParams.cfg,
+              );
+              const finalCount = Array.isArray(reply) ? reply.length : reply ? 1 : 0;
+              return {
+                queuedFinal: finalCount > 0,
+                counts: { tool: 0, block: 0, final: finalCount },
+              };
+            },
+          },
+        },
+      });
+      return runtime.channel.inbound.run(params);
+    },
+  };
+});
 
 export async function monitorWebChannelWithCapture(resolver: unknown): Promise<{
   spies: ReturnType<typeof createWebInboundDeliverySpies>;


### PR DESCRIPTION
## What Problem This Solves

Fixes broken `main` test coverage after #110095 moved inbound turn execution into core turn plans. Three missed test surfaces still mocked the retired reply-runtime dispatch path, so their mocks intercepted nothing: iMessage media-policy had two failures and one 120-second timeout, iMessage last-route had 26 failures, and the WhatsApp combined broadcast-groups case timed out. The regression bisects to merge commit `601ffa253037e20397bd62bd81fc9f7715ba6200` and reproduces on clean `origin/main`.

## Why This Change Was Made

The affected tests now mock the core turn-plan dispatch seam, matching the modernization already applied to Feishu, Slack, and Telegram in #110095 while preserving every behavioral assertion. The shared WhatsApp harness supplies the corrected dispatch mock once for all five broadcast-group tests.

## User Impact

No runtime behavior or product code changes. Maintainers regain reliable iMessage and WhatsApp regression coverage on `main`, without false failures or two-minute hangs from stale test interception points.

## Evidence

- iMessage plugin suite: 794/794 tests passed.
- WhatsApp plugin suite: 1108/1108 tests passed, including [Blacksmith Testbox run 29626860218](https://github.com/openclaw/openclaw/actions/runs/29626860218).
- Fresh autoreview on the patch, followed by a clean patch-identical rebase to head `8e53e95faad8`: zero accepted/actionable findings.
- `git diff --check origin/main...HEAD`: clean.

AI-assisted: yes. The final rebased branch received a clean structured autoreview.
