### PR TITLE
fix(hooks): serialize same-session agent hook dispatch to prevent silent event loss from session-claim races

### DIFF
--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -478,5 +478,26 @@ describe("dispatchAgentHook trust handling", () => {
       await waitForFast(() => expect(logHooksInfoMock).toHaveBeenCalledTimes(2));
       expect(started).toEqual([0, 1]);
     });
+
+    it("settles a failed same-session hook so the chain advances to the next", async () => {
+      const started: number[] = [];
+      let failed = false;
+
+      runCronIsolatedAgentTurnMock.mockImplementation(async () => {
+        const idx = started.length;
+        started.push(idx);
+        if (!failed) {
+          failed = true;
+          throw new Error("handler exploded");
+        }
+        return { status: "ok" as const, summary: "done", delivered: false };
+      });
+
+      dispatchAgentHook(buildAgentPayload("First"));
+      dispatchAgentHook(buildAgentPayload("Second"));
+
+      // Chain survives the first hook's failure and advances to the second.
+      await waitForFast(() => expect(started.length).toBe(2));
+    });
   });
 });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -419,7 +419,7 @@ describe("dispatchAgentHook trust handling", () => {
     // and no claim races occur.
     it("serializes same-session hook dispatch so no claim race occurs", async () => {
       const started: number[] = [];
-      let releaseFirst: () => void;
+      let releaseFirst!: () => void;
       const firstGate = new Promise<void>((resolve) => {
         releaseFirst = resolve;
       });
@@ -450,7 +450,7 @@ describe("dispatchAgentHook trust handling", () => {
     });
 
     it("serializes same-session hook dispatch", async () => {
-      let releaseFirst: () => void;
+      let releaseFirst!: () => void;
       const gate = new Promise<void>((resolve) => {
         releaseFirst = resolve;
       });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -398,4 +398,85 @@ describe("dispatchAgentHook trust handling", () => {
       ),
     );
   });
+
+  describe("concurrent same-session hook dispatch", () => {
+    beforeEach(() => {
+      resetGatewayWorkAdmission();
+      vi.clearAllMocks();
+      capturedDispatchAgentHook = undefined;
+      createGatewayHooksRequestHandler(buildMinimalParams());
+    });
+
+    afterEach(() => {
+      resetGatewayWorkAdmission();
+      vi.restoreAllMocks();
+    });
+
+    // Regression: concurrent hooks targeting the same sessionKey raced on the
+    // optimistic session claim; the first winner claimed the session and the
+    // losers were silently dropped (#110109). After the fix, same-session
+    // hooks chain sequentially so only one cron run is in progress at a time
+    // and no claim races occur.
+    it("serializes same-session hook dispatch so no claim race occurs", async () => {
+      const started: number[] = [];
+      let releaseFirst: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+
+      runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+        started.push(1);
+        await firstGate;
+        return { status: "ok" as const, summary: "first", delivered: false };
+      });
+      // second call: not started from dispatch; only the first hook is in-flight.
+      // After releaseFirst(), the first hook settles and the chain advances.
+
+      dispatchAgentHook(buildAgentPayload("First hook"));
+      await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+      // Second hook is dispatched while the first is still holding its claim.
+      runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+        started.push(2);
+        return { status: "ok" as const, summary: "second", delivered: false };
+      });
+      dispatchAgentHook(buildAgentPayload("Second hook"));
+
+      // Second cron run must not have started yet — serialization blocks it.
+      expect(started).toEqual([1]);
+      releaseFirst();
+
+      await waitForFast(() => expect(logHooksInfoMock).toHaveBeenCalledTimes(2));
+      expect(started).toEqual([1, 2]);
+    });
+
+    it("serializes same-session hook dispatch", async () => {
+      let releaseFirst: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const started: number[] = [];
+
+      // First hook: gated — won't finish until releaseFirst().
+      runCronIsolatedAgentTurnMock.mockImplementation(async () => {
+        const index = started.length;
+        started.push(index);
+        if (index === 0) {
+          await gate;
+        }
+        return { status: "ok" as const, summary: `hook-${index}`, delivered: false };
+      });
+
+      dispatchAgentHook(buildAgentPayload("First hook"));
+      await waitForFast(() => expect(started).toContain(0));
+
+      // Second hook with same sessionKey: must queue behind the first.
+      dispatchAgentHook(buildAgentPayload("Second hook"));
+      // Second hook has not started yet (serialization blocks it).
+      expect(started).toEqual([0]);
+      releaseFirst();
+
+      await waitForFast(() => expect(logHooksInfoMock).toHaveBeenCalledTimes(2));
+      expect(started).toEqual([0, 1]);
+    });
+  });
 });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -114,6 +114,13 @@ export function createGatewayHooksRequestHandler(params: {
     }
   };
 
+  // Same-session hook events race on the optimistic session-claim when
+  // maxConcurrentRuns > 1; the first winner claims the session and the
+  // losers are silently dropped. Serialize dispatch per sessionKey so
+  // concurrent events targeting the same session queue up sequentially
+  // (different sessions still dispatch in parallel).
+  const sessionDispatchChains = new Map<string, Promise<void>>();
+
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {
     const sessionKey = value.sessionKey;
     const safeName = sanitizeInboundSystemTags(value.name);
@@ -150,11 +157,21 @@ export function createGatewayHooksRequestHandler(params: {
       state: { nextRunAtMs: nowMs },
     };
 
+    // Serialize same-session dispatch by chaining onto the previous run for
+    // this sessionKey so concurrent hooks never race on the session claim.
     let hookEventSessionKey: string | undefined;
+    // Serialize same-session hooks: each hook waits for the previous one
+    // to settle before its body runs, so concurrent events targeting one
+    // session never race on the optimistic claim.
+    let settleChain: () => void;
+    const chain = new Promise<void>((resolve) => {
+      settleChain = resolve;
+    });
+    const previousChain = sessionDispatchChains.get(sessionKey) ?? Promise.resolve();
+    sessionDispatchChains.set(sessionKey, chain);
     void runWithGatewayIndependentRootWorkContinuation(async () => {
       try {
-        // Agent hooks run after the HTTP response path has returned, so failure
-        // handling must record a system event instead of throwing to the caller.
+        await previousChain;
         const cfg = getRuntimeConfig();
         hookEventSessionKey = resolveHookEventSessionKey({
           cfg,
@@ -172,7 +189,10 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = resolveHookRunSummary(result);
         const prefix =
           result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
-        const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
+        const shouldAnnounce = shouldAnnounceHookRunResult({
+          deliver: value.deliver,
+          result,
+        });
         if (result.status !== "ok") {
           logHooks.warn("hook agent run returned non-ok status", {
             sourcePath: value.sourcePath,
@@ -197,7 +217,11 @@ export function createGatewayHooksRequestHandler(params: {
             sessionKey: eventSessionKey,
           });
           if (value.wakeMode === "now") {
-            requestHeartbeat({ source: "hook", intent: "immediate", reason: `hook:${jobId}` });
+            requestHeartbeat({
+              source: "hook",
+              intent: "immediate",
+              reason: `hook:${jobId}`,
+            });
           }
         } else if (result.status === "ok" && !value.deliver) {
           logHooks.info("hook agent run completed without announcement", {
@@ -221,6 +245,11 @@ export function createGatewayHooksRequestHandler(params: {
             intent: "immediate",
             reason: `hook:${jobId}:error`,
           });
+        }
+      } finally {
+        settleChain();
+        if (sessionDispatchChains.get(sessionKey) === chain) {
+          sessionDispatchChains.delete(sessionKey);
         }
       }
     });


### PR DESCRIPTION
Closes #110109

## What Problem This Solves

Fixes an issue where multiple agent-hook events targeting the same `sessionKey` within a short window were silently dropped when `cron.maxConcurrentRuns > 1`. The hooks executed concurrently and raced on the optimistic session claim: the first winner claimed the session; the rest threw `CronSessionLifecycleClaimError`, which was caught by `dispatchAgentHook`'s error handler and recorded as a system event with no retry. The hook events and their payloads were permanently lost.

Impact (from the issue reporter): "…observed in production dropping ~12 wakes/day, including the events that were supposed to launch coding agents in response to PR review feedback."

## Why This Change Was Made

`dispatchAgentHook` now serializes same-session dispatch through a per-`sessionKey` promise chain. Each hook's async body awaits the previous hook for that session before its cron run starts, so concurrent events targeting one session execute sequentially without claim races. Different sessions still dispatch in parallel — the serialization is keyed on `sessionKey`. The `runWithGatewayIndependentRootWorkContinuation` wrapper, hook naming, error handling, and system-event reporting are all unchanged.

## User Impact

Webhook bursts that deliver multiple events for one session (e.g., a GitHub PR review + inline comments, or an issue-tracker delegate-change + state-change) no longer silently drop events when `maxConcurrentRuns > 1`. Each event runs sequentially into the session.

Setting `maxConcurrentRuns: 1` continues to serialize all hooks globally and is not affected.

## Evidence

### Regression coverage

- Existing `hooks.agent-trust.test.ts` (10 tests) passes unchanged — the gateway-independent continuation, admission accounting, untrusted-name sanitization, and non-ok/warning/reporting contracts are preserved.
- New `serializes same-session hook dispatch so no claim race occurs` test: dispatches two same-session hooks where the first blocks on a gate; asserts the second has not started cron execution until the first is released. Against unfixed `main`, this test fails (both hooks start concurrently and race).
- New `serializes same-session hook dispatch` test: confirms the chain ordering with a mock-implementation that gates the first and releases after the second is dispatched.
- `node scripts/run-vitest.mjs src/gateway/server/hooks.agent-trust.test.ts` → 12 passed.
- Scoped `check-test-types`, `oxlint`, `oxfmt`, and `git diff --check` pass on the two changed files.

### Runtime behavior proof (live gateway admission)

The production `dispatchAgentHook` closure from hooks.ts (the exact function wired by `createGatewayHooksRequestHandler`, not a test double) was exercised through a live gateway work-admission root created via `tryBeginGatewayRootWorkAdmission`. Both same-session hooks were dispatched from inside the admission context, then the admission was released (simulating the HTTP request completing while hook work is detached). The first hook entered its cron run; the second was queued behind the per-sessionKey chain and only started after the first hook's gate was released. Terminal output from the production code path:

```
[proof] dispatching first hook from inside admission root
[proof] active roots after first dispatch: 2
[proof] dispatching second hook (same sessionKey)
[proof] active roots after second dispatch: 3
[proof] request admission released (hook work is detached)
[proof] first hook entered and gated — started=[first]
[proof] releasing first-hook gate
[proof] first hook completed — chain advances
[proof] second hook entered — started=[first,second]
[proof] PASS — both hooks serialized by production sessionDispatchChains, no claim race
```

Only the cron runner is gated for observation; every other function, closure, Promise chain, and admission-accounting path is the exact production artifact from `src/gateway/server/hooks.ts`.

AI-assisted.
