### PR TITLE
fix(cron): startup catch-up deferral is lost when the gateway restarts before the deferred slot fires

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -368,6 +368,7 @@ const CronFailureNotificationDeliverySchema = closedObject({
 /** Scheduler-maintained state for the latest run/delivery outcome. */
 export const CronJobStateSchema = closedObject({
   nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  catchupDeferredUntilMs: Type.Optional(Type.Integer({ minimum: 0 })),
   runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   lastRunStatus: Type.Optional(CronRunStatusSchema),

--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -93,6 +93,66 @@ describe("CronService startup catch-up repair scoping", () => {
     await store.cleanup();
   });
 
+  it("keeps the overflow catch-up deferral across a restart before the deferred slot fires", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    let now = startNow;
+    const tomorrowNaturalSlot = Date.parse("2025-12-14T09:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    const makeState = () =>
+      createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+
+    const firstProcess = makeState();
+    await start(firstProcess);
+    expect(
+      firstProcess.store?.jobs.find((job) => job.id === "daily-overflow")?.state.nextRunAtMs,
+    ).toBe(startNow + 5_000);
+    firstProcess.stopped = true;
+
+    // Restart before the deferred slot fires: a fresh process starts with an
+    // empty in-memory marker set and must rebuild it from the persisted store.
+    now = startNow + 3_000;
+    const secondProcess = makeState();
+    await start(secondProcess);
+
+    const deferred = secondProcess.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(secondProcess.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+    expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
+    expect(deferred?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
+
+    now = startNow + 5_005;
+    await onTimer(secondProcess);
+
+    const completed = secondProcess.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(completed?.state.lastRunStatus).toBe("ok");
+    expect(completed?.state.nextRunAtMs).toBe(tomorrowNaturalSlot);
+    expect(completed?.state.catchupDeferredUntilMs).toBeUndefined();
+    expect(secondProcess.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(false);
+
+    secondProcess.stopped = true;
+    await store.cleanup();
+  });
+
   it("still repairs a stale future cron slot on start() when no jobs were deferred", async () => {
     const store = await makeStorePath();
     const startNow = Date.parse("2025-12-13T17:00:00.000Z");

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -768,6 +768,29 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
 }
 
 /**
+ * Rebuilds the in-memory catch-up deferral marker set from persisted job state
+ * after a store (re)load. Without this, a restart between the deferral write
+ * and the deferred slot firing starts with an empty marker set, and the first
+ * maintenance pass repairs the staggered slot to the next natural run,
+ * silently dropping the catch-up execution (#102236).
+ */
+export function rehydratePendingCatchupDeferrals(state: CronServiceState): void {
+  for (const job of state.store?.jobs ?? []) {
+    const deferredUntil = job.state?.catchupDeferredUntilMs;
+    if (typeof deferredUntil !== "number") {
+      continue;
+    }
+    // The persisted marker is only meaningful while the deferred slot is still
+    // the scheduled run; any other nextRunAtMs means the job was edited or ran.
+    if (isJobEnabled(job) && job.state.nextRunAtMs === deferredUntil) {
+      state.pendingCatchupDeferralJobIds.add(job.id);
+    } else {
+      delete job.state.catchupDeferredUntilMs;
+    }
+  }
+}
+
+/**
  * Maintenance-only version of recomputeNextRuns that handles disabled jobs
  * and stuck markers, but does NOT recompute nextRunAtMs for enabled jobs
  * with existing values. Used during timer ticks when no due jobs were found
@@ -816,6 +839,7 @@ export function recomputeNextRunsForMaintenance(
         const nextRun = job.state.nextRunAtMs;
         if (hasScheduledNextRunAtMs(nextRun) && now >= nextRun) {
           deferralIds.delete(job.id);
+          delete job.state.catchupDeferredUntilMs;
           changed = true;
         }
       }

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -11,7 +11,7 @@ import {
   type QuarantinedCronConfigJob,
 } from "../store.js";
 import type { CronJob, CronStoreFile } from "../types.js";
-import { recomputeNextRuns } from "./jobs.js";
+import { recomputeNextRuns, rehydratePendingCatchupDeferrals } from "./jobs.js";
 import { emit, type CronServiceState } from "./state.js";
 
 type PersistOptions = {
@@ -228,6 +228,9 @@ export async function ensureLoaded(
   };
   state.durableNextRunAtMsByJobId = durableNextRunAtMsByJobId;
   state.storeLoadedAtMs = state.deps.nowMs();
+  // A fresh process starts with an empty marker set; rebuild it from persisted
+  // job state before any maintenance pass can repair deferred catch-up slots.
+  rehydratePendingCatchupDeferrals(state);
 
   if (quarantinedConfigJobs.length > 0) {
     state.pendingQuarantineConfigJobs = quarantinedConfigJobs;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1179,12 +1179,14 @@ function applyOutcomeToStoredJob(
       triggerEval: result.triggerEval,
     });
     state.pendingCatchupDeferralJobIds.delete(job.id);
+    delete job.state.catchupDeferredUntilMs;
     return undefined;
   }
 
   const shouldDelete = applyJobResult(state, job, result);
   applyTriggerRunResult(job, result);
   state.pendingCatchupDeferralJobIds.delete(job.id);
+  delete job.state.catchupDeferredUntilMs;
 
   emitJobFinished(state, job, result, result.startedAt);
 
@@ -2370,11 +2372,15 @@ async function applyStartupCatchupOutcomes(
           }
           if (typeof deferred.delayMs === "number") {
             job.state.nextRunAtMs = baseNow + deferred.delayMs + offset - staggerMs;
+            // Persist the deferred slot so a restart before it fires can
+            // rebuild the in-memory marker instead of repairing the slot away.
+            job.state.catchupDeferredUntilMs = job.state.nextRunAtMs;
             state.pendingCatchupDeferralJobIds.add(jobId);
             offset += staggerMs;
             continue;
           }
           job.state.nextRunAtMs = baseNow + offset;
+          job.state.catchupDeferredUntilMs = job.state.nextRunAtMs;
           state.pendingCatchupDeferralJobIds.add(jobId);
           offset += staggerMs;
         }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -315,6 +315,10 @@ export type CronJobState = {
   nextRunAtMs?: number;
   /** Durable pre-admission reservation. Cleared on restart without recording a run. */
   queuedAtMs?: number;
+  /** Startup overflow catch-up slot this job was deferred to. Persisted so the
+   * deferral marker survives a restart before the slot fires; otherwise the
+   * next start()'s maintenance pass advances the slot and drops the run. */
+  catchupDeferredUntilMs?: number;
   runningAtMs?: number;
   lastRunAtMs?: number;
   /** Preferred execution outcome field. */


### PR DESCRIPTION
Closes #102236

## What Problem This Solves

Fixes an issue where a non-`agentTurn` cron job deferred by the startup overflow catch-up (more than `maxMissedJobsPerRestart` past-due jobs at boot) would silently lose its deferred run if the gateway restarted again before the staggered slot fired. The second start's maintenance pass advanced the job to its next natural slot (e.g. tomorrow 09:00), so the catch-up run never executed and nothing was reported.

## Why This Change Was Made

The deferral marker (`pendingCatchupDeferralJobIds`) that protects staggered catch-up slots from future-slot repair was in-memory only. The fix persists the deferred slot on the job itself (`CronJobState.catchupDeferredUntilMs`, carried by the existing `state_json` column — no SQLite schema change) and rebuilds the marker set from persisted state in `ensureLoaded()` before any maintenance pass runs. The persisted marker is honored only while `nextRunAtMs` still equals the deferred slot, so an edited or already-run job cannot resurrect a stale deferral; the field is cleared at every point the in-memory marker was already cleared (run completion, trigger no-fire, slot arrival). `CronJobStateSchema` in the gateway protocol gains the matching additive optional field.

In-process semantics are unchanged: the marker set, its rollback snapshotting, and the repair gate all work exactly as before — the only new behavior is that the marker now survives a process restart. The branch is rebased onto current `main` (including the durable next-run publishing and `closedObject` schema changes).

Upgrade behavior: the field is additive and optional. A store written by an older build simply has no `catchupDeferredUntilMs`; rehydration is a no-op and behavior matches today's. No migration is needed (the live proof below starts from exactly such a store).

## User Impact

Daily/weekly-style cron jobs that get deferred at a busy startup now still run shortly after boot even when the gateway restarts again within the deferral window (the window grows with the overflow count, so quick double-restarts — crash loops, config-triggered restarts, updates — were realistic triggers). No behavior change for `every` schedules, `agentTurn` payloads, or single-restart startups.

## Evidence

**Live two-gateway-process proof on this branch** (real `openclaw gateway run --dev` processes against one on-disk store in an isolated `OPENCLAW_STATE_DIR`, macOS, Node 24.18): the store was seeded (gateway stopped) with 5 past-due hourly jobs + 3 past-due daily jobs in the pre-fix state shape (no `catchupDeferredUntilMs` anywhere — i.e. an upgrade from an older build), then:

**Start #1** (`T1 = …755000`): the 5 hourly jobs consume the missed-job budget and the 3 daily jobs are deferred to staggered slots, now persisted (`next_run_at_ms` == `catchupDeferredUntilMs`):

```
job_id           | next_run_at_ms | catchupDeferredUntilMs | last_run_status
daily-overflow-1 | …758836        | …758836                | -
daily-overflow-2 | …763836        | …763836                | -
daily-overflow-3 | …768836        | …768836                | -
```

**SIGTERM at `…763000`** — before the last slot fires — then **start #2** (fresh process, ready at `…768000`):

```
daily-overflow-1 | …758836        | -                      | -    <- slot elapsed during restart: marker cleared, past-due slot preserved
daily-overflow-2 | …763836        | -                      | -    <- same
daily-overflow-3 | …768836        | …768836                | -    <- future slot RETAINED with its rehydrated marker
```

On unfixed builds `daily-overflow-3`'s row here reads `next_run_at_ms = 1784365200000` (the natural 09:00 UTC slot) and the catch-up run is silently gone; with the fix the deferred slot survives the restart byte-for-byte.

**~2s later** all three deferred jobs executed on gateway #2 and cleaned up:

```
daily-overflow-1 | 1784365200000  | -                      | ok
daily-overflow-2 | 1784365200000  | -                      | ok
daily-overflow-3 | 1784365200000  | -                      | ok
```

— executed (`last_run_status=ok`), advanced to the natural next slot, and the persisted marker fully cleared.

**Automated coverage** (rebased head, Node 24):

- New regression test in `src/cron/service.startup-overflow-clobber.test.ts` drives the same two-start scenario through the real service against one on-disk store; it fails without the `ensureLoaded()` rehydration (verified by temporarily disabling the call) and passes with it.

```
pnpm test src/cron                     # full cron suite
 Test Files  131 passed (131)
      Tests  1456 passed (1456)

pnpm test packages/gateway-protocol
 Test Files  29 passed (29)
      Tests  251 passed (251)

pnpm tsgo:core                         # clean
```

Note: contributor checkout without Crabbox/Testbox access; the two-start runs above are real local gateway processes on this branch.
