### PR TITLE
fix(cli): avoid macOS system CA exit hang in one-shot commands

### DIFF
--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -1,0 +1,165 @@
+// Process coverage for one-shot Gateway CLI output followed by clean exit.
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+} from "../gateway/minimal-gateway.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const activeChildren = new Set<ChildProcessWithoutNullStreams>();
+const activeServers = new Set<WebSocketServer>();
+
+afterEach(async () => {
+  await Promise.all(
+    Array.from(activeChildren, async (child) => {
+      if (child.exitCode === null && child.signalCode === null) {
+        // Let the launcher forward termination to its respawned child.
+        child.kill("SIGTERM");
+        await once(child, "close");
+      }
+    }),
+  );
+  await Promise.all(Array.from(activeServers, closeMinimalGatewayServer));
+  activeServers.clear();
+});
+
+async function startCronListGateway(token: string): Promise<{ url: string }> {
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  activeServers.add(wss);
+  wss.on("connection", (ws) => {
+    sendMinimalGatewayConnectChallenge(ws);
+    ws.on("message", (data) => {
+      const frame = parseMinimalGatewayRequestFrame(data);
+      if (frame.type !== "req" || !frame.id) {
+        return;
+      }
+      if (frame.method === "connect") {
+        expect(frame.params?.auth?.token).toBe(token);
+        sendMinimalGatewayResponse(
+          ws,
+          frame.id,
+          buildMinimalGatewayHelloOkPayload({
+            methods: ["cron.list"],
+            auth: { role: "operator", scopes: ["operator.admin"] },
+          }),
+        );
+        return;
+      }
+      if (frame.method === "cron.list") {
+        sendMinimalGatewayResponse(ws, frame.id, {
+          jobs: [],
+          snapshotRevision: "test-revision",
+          total: 0,
+          offset: 0,
+          limit: 50,
+          hasMore: false,
+          nextOffset: null,
+          deliveryPreviews: {},
+        });
+      }
+    });
+  });
+  await once(wss, "listening");
+  const address = wss.address() as AddressInfo;
+  return { url: `ws://127.0.0.1:${address.port}` };
+}
+
+describe("gateway-backed CLI process exit", () => {
+  it("exits promptly after cron list emits complete output", async () => {
+    const root = tempDirs.make("openclaw-gateway-cli-exit-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const caTriggerPath = path.join(root, "load-default-ca.mjs");
+    const token = "test-token";
+    const gateway = await startCronListGateway(token);
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      caTriggerPath,
+      `if (process.env.OPENCLAW_NODE_OPTIONS_READY === "1") {
+  const { getCACertificates } = await import("node:tls");
+  getCACertificates("default");
+}
+`,
+    );
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "remote", remote: { url: gateway.url, token } },
+      }),
+    );
+
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--import",
+        pathToFileURL(caTriggerPath).href,
+        "src/entry.ts",
+        "cron",
+        "list",
+        "--json",
+      ],
+      {
+        cwd: path.resolve("."),
+        env: {
+          ...process.env,
+          HOME: root,
+          NODE_ENV: undefined,
+          NODE_OPTIONS: undefined,
+          NODE_USE_SYSTEM_CA: "1",
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_NODE_OPTIONS_READY: undefined,
+          OPENCLAW_STATE_DIR: stateDir,
+          VITEST: undefined,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    activeChildren.add(child);
+    child.stdin.end();
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    let exitTimer: NodeJS.Timeout | undefined;
+    const result = await Promise.race([
+      once(child, "close").then(([code, signal]) => ({ code, signal })),
+      new Promise<never>((_, reject) => {
+        exitTimer = setTimeout(
+          () => reject(new Error("cron list did not exit within 10 seconds")),
+          10_000,
+        );
+        exitTimer.unref();
+      }),
+    ]).finally(() => {
+      if (exitTimer) {
+        clearTimeout(exitTimer);
+      }
+    });
+    activeChildren.delete(child);
+
+    expect(result, stderr).toEqual({ code: 0, signal: null });
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toMatchObject({ jobs: [], total: 0 });
+  }, 20_000);
+});

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 import { buildCliRespawnPlan, runCliRespawnPlan } from "./entry.respawn.js";
 
 const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
+const BUNDLED_CA_FLAG = "--use-bundled-ca";
+const OPENSSL_CA_FLAG = "--use-openssl-ca";
 const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
 const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
 
@@ -87,6 +89,100 @@ describe("buildCliRespawnPlan", () => {
     const respawnPlan = expectCliRespawnPlan(plan);
     expect(respawnPlan.argv).toEqual([EXPERIMENTAL_WARNING_FLAG, "openclaw"]);
     expect(respawnPlan.detachForProcessTree).toBe(false);
+  });
+
+  it("uses the file-backed CA store for one-shot macOS commands", () => {
+    const plan = buildCliRespawnPlan({
+      argv: ["node", "openclaw", "cron", "list", "--json"],
+      env: { NODE_USE_SYSTEM_CA: "1" },
+      execArgv: [],
+      autoNodeExtraCaCerts: undefined,
+      platform: "darwin",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual([
+      EXPERIMENTAL_WARNING_FLAG,
+      OPENSSL_CA_FLAG,
+      "openclaw",
+      "cron",
+      "list",
+      "--json",
+    ]);
+    expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("0");
+  });
+
+  it.each([
+    ["interactive commands", ["node", "openclaw", "tui"]],
+    ["the foreground Gateway", ["node", "openclaw", "gateway", "run"]],
+  ] as const)("keeps macOS system CA loading for %s", (_label, argv) => {
+    expect(
+      buildCliRespawnPlan({
+        argv: [...argv],
+        env: { NODE_USE_SYSTEM_CA: "1" },
+        execArgv: [],
+        autoNodeExtraCaCerts: undefined,
+        platform: "darwin",
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["the command line", ["--use-system-ca"], undefined],
+    ["NODE_OPTIONS", [], "--use-system-ca"],
+    ["quoted NODE_OPTIONS", [], '"--use-system-ca"'],
+    ["single-quoted NODE_OPTIONS", [], "'--use-system-ca'"],
+  ] as const)(
+    "keeps an explicit macOS system CA runtime flag from %s",
+    (_label, execArgv, nodeOptions) => {
+      const plan = buildCliRespawnPlan({
+        argv: ["node", "openclaw", "cron", "list", "--json"],
+        env: { NODE_OPTIONS: nodeOptions, NODE_USE_SYSTEM_CA: "1" },
+        execArgv: [...execArgv],
+        autoNodeExtraCaCerts: undefined,
+        platform: "darwin",
+      });
+
+      const respawnPlan = expectCliRespawnPlan(plan);
+      expect(respawnPlan.argv).not.toContain(OPENSSL_CA_FLAG);
+      expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("1");
+    },
+  );
+
+  it.each([
+    ["the command line", [BUNDLED_CA_FLAG], undefined],
+    ["NODE_OPTIONS", [], BUNDLED_CA_FLAG],
+    ["quoted NODE_OPTIONS", [], `"${BUNDLED_CA_FLAG}"`],
+  ] as const)(
+    "preserves an explicit bundled CA selection from %s",
+    (_label, execArgv, nodeOptions) => {
+      const plan = buildCliRespawnPlan({
+        argv: ["node", "openclaw", "cron", "list", "--json"],
+        env: { NODE_OPTIONS: nodeOptions, NODE_USE_SYSTEM_CA: "1" },
+        execArgv: [...execArgv],
+        autoNodeExtraCaCerts: undefined,
+        platform: "darwin",
+      });
+
+      const respawnPlan = expectCliRespawnPlan(plan);
+      expect(respawnPlan.argv).not.toContain(OPENSSL_CA_FLAG);
+      expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("0");
+    },
+  );
+
+  it("does not respawn again after selecting the macOS file-backed CA store", () => {
+    expect(
+      buildCliRespawnPlan({
+        argv: ["node", "openclaw", "cron", "list", "--json"],
+        env: {
+          NODE_USE_SYSTEM_CA: "1",
+          [OPENCLAW_NODE_OPTIONS_READY]: "1",
+        },
+        execArgv: [OPENSSL_CA_FLAG, EXPERIMENTAL_WARNING_FLAG],
+        autoNodeExtraCaCerts: undefined,
+        platform: "darwin",
+      }),
+    ).toBeNull();
   });
 
   it("does not respawn interactive commands for warning suppression only", () => {

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -16,6 +16,9 @@ import {
 } from "./process/respawn-child-runner.js";
 
 const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
+const BUNDLED_CA_FLAG = "--use-bundled-ca";
+const OPENSSL_CA_FLAG = "--use-openssl-ca";
+const SYSTEM_CA_FLAG = "--use-system-ca";
 const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
 const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
 const WINDOWS_STACK_SIZE_FLAG = "--stack-size=8192";
@@ -60,6 +63,28 @@ function hasExperimentalWarningSuppressed(
     return true;
   }
   return execArgv.some((arg) => arg === EXPERIMENTAL_WARNING_FLAG || arg === "--no-warnings");
+}
+
+function hasNodeRuntimeOption(params: {
+  env: NodeJS.ProcessEnv;
+  execArgv: string[];
+  option: string;
+}): boolean {
+  const nodeOptions = (params.env.NODE_OPTIONS ?? "").split(/\s+/u);
+  return (
+    params.execArgv.includes(params.option) ||
+    nodeOptions.some((token) => {
+      if (token === params.option) {
+        return true;
+      }
+      const quote = token[0];
+      return (
+        (quote === '"' || quote === "'") &&
+        token.at(-1) === quote &&
+        token.slice(1, -1) === params.option
+      );
+    })
+  );
 }
 
 function hasStackSizeConfigured(execArgv: string[]): boolean {
@@ -117,6 +142,23 @@ export function buildCliRespawnPlan(
       env: childEnv,
       detachForProcessTree: false,
     };
+  }
+
+  if (
+    platform === "darwin" &&
+    env.NODE_USE_SYSTEM_CA === "1" &&
+    !isTerminalInteractiveRespawnArgv(argv) &&
+    !hasNodeRuntimeOption({ env, execArgv, option: SYSTEM_CA_FLAG }) &&
+    !hasNodeRuntimeOption({ env, execArgv, option: OPENSSL_CA_FLAG })
+  ) {
+    // Node loads the macOS Keychain off-thread on the first TLS import, then joins
+    // that worker during shutdown. One-shot CLIs use the file-backed CA store instead;
+    // an explicit --use-system-ca remains the opt-in for Keychain-only trust.
+    childEnv.NODE_USE_SYSTEM_CA = "0";
+    if (!hasNodeRuntimeOption({ env, execArgv, option: BUNDLED_CA_FLAG })) {
+      childExecArgv.unshift(OPENSSL_CA_FLAG);
+    }
+    needsRespawn = true;
   }
 
   const autoNodeExtraCaCerts =


### PR DESCRIPTION
## What Problem This Solves

On macOS, every gateway-backed one-shot CLI command (`cron list/status/get/show/runs`, `channels list`, `agent`, `sessions`, `doctor`, even `config validate`) prints its complete output within ~1s and then **never exits** — the process idles toward the 600s command timeout. Any script, cron job, or CI step that runs the CLI and waits for exit hangs forever. Reproduced 6+ times across QA rounds, including on the canonical non-QA build.

## Why This Change Was Made

Root cause (confirmed by decisive A/B experiment): OpenClaw defaults `NODE_USE_SYSTEM_CA=1` on darwin (`src/bootstrap/node-startup-env.ts:36`). Node's macOS system-CA support loads the Keychain trust store on a worker thread at first TLS import and **joins that worker during process shutdown**; under load that join does not complete, keeping the (respawned) CLI child alive (`ProcessWrap`+`PipeWrap` observed via `process.getActiveResourcesInfo()`). `config validate` with default env = hang; identical command with `NODE_USE_SYSTEM_CA=0` = instant exit.

## User Impact

One-shot, non-interactive CLI invocations on macOS now respawn with `--use-openssl-ca` (file-backed CA store) and exit promptly after completing. The trust-store scope is deliberate: foreground `gateway run` skips the respawn wrapper entirely (`shouldSkipRespawnForArgv`) and the TUI/interactive commands are excluded (`isTerminalInteractiveRespawnArgv`), so long-lived processes that make provider TLS calls keep macOS Keychain trust (enterprise/corporate CAs). An explicit `--use-system-ca` (execArgv or `NODE_OPTIONS`) remains the opt-in for Keychain-only trust on one-shots, and `NODE_EXTRA_CA_CERTS` is unaffected. No respawn loop: the child env carries `NODE_USE_SYSTEM_CA=0`, so the branch cannot re-trigger.

## Evidence

- Live isolated proof (fresh gateway, this branch's build): `cron list --json` and `config validate` **EXIT with code 0**; control run with explicit `--use-system-ca` reproduces the pre-fix hang, proving the opt-in path preserves old behavior.
- Tests: 22 respawn plan tests (`src/entry.respawn.test.ts`) + new process-level regression proving a gateway-backed CLI process exits cleanly (`src/cli/gateway-backed-exit.process.test.ts`). All pass.
- Path-scoped `check-changed`: production/test tsgo, formatting, lint, guards green.
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.84), no actionable findings".
- QA provenance: found by R4 whole-system stress campaign (3 independent agents + 2 manual reproductions); also explains QA finding "doctor --fix repairs reported but never persisted" (write step sits after the hang point) — to be re-verified on this fix.
