### PR TITLE
test(qa): restore Kitchen Sink live plugin gauntlet

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -727,6 +727,7 @@ describe("qa scenario catalog", () => {
     expect(config?.requiredProviderMode).toBe("live-frontier");
     expect(config?.requiredProvider).toBe("openai");
     expect(config?.pluginSpec).toBe("npm:@openclaw/kitchen-sink@latest");
+    expect(JSON.stringify(scenario.execution.flow)).toContain('"--force"');
     expect(config?.pluginId).toBe("openclaw-kitchen-sink-fixture");
     expect(config?.pluginPersonality).toBe("conformance");
     expect(config?.adversarialPersonality).toBe("adversarial");

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -119,6 +119,7 @@ flow:
             - - plugins
               - install
               - expr: config.pluginSpec
+              - --force
             - timeoutMs: 180000
         - call: runQaCli
           args:


### PR DESCRIPTION
Closes #110322

## What Problem This Solves

Fixes an issue where the Kitchen Sink live OpenAI QA scenario stopped at plugin installation after the noninteractive npm trust gate became explicit, leaving the rest of the plugin gauntlet untested.

## Why This Change Was Made

The maintainer-owned scenario now passes `--force` for its reviewed `npm:@openclaw/kitchen-sink@latest` fixture source. This acknowledges provenance without bypassing install policy or other safety checks. The scenario catalog test pins that requirement.

## User Impact

Maintainers again get meaningful pre-release coverage for Kitchen Sink install, enablement, inspection, restart, commands, tools, channels, provider surfaces, and a live OpenAI turn.

## Evidence

- Live OpenAI Kitchen Sink scenario passed end-to-end on Blacksmith Testbox after the change. [Run](https://github.com/openclaw/openclaw/actions/runs/29627083938)
- Scenario catalog test: 44 passed.
- Full fail-safe changed gate passed, including all-project typecheck, full lint, plugin boundaries, database guards, and import-cycle checks. [Run](https://github.com/openclaw/openclaw/actions/runs/29627236093)
- Autoreview clean.

AI-assisted implementation and testing; maintainer reviewed the final patch and live behavior.
