### PR TITLE
feat(system-agent): auto-hatch into the agent after fresh setup

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32162,6 +32162,14 @@
       "id": "native.apple.2070bf43a67680ee"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 10,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
+      "source": "Wake up, my friend!",
+      "surface": "apple",
+      "id": "native.apple.ba758aa97c24ffe6"
+    },
+    {
       "kind": "conditional-branch",
       "line": 129,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32163,7 +32163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 118,
+      "line": 129,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "<redacted secret>",
       "surface": "apple",
@@ -32171,7 +32171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 217,
+      "line": 228,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "OpenClaw was interrupted. Restart to try again.",
       "surface": "apple",
@@ -32179,7 +32179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 218,
+      "line": 229,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "The Gateway connection changed. Restart OpenClaw to reconnect.",
       "surface": "apple",
@@ -32187,7 +32187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 253,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "OpenClaw is working…",
       "surface": "apple",
@@ -32195,7 +32195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 267,
+      "line": 278,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "Restart",
       "surface": "apple",
@@ -32203,7 +32203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 278,
+      "line": 289,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "Enter secret…",
       "surface": "apple",
@@ -32211,7 +32211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 291,
       "path": "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift",
       "source": "Reply to OpenClaw… (yes sets everything up)",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -20104,6 +20104,11 @@
       "translated": "تعذّر على Gateway التخطيط لـ \\(plan.summary.errors) من \\(Self.memoryNoun(plan.summary.errors)). حاول مرة أخرى."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "استيقظ يا صديقي!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<سر محجوب>"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -20104,6 +20104,11 @@
       "translated": "Das Gateway konnte \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)) nicht einplanen. Versuchen Sie es erneut."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Wach auf, mein Freund!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<redacted secret>"

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -20104,6 +20104,11 @@
       "translated": "El Gateway no pudo planificar \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Inténtalo de nuevo."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "¡Despierta, amigo mío!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<secreto redactado>"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway نتوانست برای \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)) برنامه‌ریزی کند. دوباره تلاش کنید."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "بیدار شو، دوست من!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<رمز محرمانه حذف‌شده>"

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -20104,6 +20104,11 @@
       "translated": "Le Gateway n’a pas pu planifier \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Réessayez."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Réveille-toi, mon ami !"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<secret masqué>"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway, \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)) के लिए योजना नहीं बना सका। फिर से कोशिश करें।"
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "जागो, मेरे दोस्त!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<गोपनीय जानकारी हटाई गई>"

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway tidak dapat merencanakan \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Coba lagi."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Bangunlah, temanku!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<rahasia disunting>"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -20104,6 +20104,11 @@
       "translated": "Il Gateway non è riuscito a pianificare \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Riprova."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Svegliati, amico mio!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<segreto oscurato>"

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway は \\(plan.summary.errors) 件の\\(Self.memoryNoun(plan.summary.errors))のプランを作成できませんでした。もう一度お試しください。"
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "目を覚まして、友よ！"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<編集済みのシークレット>"

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway에서 \\(plan.summary.errors)개의 \\(Self.memoryNoun(plan.summary.errors))을(를) 계획할 수 없습니다. 다시 시도해 보세요."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "일어나, 친구야!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<가려진 비밀 값>"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -20104,6 +20104,11 @@
       "translated": "De Gateway kon geen plan maken voor \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Probeer het opnieuw."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Word wakker, mijn vriend!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<geheim geredigeerd>"

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway nie mógł zaplanować \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Spróbuj ponownie."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Obudź się, przyjacielu!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<sekret ukryty>"

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -20104,6 +20104,11 @@
       "translated": "O Gateway não conseguiu planejar \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Tente novamente."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Acorde, meu amigo!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<segredo ocultado>"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway не удалось спланировать \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Повторите попытку."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Проснись, мой друг!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<секрет скрыт>"

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway kunde inte planera \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Försök igen."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Vakna, min vän!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<redigerad hemlighet>"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway ไม่สามารถวางแผน \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)) ได้ โปรดลองอีกครั้ง"
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "ตื่นได้แล้ว เพื่อนของฉัน!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<ข้อมูลลับถูกปกปิด>"

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway, \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)) için plan oluşturamadı. Tekrar deneyin."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Uyan, dostum!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<gizli bilgi çıkarıldı>"

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway не зміг спланувати \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Спробуйте ще раз."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Прокидайся, друже!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<прихований секрет>"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway không thể lập kế hoạch cho \\(plan.summary.errors) \\(Self.memoryNoun(plan.summary.errors)). Hãy thử lại."
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "Thức dậy đi, bạn tôi!"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<bí mật đã được ẩn>"

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway 无法规划 \\(plan.summary.errors) 个\\(Self.memoryNoun(plan.summary.errors))。请重试。"
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "醒醒，我的朋友！"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<已隐藏的密钥>"

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -20104,6 +20104,11 @@
       "translated": "Gateway 無法規劃 \\(plan.summary.errors) 個\\(Self.memoryNoun(plan.summary.errors))。請再試一次。"
     },
     {
+      "id": "native.apple.ba758aa97c24ffe6",
+      "source": "Wake up, my friend!",
+      "translated": "醒醒，我的朋友！"
+    },
+    {
       "id": "native.apple.1400567a01a8d7c0",
       "source": "<redacted secret>",
       "translated": "<已遮蔽的密鑰>"

--- a/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
+++ b/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
@@ -19,7 +19,7 @@ enum AppNavigationActions {
         }
     }
 
-    static func openChat(sessionKey: String? = nil, agentID: String? = nil) {
+    static func openChat(sessionKey: String? = nil, agentID: String? = nil, draft: String? = nil) {
         NSApp.activate(ignoringOtherApps: true)
         Task { @MainActor in
             let resolvedSessionKey = if let sessionKey {
@@ -27,7 +27,7 @@ enum AppNavigationActions {
             } else {
                 await WebChatManager.shared.preferredSessionKey()
             }
-            WebChatManager.shared.show(sessionKey: resolvedSessionKey, agentID: agentID)
+            WebChatManager.shared.show(sessionKey: resolvedSessionKey, agentID: agentID, draft: draft)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
@@ -7,7 +7,7 @@ enum SystemAgentDraft: String, Decodable {
 
     var composerValue: String {
         switch self {
-        case .hatch: "Wake up, my friend!"
+        case .hatch: String(localized: "Wake up, my friend!")
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
@@ -2,6 +2,16 @@ import Foundation
 import Observation
 import SwiftUI
 
+enum SystemAgentDraft: String, Decodable {
+    case hatch
+
+    var text: String {
+        switch self {
+        case .hatch: String(localized: "Wake up, my friend!")
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class OnboardingSystemAgentChatState {
@@ -58,7 +68,7 @@ final class SystemAgentOnboardingChatModel {
     private(set) var expectsSensitiveReply = false
     var input = ""
     /// Set when OpenClaw hands off to the normal agent ("talk to agent").
-    var onAgentHandoff: (() -> Void)?
+    var onAgentHandoff: ((SystemAgentDraft?) -> Void)?
     /// Called after every assistant reply (setup may have applied config).
     var onReplyReceived: (() -> Void)?
 
@@ -89,6 +99,7 @@ final class SystemAgentOnboardingChatModel {
         let reply: String
         let action: String
         let sensitive: Bool?
+        let agentDraft: SystemAgentDraft?
     }
 
     func startIfNeeded() async {
@@ -207,7 +218,7 @@ final class SystemAgentOnboardingChatModel {
             self.messages.append(Message(role: .assistant, text: result.reply))
             self.onReplyReceived?()
             if result.action == "open-agent" {
-                self.onAgentHandoff?()
+                self.onAgentHandoff?(result.agentDraft)
             }
         } catch {
             guard self.requestGeneration == generation else { return }

--- a/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
@@ -5,9 +5,9 @@ import SwiftUI
 enum SystemAgentDraft: String, Decodable {
     case hatch
 
-    var text: String {
+    var composerValue: String {
         switch self {
-        case .hatch: String(localized: "Wake up, my friend!")
+        case .hatch: "Wake up, my friend!"
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -53,7 +53,9 @@ extension OnboardingView {
     }
 
     func prepareSystemAgentHandoff() {
-        systemAgentState.chat.onAgentHandoff = { [self] in self.finish() }
+        systemAgentState.chat.onAgentHandoff = { [self] agentDraft in
+            self.finish(agentDraft: agentDraft)
+        }
         aiSetup.onPendingActivationDeadline = { [self] deadline, routeIdentity in
             let currentRouteIdentity = self.aiSetupRouteIdentityProvider()
             guard currentRouteIdentity == routeIdentity else { return }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -117,7 +117,7 @@ extension OnboardingView {
         // Land people in the real conversation, not on an empty desktop: the
         // agent chat is the product, and it is verified working by now.
         if state.connectionMode != .unconfigured {
-            AppNavigationActions.openChat(draft: agentDraft?.text)
+            AppNavigationActions.openChat(draft: agentDraft?.composerValue)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -110,14 +110,14 @@ extension OnboardingView {
         }
     }
 
-    func finish() {
+    func finish(agentDraft: SystemAgentDraft? = nil) {
         aiSetup.clearCompletedHandoffIfOwned()
         OnboardingController.markComplete()
         OnboardingController.shared.close()
         // Land people in the real conversation, not on an empty desktop: the
         // agent chat is the product, and it is verified working by now.
         if state.connectionMode != .unconfigured {
-            AppNavigationActions.openChat()
+            AppNavigationActions.openChat(draft: agentDraft?.text)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
+++ b/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
@@ -544,6 +544,142 @@
           }
         }
       }
+    },
+    "Wake up, my friend!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wake up, my friend!"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "醒醒，我的朋友！"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "醒醒，我的朋友！"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acorde, meu amigo!"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wach auf, mein Freund!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Despierta, amigo mío!"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目を覚まして、友よ！"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일어나, 친구야!"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réveille-toi, mon ami !"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जागो, मेरे दोस्त!"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استيقظ يا صديقي!"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svegliati, amico mio!"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyan, dostum!"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прокидайся, друже!"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bangunlah, temanku!"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obudź się, przyjacielu!"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตื่นได้แล้ว เพื่อนของฉัน!"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thức dậy đi, bạn tôi!"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Word wakker, mijn vriend!"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بیدار شو، دوست من!"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проснись, мой друг!"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vakna, min vän!"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
@@ -49,7 +49,7 @@ struct SystemAgentSettings: View {
         onReplyReceived: @escaping () -> Void)
     {
         chat.onAgentHandoff = { agentDraft in
-            AppNavigationActions.openChat(draft: agentDraft?.text)
+            AppNavigationActions.openChat(draft: agentDraft?.composerValue)
         }
         chat.onReplyReceived = onReplyReceived
     }

--- a/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
@@ -48,8 +48,8 @@ struct SystemAgentSettings: View {
         for chat: SystemAgentOnboardingChatModel,
         onReplyReceived: @escaping () -> Void)
     {
-        chat.onAgentHandoff = {
-            AppNavigationActions.openChat()
+        chat.onAgentHandoff = { agentDraft in
+            AppNavigationActions.openChat(draft: agentDraft?.text)
         }
         chat.onReplyReceived = onReplyReceived
     }

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -53,13 +53,14 @@ final class WebChatManager {
         self.currentChatRoute?.sessionKey ?? self.panelRoute?.sessionKey ?? self.windowRoute?.sessionKey
     }
 
-    func show(sessionKey: String, agentID: String? = nil) {
+    func show(sessionKey: String, agentID: String? = nil, draft: String? = nil) {
         let route = WebChatRoute(sessionKey: sessionKey, agentID: agentID)
         self.closePanel()
         if let controller = self.windowController {
             // The window shell switches sessions in place (sidebar, /new);
             // full route identity tracks those switches and the global owner.
             if Self.shouldReuseController(currentRoute: self.windowRoute, requestedRoute: route) {
+                controller.applyDraftIfEmpty(draft)
                 controller.show()
                 return
             }
@@ -71,6 +72,7 @@ final class WebChatManager {
         let controller = WebChatSwiftUIWindowController(
             sessionKey: route.sessionKey,
             agentID: route.agentID,
+            initialDraft: draft,
             presentation: .window)
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -804,6 +804,7 @@ final class WebChatSwiftUIWindowController {
     private let presentation: WebChatPresentation
     private let sessionKey: String
     private let initialActiveAgentID: String?
+    private let viewModel: OpenClawChatViewModel
     private let contentController: NSViewController
     private let sessionKeyRelay: WebChatSessionKeyRelay
     private let speech: OpenClawChatSpeechController
@@ -819,6 +820,7 @@ final class WebChatSwiftUIWindowController {
     convenience init(
         sessionKey: String,
         agentID: String? = nil,
+        initialDraft: String? = nil,
         presentation: WebChatPresentation)
     {
         // Connection-mode changes tear chat windows down via resetTunnels(),
@@ -829,6 +831,7 @@ final class WebChatSwiftUIWindowController {
         self.init(
             sessionKey: sessionKey,
             agentID: agentID,
+            initialDraft: initialDraft,
             presentation: presentation,
             cachedRoutingIdentity: context?.routingIdentity,
             store: context?.store)
@@ -837,6 +840,7 @@ final class WebChatSwiftUIWindowController {
     convenience init(
         sessionKey: String,
         agentID: String?,
+        initialDraft: String? = nil,
         presentation: WebChatPresentation,
         cachedRoutingIdentity: OpenClawChatSessionRoutingIdentity?,
         store: OpenClawChatSQLiteTranscriptCache?)
@@ -847,6 +851,7 @@ final class WebChatSwiftUIWindowController {
             cachedDefaultAgentID: cachedRoutingIdentity?.defaultAgentID)
         self.init(
             sessionKey: sessionKey,
+            initialDraft: initialDraft,
             presentation: presentation,
             transport: MacGatewayChatTransport(
                 outboxGatewayID: store?.gatewayID,
@@ -860,6 +865,7 @@ final class WebChatSwiftUIWindowController {
 
     init(
         sessionKey: String,
+        initialDraft: String? = nil,
         presentation: WebChatPresentation,
         transport: any OpenClawChatTransport,
         initialActiveAgentID: String? = nil,
@@ -909,6 +915,12 @@ final class WebChatSwiftUIWindowController {
             onVerbosePreferenceChanged: { level in
                 Self.persistVerbosePreference(level)
             })
+        if let initialDraft,
+           !initialDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            vm.input = initialDraft
+        }
+        self.viewModel = vm
         let explicitAgentID = WebChatRoute.normalizedAgentID(explicitAgentID)
         Task { @MainActor [weak vm] in
             let pushes = await GatewayConnection.shared.subscribe()
@@ -975,6 +987,14 @@ final class WebChatSwiftUIWindowController {
 
     var isVisible: Bool {
         self.window?.isVisible ?? false
+    }
+
+    func applyDraftIfEmpty(_ draft: String?) {
+        guard self.viewModel.input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let draft,
+              !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
+        self.viewModel.input = draft
     }
 
     func show() {
@@ -1229,6 +1249,10 @@ final class WebChatSwiftUIWindowController {
 
     var _testActiveAgentID: String? {
         self.initialActiveAgentID
+    }
+
+    var _testDraft: String {
+        self.viewModel.input
     }
     #endif
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
@@ -98,8 +98,13 @@ private func respondToSystemAgentHealth(
     return true
 }
 
-private func systemAgentResponse(id: String, action: String = "none") -> Data {
-    Data(
+private func systemAgentResponse(
+    id: String,
+    action: String = "none",
+    agentDraft: String? = nil) -> Data
+{
+    let agentDraftField = agentDraft.map { ",\n            \"agentDraft\": \"\($0)\"" } ?? ""
+    return Data(
         """
         {
           "type": "res",
@@ -109,7 +114,7 @@ private func systemAgentResponse(id: String, action: String = "none") -> Data {
             "sessionId": "test-session",
             "reply": "ready",
             "action": "\(action)",
-            "sensitive": false
+            "sensitive": false\(agentDraftField)
           }
         }
         """.utf8)
@@ -477,6 +482,32 @@ struct OnboardingSystemAgentChatTests {
         #expect(session.latestTask()?.snapshotSendCount() == 2)
     }
 
+    @Test func `agent handoff carries the hatch draft intent`() async throws {
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+                guard sendIndex > 0,
+                      let id = GatewayWebSocketTestSupport.requestID(from: message)
+                else { return }
+                task.emitReceiveSuccess(.data(systemAgentResponse(
+                    id: id,
+                    action: "open-agent",
+                    agentDraft: "hatch")))
+            })
+        })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let gateway = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        let chat = SystemAgentOnboardingChatModel(gateway: gateway)
+        var receivedDraft: SystemAgentDraft?
+        chat.onAgentHandoff = { receivedDraft = $0 }
+
+        await chat.startIfNeeded()
+
+        #expect(receivedDraft == .hatch)
+        #expect(receivedDraft?.text == "Wake up, my friend!")
+    }
+
     @Test func `settings callback refreshes inference after assistant reply`() async throws {
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
@@ -514,7 +545,7 @@ struct OnboardingSystemAgentChatTests {
         var replyCount = 0
         var handoffCount = 0
         chat.onReplyReceived = { replyCount += 1 }
-        chat.onAgentHandoff = { handoffCount += 1 }
+        chat.onAgentHandoff = { _ in handoffCount += 1 }
         chat.input = "route-bound secret"
         state.isPresented = true
 
@@ -612,7 +643,7 @@ struct OnboardingSystemAgentChatTests {
         var replyCount = 0
         var handoffCount = 0
         chat.onReplyReceived = { replyCount += 1 }
-        chat.onAgentHandoff = { handoffCount += 1 }
+        chat.onAgentHandoff = { _ in handoffCount += 1 }
 
         let startTask = Task { await chat.startIfNeeded() }
         var requestStarted = false

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
@@ -505,7 +505,7 @@ struct OnboardingSystemAgentChatTests {
         await chat.startIfNeeded()
 
         #expect(receivedDraft == .hatch)
-        #expect(receivedDraft?.text == "Wake up, my friend!")
+        #expect(receivedDraft?.composerValue == "Wake up, my friend!")
     }
 
     @Test func `settings callback refreshes inference after assistant reply`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -94,6 +94,19 @@ struct WebChatSwiftUISmokeTests {
         controller.close()
     }
 
+    @Test func `initial draft populates an empty composer without replacing user text`() {
+        let controller = WebChatSwiftUIWindowController(
+            sessionKey: "main",
+            initialDraft: "Wake up, my friend!",
+            presentation: .window,
+            transport: TestTransport())
+
+        #expect(controller._testDraft == "Wake up, my friend!")
+        controller.applyDraftIfEmpty("replacement")
+        #expect(controller._testDraft == "Wake up, my friend!")
+        controller.close()
+    }
+
     @Test func `controller explicit agent wins and nil falls back to cached default`() throws {
         let cachedIdentity = try #require(OpenClawChatSessionRoutingIdentity(
             scope: "global",

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6904,6 +6904,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
     public let reply: String
     public let sensitive: Bool?
     public let action: AnyCodable
+    public let agentdraft: String?
     public let needsapproval: Bool?
     public let proposalid: String?
     public let question: [String: AnyCodable]?
@@ -6913,6 +6914,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         reply: String,
         sensitive: Bool? = nil,
         action: AnyCodable,
+        agentdraft: String? = nil,
         needsapproval: Bool? = nil,
         proposalid: String? = nil,
         question: [String: AnyCodable]? = nil)
@@ -6921,6 +6923,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         self.reply = reply
         self.sensitive = sensitive
         self.action = action
+        self.agentdraft = agentdraft
         self.needsapproval = needsapproval
         self.proposalid = proposalid
         self.question = question
@@ -6931,6 +6934,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         case reply
         case sensitive
         case action
+        case agentdraft = "agentDraft"
         case needsapproval = "needsApproval"
         case proposalid = "proposalId"
         case question

--- a/packages/gateway-protocol/src/schema/openclaw.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.ts
@@ -67,6 +67,8 @@ export const SystemAgentChatResultSchema = closedObject({
     Type.Literal("open-agent"),
     Type.Literal("exit"),
   ]),
+  /** Optional localized-draft intent for an `open-agent` handoff. */
+  agentDraft: Type.Optional(Type.Literal("hatch")),
   needsApproval: Type.Optional(Type.Boolean()),
   proposalId: Type.Optional(NonEmptyString),
   question: Type.Optional(SystemAgentChatQuestionSchema),

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -381,6 +381,7 @@ const MACOS_CATALOG = {
       "Save",
     ],
     "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift": ["Run now"],
+    "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift": ["Wake up, my friend!"],
   },
 } as const;
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -775,11 +775,12 @@ describe("ensureAgentWorkspace", () => {
       .mockRejectedValueOnce(Object.assign(new Error("not a directory"), { code: "ENOTDIR" }));
 
     try {
-      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+      const result = await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
       expect(rmSpy).toHaveBeenCalledWith(bootstrapPath, { force: true });
       await expect(fs.access(bootstrapPath)).resolves.toBeUndefined();
       const state = await readWorkspaceState(tempDir);
       expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+      expect(result.bootstrapPending).toBe(false);
       await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toBe("complete");
       await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
     } finally {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -707,6 +707,7 @@ export async function ensureAgentWorkspace(params?: {
   userPath?: string;
   heartbeatPath?: string;
   bootstrapPath?: string;
+  bootstrapExists?: boolean;
   identityPathCreated?: boolean;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
@@ -753,7 +754,7 @@ export async function ensureAgentWorkspace(params?: {
     if (hasContentEvidence) {
       await maybeWriteWorkspaceAttestation(dir);
     }
-    return { dir };
+    return { dir, bootstrapExists: false };
   }
 
   const agentsPath = path.join(dir, DEFAULT_AGENTS_FILENAME);
@@ -937,6 +938,7 @@ export async function ensureAgentWorkspace(params?: {
     userPath,
     heartbeatPath,
     bootstrapPath,
+    bootstrapExists,
     identityPathCreated,
   };
 }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -707,7 +707,7 @@ export async function ensureAgentWorkspace(params?: {
   userPath?: string;
   heartbeatPath?: string;
   bootstrapPath?: string;
-  bootstrapExists?: boolean;
+  bootstrapPending?: boolean;
   identityPathCreated?: boolean;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
@@ -754,7 +754,7 @@ export async function ensureAgentWorkspace(params?: {
     if (hasContentEvidence) {
       await maybeWriteWorkspaceAttestation(dir);
     }
-    return { dir, bootstrapExists: false };
+    return { dir, bootstrapPending: false };
   }
 
   const agentsPath = path.join(dir, DEFAULT_AGENTS_FILENAME);
@@ -938,7 +938,7 @@ export async function ensureAgentWorkspace(params?: {
     userPath,
     heartbeatPath,
     bootstrapPath,
-    bootstrapExists,
+    bootstrapPending: !state.setupCompletedAt && bootstrapExists,
     identityPathCreated,
   };
 }

--- a/src/commands/onboard-guided.custodian.test.ts
+++ b/src/commands/onboard-guided.custodian.test.ts
@@ -114,6 +114,7 @@ function setupDeps(params: {
         configPath: "/tmp/openclaw.json",
         configHashBefore: null,
         configHashAfter: null,
+        bootstrapPending: false,
         lines: [],
       })),
     launchHatchTui: vi.fn(async () => undefined),

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -100,6 +100,16 @@ function detection(
   };
 }
 
+function setupApplyResult() {
+  return {
+    configPath: "/tmp/openclaw.json",
+    configHashBefore: null,
+    configHashAfter: null,
+    bootstrapPending: false,
+    lines: [],
+  };
+}
+
 function setupDeps(params: {
   prompter: WizardPrompter;
   detect?: GuidedOnboardingDeps["detect"];
@@ -120,15 +130,7 @@ function setupDeps(params: {
   return {
     createPrompter: () => params.prompter,
     persistAccessMode: vi.fn(async () => undefined),
-    applySetup:
-      params.applySetup ??
-      vi.fn(async () => ({
-        configPath: "/tmp/openclaw.json",
-        configHashBefore: null,
-        configHashAfter: null,
-        bootstrapPending: false,
-        lines: [],
-      })),
+    applySetup: params.applySetup ?? vi.fn(async () => setupApplyResult()),
     launchHatchTui: vi.fn(async () => undefined),
     listManualOptions: vi.fn(async () => ({
       manualProviders: [],
@@ -228,13 +230,7 @@ describe("runGuidedOnboarding", () => {
       select,
       confirm: vi.fn(async () => false),
     });
-    const applySetup = vi.fn(async () => ({
-      configPath: "/tmp/openclaw.json",
-      configHashBefore: null,
-      configHashAfter: null,
-      bootstrapPending: false,
-      lines: [],
-    }));
+    const applySetup = vi.fn(async () => setupApplyResult());
     const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
       async ({ config }) => config,
     );
@@ -277,13 +273,7 @@ describe("runGuidedOnboarding", () => {
 
   it("hands the custodian hatch to the browser after apply and recommendations", async () => {
     const prompter = createWizardPrompter();
-    const applySetup = vi.fn(async () => ({
-      configPath: "/tmp/openclaw.json",
-      configHashBefore: null,
-      configHashAfter: null,
-      bootstrapPending: false,
-      lines: [],
-    }));
+    const applySetup = vi.fn(async () => setupApplyResult());
     const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
       async ({ config }) => config,
     );

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -126,6 +126,7 @@ function setupDeps(params: {
         configPath: "/tmp/openclaw.json",
         configHashBefore: null,
         configHashAfter: null,
+        bootstrapPending: false,
         lines: [],
       })),
     launchHatchTui: vi.fn(async () => undefined),
@@ -231,6 +232,7 @@ describe("runGuidedOnboarding", () => {
       configPath: "/tmp/openclaw.json",
       configHashBefore: null,
       configHashAfter: null,
+      bootstrapPending: false,
       lines: [],
     }));
     const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
@@ -279,6 +281,7 @@ describe("runGuidedOnboarding", () => {
       configPath: "/tmp/openclaw.json",
       configHashBefore: null,
       configHashAfter: null,
+      bootstrapPending: false,
       lines: [],
     }));
     const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -251,7 +251,7 @@ export async function ensureWorkspaceAndSessions(
     skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
     agentId?: string;
   },
-) {
+): Promise<{ bootstrapExists: boolean }> {
   const ws = await ensureAgentWorkspace({
     dir: workspaceDir,
     ensureBootstrapFiles: !options?.skipBootstrap,
@@ -261,6 +261,7 @@ export async function ensureWorkspaceAndSessions(
   const sessionsDir = resolveSessionTranscriptsDirForAgent(options?.agentId);
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
+  return { bootstrapExists: ws.bootstrapExists === true };
 }
 
 /** Moves a path to Trash when it exists, logging a manual-delete fallback on failure. */

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -251,7 +251,7 @@ export async function ensureWorkspaceAndSessions(
     skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
     agentId?: string;
   },
-): Promise<{ bootstrapExists: boolean }> {
+): Promise<{ bootstrapPending: boolean }> {
   const ws = await ensureAgentWorkspace({
     dir: workspaceDir,
     ensureBootstrapFiles: !options?.skipBootstrap,
@@ -261,7 +261,7 @@ export async function ensureWorkspaceAndSessions(
   const sessionsDir = resolveSessionTranscriptsDirForAgent(options?.agentId);
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
-  return { bootstrapExists: ws.bootstrapExists === true };
+  return { bootstrapPending: ws.bootstrapPending === true };
 }
 
 /** Moves a path to Trash when it exists, logging a manual-delete fallback on failure. */

--- a/src/commands/onboard-remote-gateway.test.ts
+++ b/src/commands/onboard-remote-gateway.test.ts
@@ -179,6 +179,7 @@ describe("runRemoteGatewayInferenceOnboarding", () => {
             sessionId: (options.params as { sessionId: string }).sessionId,
             reply: "Inference is ready. I can configure the rest.",
             action: "open-agent",
+            agentDraft: "hatch",
           };
         }
         throw new Error(`unexpected Gateway method ${options.method}`);
@@ -192,6 +193,7 @@ describe("runRemoteGatewayInferenceOnboarding", () => {
             }),
           }),
           deliver: false,
+          message: "Wake up, my friend!",
           boundGateway: {
             url: "wss://selected.example/ws",
             ...auth,

--- a/src/commands/onboard-remote-gateway.ts
+++ b/src/commands/onboard-remote-gateway.ts
@@ -15,6 +15,7 @@ import type {
   SetupInferenceDetection,
   SetupInferenceFailureStatus,
 } from "../system-agent/setup-inference.js";
+import { t } from "../wizard/i18n/index.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
 import type { GuidedOnboardingDeps } from "./onboard-guided.js";
 
@@ -269,6 +270,7 @@ export async function runRemoteGatewayInferenceOnboarding(
         timeoutMs: GATEWAY_SYSTEM_AGENT_CHAT_TIMEOUT_MS,
       });
 
+      let agentDraft: SystemAgentChatResult["agentDraft"];
       try {
         for (;;) {
           await prompter.note(reply.reply, "OpenClaw");
@@ -277,6 +279,7 @@ export async function runRemoteGatewayInferenceOnboarding(
             return;
           }
           if (reply.action === "open-agent") {
+            agentDraft = reply.agentDraft;
             await prompter.outro("Opening your agent…");
             break;
           }
@@ -305,6 +308,7 @@ export async function runRemoteGatewayInferenceOnboarding(
       await runTui({
         config: boundConfig,
         deliver: false,
+        ...(agentDraft === "hatch" ? { message: t("wizard.finalize.bootstrapHatchMessage") } : {}),
         boundGateway: {
           url: target.gatewayUrl,
           ...(target.token ? { token: target.token } : {}),

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -853,7 +853,26 @@ describe("openclaw.chat", () => {
     });
 
     expect(call.payload).toMatchObject({ action: "open-agent" });
+    expect(call.payload).not.toHaveProperty("agentDraft");
     expect((call.payload as { reply: string }).reply).toContain("continue with your agent");
+  });
+
+  it("forwards the hatch draft intent with an agent handoff", async () => {
+    const engine = makeVerifiedEngine();
+    vi.spyOn(engine, "handle").mockResolvedValue({
+      text: "Your agent is hatching.",
+      action: "open-tui",
+      agentDraft: "hatch",
+      handoff: { kind: "open-tui" },
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const call = await callChat(makeContext(sessions), {
+      sessionId: "s1",
+      message: "yes",
+    });
+
+    expect(call.payload).toMatchObject({ action: "open-agent", agentDraft: "hatch" });
   });
 
   it("resets a session on request", async () => {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -590,6 +590,9 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
                 ? "Setup here is done — continue with your agent."
                 : "Nothing to change."),
             action,
+            ...(action === "open-agent" && reply.agentDraft
+              ? { agentDraft: reply.agentDraft }
+              : {}),
             ...(reply.sensitive === true ? { sensitive: true } : {}),
             ...(reply.question ? { question: reply.question } : {}),
             ...(proposalId ? { needsApproval: true, proposalId } : {}),

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -414,6 +414,7 @@ describe("SystemAgentChatEngine", () => {
 
     expect(applySetup).toHaveBeenCalledOnce();
     expect(reply.action).toBe("open-tui");
+    expect(reply.agentDraft).toBe("hatch");
     expect(reply.handoff).toMatchObject({ kind: "open-tui", workspace: "/tmp/hatch-work" });
     expect(reply.text).toContain("Your agent is hatching");
     expect(reply.text).toContain("Settings → Ask OpenClaw");
@@ -466,6 +467,7 @@ describe("SystemAgentChatEngine", () => {
 
     expect(applySetup).toHaveBeenCalledOnce();
     expect(reply.action).toBe("none");
+    expect(reply.agentDraft).toBeUndefined();
     expect(reply.handoff).toBeUndefined();
     expect(reply.text).not.toContain("Your agent is hatching");
   });
@@ -479,6 +481,7 @@ describe("SystemAgentChatEngine", () => {
     const reply = await engine.handle("yes");
 
     expect(reply.action).toBe("none");
+    expect(reply.agentDraft).toBeUndefined();
     expect(reply.handoff).toBeUndefined();
   });
 

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -419,6 +419,57 @@ describe("SystemAgentChatEngine", () => {
     expect(reply.text).toContain("Settings → Ask OpenClaw");
   });
 
+  it("stays in setup when post-write verification flags the config", async () => {
+    useTempStateDir();
+    const verifyInferenceConfig = vi.fn(async () => ({
+      ok: true as const,
+      modelRef: "openai/gpt-5.5",
+      latencyMs: 100,
+    }));
+    let applied = false;
+    const applySetup = vi.fn(async () => {
+      applied = true;
+      return {
+        configPath: "/tmp/openclaw.json",
+        configHashBefore: "before",
+        configHashAfter: "after",
+        lines: ["Workspace: /tmp/hatch-work"],
+      };
+    });
+    // The written config turns out invalid: post-write verification must hold
+    // the user in setup instead of hatching into an agent that cannot answer.
+    // Reads stay valid through preflight/apply and flip only after the write.
+    const validSnapshot = mocks.readConfigFileSnapshot.getMockImplementation()!;
+    mocks.readConfigFileSnapshot.mockImplementation(async () => {
+      const snapshot = await validSnapshot();
+      return applied
+        ? ({
+            ...snapshot,
+            valid: false,
+            issues: [{ path: "agents", message: "broken" }],
+          } as never)
+        : snapshot;
+    });
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => ({ text: "repair suggestion" }),
+      planWithAssistant: async () => null,
+      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
+      deps: {
+        applySetup,
+        verifyInferenceConfig,
+        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
+      },
+    });
+    engine.propose({ kind: "setup", workspace: "/tmp/hatch-work" });
+
+    const reply = await engine.handle("yes");
+
+    expect(applySetup).toHaveBeenCalledOnce();
+    expect(reply.action).toBe("none");
+    expect(reply.handoff).toBeUndefined();
+    expect(reply.text).not.toContain("Your agent is hatching");
+  });
+
   it("does not hand off when a non-setup persistent operation applies", async () => {
     useTempStateDir();
     const runConfigSet = vi.fn(async () => {});

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -396,6 +396,7 @@ describe("SystemAgentChatEngine", () => {
       configPath: "/tmp/openclaw.json",
       configHashBefore: "before",
       configHashAfter: "after",
+      bootstrapPending: true,
       lines: ["Workspace: /tmp/hatch-work"],
     }));
     const engine = new SystemAgentChatEngine({
@@ -424,6 +425,39 @@ describe("SystemAgentChatEngine", () => {
     expect(reply.text).toContain("Settings → Ask OpenClaw");
   });
 
+  it("stays in setup when an established workspace has no bootstrap pending", async () => {
+    useTempStateDir();
+    const applySetup = vi.fn(async () => ({
+      configPath: "/tmp/openclaw.json",
+      configHashBefore: "before",
+      configHashAfter: "after",
+      bootstrapPending: false,
+      lines: ["Workspace: /tmp/established-work"],
+    }));
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
+      deps: {
+        applySetup,
+        verifyInferenceConfig: vi.fn(async () => ({
+          ok: true as const,
+          modelRef: "openai/gpt-5.5",
+          latencyMs: 100,
+        })),
+        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
+      },
+    });
+    engine.propose({ kind: "setup", workspace: "/tmp/established-work" });
+
+    const reply = await engine.handle("yes");
+
+    expect(reply.action).toBe("none");
+    expect(reply.agentDraft).toBeUndefined();
+    expect(reply.handoff).toBeUndefined();
+    expect(reply.text).not.toContain("Your agent is hatching");
+  });
+
   it("stays in setup when post-write verification flags the config", async () => {
     useTempStateDir();
     const verifyInferenceConfig = vi.fn(async () => ({
@@ -438,6 +472,7 @@ describe("SystemAgentChatEngine", () => {
         configPath: "/tmp/openclaw.json",
         configHashBefore: "before",
         configHashAfter: "after",
+        bootstrapPending: true,
         lines: ["Workspace: /tmp/hatch-work"],
       };
     });
@@ -532,6 +567,7 @@ describe("SystemAgentChatEngine", () => {
       configPath: "/tmp/openclaw.json",
       configHashBefore: null,
       configHashAfter: "after",
+      bootstrapPending: false,
       lines: ["Workspace: /tmp/work"],
     }));
     expect(
@@ -1426,6 +1462,7 @@ describe("SystemAgentChatEngine", () => {
       configPath: "/tmp/openclaw.json",
       configHashBefore: "before",
       configHashAfter: "after",
+      bootstrapPending: false,
       lines: ["Workspace: /tmp/new-work"],
     }));
     let pendingOperation = "";

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -385,6 +385,52 @@ describe("SystemAgentChatEngine", () => {
     expect(engine.hasPendingProposal()).toBe(false);
   });
 
+  it("hatches into the agent after a fresh setup applies", async () => {
+    useTempStateDir();
+    const verifyInferenceConfig = vi.fn(async () => ({
+      ok: true as const,
+      modelRef: "openai/gpt-5.5",
+      latencyMs: 100,
+    }));
+    const applySetup = vi.fn(async () => ({
+      configPath: "/tmp/openclaw.json",
+      configHashBefore: "before",
+      configHashAfter: "after",
+      lines: ["Workspace: /tmp/hatch-work"],
+    }));
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
+      deps: {
+        applySetup,
+        verifyInferenceConfig,
+        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
+      },
+    });
+    engine.propose({ kind: "setup", workspace: "/tmp/hatch-work" });
+
+    const reply = await engine.handle("yes");
+
+    expect(applySetup).toHaveBeenCalledOnce();
+    expect(reply.action).toBe("open-tui");
+    expect(reply.handoff).toMatchObject({ kind: "open-tui", workspace: "/tmp/hatch-work" });
+    expect(reply.text).toContain("Your agent is hatching");
+    expect(reply.text).toContain("Settings → Ask OpenClaw");
+  });
+
+  it("does not hand off when a non-setup persistent operation applies", async () => {
+    useTempStateDir();
+    const runConfigSet = vi.fn(async () => {});
+    const engine = new SystemAgentChatEngine({ deps: { runConfigSet } });
+    engine.propose({ kind: "config-set", path: "gateway.port", value: "19002" });
+
+    const reply = await engine.handle("yes");
+
+    expect(reply.action).toBe("none");
+    expect(reply.handoff).toBeUndefined();
+  });
+
   it("rejects a seeded approval when its binding changes during classification", async () => {
     const baseConfig = {
       agents: { defaults: { model: "openai/gpt-5.5" } },

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -415,7 +415,11 @@ describe("SystemAgentChatEngine", () => {
     expect(applySetup).toHaveBeenCalledOnce();
     expect(reply.action).toBe("open-tui");
     expect(reply.agentDraft).toBe("hatch");
-    expect(reply.handoff).toMatchObject({ kind: "open-tui", workspace: "/tmp/hatch-work" });
+    expect(reply.handoff).toMatchObject({
+      kind: "open-tui",
+      workspace: "/tmp/hatch-work",
+      agentDraft: "hatch",
+    });
     expect(reply.text).toContain("Your agent is hatching");
     expect(reply.text).toContain("Settings → Ask OpenClaw");
   });

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -79,6 +79,8 @@ type SystemAgentChatReplyAction = "none" | "exit" | "open-tui" | "open-setup";
 type SystemAgentChatReply = {
   text: string;
   action: SystemAgentChatReplyAction;
+  /** Client-localized draft intent for the destination agent chat. */
+  agentDraft?: "hatch";
   /** The next hosted-wizard reply contains a secret and must be masked/redacted by hosts. */
   sensitive?: boolean;
   /** Present when the host must leave chat for an interactive handoff. */
@@ -639,6 +641,7 @@ export class SystemAgentChatEngine {
           "Your agent is hatching — handing you over now. You can always find me in Settings → Ask OpenClaw.",
         ].join("\n\n"),
         action: "open-tui",
+        agentDraft: "hatch",
         handoff: {
           kind: "open-tui",
           ...(operation.workspace ? { workspace: operation.workspace } : {}),

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -629,7 +629,10 @@ export class SystemAgentChatEngine {
     // The hatch is a ceremony: a fresh-install setup just created the agent,
     // so hand the user straight into it instead of parking them here. The
     // seeded BOOTSTRAP runs the birth sequence on the agent's first turn.
-    if (operation.kind === "setup" && result?.applied) {
+    // Only on clean post-write verification: a non-null verify means the
+    // written config is suspect, and handing off would bury the warning in an
+    // agent session that may not answer — stay in setup to repair it.
+    if (operation.kind === "setup" && result?.applied && verify === null) {
       return {
         text: [
           baseText,

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -634,7 +634,12 @@ export class SystemAgentChatEngine {
     // Only on clean post-write verification: a non-null verify means the
     // written config is suspect, and handing off would bury the warning in an
     // agent session that may not answer — stay in setup to repair it.
-    if (operation.kind === "setup" && result?.applied && verify === null) {
+    if (
+      operation.kind === "setup" &&
+      result?.applied &&
+      result.bootstrapPending === true &&
+      verify === null
+    ) {
       return {
         text: [
           baseText,

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -644,6 +644,7 @@ export class SystemAgentChatEngine {
         agentDraft: "hatch",
         handoff: {
           kind: "open-tui",
+          agentDraft: "hatch",
           ...(operation.workspace ? { workspace: operation.workspace } : {}),
         },
       };

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -623,10 +623,27 @@ export class SystemAgentChatEngine {
     }
     const verify = result?.applied ? await this.verifyConfigAfterWrite() : null;
     const followUp = this.armFollowUp(result?.followUp);
+    const baseText = [capture.read() || "Applied. Audit entry written.", verify, followUp]
+      .filter(Boolean)
+      .join("\n\n");
+    // The hatch is a ceremony: a fresh-install setup just created the agent,
+    // so hand the user straight into it instead of parking them here. The
+    // seeded BOOTSTRAP runs the birth sequence on the agent's first turn.
+    if (operation.kind === "setup" && result?.applied) {
+      return {
+        text: [
+          baseText,
+          "Your agent is hatching — handing you over now. You can always find me in Settings → Ask OpenClaw.",
+        ].join("\n\n"),
+        action: "open-tui",
+        handoff: {
+          kind: "open-tui",
+          ...(operation.workspace ? { workspace: operation.workspace } : {}),
+        },
+      };
+    }
     return {
-      text: [capture.read() || "Applied. Audit entry written.", verify, followUp]
-        .filter(Boolean)
-        .join("\n\n"),
+      text: baseText,
       action: "none",
     };
   }

--- a/src/system-agent/operation-types.ts
+++ b/src/system-agent/operation-types.ts
@@ -44,5 +44,5 @@ export type SystemAgentOperation =
   | { kind: "plugin-uninstall"; pluginId: string }
   | { kind: "audit" }
   | { kind: "create-agent"; agentId: string; workspace?: string; model?: string }
-  | { kind: "open-tui"; agentId?: string; workspace?: string }
+  | { kind: "open-tui"; agentId?: string; workspace?: string; agentDraft?: "hatch" }
   | { kind: "set-default-model"; model: string; agentId?: string };

--- a/src/system-agent/operations-execute.ts
+++ b/src/system-agent/operations-execute.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { t } from "../wizard/i18n/index.js";
 import { isReservedSystemAgentId } from "./agent-id.js";
 import { resolveSystemAgentAuditPath } from "./audit.js";
 import {
@@ -464,7 +465,15 @@ export async function executeSystemAgentOperation(
       });
       const session = agentId ? buildAgentMainSessionKey({ agentId }) : undefined;
       const runTui = opts.deps?.runTui ?? (await import("../tui/tui.js")).runTui;
-      const result = await runTui({ local: true, session, deliver: false, historyLimit: 200 });
+      const result = await runTui({
+        local: true,
+        session,
+        deliver: false,
+        historyLimit: 200,
+        ...(operation.agentDraft === "hatch"
+          ? { message: t("wizard.finalize.bootstrapHatchMessage") }
+          : {}),
+      });
       if (result?.exitReason === "return-to-system-agent") {
         runtime.log(
           result.systemAgentMessage

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -236,6 +236,7 @@ type PersistentApplyContext = {
 
 type PersistentApplyOutcome = {
   summary: string;
+  bootstrapPending?: boolean;
   details?: Record<string, unknown>;
   /** Overrides the after-snapshot config path in the audit record. */
   configPath?: string;
@@ -280,7 +281,12 @@ export async function applyPersistentOperation(params: {
     );
   }
   runtime.log(`[openclaw] done: ${auditOperation}`);
-  return { applied: true };
+  return {
+    applied: true,
+    ...(outcome.bootstrapPending === undefined
+      ? {}
+      : { bootstrapPending: outcome.bootstrapPending }),
+  };
 }
 
 export async function runConfigSetOperation(params: {
@@ -499,6 +505,7 @@ export async function executeSetup(
       ctx.runtime.log(`Default model: ${verified.modelRef} (verified and kept)`);
       return {
         summary: "Bootstrapped setup workspace",
+        bootstrapPending: applied.bootstrapPending,
         configPath: after.path || applied.configPath,
         details: {
           workspace,

--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -19,6 +19,8 @@ export type { SystemAgentOperation };
 /** Result returned by the operation executor. */
 export type SystemAgentOperationResult = {
   applied: boolean;
+  /** Setup created or preserved BOOTSTRAP.md for the agent's first turn. */
+  bootstrapPending?: boolean;
   exitsInteractive?: boolean;
   message?: string;
   nextInput?: string;

--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -64,6 +64,7 @@ export type SystemAgentCommandDeps = {
     session?: string;
     deliver?: boolean;
     historyLimit?: number;
+    message?: string;
   }) => Promise<TuiResult | void>;
   /** Where setup side effects run; the gateway surface never manages its own daemon. */
   setupSurface?: "cli" | "gateway";

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -185,6 +185,7 @@ describe("parseSystemAgentOperation", () => {
       configPath: path.join(tempDir, "openclaw.json"),
       configHashBefore: "mock-hash-0",
       configHashAfter: "mock-hash-1",
+      bootstrapPending: true,
       lines: ["Workspace: /tmp/work"],
     }));
     const deps = {
@@ -218,6 +219,7 @@ describe("parseSystemAgentOperation", () => {
       },
     );
     expect(result.applied).toBe(true);
+    expect(result.bootstrapPending).toBe(true);
 
     expect(lines.join("\n")).toContain("[openclaw] done: openclaw.setup");
     expect(applySetup).toHaveBeenCalledWith(
@@ -339,6 +341,7 @@ describe("parseSystemAgentOperation", () => {
       configPath: "/tmp/openclaw.json",
       configHashBefore: "mock-hash-0",
       configHashAfter: "mock-hash-1",
+      bootstrapPending: false,
       lines: [],
     }));
 
@@ -401,6 +404,7 @@ describe("parseSystemAgentOperation", () => {
       configPath: path.join(tempDir, "openclaw.json"),
       configHashBefore: "mock-hash-0",
       configHashAfter: "mock-hash-1",
+      bootstrapPending: false,
       lines: ["Workspace: /tmp/work"],
     }));
 
@@ -421,7 +425,7 @@ describe("parseSystemAgentOperation", () => {
       },
     );
 
-    expect(result).toEqual({ applied: true });
+    expect(result).toEqual({ applied: true, bootstrapPending: false });
     expect(applySetup).toHaveBeenCalledWith(
       {
         workspace: "/tmp/work",

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -1006,6 +1006,25 @@ describe("parseSystemAgentOperation", () => {
     );
   });
 
+  it("seeds a fresh hatch into the agent TUI", async () => {
+    const { runtime } = createSystemAgentTestRuntime();
+    const runTui = vi.fn(async () => ({ exitReason: "exit" as const }));
+
+    await executeSystemAgentOperation(
+      { kind: "open-tui", agentId: "work", agentDraft: "hatch" },
+      runtime,
+      { deps: { runTui } },
+    );
+
+    expect(runTui).toHaveBeenCalledWith({
+      local: true,
+      session: "agent:work:main",
+      deliver: false,
+      historyLimit: 200,
+      message: "Wake up, my friend!",
+    });
+  });
+
   it("re-enters the OpenClaw shell when the agent TUI returns without a request", async () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     const runTui = vi.fn(async () => ({

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -288,6 +288,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     );
     mocks.ensureWorkspace.mockImplementation(async () => {
       mocks.events.push("workspace");
+      return { bootstrapExists: true };
     });
     mocks.ensureGatewayService.mockResolvedValue({ installDaemon: false });
     mocks.refreshPluginRegistry.mockResolvedValue(undefined);
@@ -321,6 +322,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     const result = await applySystemAgentSetup(baseParams({ expectedConfigHash: null }));
 
     expect(result.configHashBefore).toBeNull();
+    expect(result.bootstrapPending).toBe(true);
     expect(mocks.state.persistedConfig).toMatchObject({
       agents: { defaults: { workspace: "/tmp/openclaw-workspace" } },
     });

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -288,7 +288,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     );
     mocks.ensureWorkspace.mockImplementation(async () => {
       mocks.events.push("workspace");
-      return { bootstrapExists: true };
+      return { bootstrapPending: true };
     });
     mocks.ensureGatewayService.mockResolvedValue({ installDaemon: false });
     mocks.refreshPluginRegistry.mockResolvedValue(undefined);

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -64,6 +64,7 @@ export type SystemAgentSetupApplyResult = {
   configPath: string;
   configHashBefore: string | null;
   configHashAfter: string | null;
+  bootstrapPending: boolean;
   lines: string[];
 };
 
@@ -510,7 +511,7 @@ export async function applySystemAgentSetup(
     }
   };
 
-  await runCommittedFollowUp(
+  const workspaceResult = await runCommittedFollowUp(
     async () =>
       await onboardHelpers.ensureWorkspaceAndSessions(workspace, runtime, {
         skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
@@ -612,6 +613,7 @@ export async function applySystemAgentSetup(
     configPath: committed.path,
     configHashBefore: committed.previousHash,
     configHashAfter: committed.persistedHash,
+    bootstrapPending: workspaceResult?.bootstrapExists === true,
     lines,
   };
 }

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -613,7 +613,7 @@ export async function applySystemAgentSetup(
     configPath: committed.path,
     configHashBefore: committed.previousHash,
     configHashAfter: committed.persistedHash,
-    bootstrapPending: workspaceResult?.bootstrapExists === true,
+    bootstrapPending: workspaceResult?.bootstrapPending === true,
     lines,
   };
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1832,6 +1832,7 @@ export const en: TranslationMap = {
     title: "OpenClaw",
     subtitle: "Your system setup guide",
     exitSetup: "Exit setup",
+    hatchDraft: "Wake up, my friend!",
     placeholder: "Message OpenClaw…",
     sensitivePlaceholder: "Enter sensitive value…",
     sensitiveReply: "Sensitive reply sent",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -625,6 +625,7 @@ describe("custodian page", () => {
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
       reply: "Your agent is hatching — handing you over now.",
       action: "open-agent",
+      agentDraft: "hatch",
     });
     const { context } = createContext(request);
     const { page } = await mountPage(context);
@@ -632,8 +633,21 @@ describe("custodian page", () => {
     await page.updateComplete;
 
     expect(context.navigate).toHaveBeenCalledWith("chat", {
-      search: `?draft=${encodeURIComponent("Wake up, my friend!")}`,
+      search: `?session=main&draft=${encodeURIComponent("Wake up, my friend!")}`,
     });
+  });
+
+  it("hands off to normal agent chat without the hatch draft", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Setup here is done — continue with your agent.",
+      action: "open-agent",
+    });
+    const { context } = createContext(request);
+    await mountPage(context);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    expect(context.navigate).toHaveBeenCalledWith("chat");
   });
 
   it("exits setup through normal chat navigation", async () => {

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -620,6 +620,22 @@ describe("custodian page", () => {
     expect(request.mock.calls[1]?.[1]).not.toHaveProperty("message");
   });
 
+  it("hands off to agent chat with the hatch draft on open-agent", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Your agent is hatching — handing you over now.",
+      action: "open-agent",
+    });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await page.updateComplete;
+
+    expect(context.navigate).toHaveBeenCalledWith("chat", {
+      search: `?draft=${encodeURIComponent("Wake up, my friend!")}`,
+    });
+  });
+
   it("exits setup through normal chat navigation", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -9,6 +9,7 @@ import "../../components/option-card.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { searchForSession } from "../../lib/sessions/navigation.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/custodian.css";
@@ -199,11 +200,16 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.retryParams = null;
       this.appendAssistant(result.reply, parseCustodianQuestion(result.question));
       if (result.action === "open-agent") {
-        // Hatch handoff: land in the agent chat with the birth-sequence opener
-        // prefilled so one Send wakes the freshly seeded BOOTSTRAP.
-        this.context.navigate("chat", {
-          search: `?draft=${encodeURIComponent(t("custodian.hatchDraft"))}`,
-        });
+        const sessionKey = this.context.gateway.snapshot.sessionKey?.trim();
+        if (result.agentDraft === "hatch" && sessionKey) {
+          // Preserve the destination session while preloading the localized
+          // birth-sequence opener; draft-only chat routes are intentionally invalid.
+          this.context.navigate("chat", {
+            search: `${searchForSession(sessionKey)}&draft=${encodeURIComponent(t("custodian.hatchDraft"))}`,
+          });
+        } else {
+          this.exitSetup();
+        }
       } else if (result.action === "exit") {
         this.exitSetup();
       }

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -198,7 +198,13 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.sensitive = result.sensitive === true;
       this.retryParams = null;
       this.appendAssistant(result.reply, parseCustodianQuestion(result.question));
-      if (result.action === "open-agent" || result.action === "exit") {
+      if (result.action === "open-agent") {
+        // Hatch handoff: land in the agent chat with the birth-sequence opener
+        // prefilled so one Send wakes the freshly seeded BOOTSTRAP.
+        this.context.navigate("chat", {
+          search: `?draft=${encodeURIComponent(t("custodian.hatchDraft"))}`,
+        });
+      } else if (result.action === "exit") {
         this.exitSetup();
       }
     } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Phase 5 PR2 of the custodian onboarding redesign (plan: `docs/start/onboarding-redesign.md`). After a fresh-install setup applies in the custodian conversation, users were parked in the custodian with a "talk to agent" hint instead of the decided hatch ceremony — the moment the plan calls the identity beat of onboarding.

## Why This Change Was Made

The plan's decided principles: "the hatch is a ceremony" and "zero agents on first run auto-hatches with an announcement". The pieces already shipped — `create-agent`/setup operations, the seeded `BOOTSTRAP.md` birth sequence (phase 5 PR1), the web custodian surface (phase 4) — this PR connects them.

## User Impact

- A fresh-install `setup` apply in the OpenClaw conversation now announces the hatch ("Your agent is hatching — handing you over now. You can always find me in Settings → Ask OpenClaw.") and hands straight off: `open-tui` in the terminal (the TUI backend's existing handoff opens the agent), mapped to `open-agent` for gateway clients.
- The web custodian page turns `open-agent` into a navigation to agent chat with the birth-sequence opener ("Wake up, my friend!" — the same seed the CLI hatch uses) prefilled as a composer draft, so one Send wakes the seeded `BOOTSTRAP` and the agent names itself.
- The hatch fires only on clean post-write verification: if the written config is flagged, the user stays in setup with the warning instead of being dropped into an agent that cannot answer.
- Non-setup persistent operations keep their in-place replies; nothing changes for configured installs (setup does not re-apply there).
- Avatar/image-gen ladder remains a follow-up per the plan.

## Evidence

- Engine suite: 59 tests green, including "hatches into the agent after a fresh setup applies" (announcement + `open-tui` + workspace handoff), "stays in setup when post-write verification flags the config", and "does not hand off when a non-setup persistent operation applies".
- Custodian page: 18 tests green including "hands off to agent chat with the hatch draft on open-agent" (draft URL-encoded); full `ui/src` shard 4393 tests green post-rebase over #110269; `pnpm ui:i18n:baseline`/`verify` green (new key `custodian.hatchDraft`).
- Autoreview (Codex, branch mode, xhigh): clean post-rebase ("patch is correct", 0.87); the one finding during development (unconditional handoff despite failed verification) was fixed with the regression test above.
- Live context: the custodian surfaces around this handoff were live-verified this session (typed welcome cards, caretaker vs onboarding greeting, Exit setup gating). Known gap, stated honestly: the full fresh-install *web* hatch (setup apply → open-agent → draft) was not run live end-to-end — the equivalent CLI hatch path (seeded TUI handoff) was live-tested when phases 2-3 landed, and the web-specific delta is covered by the unit tests above.
