### PR TITLE
fix(nostr): profile imports no longer crash on non-object content

### DIFF
--- a/extensions/nostr/src/nostr-profile-import.test.ts
+++ b/extensions/nostr/src/nostr-profile-import.test.ts
@@ -119,6 +119,24 @@ describe("nostr-profile-import", () => {
         vi.useRealTimers();
       }
     });
+
+    it("rejects profile content that is not a JSON object", async () => {
+      mockState.subscribeMany.mockImplementation((_relays, _filter, params) => {
+        params.onevent?.(createProfileEvent({ content: "null" }));
+        params.oneose?.();
+      });
+
+      await expect(
+        importProfileFromRelays({
+          pubkey: "a".repeat(64),
+          relays: ["wss://relay.example"],
+        }),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: "Profile event content must be a JSON object",
+        sourceRelay: "wss://relay.example",
+      });
+    });
   });
 
   describe("mergeProfiles", () => {

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -159,9 +159,9 @@ export async function importProfileFromRelays(
     );
 
     // Parse the profile content
-    let content: ProfileContent;
+    let parsedContent: unknown;
     try {
-      content = JSON.parse(bestEvent.event.content) as ProfileContent;
+      parsedContent = JSON.parse(bestEvent.event.content) as unknown;
     } catch {
       return {
         ok: false,
@@ -170,6 +170,19 @@ export async function importProfileFromRelays(
         sourceRelay: bestEvent.relay,
       };
     }
+    if (
+      typeof parsedContent !== "object" ||
+      parsedContent === null ||
+      Array.isArray(parsedContent)
+    ) {
+      return {
+        ok: false,
+        error: "Profile event content must be a JSON object",
+        relaysQueried,
+        sourceRelay: bestEvent.relay,
+      };
+    }
+    const content = parsedContent as ProfileContent;
 
     // Convert to our profile format
     const profile = contentToProfile(content);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users importing a Nostr profile would receive an internal server error when the newest signed kind 0 event contained valid JSON that was not an object, such as `null`.

## Why This Change Was Made

NIP-01 defines kind 0 content as a stringified JSON object. The import boundary now rejects other valid JSON shapes before converting profile fields, returning the existing structured import failure response instead of allowing a runtime `TypeError` to escape. No profile schema, relay selection, or merge behavior changes.

Reference: https://github.com/nostr-protocol/nips/blob/master/01.md#kinds

## User Impact

Malformed profile metadata from a relay no longer crashes the profile import HTTP route. Users receive HTTP 200 with `ok: false` and a clear `Profile event content must be a JSON object` message; valid object profiles continue to import normally.

## Evidence

- Regression-first proof: the new focused test failed on the prior implementation with a `TypeError` (1 failed, 9 passed), then passed after the fix (10 passed).
- `node scripts/run-vitest.mjs extensions/nostr/src/nostr-profile-import.test.ts` — 10 tests passed on the final rebased diff.
- `pnpm test:extension nostr` — passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed` — passed, including formatting, type checks, lint, plugin boundaries, and import-cycle checks.
- `pnpm build` — passed for both the patch checkout and an unchanged-main control checkout.
- Real third-party Nostr relay proof used temporary random credentials, the public `wss://relay.nostr.net` relay, linked plugin installation, and a session-owned `openclaw gateway run`:
  - Before: relay accepted and returned signed event `8b8e0cd84104ea82163c6ac237eda741791ef92c4e5f81db62be64d9305c60c1`; profile import returned HTTP 500 with `Internal server error`.
  - After: relay accepted and returned signed event `174677aca9ee01106383e8700ed39548374e2900e747d746a3b899692203ca28`; profile import returned HTTP 200 with `ok: false` and `Profile event content must be a JSON object`.
  - Both runs used OpenClaw commands (`plugins install --link` and `gateway run`); no CoClaw path was observed.
- The live run was performed on the patch-identical diff based at `1ca26c508db14b141935c8f1c7c71660c8a14273`. The final rebase advanced only unrelated paths; `extensions/nostr` was unchanged.
