### PR TITLE
fix(agents): keep sender-scoped tools in delegated runs

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6291,11 +6291,13 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let execnode: AnyCodable?
     public let model: AnyCodable?
     public let spawnedby: AnyCodable?
+    public let completionownersessionkey: AnyCodable?
     public let spawnedworkspacedir: AnyCodable?
     public let spawnedcwd: AnyCodable?
     public let spawndepth: AnyCodable?
     public let subagentrole: AnyCodable?
     public let subagentcontrolscope: AnyCodable?
+    public let inheritedtoolpolicyversion: AnyCodable?
     public let inheritedtoolallow: AnyCodable?
     public let inheritedtooldeny: AnyCodable?
     public let sendpolicy: AnyCodable?
@@ -6326,11 +6328,13 @@ public struct SessionsPatchParams: Codable, Sendable {
         execnode: AnyCodable? = nil,
         model: AnyCodable? = nil,
         spawnedby: AnyCodable? = nil,
+        completionownersessionkey: AnyCodable? = nil,
         spawnedworkspacedir: AnyCodable? = nil,
         spawnedcwd: AnyCodable? = nil,
         spawndepth: AnyCodable? = nil,
         subagentrole: AnyCodable? = nil,
         subagentcontrolscope: AnyCodable? = nil,
+        inheritedtoolpolicyversion: AnyCodable? = nil,
         inheritedtoolallow: AnyCodable? = nil,
         inheritedtooldeny: AnyCodable? = nil,
         sendpolicy: AnyCodable? = nil,
@@ -6360,11 +6364,13 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.execnode = execnode
         self.model = model
         self.spawnedby = spawnedby
+        self.completionownersessionkey = completionownersessionkey
         self.spawnedworkspacedir = spawnedworkspacedir
         self.spawnedcwd = spawnedcwd
         self.spawndepth = spawndepth
         self.subagentrole = subagentrole
         self.subagentcontrolscope = subagentcontrolscope
+        self.inheritedtoolpolicyversion = inheritedtoolpolicyversion
         self.inheritedtoolallow = inheritedtoolallow
         self.inheritedtooldeny = inheritedtooldeny
         self.sendpolicy = sendpolicy
@@ -6396,11 +6402,13 @@ public struct SessionsPatchParams: Codable, Sendable {
         case execnode = "execNode"
         case model
         case spawnedby = "spawnedBy"
+        case completionownersessionkey = "completionOwnerSessionKey"
         case spawnedworkspacedir = "spawnedWorkspaceDir"
         case spawnedcwd = "spawnedCwd"
         case spawndepth = "spawnDepth"
         case subagentrole = "subagentRole"
         case subagentcontrolscope = "subagentControlScope"
+        case inheritedtoolpolicyversion = "inheritedToolPolicyVersion"
         case inheritedtoolallow = "inheritedToolAllow"
         case inheritedtooldeny = "inheritedToolDeny"
         case sendpolicy = "sendPolicy"

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -462,6 +462,7 @@ final answer, the correct follow-up is the exact silent token
 
 ### Tool policy by depth
 
+- A child captures the requester's effective sender policy when it is spawned. Senderless child runs and authenticated operator resumes keep that snapshot even if `toolsBySender` changes later; current global, agent, provider, sandbox, and sub-agent restrictions still apply. A new external channel turn targeting the child re-resolves current sender policy instead.
 - Role and control scope are written into session metadata at spawn time. That keeps flat or restored session keys from accidentally regaining orchestrator privileges.
 - **Depth 1 (orchestrator, when `maxSpawnDepth >= 2`):** gets `sessions_spawn`, `subagents`, `sessions_list`, `sessions_history` so it can spawn children and inspect their status. Other session/system tools remain denied.
 - **Depth 1 (leaf, when `maxSpawnDepth == 1`):** no session tools (current default behavior).

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -27,6 +27,24 @@ import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { createCodexTestModel } from "./test-support.js";
 
+const hoisted = vi.hoisted(() => ({
+  resolveWebSearchToolPolicy: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness")>();
+
+  return {
+    ...actual,
+    resolveWebSearchToolPolicy: (
+      ...args: Parameters<(typeof actual)["resolveWebSearchToolPolicy"]>
+    ) => {
+      hoisted.resolveWebSearchToolPolicy(...args);
+      return actual.resolveWebSearchToolPolicy(...args);
+    },
+  };
+});
+
 let tempDir: string;
 
 function setOpenClawCodingToolsFactoryForTests(
@@ -149,6 +167,7 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   beforeEach(async () => {
+    hoisted.resolveWebSearchToolPolicy.mockClear();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-tools-"));
   });
 
@@ -428,6 +447,37 @@ describe("Codex app-server dynamic tool build", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["message"]);
     expect(persistentWebSearchAllowed).toBe(true);
     expect(webSearchAllowed).toBe(false);
+  });
+
+  it("forwards trusted completion lineage to tool and web-search policy construction", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.inputProvenance = {
+      kind: "inter_session",
+      sourceSessionKey: "agent:main:subagent:codex-child",
+      sourceTool: "subagent_announce",
+    };
+    params.trustedInternalHandoff = true;
+    let receivedOptions: unknown;
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      receivedOptions = options;
+      return [createRuntimeDynamicTool("message")];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir);
+
+    expect(receivedOptions).toMatchObject({
+      inputProvenance: params.inputProvenance,
+      trustedInternalHandoff: true,
+    });
+    expect(hoisted.resolveWebSearchToolPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputProvenance: params.inputProvenance,
+        trustedInternalHandoff: true,
+      }),
+    );
   });
 
   it("keeps persistent search denied when global and sender policy both deny it", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -265,6 +265,8 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
     senderIsOwner: params.senderIsOwner,
+    inputProvenance: params.inputProvenance,
+    trustedInternalHandoff: params.trustedInternalHandoff,
     allowGatewaySubagentBinding:
       params.allowGatewaySubagentBinding || isForcedPrivateQaCodexRuntime(),
     ...sessionKeys,
@@ -392,6 +394,8 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
+    inputProvenance: params.inputProvenance,
+    trustedInternalHandoff: params.trustedInternalHandoff,
   });
   const senderScopedWebSearchRestriction =
     !webSearchPolicy.allowed && webSearchPolicy.persistentAllowed;

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -416,6 +416,7 @@ export const SessionsPatchParamsSchema = closedObject({
   subagentControlScope: Type.Optional(
     Type.Union([Type.Literal("children"), Type.Literal("none"), Type.Null()]),
   ),
+  inheritedToolPolicyVersion: Type.Optional(Type.Union([Type.Literal(1), Type.Null()])),
   inheritedToolAllow: Type.Optional(Type.Union([Type.Array(NonEmptyString), Type.Null()])),
   inheritedToolDeny: Type.Optional(Type.Union([Type.Array(NonEmptyString), Type.Null()])),
   sendPolicy: Type.Optional(Type.Union([Type.Literal("allow"), Type.Literal("deny"), Type.Null()])),

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -406,6 +406,7 @@ export const SessionsPatchParamsSchema = closedObject({
   execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  completionOwnerSessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   spawnedWorkspaceDir: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   spawnedCwd: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   spawnDepth: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),

--- a/qa/scenarios/agents/issue-109025-completion-policy-live.yaml
+++ b/qa/scenarios/agents/issue-109025-completion-policy-live.yaml
@@ -1,0 +1,148 @@
+title: Issue 109025 completion handoff sender-policy live probe
+
+scenario:
+  id: issue-109025-completion-policy-live
+  surface: subagents
+  runtimeParityTier: live-only
+  coverage:
+    secondary:
+      - agents.subagents
+      - runtime.delivery
+      - channels.qa-channel
+  gatewayConfigPatch:
+    tools:
+      toolsBySender:
+        "*":
+          deny:
+            - exec
+            - process
+            - nodes
+            - gateway
+            - write
+        "id:alice":
+          deny:
+            - write
+  objective: Prove a dormant requester-agent completion handoff retains the original requester's exact sender tool policy instead of reapplying the wildcard deny.
+  successCriteria:
+    - An exact-sender parent spawns a child and yields before the child completes.
+    - The child follows a serial filesystem-read chain that remains allowed by the wildcard policy.
+    - The child completion wakes the requester agent without a new external sender turn.
+    - The requester-agent continuation uses exec, which the wildcard policy denies, to generate a fresh marker while write remains denied.
+    - The QA runner reads the exec-created proof file and finds the exact same unpredictable marker in Gateway output.
+  docsRefs:
+    - docs/gateway/config-tools.md
+    - docs/tools/subagents.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/agents/requester-tool-policy.ts
+    - src/agents/subagent-announce-delivery.ts
+    - src/agents/subagent-capabilities.ts
+    - src/agents/tools/sessions-yield-tool.ts
+  execution:
+    kind: flow
+    suiteIsolation: isolated
+    isolationReason: Mutates sender tool policy and exercises a yielded parent with a live child completion.
+    channel: qa-channel
+    retryCount: 0
+    summary: Exercise exact sender policy through a real inbound turn, dormant requester-agent completion, and restricted exec call.
+    config:
+      childLabelPrefix: issue-109025-completion-child
+      chainFilePrefix: issue-109025-completion-chain
+      completionPrefix: ISSUE109025_COMPLETION_EXEC_OK
+
+flow:
+  steps:
+    - name: dormant requester completion retains exact-sender exec authority
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 120000
+        - call: waitForTransportReady
+          args:
+            - ref: env
+            - 120000
+        - resetTransport: true
+        - set: parentSessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: 'default', peer: { kind: 'direct', id: 'alice' }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - set: childLabel
+          value:
+            expr: "`${config.childLabelPrefix}-${randomUUID().slice(0, 8)}`"
+        - set: chainNonce
+          value:
+            expr: randomUUID().slice(0, 8)
+        - set: chainFiles
+          value:
+            expr: "[1, 2, 3, 4].map((index) => `${config.chainFilePrefix}-${chainNonce}-${index}.txt`)"
+        - set: proofFile
+          value:
+            expr: "`issue-109025-exec-proof-${randomUUID()}.txt`"
+        - set: proofPath
+          value:
+            expr: path.join(env.gateway.workspaceDir, proofFile)
+        - set: execCommand
+          value:
+            expr: |-
+              `node -e ${JSON.stringify(`const fs=require("node:fs");const crypto=require("node:crypto");const marker="${config.completionPrefix}:"+crypto.randomUUID();fs.writeFileSync(${JSON.stringify(proofFile)},marker+"\n");process.stdout.write(marker+"\n");`)}`
+        - call: fs.writeFile
+          args:
+            - expr: path.join(env.gateway.workspaceDir, chainFiles[0])
+            - expr: "`${chainFiles[1]}\n`"
+            - utf8
+        - call: fs.writeFile
+          args:
+            - expr: path.join(env.gateway.workspaceDir, chainFiles[1])
+            - expr: "`${chainFiles[2]}\n`"
+            - utf8
+        - call: fs.writeFile
+          args:
+            - expr: path.join(env.gateway.workspaceDir, chainFiles[2])
+            - expr: "`${chainFiles[3]}\n`"
+            - utf8
+        - call: fs.writeFile
+          args:
+            - expr: path.join(env.gateway.workspaceDir, chainFiles[3])
+            - CHILD_READY
+            - utf8
+        - sendInbound:
+            conversation:
+              id: issue-109025-completion
+              kind: direct
+            senderId: alice
+            senderName: Alice
+            text:
+              expr: |-
+                `Issue 109025 dormant completion probe. Follow these steps exactly.
+                1. Call sessions_spawn exactly once with runtime subagent, label ${childLabel}, and this task: "Use only the filesystem read tool. Start by reading ${chainFiles[0]}. Its trimmed contents name the next workspace file to read. Continue following one filename at a time until a file contains CHILD_READY. You must perform each read serially because later filenames are not in this task. Then reply exactly CHILD_DONE and nothing else. Do not use exec or process."
+                2. Immediately after sessions_spawn succeeds, call sessions_yield. Do not wait for the child and do not send a normal final reply.
+                3. When the CHILD_DONE completion event later resumes you, use the exec tool to run this exact command: ${execCommand}
+                Do not use read or write for this step. Then reply with exactly the command's trimmed stdout.`
+        - call: waitForCondition
+          saveAs: expectedFinalMarker
+          args:
+            - lambda:
+                async: true
+                expr: "fs.readFile(proofPath, 'utf8').then((text) => { const marker = text.trim(); return marker.startsWith(`${config.completionPrefix}:`) && readGatewayLogs().includes(marker) ? marker : undefined; }).catch(() => undefined)"
+            - 60000
+            - 250
+        - call: readSessionTranscriptSummary
+          saveAs: parentTranscript
+          args:
+            - ref: env
+            - ref: parentSessionKey
+        - set: gatewayLogs
+          value:
+            expr: readGatewayLogs()
+        - assert:
+            expr: "(parentTranscript.assistantToolCallCounts.sessions_yield ?? 0) >= 1"
+            message:
+              expr: "`parent did not yield before completion; parentTools=${JSON.stringify(parentTranscript.assistantToolCallCounts ?? {})}`"
+        - assert:
+            expr: gatewayLogs.includes(expectedFinalMarker)
+            message:
+              expr: "`completion continuation did not produce the exec-created marker; marker=${String(expectedFinalMarker ?? '')}`"
+        - assert:
+            expr: "gatewayLogs.indexOf('CHILD_DONE') >= 0 && gatewayLogs.indexOf(expectedFinalMarker) > gatewayLogs.indexOf('CHILD_DONE')"
+            message: child completion did not precede the exec-created continuation marker
+      detailsExpr: "`parentSession=${parentSessionKey} parentTools=${JSON.stringify(parentTranscript.assistantToolCallCounts ?? {})} execMarker=${String(expectedFinalMarker ?? '')}`"

--- a/qa/scenarios/agents/issue-109025-sender-policy-live.yaml
+++ b/qa/scenarios/agents/issue-109025-sender-policy-live.yaml
@@ -1,0 +1,125 @@
+title: Issue 109025 sender-scoped subagent tool inheritance live probe
+
+scenario:
+  id: issue-109025-sender-policy-live
+  surface: subagents
+  runtimeParityTier: live-only
+  coverage:
+    secondary:
+      - agents.subagents
+      - tools.fs.read
+  gatewayConfigPatch:
+    tools:
+      toolsBySender:
+        "*":
+          deny:
+            - group:runtime
+            - group:fs
+        "id:alice": {}
+  objective: Prove a sender-less child retains its external requester's exact sender tool policy instead of reapplying the wildcard deny.
+  successCriteria:
+    - The inbound parent writes a proof file and calls sessions_spawn.
+    - The child reads a secret marker file that was not included in the prompt.
+    - The parent returns the exact marker learned from the child.
+  docsRefs:
+    - docs/gateway/config-tools.md
+    - docs/tools/subagents.md
+  codeRefs:
+    - src/agents/conversation-capability-profile.ts
+    - src/agents/requester-tool-policy.ts
+    - src/agents/sender-tool-policy.ts
+    - src/agents/subagent-capabilities.ts
+  execution:
+    kind: flow
+    suiteIsolation: isolated
+    isolationReason: Mutates tool policy and requires a fresh parent/child session lineage.
+    channel: qa-channel
+    retryCount: 0
+    summary: Exercise exact sender policy through a real inbound channel turn and native subagent spawn.
+    config:
+      childLabel: issue-109025-child
+      parentProofFile: issue-109025-parent-proof.txt
+      secretFile: issue-109025-secret.txt
+      parentDoneMarker: ISSUE109025_PARENT_DONE
+
+flow:
+  steps:
+    - name: exact-sender parent delegates a filesystem read to its sender-less child
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 120000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 120000
+        - call: reset
+        - set: expectedMarker
+          value:
+            expr: "`ISSUE-109025-SECRET-${randomUUID()}`"
+        - set: secretPath
+          value:
+            expr: "path.join(env.gateway.workspaceDir, config.secretFile)"
+        - set: parentProofPath
+          value:
+            expr: "path.join(env.gateway.workspaceDir, config.parentProofFile)"
+        - call: fs.writeFile
+          args:
+            - ref: secretPath
+            - expr: "`${expectedMarker}\n`"
+            - utf8
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.length"
+        - sendInbound:
+            conversation:
+              id: issue-109025
+              kind: direct
+            senderId: alice
+            senderName: Alice
+            text:
+              expr: |-
+                `Issue 109025 live probe. Follow these steps exactly.
+                1. Use your filesystem write capability to create ${config.parentProofFile} in the workspace with exactly PARENT_OK.
+                2. Do not read ${config.secretFile} yourself and do not guess its contents.
+                3. Call the OpenClaw sessions_spawn tool exactly once with runtime subagent, label ${config.childLabel}, and task: "Use the filesystem read tool to read ${config.secretFile} in the workspace. Reply with its exact single-line contents and nothing else. You must actually read the file; do not guess."
+                4. Wait for the child to finish.
+                5. Reply with ${config.parentDoneMarker}: followed by the child's exact result.`
+        - call: waitForOutboundMessage
+          saveAs: outbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.direction === 'outbound' && candidate.conversation.id === 'issue-109025' && String(candidate.text ?? '').includes(config.parentDoneMarker)"
+            - expr: "liveTurnTimeoutMs(env, 240000)"
+            - sinceIndex:
+                ref: outboundStartIndex
+        - call: fs.readFile
+          saveAs: parentProof
+          args:
+            - ref: parentProofPath
+            - utf8
+        - assert:
+            expr: "String(parentProof).trim() === 'PARENT_OK'"
+            message:
+              expr: "`exact-sender parent did not retain filesystem write capability; outbound=${String(outbound.text ?? '')}`"
+        - call: waitForCondition
+          saveAs: childRow
+          args:
+            - lambda:
+                async: true
+                expr: "readRawQaSessionStore(env).then((store) => { const match = Object.entries(store).find(([, entry]) => entry?.label === config.childLabel && typeof entry?.spawnedBy === 'string'); return match ? { key: match[0], entry: match[1] } : undefined; })"
+            - 60000
+            - 250
+        - call: readSessionTranscriptSummary
+          saveAs: childTranscript
+          args:
+            - ref: env
+            - expr: childRow.key
+        - assert:
+            expr: "normalizeLowercaseStringOrEmpty(childTranscript.finalText).includes(normalizeLowercaseStringOrEmpty(expectedMarker))"
+            message:
+              expr: "`reproduced issue 109025: parentProof=${String(parentProof).trim()} spawnedBy=${String(childRow.entry.spawnedBy ?? '')} childTools=${JSON.stringify(childTranscript.assistantToolCallCounts ?? {})} childFinal=${String(childTranscript.finalText ?? '')} outbound=${String(outbound.text ?? '')}`"
+      detailsExpr: "`parentProof=${String(parentProof).trim()} spawnedBy=${String(childRow.entry.spawnedBy ?? '')} childTools=${JSON.stringify(childTranscript.assistantToolCallCounts ?? {})} childFinal=${String(childTranscript.finalText ?? '')} outbound=${String(outbound.text ?? '')}`"

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -867,6 +867,7 @@ describe("spawnAcpDirect", () => {
       key: accepted.childSessionKey,
       spawnedBy: "agent:main:main",
       completionOwnerSessionKey: "agent:main:main",
+      inheritedToolPolicyVersion: 1,
     });
     expectBindingCallFields({
       targetKind: "session",

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -866,6 +866,7 @@ describe("spawnAcpDirect", () => {
     expectSessionPatchFields({
       key: accepted.childSessionKey,
       spawnedBy: "agent:main:main",
+      completionOwnerSessionKey: "agent:main:main",
     });
     expectBindingCallFields({
       targetKind: "session",

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1289,6 +1289,7 @@ export async function spawnAcpDirect(
         params: {
           key: sessionKey,
           spawnedBy: requesterInternalKey,
+          completionOwnerSessionKey: ownership.completionRequesterSessionKey,
           ...admission.childSessionPatch,
           ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
           ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1291,6 +1291,7 @@ export async function spawnAcpDirect(
           spawnedBy: requesterInternalKey,
           completionOwnerSessionKey: ownership.completionRequesterSessionKey,
           ...admission.childSessionPatch,
+          inheritedToolPolicyVersion: 1,
           ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
           ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
           ...(params.label ? { label: params.label } : {}),

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -24,6 +24,7 @@ import type {
 import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../security/dangerous-tools.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { SkillSnapshot, SkillUsagePath } from "../skills/types.js";
 import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
@@ -463,6 +464,9 @@ type OpenClawCodingToolsOptions = {
   skillUsagePaths?: SkillUsagePath[];
   /** Prepared conversation-scoped facts for callers that already resolved this run context. */
   conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
+  inputProvenance?: InputProvenance;
+  /** Trusted in-process completion handoff; never derived from model-facing input. */
+  trustedInternalHandoff?: boolean;
 };
 
 function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions): AnyAgentTool[] {
@@ -520,6 +524,8 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       skillsSnapshot: options?.skillsSnapshot,
       sandboxToolPolicy,
       runtimeToolAllowlist: options?.runtimeToolAllowlist,
+      inputProvenance: options?.inputProvenance,
+      trustedInternalHandoff: options?.trustedInternalHandoff,
     });
   const {
     agentId,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -948,6 +948,7 @@ export function runAgentAttempt(params: {
     bootstrapContextRunKind: params.opts.bootstrapContextRunKind,
     toolsAllow: params.opts.toolsAllow,
     runtimePluginToolGrant: params.opts.runtimePluginToolGrant,
+    trustedInternalHandoff: params.opts.trustedInternalHandoff,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,
     sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -122,6 +122,8 @@ export type AgentCommandOpts = {
   toolsAllow?: string[];
   /** Trusted owner-scoped plugin tool grant; normal policy and deny rules still apply. */
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  /** Trusted in-process subagent-completion handoff; never accepted from public RPC params. */
+  trustedInternalHandoff?: boolean;
   /** Internal marker for an auto-applied cap that CLI runtimes must omit. */
   toolsAllowIsDefault?: boolean;
   /** Preserve the originating run's message-tool policy across internal continuation turns. */

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -226,6 +226,7 @@ describe("resolveConversationCapabilityProfile", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      spawnedBy: "agent:main:main",
       inheritedToolAllow: ["image_generate"],
     } as SessionEntry);
 
@@ -240,6 +241,7 @@ describe("resolveConversationCapabilityProfile", () => {
 
       expect(profile.policy.explicitToolAllowlist).toContain("image_generate");
       expect(profile.policy.explicitToolOverrideAllowlist).not.toContain("image_generate");
+      expect(profile.policy.delegated).toBe(true);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -242,6 +242,7 @@ describe("resolveConversationCapabilityProfile", () => {
       expect(profile.policy.explicitToolAllowlist).toContain("image_generate");
       expect(profile.policy.explicitToolOverrideAllowlist).not.toContain("image_generate");
       expect(profile.policy.delegated).toBe(true);
+      expect(profile.policy.requesterPolicySource).toBe("persisted-child");
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -227,6 +227,7 @@ describe("resolveConversationCapabilityProfile", () => {
       subagentRole: "orchestrator",
       subagentControlScope: "children",
       spawnedBy: "agent:main:main",
+      inheritedToolPolicyVersion: 1,
       inheritedToolAllow: ["image_generate"],
     } as SessionEntry);
 

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -8,23 +8,17 @@ import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { SkillSnapshot } from "../skills/types.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
 import {
   resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
   resolveTrustedGroupId,
   sessionKeyNamesGroupConversation,
 } from "./agent-tools.policy.js";
+import { resolveRequesterToolPolicies } from "./requester-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
-import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "./subagent-capabilities.js";
 import type { PromptMode } from "./system-prompt.types.js";
 import {
   collectExplicitAllowlist,
@@ -81,6 +75,9 @@ export type ConversationCapabilityProfileParams = {
   sandboxToolPolicy?: SandboxToolPolicy;
   runtimeToolAllowlist?: string[];
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  inputProvenance?: InputProvenance;
+  /** Trusted in-process completion handoff; public callers cannot set this fact. */
+  trustedInternalHandoff?: boolean;
 };
 
 export type ResolvedConversationCapabilityProfile = {
@@ -169,6 +166,7 @@ export type ResolvedConversationCapabilityProfile = {
     sandboxPolicy?: SandboxToolPolicy;
     subagentPolicy?: SandboxToolPolicy;
     inheritedToolPolicy?: SandboxToolPolicy;
+    delegated: boolean;
     inheritancePolicies: Array<ToolPolicyLike | undefined>;
     explicitToolAllowlist: string[];
     /** Explicit config/runtime grants only; excludes built-in profile expansion. */
@@ -198,11 +196,19 @@ export function resolveConversationCapabilityProfile(
   // against; mask them whenever the trust check dropped the caller group id.
   const trustedGroupChannel = trustedGroup.dropped ? null : params.groupChannel;
   const trustedGroupSpace = trustedGroup.dropped ? null : params.groupSpace;
-  const groupPolicy = resolveGroupToolPolicy({
+  // Owner WebChat intentionally has no external sender identity. Its trusted
+  // owner state must not fall through to the wildcard policy for guests.
+  const isOwnerInternalSession =
+    params.senderIsOwner === true &&
+    normalizeMessageChannel(messageProvider ?? params.messageChannel) === INTERNAL_MESSAGE_CHANNEL;
+  const subagentSessionKey = params.sandboxSessionKey ?? params.sessionKey;
+  const requesterPolicies = resolveRequesterToolPolicies({
     config: params.config,
     sessionKey: params.sessionKey,
+    subagentSessionKey,
+    agentId: effective.agentId,
     spawnedBy: params.spawnedBy,
-    messageProvider: messageProvider ?? undefined,
+    messageProvider,
     groupId: trustedGroup.groupId,
     groupChannel: trustedGroupChannel,
     groupSpace: trustedGroupSpace,
@@ -211,46 +217,13 @@ export function resolveConversationCapabilityProfile(
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
+    inputProvenance: params.inputProvenance,
+    trustedInternalHandoff: params.trustedInternalHandoff,
+    senderPolicyMode: isOwnerInternalSession ? "never" : "always",
   });
-  // Owner WebChat intentionally has no external sender identity. Its trusted
-  // owner state must not fall through to the wildcard policy for guests.
-  const isOwnerInternalSession =
-    params.senderIsOwner === true &&
-    normalizeMessageChannel(messageProvider ?? params.messageChannel) === INTERNAL_MESSAGE_CHANNEL;
-  const senderPolicy = isOwnerInternalSession
-    ? undefined
-    : resolveSenderToolPolicy({
-        config: params.config,
-        agentId: effective.agentId,
-        messageProvider,
-        senderId: params.senderId,
-        senderName: params.senderName,
-        senderUsername: params.senderUsername,
-        senderE164: params.senderE164,
-      });
+  const { groupPolicy, senderPolicy, subagentPolicy, inheritedToolPolicy } = requesterPolicies;
   const profilePolicy = resolveToolProfilePolicy(effective.profile);
   const providerProfilePolicy = resolveToolProfilePolicy(effective.providerProfile);
-  const subagentSessionKey = params.sandboxSessionKey ?? params.sessionKey;
-  const subagentStore = resolveSubagentCapabilityStore(subagentSessionKey, {
-    cfg: params.config,
-  });
-  const subagentPolicy =
-    subagentSessionKey &&
-    isSubagentEnvelopeSession(subagentSessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, subagentSessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    params.config,
-    subagentSessionKey,
-    {
-      store: subagentStore,
-    },
-  );
   const configuredOverridePolicies = [
     effective.globalPolicy,
     effective.globalProviderPolicy,
@@ -372,6 +345,7 @@ export function resolveConversationCapabilityProfile(
       sandboxPolicy: params.sandboxToolPolicy,
       subagentPolicy,
       inheritedToolPolicy,
+      delegated: requesterPolicies.delegated,
       inheritancePolicies,
       explicitToolAllowlist: collectExplicitAllowlist(inheritancePolicies),
       explicitToolOverrideAllowlist: collectExplicitAllowlist(explicitOverridePolicies),

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -17,7 +17,10 @@ import {
   resolveTrustedGroupId,
   sessionKeyNamesGroupConversation,
 } from "./agent-tools.policy.js";
-import { resolveRequesterToolPolicies } from "./requester-tool-policy.js";
+import {
+  resolveRequesterToolPolicies,
+  type RequesterToolPolicySource,
+} from "./requester-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import type { PromptMode } from "./system-prompt.types.js";
 import {
@@ -167,6 +170,7 @@ export type ResolvedConversationCapabilityProfile = {
     subagentPolicy?: SandboxToolPolicy;
     inheritedToolPolicy?: SandboxToolPolicy;
     delegated: boolean;
+    requesterPolicySource: RequesterToolPolicySource;
     inheritancePolicies: Array<ToolPolicyLike | undefined>;
     explicitToolAllowlist: string[];
     /** Explicit config/runtime grants only; excludes built-in profile expansion. */
@@ -346,6 +350,7 @@ export function resolveConversationCapabilityProfile(
       subagentPolicy,
       inheritedToolPolicy,
       delegated: requesterPolicies.delegated,
+      requesterPolicySource: requesterPolicies.requesterPolicySource,
       inheritancePolicies,
       explicitToolAllowlist: collectExplicitAllowlist(inheritancePolicies),
       explicitToolOverrideAllowlist: collectExplicitAllowlist(explicitOverridePolicies),

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1122,6 +1122,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
       spawnWorkspaceDir,
       skillsSnapshot: skillsSnapshotForRun,
       sandboxToolPolicy: sandbox?.tools,
+      inputProvenance: params.inputProvenance,
+      trustedInternalHandoff: params.trustedInternalHandoff,
     });
     const toolsEnabled = supportsModelTools(effectiveModel);
     const toolsRaw = toolsEnabled

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -8,6 +8,7 @@ import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import type { CommandQueueEnqueueFn } from "../../process/command-queue.types.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../bash-tools.exec-types.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
@@ -49,6 +50,9 @@ export type CompactEmbeddedAgentSessionParams = {
   groupSpace?: string | null;
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
+  inputProvenance?: InputProvenance;
+  /** Trusted in-process subagent-completion handoff; never derived from public input. */
+  trustedInternalHandoff?: boolean;
   sessionFile: string;
   /** Optional caller-observed live prompt tokens used for compaction diagnostics. */
   currentTokenCount?: number;

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -170,6 +170,8 @@ export function prepareEmbeddedAttemptToolBase(params: {
     sandboxToolPolicy: params.sandbox?.tools,
     runtimeToolAllowlist: effectiveToolsAllow,
     runtimePluginToolGrant: attempt.runtimePluginToolGrant,
+    inputProvenance: attempt.inputProvenance,
+    trustedInternalHandoff: attempt.trustedInternalHandoff,
   });
   const localModelLeanEnabled = isLocalModelLeanEnabled({
     config: attempt.config,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -231,6 +231,8 @@ export type RunEmbeddedAgentParams = {
   toolsAllow?: string[];
   /** Owner-scoped plugin tool grant; normal policy and deny rules still apply. */
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  /** Trusted in-process subagent-completion handoff; never derived from public input. */
+  trustedInternalHandoff?: boolean;
   /** Seen bootstrap truncation warning signatures for this session (once mode dedupe). */
   bootstrapPromptWarningSignaturesSeen?: string[];
   /** Last shown bootstrap truncation warning signature for this session. */

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -326,6 +326,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     taskSuggestionDeliveryMode: params.taskSuggestionDeliveryMode,
     inputProvenance: params.inputProvenance,
+    trustedInternalHandoff: params.trustedInternalHandoff,
     streamParams: params.streamParams,
     modelRun: params.modelRun,
     disableTrajectory: params.disableTrajectory,

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -143,6 +143,8 @@ type PluginHarnessToolPolicyContext = Pick<
   | "senderUsername"
   | "senderE164"
   | "senderIsOwner"
+  | "inputProvenance"
+  | "trustedInternalHandoff"
 >;
 
 type PluginHarnessToolPolicy = { allow?: string[]; deny?: string[] };
@@ -619,6 +621,8 @@ function resolvePluginHarnessToolPolicies(
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
     senderIsOwner: params.senderIsOwner,
+    inputProvenance: params.inputProvenance,
+    trustedInternalHandoff: params.trustedInternalHandoff,
   });
   const groupPolicyParams = {
     config: params.config,

--- a/src/agents/requester-tool-policy.test.ts
+++ b/src/agents/requester-tool-policy.test.ts
@@ -54,6 +54,7 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(result.delegated).toBe(false);
+    expect(result.requesterPolicySource).toBe("current-request");
     expect(result.senderPolicy).toBeUndefined();
   });
 
@@ -74,13 +75,14 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("persisted-child");
     expect(result.senderPolicy).toBeUndefined();
     expect(result.groupPolicy).toBeUndefined();
     expect(result.inheritedToolPolicy).toEqual({ deny: ["message"] });
     expect(result.subagentPolicy).toBeDefined();
   });
 
-  it("keeps delegated web search aligned with the inherited projection", async () => {
+  it("keeps the sender snapshot while applying current non-sender restrictions", async () => {
     const childSessionKey = "agent:main:subagent:web-search";
     await writeSession(childSessionKey, {
       spawnedBy: "agent:main:discord:direct:alice",
@@ -104,6 +106,21 @@ describe("resolveRequesterToolPolicies", () => {
         sessionKey: childSessionKey,
       }),
     ).toEqual({ allowed: true, persistentAllowed: true });
+    expect(
+      resolveWebSearchToolPolicy({
+        config: config({
+          tools: {
+            deny: ["web_search"],
+            toolsBySender: {
+              "*": { deny: ["web_search"] },
+              "id:alice": {},
+            },
+          },
+        }),
+        agentId: "main",
+        sessionKey: childSessionKey,
+      }),
+    ).toEqual({ allowed: false, persistentAllowed: false });
     expect(
       resolveWebSearchToolPolicy({
         config: cfg,
@@ -168,11 +185,32 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(result.delegated).toBe(false);
+    expect(result.requesterPolicySource).toBe("current-request");
     expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
     expect(result.subagentPolicy).toBeDefined();
   });
 
-  it("applies a new external sender policy to an existing child session", async () => {
+  it("does not trust partial persisted lineage as an authority envelope", async () => {
+    const childSessionKey = "agent:main:subagent:partial";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: childSessionKey,
+    });
+
+    expect(result.delegated).toBe(false);
+    expect(result.requesterPolicySource).toBe("current-request");
+    expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+  });
+
+  it.each([
+    ["sender identity", { senderId: "bob" }],
+    ["external provenance", { inputProvenance: { kind: "external_user" as const } }],
+  ])("applies current policy to an existing child with %s", async (_label, externalFacts) => {
     const childSessionKey = "agent:main:subagent:external-turn";
     await writeSession(childSessionKey, {
       spawnedBy: "agent:main:discord:direct:alice",
@@ -187,11 +225,11 @@ describe("resolveRequesterToolPolicies", () => {
       agentId: "main",
       sessionKey: childSessionKey,
       messageProvider: "discord",
-      senderId: "bob",
-      inputProvenance: { kind: "external_user" },
+      ...externalFacts,
     });
 
     expect(result.delegated).toBe(false);
+    expect(result.requesterPolicySource).toBe("current-request");
     expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
     expect(result.inheritedToolPolicy).toEqual({ deny: ["message"] });
   });
@@ -212,6 +250,7 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("persisted-child");
     expect(result.inheritedToolPolicy).toBeUndefined();
     expect(result.senderPolicy).toBeUndefined();
   });
@@ -241,6 +280,7 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("completion-handoff");
     expect(result.senderPolicy).toBeUndefined();
     expect(result.inheritedToolPolicy).toEqual({
       allow: ["read", "message"],
@@ -280,6 +320,7 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("completion-handoff");
     expect(result.inheritedToolPolicy).toEqual({ deny: ["exec"] });
   });
 
@@ -312,8 +353,10 @@ describe("resolveRequesterToolPolicies", () => {
     });
 
     expect(untrusted.delegated).toBe(false);
+    expect(untrusted.requesterPolicySource).toBe("current-request");
     expect(untrusted.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
     expect(mismatched.delegated).toBe(false);
+    expect(mismatched.requesterPolicySource).toBe("current-request");
     expect(mismatched.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
   });
 });

--- a/src/agents/requester-tool-policy.test.ts
+++ b/src/agents/requester-tool-policy.test.ts
@@ -288,6 +288,51 @@ describe("resolveRequesterToolPolicies", () => {
     });
   });
 
+  it("restores a verified completion handoff to a distinct immutable completion owner", async () => {
+    const controllerSessionKey = "agent:main:discord:direct:alice";
+    const completionOwnerSessionKey = "agent:main:main";
+    const childSessionKey = "agent:main:subagent:child";
+    await writeSession(childSessionKey, {
+      spawnedBy: controllerSessionKey,
+      completionOwnerSessionKey,
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolAllow: ["read", "exec"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: completionOwnerSessionKey,
+      trustedInternalHandoff: true,
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: childSessionKey,
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("completion-handoff");
+    expect(result.senderPolicy).toBeUndefined();
+    expect(result.inheritedToolPolicy).toEqual({ allow: ["read", "exec"] });
+
+    const controllerResult = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: controllerSessionKey,
+      trustedInternalHandoff: true,
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: childSessionKey,
+        sourceTool: "subagent_announce",
+      },
+    });
+    expect(controllerResult.delegated).toBe(false);
+    expect(controllerResult.requesterPolicySource).toBe("current-request");
+  });
+
   it("walks nested lineage to the projection captured from the target requester", async () => {
     const requesterSessionKey = "agent:main:discord:direct:alice";
     const parentChildSessionKey = "agent:main:subagent:parent-child";
@@ -351,6 +396,13 @@ describe("resolveRequesterToolPolicies", () => {
       trustedInternalHandoff: true,
       inputProvenance: provenance,
     });
+    const mismatchedCompletionOwner = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      trustedInternalHandoff: true,
+      inputProvenance: provenance,
+    });
 
     expect(untrusted.delegated).toBe(false);
     expect(untrusted.requesterPolicySource).toBe("current-request");
@@ -358,5 +410,7 @@ describe("resolveRequesterToolPolicies", () => {
     expect(mismatched.delegated).toBe(false);
     expect(mismatched.requesterPolicySource).toBe("current-request");
     expect(mismatched.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+    expect(mismatchedCompletionOwner.delegated).toBe(false);
+    expect(mismatchedCompletionOwner.requesterPolicySource).toBe("current-request");
   });
 });

--- a/src/agents/requester-tool-policy.test.ts
+++ b/src/agents/requester-tool-policy.test.ts
@@ -1,0 +1,319 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveRequesterToolPolicies } from "./requester-tool-policy.js";
+import { resolveWebSearchToolPolicy } from "./web-search-tool-policy.js";
+
+describe("resolveRequesterToolPolicies", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-requester-policy-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeSession(sessionKey: string, patch: Partial<SessionEntry>) {
+    await replaceSessionEntry({ storePath, sessionKey }, {
+      sessionId: `${sessionKey}-session`,
+      updatedAt: Date.now(),
+      ...patch,
+    } as SessionEntry);
+  }
+
+  function config(overrides: OpenClawConfig = {}): OpenClawConfig {
+    return {
+      ...overrides,
+      session: { ...overrides.session, store: storePath },
+      tools: {
+        ...overrides.tools,
+        toolsBySender: {
+          "*": { deny: ["group:runtime", "group:fs"] },
+          "id:alice": {},
+          ...overrides.tools?.toolsBySender,
+        },
+      },
+    };
+  }
+
+  it("resolves exact sender policy for an external requester", () => {
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: "agent:main:discord:direct:alice",
+      messageProvider: "discord",
+      senderId: "alice",
+    });
+
+    expect(result.delegated).toBe(false);
+    expect(result.senderPolicy).toBeUndefined();
+  });
+
+  it("uses a persisted child projection without re-resolving sender policy", async () => {
+    const childSessionKey = "agent:main:subagent:child";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolDeny: ["message"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: childSessionKey,
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.senderPolicy).toBeUndefined();
+    expect(result.groupPolicy).toBeUndefined();
+    expect(result.inheritedToolPolicy).toEqual({ deny: ["message"] });
+    expect(result.subagentPolicy).toBeDefined();
+  });
+
+  it("keeps delegated web search aligned with the inherited projection", async () => {
+    const childSessionKey = "agent:main:subagent:web-search";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+    });
+    const cfg = config({
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["web_search"] },
+          "id:alice": {},
+        },
+      },
+    });
+
+    expect(
+      resolveWebSearchToolPolicy({
+        config: cfg,
+        agentId: "main",
+        sessionKey: childSessionKey,
+      }),
+    ).toEqual({ allowed: true, persistentAllowed: true });
+    expect(
+      resolveWebSearchToolPolicy({
+        config: cfg,
+        agentId: "main",
+        sessionKey: "agent:main:subagent:forged",
+      }),
+    ).toEqual({ allowed: false, persistentAllowed: false });
+  });
+
+  it("does not re-resolve group sender policy for a verified child", async () => {
+    const parentSessionKey = "agent:main:telegram:group:dev";
+    const childSessionKey = "agent:main:subagent:group-child";
+    await writeSession(childSessionKey, {
+      spawnedBy: parentSessionKey,
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+    });
+    const cfg = config({
+      channels: {
+        telegram: {
+          groups: {
+            dev: {
+              toolsBySender: {
+                "*": { deny: ["read"] },
+                "id:alice": {},
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const child = resolveRequesterToolPolicies({
+      config: cfg,
+      agentId: "main",
+      sessionKey: childSessionKey,
+      spawnedBy: parentSessionKey,
+      messageProvider: "telegram",
+      groupId: "dev",
+    });
+    const forged = resolveRequesterToolPolicies({
+      config: cfg,
+      agentId: "main",
+      sessionKey: "agent:main:subagent:forged",
+      spawnedBy: parentSessionKey,
+      messageProvider: "telegram",
+      groupId: "dev",
+    });
+
+    expect(child.delegated).toBe(true);
+    expect(child.groupPolicy).toBeUndefined();
+    expect(forged.delegated).toBe(false);
+    expect(forged.groupPolicy).toEqual({ deny: ["read"] });
+  });
+
+  it("does not trust a subagent-shaped key without a persisted envelope", () => {
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: "agent:main:subagent:forged",
+    });
+
+    expect(result.delegated).toBe(false);
+    expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+    expect(result.subagentPolicy).toBeDefined();
+  });
+
+  it("applies a new external sender policy to an existing child session", async () => {
+    const childSessionKey = "agent:main:subagent:external-turn";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolDeny: ["message"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: childSessionKey,
+      messageProvider: "discord",
+      senderId: "bob",
+      inputProvenance: { kind: "external_user" },
+    });
+
+    expect(result.delegated).toBe(false);
+    expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+    expect(result.inheritedToolPolicy).toEqual({ deny: ["message"] });
+  });
+
+  it("treats an empty projection as valid only for verified lineage", async () => {
+    const childSessionKey = "agent:main:subagent:unrestricted";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: childSessionKey,
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.inheritedToolPolicy).toBeUndefined();
+    expect(result.senderPolicy).toBeUndefined();
+  });
+
+  it("restores a verified completion handoff from the direct child projection", async () => {
+    const requesterSessionKey = "agent:main:discord:direct:alice";
+    const childSessionKey = "agent:main:subagent:child";
+    await writeSession(childSessionKey, {
+      spawnedBy: requesterSessionKey,
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolAllow: ["read", "message"],
+      inheritedToolDeny: ["exec"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: requesterSessionKey,
+      trustedInternalHandoff: true,
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: childSessionKey,
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.senderPolicy).toBeUndefined();
+    expect(result.inheritedToolPolicy).toEqual({
+      allow: ["read", "message"],
+      deny: ["exec"],
+    });
+  });
+
+  it("walks nested lineage to the projection captured from the target requester", async () => {
+    const requesterSessionKey = "agent:main:discord:direct:alice";
+    const parentChildSessionKey = "agent:main:subagent:parent-child";
+    const leafSessionKey = "agent:main:subagent:leaf";
+    await writeSession(parentChildSessionKey, {
+      spawnedBy: requesterSessionKey,
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolDeny: ["exec"],
+    });
+    await writeSession(leafSessionKey, {
+      spawnedBy: parentChildSessionKey,
+      spawnDepth: 2,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+      inheritedToolDeny: ["exec", "read"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: requesterSessionKey,
+      trustedInternalHandoff: true,
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: leafSessionKey,
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.inheritedToolPolicy).toEqual({ deny: ["exec"] });
+  });
+
+  it("fails closed for untrusted or mismatched completion handoffs", async () => {
+    const childSessionKey = "agent:main:subagent:child";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+    });
+    const provenance = {
+      kind: "inter_session" as const,
+      sourceSessionKey: childSessionKey,
+      sourceTool: "subagent_announce",
+    };
+
+    const untrusted = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: "agent:main:discord:direct:alice",
+      inputProvenance: provenance,
+    });
+    const mismatched = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: "agent:main:discord:direct:bob",
+      trustedInternalHandoff: true,
+      inputProvenance: provenance,
+    });
+
+    expect(untrusted.delegated).toBe(false);
+    expect(untrusted.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+    expect(mismatched.delegated).toBe(false);
+    expect(mismatched.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+  });
+});

--- a/src/agents/requester-tool-policy.test.ts
+++ b/src/agents/requester-tool-policy.test.ts
@@ -65,6 +65,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
       inheritedToolDeny: ["message"],
     });
 
@@ -89,6 +90,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
     });
     const cfg = config({
       tools: {
@@ -138,6 +140,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
     });
     const cfg = config({
       channels: {
@@ -207,6 +210,28 @@ describe("resolveRequesterToolPolicies", () => {
     expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
   });
 
+  it("re-resolves sender policy for an unversioned legacy child envelope", async () => {
+    const childSessionKey = "agent:main:subagent:legacy";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolDeny: ["message"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: childSessionKey,
+    });
+
+    expect(result.delegated).toBe(false);
+    expect(result.requesterPolicySource).toBe("current-request");
+    expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
+    expect(result.inheritedToolPolicy).toEqual({ deny: ["message"] });
+  });
+
   it.each([
     ["sender identity", { senderId: "bob" }],
     ["external provenance", { inputProvenance: { kind: "external_user" as const } }],
@@ -217,6 +242,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
       inheritedToolDeny: ["message"],
     });
 
@@ -241,6 +267,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
     });
 
     const result = resolveRequesterToolPolicies({
@@ -263,6 +290,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
       inheritedToolAllow: ["read", "message"],
       inheritedToolDeny: ["exec"],
     });
@@ -298,6 +326,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
       inheritedToolAllow: ["read", "exec"],
     });
 
@@ -342,6 +371,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
       inheritedToolDeny: ["exec"],
     });
     await writeSession(leafSessionKey, {
@@ -349,6 +379,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 2,
       subagentRole: "leaf",
       subagentControlScope: "none",
+      inheritedToolPolicyVersion: 1,
       inheritedToolDeny: ["exec", "read"],
     });
 
@@ -376,6 +407,7 @@ describe("resolveRequesterToolPolicies", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
     });
     const provenance = {
       kind: "inter_session" as const,
@@ -412,5 +444,33 @@ describe("resolveRequesterToolPolicies", () => {
     expect(mismatched.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
     expect(mismatchedCompletionOwner.delegated).toBe(false);
     expect(mismatchedCompletionOwner.requesterPolicySource).toBe("current-request");
+  });
+
+  it("re-resolves sender policy for completion from an unversioned legacy child", async () => {
+    const requesterSessionKey = "agent:main:discord:direct:alice";
+    const childSessionKey = "agent:main:subagent:legacy-completion";
+    await writeSession(childSessionKey, {
+      spawnedBy: requesterSessionKey,
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      inheritedToolAllow: ["read", "exec"],
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: requesterSessionKey,
+      trustedInternalHandoff: true,
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: childSessionKey,
+        sourceTool: "subagent_announce",
+      },
+    });
+
+    expect(result.delegated).toBe(false);
+    expect(result.requesterPolicySource).toBe("current-request");
+    expect(result.senderPolicy).toEqual({ deny: ["group:runtime", "group:fs"] });
   });
 });

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -131,7 +131,10 @@ function resolveDelegatedPolicy(
       return { delegated: false };
     }
     const parentSessionKey = resolveRequesterStoreKey(params.config, envelope.spawnedBy);
-    if (parentSessionKey === targetSessionKey) {
+    const completionOwnerSessionKey = envelope.completionOwnerSessionKey
+      ? resolveRequesterStoreKey(params.config, envelope.completionOwnerSessionKey)
+      : undefined;
+    if ((completionOwnerSessionKey ?? parentSessionKey) === targetSessionKey) {
       return {
         delegated: true,
         source: "completion-handoff",

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -24,8 +24,15 @@ import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 
 const MAX_DELEGATION_LINEAGE_DEPTH = 32;
 
+export type RequesterToolPolicySource =
+  | "current-request"
+  | "persisted-child"
+  | "completion-handoff";
+
 type RequesterToolPolicyResolution = {
   delegated: boolean;
+  /** Diagnostic fact identifying whether policy came from live ingress or delegated state. */
+  requesterPolicySource: RequesterToolPolicySource;
   groupPolicy?: SandboxToolPolicy;
   senderPolicy?: SandboxToolPolicy;
   subagentPolicy?: SandboxToolPolicy;
@@ -72,10 +79,13 @@ function policyFromEnvelope(
 function resolveDelegatedPolicy(
   params: RequesterToolPolicyParams,
   subagentStore: SessionCapabilityStore | undefined,
-): {
-  delegated: boolean;
-  policy?: SandboxToolPolicy;
-} {
+):
+  | { delegated: false }
+  | {
+      delegated: true;
+      source: Exclude<RequesterToolPolicySource, "current-request">;
+      policy?: SandboxToolPolicy;
+    } {
   const provenance = normalizeInputProvenance(params.inputProvenance);
   const hasExternalRequester =
     provenance?.kind === "external_user" ||
@@ -86,7 +96,13 @@ function resolveDelegatedPolicy(
       store: subagentStore,
     });
     if (ownEnvelope) {
-      return { delegated: true, policy: policyFromEnvelope(ownEnvelope) };
+      // Senderless child and trusted-operator resumes keep the spawn-time requester snapshot.
+      // Later toolsBySender edits are non-retroactive; current non-sender restrictions layer later.
+      return {
+        delegated: true,
+        source: "persisted-child",
+        policy: policyFromEnvelope(ownEnvelope),
+      };
     }
   }
   if (!params.trustedInternalHandoff) {
@@ -116,7 +132,11 @@ function resolveDelegatedPolicy(
     }
     const parentSessionKey = resolveRequesterStoreKey(params.config, envelope.spawnedBy);
     if (parentSessionKey === targetSessionKey) {
-      return { delegated: true, policy: policyFromEnvelope(envelope) };
+      return {
+        delegated: true,
+        source: "completion-handoff",
+        policy: policyFromEnvelope(envelope),
+      };
     }
     currentSessionKey = parentSessionKey;
   }
@@ -147,6 +167,7 @@ export function resolveRequesterToolPolicies(
     // Re-resolving either without external identity would incorrectly select its wildcard.
     return {
       delegated: true,
+      requesterPolicySource: delegatedPolicy.source,
       subagentPolicy,
       inheritedToolPolicy: delegatedPolicy.policy,
       subagentStore,
@@ -158,6 +179,7 @@ export function resolveRequesterToolPolicies(
     (senderPolicyMode === "when-sender-id" && Boolean(params.senderId));
   return {
     delegated: false,
+    requesterPolicySource: "current-request",
     groupPolicy: resolveGroupToolPolicy({
       config: params.config,
       sessionKey: params.sessionKey,

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -24,7 +24,7 @@ import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 
 const MAX_DELEGATION_LINEAGE_DEPTH = 32;
 
-export type RequesterToolPolicyResolution = {
+type RequesterToolPolicyResolution = {
   delegated: boolean;
   groupPolicy?: SandboxToolPolicy;
   senderPolicy?: SandboxToolPolicy;

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -1,0 +1,192 @@
+/**
+ * Canonical requester-scoped policy resolution for external and delegated runs.
+ * Sender-dependent policy resolves once at trusted ingress; verified descendants
+ * consume the persisted effective parent projection instead of guessing identity.
+ */
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
+import { normalizeInputProvenance } from "../sessions/input-provenance.js";
+import {
+  resolveGroupToolPolicy,
+  resolveInheritedToolPolicyForSession,
+  resolveSubagentToolPolicyForSession,
+} from "./agent-tools.policy.js";
+import type { SandboxToolPolicy } from "./sandbox/types.js";
+import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolvePersistedSubagentToolPolicyEnvelope,
+  resolveSubagentCapabilityStore,
+  type SessionCapabilityStore,
+} from "./subagent-capabilities.js";
+import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
+
+const MAX_DELEGATION_LINEAGE_DEPTH = 32;
+
+export type RequesterToolPolicyResolution = {
+  delegated: boolean;
+  groupPolicy?: SandboxToolPolicy;
+  senderPolicy?: SandboxToolPolicy;
+  subagentPolicy?: SandboxToolPolicy;
+  inheritedToolPolicy?: SandboxToolPolicy;
+  subagentStore?: SessionCapabilityStore;
+};
+
+type SenderPolicyMode = "always" | "when-sender-id" | "never";
+
+type RequesterToolPolicyParams = {
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  subagentSessionKey?: string;
+  spawnedBy?: string | null;
+  messageProvider?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  accountId?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+  inputProvenance?: InputProvenance;
+  trustedInternalHandoff?: boolean;
+  senderPolicyMode?: SenderPolicyMode;
+};
+
+function policyFromEnvelope(
+  envelope: ReturnType<typeof resolvePersistedSubagentToolPolicyEnvelope>,
+): SandboxToolPolicy | undefined {
+  if (!envelope) {
+    return undefined;
+  }
+  return envelope.inheritedToolAllow.length > 0 || envelope.inheritedToolDeny.length > 0
+    ? {
+        ...(envelope.inheritedToolAllow.length > 0 ? { allow: envelope.inheritedToolAllow } : {}),
+        ...(envelope.inheritedToolDeny.length > 0 ? { deny: envelope.inheritedToolDeny } : {}),
+      }
+    : undefined;
+}
+
+function resolveDelegatedPolicy(
+  params: RequesterToolPolicyParams,
+  subagentStore: SessionCapabilityStore | undefined,
+): {
+  delegated: boolean;
+  policy?: SandboxToolPolicy;
+} {
+  const provenance = normalizeInputProvenance(params.inputProvenance);
+  const hasExternalRequester =
+    provenance?.kind === "external_user" ||
+    Boolean(params.senderId || params.senderName || params.senderUsername || params.senderE164);
+  if (!hasExternalRequester) {
+    const ownEnvelope = resolvePersistedSubagentToolPolicyEnvelope(params.subagentSessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    });
+    if (ownEnvelope) {
+      return { delegated: true, policy: policyFromEnvelope(ownEnvelope) };
+    }
+  }
+  if (!params.trustedInternalHandoff) {
+    return { delegated: false };
+  }
+  if (
+    provenance?.kind !== "inter_session" ||
+    normalizeOptionalLowercaseString(provenance.sourceTool) !== "subagent_announce" ||
+    !provenance.sourceSessionKey ||
+    !params.sessionKey
+  ) {
+    return { delegated: false };
+  }
+  const targetSessionKey = resolveRequesterStoreKey(params.config, params.sessionKey);
+  let currentSessionKey = resolveRequesterStoreKey(params.config, provenance.sourceSessionKey);
+  const visited = new Set<string>();
+  for (let depth = 0; depth < MAX_DELEGATION_LINEAGE_DEPTH; depth += 1) {
+    if (visited.has(currentSessionKey)) {
+      return { delegated: false };
+    }
+    visited.add(currentSessionKey);
+    const envelope = resolvePersistedSubagentToolPolicyEnvelope(currentSessionKey, {
+      cfg: params.config,
+    });
+    if (!envelope) {
+      return { delegated: false };
+    }
+    const parentSessionKey = resolveRequesterStoreKey(params.config, envelope.spawnedBy);
+    if (parentSessionKey === targetSessionKey) {
+      return { delegated: true, policy: policyFromEnvelope(envelope) };
+    }
+    currentSessionKey = parentSessionKey;
+  }
+  return { delegated: false };
+}
+
+/** Resolve sender/group policy or a verified inherited projection, never both. */
+export function resolveRequesterToolPolicies(
+  params: RequesterToolPolicyParams,
+): RequesterToolPolicyResolution {
+  const subagentSessionKey = params.subagentSessionKey ?? params.sessionKey;
+  const subagentStore = resolveSubagentCapabilityStore(subagentSessionKey, {
+    cfg: params.config,
+  });
+  const delegatedPolicy = resolveDelegatedPolicy({ ...params, subagentSessionKey }, subagentStore);
+  const subagentPolicy =
+    subagentSessionKey &&
+    isSubagentEnvelopeSession(subagentSessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, subagentSessionKey, {
+          store: subagentStore,
+        })
+      : undefined;
+  if (delegatedPolicy.delegated) {
+    // The persisted projection already includes both global and group sender policy.
+    // Re-resolving either without external identity would incorrectly select its wildcard.
+    return {
+      delegated: true,
+      subagentPolicy,
+      inheritedToolPolicy: delegatedPolicy.policy,
+      subagentStore,
+    };
+  }
+  const senderPolicyMode = params.senderPolicyMode ?? "always";
+  const shouldResolveSenderPolicy =
+    senderPolicyMode === "always" ||
+    (senderPolicyMode === "when-sender-id" && Boolean(params.senderId));
+  return {
+    delegated: false,
+    groupPolicy: resolveGroupToolPolicy({
+      config: params.config,
+      sessionKey: params.sessionKey,
+      spawnedBy: params.spawnedBy,
+      messageProvider: params.messageProvider ?? undefined,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      accountId: params.accountId,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+    }),
+    senderPolicy: shouldResolveSenderPolicy
+      ? resolveSenderToolPolicy({
+          config: params.config,
+          agentId: params.agentId,
+          messageProvider: params.messageProvider,
+          senderId: params.senderId,
+          senderName: params.senderName,
+          senderUsername: params.senderUsername,
+          senderE164: params.senderE164,
+        })
+      : undefined,
+    subagentPolicy,
+    inheritedToolPolicy: resolveInheritedToolPolicyForSession(params.config, subagentSessionKey, {
+      store: subagentStore,
+    }),
+    subagentStore,
+  };
+}

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1633,6 +1633,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       requesterSessionOrigin: slackThreadOrigin,
       completionDirectOrigin: slackThreadOrigin,
       directOrigin: slackThreadOrigin,
+      sourceSessionKey: "agent:main:subagent:child",
       requesterIsSubagent: false,
       expectsCompletionMessage: true,
       bestEffortDeliver: true,
@@ -1657,6 +1658,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       allowSyntheticCronRunContinuation: false,
       expectFinal: true,
       forceSyntheticClient: true,
+      delegatedToolPolicyHandoff: true,
       timeoutMs: 120_000,
     });
   });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -30,6 +30,7 @@ import { normalizeAccountId } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   isAgentMediatedCompletionSourceTool,
+  normalizeInputProvenance,
   shouldPreserveUserFacingSessionStateForInputProvenance,
 } from "../sessions/input-provenance.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
@@ -150,6 +151,7 @@ async function runAnnounceAgentCall(params: {
   timeoutMs?: number;
 }): Promise<unknown> {
   let accepted = false;
+  const inputProvenance = normalizeInputProvenance(params.agentParams.inputProvenance);
   try {
     return await subagentAnnounceDeliveryDeps.dispatchGatewayMethodInProcess(
       "agent",
@@ -162,6 +164,10 @@ async function runAnnounceAgentCall(params: {
           shouldPreserveUserFacingSessionStateForInputProvenance(
             params.agentParams.inputProvenance,
           ),
+        delegatedToolPolicyHandoff:
+          inputProvenance?.kind === "inter_session" &&
+          inputProvenance.sourceTool === "subagent_announce" &&
+          Boolean(inputProvenance.sourceSessionKey),
         onAccepted: () => {
           accepted = true;
         },

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -61,7 +61,7 @@ export type SessionCapabilityStore = Record<
   }
 >;
 
-export type PersistedSubagentToolPolicyEnvelope = {
+type PersistedSubagentToolPolicyEnvelope = {
   sessionKey: string;
   spawnedBy: string;
   inheritedToolAllow: string[];

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -43,6 +43,7 @@ type SessionCapabilityEntry = {
   subagentRole?: unknown;
   subagentControlScope?: unknown;
   spawnedBy?: unknown;
+  completionOwnerSessionKey?: unknown;
   inheritedToolAllow?: unknown;
   inheritedToolDeny?: unknown;
 };
@@ -56,6 +57,7 @@ export type SessionCapabilityStore = Record<
     subagentRole?: unknown;
     subagentControlScope?: unknown;
     spawnedBy?: unknown;
+    completionOwnerSessionKey?: unknown;
     inheritedToolAllow?: unknown;
     inheritedToolDeny?: unknown;
   }
@@ -64,6 +66,7 @@ export type SessionCapabilityStore = Record<
 type PersistedSubagentToolPolicyEnvelope = {
   sessionKey: string;
   spawnedBy: string;
+  completionOwnerSessionKey?: string;
   inheritedToolAllow: string[];
   inheritedToolDeny: string[];
 };
@@ -330,9 +333,11 @@ export function resolvePersistedSubagentToolPolicyEnvelope(
   ) {
     return undefined;
   }
+  const completionOwnerSessionKey = normalizeOptionalString(entry.completionOwnerSessionKey);
   return {
     sessionKey: normalizedSessionKey,
     spawnedBy,
+    ...(completionOwnerSessionKey ? { completionOwnerSessionKey } : {}),
     inheritedToolAllow: normalizeInheritedToolAllowlist(entry.inheritedToolAllow),
     inheritedToolDeny: normalizeInheritedToolDenylist(entry.inheritedToolDeny),
   };

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -44,6 +44,7 @@ type SessionCapabilityEntry = {
   subagentControlScope?: unknown;
   spawnedBy?: unknown;
   completionOwnerSessionKey?: unknown;
+  inheritedToolPolicyVersion?: unknown;
   inheritedToolAllow?: unknown;
   inheritedToolDeny?: unknown;
 };
@@ -58,6 +59,7 @@ export type SessionCapabilityStore = Record<
     subagentControlScope?: unknown;
     spawnedBy?: unknown;
     completionOwnerSessionKey?: unknown;
+    inheritedToolPolicyVersion?: unknown;
     inheritedToolAllow?: unknown;
     inheritedToolDeny?: unknown;
   }
@@ -328,6 +330,7 @@ export function resolvePersistedSubagentToolPolicyEnvelope(
   if (
     !entry ||
     !spawnedBy ||
+    entry.inheritedToolPolicyVersion !== 1 ||
     !isSubagentEnvelopeSession(normalizedSessionKey, { ...opts, store, entry }) ||
     (!hasSpawnDepth && role === undefined && controlScope === undefined)
   ) {

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -61,6 +61,13 @@ export type SessionCapabilityStore = Record<
   }
 >;
 
+export type PersistedSubagentToolPolicyEnvelope = {
+  sessionKey: string;
+  spawnedBy: string;
+  inheritedToolAllow: string[];
+  inheritedToolDeny: string[];
+};
+
 function normalizeSubagentRole(value: unknown): SubagentSessionRole | undefined {
   const trimmed = normalizeOptionalLowercaseString(value);
   return SUBAGENT_SESSION_ROLES.find((entry) => entry === trimmed);
@@ -284,6 +291,51 @@ export function isSubagentEnvelopeSession(
     store,
     entry: opts?.entry,
   });
+}
+
+/**
+ * Resolve a persisted child envelope that is strong enough to carry authority.
+ * Session-key shape alone is useful for fail-closed subagent restrictions, but
+ * never sufficient to bypass requester-scoped policy re-resolution.
+ */
+export function resolvePersistedSubagentToolPolicyEnvelope(
+  sessionKey: string | undefined | null,
+  opts?: {
+    cfg?: OpenClawConfig;
+    store?: SessionCapabilityStore;
+  },
+): PersistedSubagentToolPolicyEnvelope | undefined {
+  const normalizedSessionKey = normalizeOptionalString(sessionKey);
+  if (!normalizedSessionKey || !shouldInspectStoredSubagentEnvelope(normalizedSessionKey)) {
+    return undefined;
+  }
+  const store = resolveSubagentCapabilityStore(normalizedSessionKey, opts);
+  const entry = resolveSessionCapabilityEntry({
+    sessionKey: normalizedSessionKey,
+    cfg: opts?.cfg,
+    store,
+  });
+  const spawnedBy = normalizeOptionalString(entry?.spawnedBy);
+  const hasSpawnDepth =
+    typeof entry?.spawnDepth === "number" &&
+    Number.isInteger(entry.spawnDepth) &&
+    entry.spawnDepth >= 1;
+  const role = normalizeSubagentRole(entry?.subagentRole);
+  const controlScope = normalizeSubagentControlScope(entry?.subagentControlScope);
+  if (
+    !entry ||
+    !spawnedBy ||
+    !isSubagentEnvelopeSession(normalizedSessionKey, { ...opts, store, entry }) ||
+    (!hasSpawnDepth && role === undefined && controlScope === undefined)
+  ) {
+    return undefined;
+  }
+  return {
+    sessionKey: normalizedSessionKey,
+    spawnedBy,
+    inheritedToolAllow: normalizeInheritedToolAllowlist(entry.inheritedToolAllow),
+    inheritedToolDeny: normalizeInheritedToolDenylist(entry.inheritedToolDeny),
+  };
 }
 
 /**

--- a/src/agents/subagent-spawn.depth-limits.test.ts
+++ b/src/agents/subagent-spawn.depth-limits.test.ts
@@ -172,6 +172,7 @@ describe("subagent spawn depth + child limits", () => {
     }
     expect(childSession.inheritedToolAllow).toEqual(["sessions_spawn", "read"]);
     expect(childSession.inheritedToolDeny).toEqual(["exec", "read"]);
+    expect(childSession.inheritedToolPolicyVersion).toBe(1);
   });
 
   it("rejects callers when stored spawn depth is already at the configured max", async () => {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -1489,6 +1489,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[registerInput.childSessionKey]?.completionOwnerSessionKey).toBe(
       "agent:main:main",
     );
+    expect(persistedStore?.[registerInput.childSessionKey]?.inheritedToolPolicyVersion).toBe(1);
   });
 
   it("persists the spawning session as the stable swarm limit owner", async () => {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -1463,6 +1463,12 @@ describe("spawnSubagentDirect seam flow", () => {
   });
 
   it("keeps controller ownership separate from completion ownership", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
     await spawnSubagentDirect(
       {
         task: "background work",
@@ -1480,6 +1486,9 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(registerInput.controllerSessionKey).toBe("agent:main:telegram:default:direct:456");
     expect(registerInput.requesterSessionKey).toBe("agent:main:main");
     expect(registerInput.requesterDisplayKey).toBe("agent:main:main");
+    expect(persistedStore?.[registerInput.childSessionKey]?.completionOwnerSessionKey).toBe(
+      "agent:main:main",
+    );
   });
 
   it("persists the spawning session as the stable swarm limit owner", async () => {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -1486,10 +1486,12 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(registerInput.controllerSessionKey).toBe("agent:main:telegram:default:direct:456");
     expect(registerInput.requesterSessionKey).toBe("agent:main:main");
     expect(registerInput.requesterDisplayKey).toBe("agent:main:main");
-    expect(persistedStore?.[registerInput.childSessionKey]?.completionOwnerSessionKey).toBe(
-      "agent:main:main",
-    );
-    expect(persistedStore?.[registerInput.childSessionKey]?.inheritedToolPolicyVersion).toBe(1);
+    const childSessionKey = registerInput.childSessionKey;
+    if (typeof childSessionKey !== "string") {
+      throw new Error("registered childSessionKey must be a string");
+    }
+    expect(persistedStore?.[childSessionKey]?.completionOwnerSessionKey).toBe("agent:main:main");
+    expect(persistedStore?.[childSessionKey]?.inheritedToolPolicyVersion).toBe(1);
   });
 
   it("persists the spawning session as the stable swarm limit owner", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -360,6 +360,9 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   if (patch.subagentControlScope === "children" || patch.subagentControlScope === "none") {
     entry.subagentControlScope = patch.subagentControlScope;
   }
+  if (patch.inheritedToolPolicyVersion === 1) {
+    entry.inheritedToolPolicyVersion = 1;
+  }
   if (typeof patch.spawnedBy === "string" && patch.spawnedBy.trim()) {
     entry.spawnedBy = patch.spawnedBy.trim();
   }
@@ -1334,6 +1337,7 @@ export async function spawnSubagentDirect(
 
     const initialChildSessionPatch: Record<string, unknown> = {
       ...admission.childSessionPatch,
+      inheritedToolPolicyVersion: 1,
       ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
       ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
       ...plan.initialSessionPatch,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -363,6 +363,12 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   if (typeof patch.spawnedBy === "string" && patch.spawnedBy.trim()) {
     entry.spawnedBy = patch.spawnedBy.trim();
   }
+  if (
+    typeof patch.completionOwnerSessionKey === "string" &&
+    patch.completionOwnerSessionKey.trim()
+  ) {
+    entry.completionOwnerSessionKey = patch.completionOwnerSessionKey.trim();
+  }
   if (typeof patch.spawnedWorkspaceDir === "string" && patch.spawnedWorkspaceDir.trim()) {
     entry.spawnedWorkspaceDir = patch.spawnedWorkspaceDir.trim();
   }
@@ -1500,6 +1506,7 @@ export async function spawnSubagentDirect(
     });
     const spawnLineagePatchError = await patchChildSession({
       spawnedBy: spawnedByKey,
+      completionOwnerSessionKey: ownership.completionRequesterSessionKey,
       ...(spawnedMetadata.workspaceDir
         ? { spawnedWorkspaceDir: spawnedMetadata.workspaceDir }
         : {}),

--- a/src/agents/web-search-tool-policy.ts
+++ b/src/agents/web-search-tool-policy.ts
@@ -1,16 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
-} from "./agent-tools.policy.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
+import { resolveEffectiveToolPolicy, resolveGroupToolPolicy } from "./agent-tools.policy.js";
+import { resolveRequesterToolPolicies } from "./requester-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox.js";
 import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "./subagent-capabilities.js";
 import { isToolAllowedByPolicies } from "./tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
@@ -31,6 +24,8 @@ export type WebSearchToolPolicyParams = {
   senderName?: string | null;
   senderUsername?: string | null;
   senderE164?: string | null;
+  inputProvenance?: InputProvenance;
+  trustedInternalHandoff?: boolean;
 };
 
 type WebSearchToolPolicyResolution = {
@@ -74,47 +69,27 @@ export function resolveWebSearchToolPolicy(
     groupSpace: params.groupSpace,
     accountId: params.agentAccountId,
   };
-  const groupPolicy = resolveGroupToolPolicy({
-    ...groupPolicyParams,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const persistentGroupPolicy = resolveGroupToolPolicy(groupPolicyParams);
   const senderPolicyParams = {
     config: params.config,
     agentId,
     messageProvider: params.messageProvider,
   };
-  const senderPolicy = resolveSenderToolPolicy({
-    ...senderPolicyParams,
+  const requesterPolicies = resolveRequesterToolPolicies({
+    ...groupPolicyParams,
+    agentId,
     senderId: params.senderId,
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
+    inputProvenance: params.inputProvenance,
+    trustedInternalHandoff: params.trustedInternalHandoff,
   });
-  const persistentSenderPolicy = resolveSenderToolPolicy(senderPolicyParams);
-  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
-    cfg: params.config,
-  });
-  const subagentPolicy =
-    params.sessionKey &&
-    isSubagentEnvelopeSession(params.sessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    params.config,
-    params.sessionKey,
-    {
-      store: subagentStore,
-    },
-  );
+  const persistentGroupPolicy = requesterPolicies.delegated
+    ? undefined
+    : resolveGroupToolPolicy(groupPolicyParams);
+  const persistentSenderPolicy = requesterPolicies.delegated
+    ? undefined
+    : resolveSenderToolPolicy(senderPolicyParams);
   const fixedPolicies = [
     profilePolicy,
     providerProfilePolicy,
@@ -123,12 +98,16 @@ export function resolveWebSearchToolPolicy(
     agentPolicy,
     agentProviderPolicy,
   ];
-  const trailingPolicies = [params.sandboxToolPolicy, subagentPolicy, inheritedToolPolicy];
+  const trailingPolicies = [
+    params.sandboxToolPolicy,
+    requesterPolicies.subagentPolicy,
+    requesterPolicies.inheritedToolPolicy,
+  ];
   return {
     allowed: isToolAllowedByPolicies("web_search", [
       ...fixedPolicies,
-      groupPolicy,
-      senderPolicy,
+      requesterPolicies.groupPolicy,
+      requesterPolicies.senderPolicy,
       ...trailingPolicies,
     ]),
     persistentAllowed: isToolAllowedByPolicies("web_search", [

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -973,6 +973,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       senderName: params.followupRun.run.senderName,
       senderUsername: params.followupRun.run.senderUsername,
       senderE164: params.followupRun.run.senderE164,
+      inputProvenance: params.followupRun.run.inputProvenance,
       sessionFile,
       workspaceDir: params.followupRun.run.workspaceDir,
       cwd: params.followupRun.run.cwd,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -257,6 +257,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     senderName: params.ctx.SenderName,
     senderUsername: params.ctx.SenderUsername,
     senderE164: params.ctx.SenderE164,
+    inputProvenance: params.ctx.InputProvenance,
     sessionFile: runtime.resolveSessionFilePath(
       sessionId,
       targetSessionEntry,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -296,6 +296,8 @@ export type SessionEntry = SessionRestartRecoveryState &
     subagentRole?: "orchestrator" | "leaf";
     /** Explicit control scope assigned at spawn time for subagent control decisions. */
     subagentControlScope?: "children" | "none";
+    /** Version of the requester tool-policy snapshot captured when this child was spawned. */
+    inheritedToolPolicyVersion?: 1;
     /** Session-scoped tool deny entries inherited from the caller that created this session. */
     inheritedToolDeny?: string[];
     /** Session-scoped tool allow entries inherited from the caller that created this session. */

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -275,6 +275,8 @@ export type SessionEntry = SessionRestartRecoveryState &
     sessionFile?: string;
     /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
     spawnedBy?: string;
+    /** Immutable session key authorized to receive this child's completion handoff. */
+    completionOwnerSessionKey?: string;
     /** Workspace inherited by spawned sessions and reused on later turns for the same child session. */
     spawnedWorkspaceDir?: string;
     /** Task working directory inherited by spawned sessions and reused on later turns. */

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -399,6 +399,7 @@ describe("method scope resolution", () => {
     ["model", { key: "agent:main:ios-1", model: "anthropic/claude-sonnet-5" }],
     ["sendPolicy", { key: "agent:main:ios-1", sendPolicy: "deny" }],
     ["inheritedToolAllow", { key: "agent:main:ios-1", inheritedToolAllow: ["exec"] }],
+    ["inheritedToolPolicyVersion", { key: "agent:main:ios-1", inheritedToolPolicyVersion: 1 }],
     ["spawnedBy", { key: "agent:main:ios-1", spawnedBy: "agent:main:main" }],
     ["mixed with safe fields", { key: "agent:main:ios-1", label: "x", execHost: "node-1" }],
     ["unknown fields", { key: "agent:main:ios-1", futureField: true }],

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -276,6 +276,10 @@ export function startAgentRunExecution(params: {
           params.client.internal.runtimePluginToolGrant?.pluginId
           ? params.client.internal.runtimePluginToolGrant
           : undefined;
+      const trustedInternalHandoff =
+        params.client?.internal?.delegatedToolPolicyHandoff === true &&
+        params.inputProvenance?.kind === "inter_session" &&
+        params.inputProvenance.sourceTool === "subagent_announce";
 
       const restartRecoveryChannelContext = resolveAgentRestartRecoveryChannelContext({
         canUseInternalRuntimeHandoff: params.canUseInternalRuntimeHandoff,
@@ -341,6 +345,7 @@ export function startAgentRunExecution(params: {
           bootstrapContextRunKind: params.effectiveBootstrapContextRunKind,
           toolsAllow: params.restoredCronContinuation?.toolsAllow,
           runtimePluginToolGrant,
+          trustedInternalHandoff,
           toolsAllowIsDefault: params.restoredCronContinuation?.toolsAllowIsDefault,
           requireExplicitMessageTarget:
             params.restoredCronContinuation?.cliSessionBindingFacts?.requireExplicitMessageTarget,

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -421,6 +421,33 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("forwards trusted delegated policy handoffs only from internal client metadata", async () => {
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "child completed",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "delegated-policy-handoff",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:subagent:child",
+          sourceTool: "subagent_announce",
+        },
+      },
+      {
+        client: {
+          internal: {
+            delegatedToolPolicyHandoff: true,
+          },
+        } as never,
+      },
+    );
+
+    const call = await waitForAgentCommandCall<{ trustedInternalHandoff?: boolean }>();
+    expect(call.trustedInternalHandoff).toBe(true);
+  });
+
   it("does not claim stale pre-existing sessions for plugin runtime cleanup", async () => {
     const sessionKey = "agent:main:existing-user-session";
     const existingEntry = {

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -92,6 +92,8 @@ export type GatewayClient = {
     internalDeliverySuppressText?: boolean;
     /** Plugin-owned tools authorized for this internal subagent run. */
     runtimePluginToolGrant?: RuntimePluginToolGrant;
+    /** In-process subagent-completion handoff eligible for verified policy inheritance. */
+    delegatedToolPolicyHandoff?: true;
   };
 };
 

--- a/src/gateway/server-plugin-runtime-client.ts
+++ b/src/gateway/server-plugin-runtime-client.ts
@@ -20,6 +20,7 @@ export function createSyntheticPluginRuntimeClient(params?: {
   internalDeliverySuppressText?: boolean;
   pluginRuntimeOwnerId?: string;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  delegatedToolPolicyHandoff?: boolean;
   scopes?: string[];
 }): NonNullable<GatewayRequestOptions["client"]> {
   const pluginRuntimeOwnerId =
@@ -53,6 +54,9 @@ export function createSyntheticPluginRuntimeClient(params?: {
       ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
       ...(params?.runtimePluginToolGrant
         ? { runtimePluginToolGrant: params.runtimePluginToolGrant }
+        : {}),
+      ...(params?.delegatedToolPolicyHandoff === true
+        ? { delegatedToolPolicyHandoff: true as const }
         : {}),
     },
   };

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -918,6 +918,23 @@ describe("loadGatewayPlugins", () => {
     ).resolves.toEqual({ status: "ok" });
   });
 
+  test("carries delegated tool-policy handoffs only in synthetic client context", async () => {
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("delegated-tool-policy"));
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      expect(opts.req.params).not.toHaveProperty("delegatedToolPolicyHandoff");
+      expect(opts.client?.internal?.delegatedToolPolicyHandoff).toBe(true);
+      opts.respond(true, { status: "ok" });
+    });
+
+    await expect(
+      serverPluginsModule.dispatchGatewayMethodInProcess(
+        "agent",
+        { sessionKey: "agent:main:main" },
+        { delegatedToolPolicyHandoff: true, forceSyntheticClient: true },
+      ),
+    ).resolves.toEqual({ status: "ok" });
+  });
+
   test("carries scoped delivery media only in the synthetic client context", async () => {
     serverPluginsModule.setFallbackGatewayContext(createTestContext("scoped-delivery-media"));
     handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
@@ -1482,6 +1499,7 @@ describe("loadGatewayPlugins", () => {
             pluginId: "other-plugin",
             toolNames: ["other_plugin_tool"],
           },
+          delegatedToolPolicyHandoff: true,
         },
       } as unknown as GatewayRequestOptions["client"],
       isWebchatConnect: () => false,
@@ -1498,6 +1516,7 @@ describe("loadGatewayPlugins", () => {
 
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("workboard");
     expect(getLastDispatchedClientInternal().runtimePluginToolGrant).toBeUndefined();
+    expect(getLastDispatchedClientInternal().delegatedToolPolicyHandoff).toBeUndefined();
   });
 
   test("forwards lightContext as lightweight bootstrap context on subagent run", async () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -245,6 +245,7 @@ type DispatchGatewayMethodInProcessOptions = {
   onAccepted?: (payload: unknown) => void;
   pluginRuntimeOwnerId?: string;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  delegatedToolPolicyHandoff?: boolean;
   requireScopedClient?: boolean;
   syntheticScopes?: string[];
   timeoutMs?: number;
@@ -285,15 +286,22 @@ export async function dispatchGatewayMethodInProcessRaw(
     ...(options?.runtimePluginToolGrant
       ? { runtimePluginToolGrant: options.runtimePluginToolGrant }
       : {}),
+    delegatedToolPolicyHandoff: options?.delegatedToolPolicyHandoff === true,
     scopes: options?.syntheticScopes,
   });
   const scopedClient = mergePluginRuntimeClientInternal(
     scope?.client,
-    pluginRuntimeOwnerId || options?.agentRunTracking || options?.runtimePluginToolGrant
+    pluginRuntimeOwnerId ||
+      options?.agentRunTracking ||
+      options?.runtimePluginToolGrant ||
+      options?.delegatedToolPolicyHandoff ||
+      scope?.client?.internal?.delegatedToolPolicyHandoff
       ? {
           ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
           ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
           runtimePluginToolGrant: options?.runtimePluginToolGrant,
+          delegatedToolPolicyHandoff:
+            options?.delegatedToolPolicyHandoff === true ? (true as const) : undefined,
         }
       : undefined,
   );

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1292,6 +1292,29 @@ describe("gateway sessions patch", () => {
     expect(entry.spawnedBy).toBe("agent:main:main");
   });
 
+  test("sets an immutable completion owner for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: "agent:main:acp:child",
+        patch: {
+          key: "agent:main:acp:child",
+          completionOwnerSessionKey: "agent:main:main",
+        },
+      }),
+    );
+    expect(entry.completionOwnerSessionKey).toBe("agent:main:main");
+
+    const result = await runPatch({
+      storeKey: "agent:main:acp:child",
+      store: { "agent:main:acp:child": entry },
+      patch: {
+        key: "agent:main:acp:child",
+        completionOwnerSessionKey: "agent:main:discord:direct:bob",
+      },
+    });
+    expectPatchError(result, "completionOwnerSessionKey cannot be changed once set");
+  });
+
   test("sets spawnedWorkspaceDir for subagent sessions", async () => {
     const entry = expectPatchOk(
       await runPatch({

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1338,6 +1338,23 @@ describe("gateway sessions patch", () => {
     expect(entry.spawnDepth).toBe(2);
   });
 
+  test("sets an immutable requester policy snapshot version for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: "agent:main:acp:child",
+        patch: { key: "agent:main:acp:child", inheritedToolPolicyVersion: 1 },
+      }),
+    );
+    expect(entry.inheritedToolPolicyVersion).toBe(1);
+
+    const result = await runPatch({
+      storeKey: "agent:main:acp:child",
+      store: { "agent:main:acp:child": entry },
+      patch: { key: "agent:main:acp:child", inheritedToolPolicyVersion: null },
+    });
+    expectPatchError(result, "inheritedToolPolicyVersion cannot be cleared once set");
+  });
+
   test("sets inheritedToolDeny for ACP sessions", async () => {
     const entry = expectPatchOk(
       await runPatch({
@@ -1395,6 +1412,13 @@ describe("gateway sessions patch", () => {
       patch: { key: MAIN_SESSION_KEY, inheritedToolDeny: ["exec"] },
     });
     expectPatchError(result, "inheritedToolDeny is only supported");
+  });
+
+  test("rejects inheritedToolPolicyVersion on non-subagent sessions", async () => {
+    const result = await runPatch({
+      patch: { key: MAIN_SESSION_KEY, inheritedToolPolicyVersion: 1 },
+    });
+    expectPatchError(result, "inheritedToolPolicyVersion is only supported");
   });
 
   test("rejects inheritedToolAllow on non-subagent sessions", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -361,6 +361,24 @@ export async function projectSessionsPatchEntry(params: {
     }
   }
 
+  if ("inheritedToolPolicyVersion" in patch) {
+    const raw = patch.inheritedToolPolicyVersion;
+    if (raw === null) {
+      if (existing?.inheritedToolPolicyVersion !== undefined) {
+        return invalid("inheritedToolPolicyVersion cannot be cleared once set");
+      }
+    } else if (raw !== undefined) {
+      const lineage = checkSpawnLineage("inheritedToolPolicyVersion");
+      if (lineage) {
+        return lineage;
+      }
+      if (raw !== 1) {
+        return invalid("invalid inheritedToolPolicyVersion (expected 1)");
+      }
+      next.inheritedToolPolicyVersion = 1;
+    }
+  }
+
   if ("inheritedToolDeny" in patch) {
     const raw = patch.inheritedToolDeny;
     if (raw === null) {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -244,7 +244,7 @@ export async function projectSessionsPatchEntry(params: {
       ? null
       : invalid(`${field} is only supported for subagent:* or acp:* sessions`);
   const applyImmutableString = (
-    field: "spawnedBy" | "spawnedWorkspaceDir" | "spawnedCwd",
+    field: "spawnedBy" | "completionOwnerSessionKey" | "spawnedWorkspaceDir" | "spawnedCwd",
     checkLineageBeforeEmpty: boolean,
   ): PatchError => {
     if (!(field in patch)) {
@@ -307,6 +307,7 @@ export async function projectSessionsPatchEntry(params: {
 
   for (const fieldParams of [
     { field: "spawnedBy" as const, checkLineageBeforeEmpty: false },
+    { field: "completionOwnerSessionKey" as const, checkLineageBeforeEmpty: false },
     { field: "spawnedWorkspaceDir" as const, checkLineageBeforeEmpty: true },
     { field: "spawnedCwd" as const, checkLineageBeforeEmpty: true },
   ]) {

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -1,7 +1,12 @@
 /**
  * Gateway tool-resolution exclusion tests.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 type CreateOpenClawToolsArg = {
@@ -403,6 +408,48 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
     expect(readCreateToolsArgs().pluginToolDenylist).toContain("exec");
+  });
+
+  it("uses persisted delegated policy instead of the sender wildcard", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-delegated-policy-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const sessionKey = "agent:main:subagent:gateway-child";
+    await replaceSessionEntry({ storePath, sessionKey }, {
+      sessionId: "gateway-child-session",
+      updatedAt: Date.now(),
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+    } as SessionEntry);
+
+    try {
+      const result = resolveGatewayScopedTools({
+        cfg: {
+          session: { store: storePath },
+          tools: {
+            toolsBySender: {
+              "*": { deny: ["group:runtime", "group:fs"] },
+              "id:alice": {},
+            },
+          },
+        } as OpenClawConfig,
+        sessionKey,
+        surface: "loopback",
+        senderIsOwner: false,
+        messageProvider: "discord",
+        includeNodeExecTool: true,
+      });
+
+      expect(result.tools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining(["read", "exec"]),
+      );
+      expect(readCreateToolsArgs().pluginToolDenylist).not.toEqual(
+        expect.arrayContaining(["read", "exec"]),
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("filters node exec through plugin group policy bound to group labels", () => {

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -421,6 +421,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
     } as SessionEntry);
 
     try {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,12 +1,7 @@
 // Gateway-scoped tool resolution for HTTP and loopback tool surfaces.
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { filterToolsByMessageProvider } from "../agents/agent-tools.message-provider-policy.js";
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
-} from "../agents/agent-tools.policy.js";
+import { resolveEffectiveToolPolicy } from "../agents/agent-tools.policy.js";
 import type { ExecElevatedDefaults } from "../agents/bash-tools.exec-types.js";
 import { nodeExecSchema } from "../agents/bash-tools.schemas.js";
 import {
@@ -16,12 +11,8 @@ import {
 } from "../agents/exec-defaults.js";
 import { createLazyExecTool, resolveExecToolConfig } from "../agents/lazy-exec-tool.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
+import { resolveRequesterToolPolicies } from "../agents/requester-tool-policy.js";
 import { resolveSandboxRuntimeStatus } from "../agents/sandbox/runtime-status.js";
-import { resolveSenderToolPolicy } from "../agents/sender-tool-policy.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../agents/subagent-capabilities.js";
 import { buildDeclaredToolAllowlistContext } from "../agents/tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
@@ -148,9 +139,17 @@ export function resolveGatewayScopedTools(params: {
     ...runtimeAlsoAllow,
   ]);
   const senderId = params.channelContext?.sender?.id;
-  const groupPolicy = resolveGroupToolPolicy({
+  // Only immutable Gateway-launched grants can opt into node exec. Match the
+  // embedded runner's wildcard sender policy while preserving owner WebChat.
+  const isOwnerInternalSession =
+    nodeExecSurface &&
+    params.senderIsOwner === true &&
+    normalizeMessageChannel(params.messageProvider) === INTERNAL_MESSAGE_CHANNEL;
+  const requesterPolicies = resolveRequesterToolPolicies({
     config: params.cfg,
     sessionKey: runtimePolicySessionKey,
+    subagentSessionKey: runtimePolicySessionKey,
+    agentId,
     spawnedBy: params.spawnedBy,
     messageProvider: params.messageProvider,
     groupId: params.groupId,
@@ -161,47 +160,19 @@ export function resolveGatewayScopedTools(params: {
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
+    senderPolicyMode: nodeExecSurface
+      ? isOwnerInternalSession
+        ? "never"
+        : "always"
+      : "when-sender-id",
   });
-  // Only immutable Gateway-launched grants can opt into node exec. Match the
-  // embedded runner's wildcard sender policy while preserving owner WebChat.
-  const isOwnerInternalSession =
-    nodeExecSurface &&
-    params.senderIsOwner === true &&
-    normalizeMessageChannel(params.messageProvider) === INTERNAL_MESSAGE_CHANNEL;
-  const shouldResolveSenderPolicy = nodeExecSurface ? !isOwnerInternalSession : Boolean(senderId);
-  const senderPolicy = shouldResolveSenderPolicy
-    ? resolveSenderToolPolicy({
-        config: params.cfg,
-        agentId,
-        messageProvider: params.messageProvider,
-        senderId,
-        senderName: params.senderName,
-        senderUsername: params.senderUsername,
-        senderE164: params.senderE164,
-      })
-    : undefined;
+  const { groupPolicy, senderPolicy, subagentPolicy, inheritedToolPolicy } = requesterPolicies;
   const sandboxRuntime = resolveSandboxRuntimeStatus({
     cfg: params.cfg,
     sessionKey: runtimePolicySessionKey,
     agentId,
   });
   const sandboxPolicy = sandboxRuntime.sandboxed ? sandboxRuntime.toolPolicy : undefined;
-  const subagentStore = resolveSubagentCapabilityStore(runtimePolicySessionKey, {
-    cfg: params.cfg,
-  });
-  const subagentPolicy = isSubagentEnvelopeSession(runtimePolicySessionKey, {
-    cfg: params.cfg,
-    store: subagentStore,
-  })
-    ? resolveSubagentToolPolicyForSession(params.cfg, runtimePolicySessionKey, {
-        store: subagentStore,
-      })
-    : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    params.cfg,
-    runtimePolicySessionKey,
-    { store: subagentStore },
-  );
   const excludedToolNames = params.excludeToolNames ? Array.from(params.excludeToolNames) : [];
   const gatewayToolsCfg = params.cfg.gateway?.tools;
   const defaultGatewayDeny =

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -37,6 +37,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "swarmOutputSchema",
   "subagentRole",
   "subagentControlScope",
+  "inheritedToolPolicyVersion",
   "inheritedToolDeny",
   "inheritedToolAllow",
   "mainRestartRecovery",

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -25,6 +25,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "lastActivityAt",
   "sessionFile",
   "spawnedBy",
+  "completionOwnerSessionKey",
   "spawnedWorkspaceDir",
   "spawnedCwd",
   "worktree",

--- a/src/skills/runtime/tool-dispatch.test.ts
+++ b/src/skills/runtime/tool-dispatch.test.ts
@@ -1,5 +1,10 @@
 // Skill tool dispatch tests cover policy-filtered tool surfaces.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 type CreateOpenClawToolsArg = {
@@ -80,5 +85,43 @@ describe("resolveSkillDispatchTools", () => {
     expect(args?.beforeToolCallHookContext?.skillCommand?.skillFile).toBe(
       "/workspace/skills/daily-brief/SKILL.md",
     );
+  });
+
+  it("uses persisted delegated policy instead of a sender wildcard", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-skill-delegated-policy-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const sessionKey = "agent:main:subagent:skill-child";
+    await replaceSessionEntry({ storePath, sessionKey }, {
+      sessionId: "skill-child-session",
+      updatedAt: Date.now(),
+      spawnedBy: "agent:main:telegram:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+    } as SessionEntry);
+
+    try {
+      const tools = resolveSkillDispatchTools({
+        message: { surface: "telegram" },
+        cfg: {
+          session: { store: storePath },
+          tools: {
+            toolsBySender: {
+              "*": { deny: ["group:runtime", "group:fs"] },
+              "id:alice": {},
+            },
+          },
+        } as OpenClawConfig,
+        agentId: "main",
+        sessionKey,
+        workspaceDir: "/tmp/openclaw-skill-tool-dispatch-test",
+        provider: "openai",
+        model: "gpt-5.5",
+      });
+
+      expect(tools.map((tool) => tool.name)).toEqual(expect.arrayContaining(["read", "exec"]));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/skills/runtime/tool-dispatch.test.ts
+++ b/src/skills/runtime/tool-dispatch.test.ts
@@ -98,6 +98,7 @@ describe("resolveSkillDispatchTools", () => {
       spawnDepth: 1,
       subagentRole: "orchestrator",
       subagentControlScope: "children",
+      inheritedToolPolicyVersion: 1,
     } as SessionEntry);
 
     try {

--- a/src/skills/runtime/tool-dispatch.ts
+++ b/src/skills/runtime/tool-dispatch.ts
@@ -1,18 +1,9 @@
 // Skill tool dispatch routes runtime skill tool calls through the active session context.
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
-} from "../../agents/agent-tools.policy.js";
+import { resolveEffectiveToolPolicy } from "../../agents/agent-tools.policy.js";
 import type { AnyAgentTool } from "../../agents/agent-tools.types.js";
 import { createOpenClawTools } from "../../agents/openclaw-tools.runtime.js";
+import { resolveRequesterToolPolicies } from "../../agents/requester-tool-policy.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
-import { resolveSenderToolPolicy } from "../../agents/sender-tool-policy.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../../agents/subagent-capabilities.js";
 import { buildDeclaredToolAllowlistContext } from "../../agents/tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
@@ -103,9 +94,11 @@ export function resolveSkillDispatchTools(params: {
     providerProfileAlsoAllow,
   );
   const groupId = params.sessionEntry?.groupId ?? params.groupId;
-  const groupPolicy = resolveGroupToolPolicy({
+  const requesterPolicies = resolveRequesterToolPolicies({
     config: params.cfg,
     sessionKey: params.sessionKey,
+    subagentSessionKey: params.sessionKey,
+    agentId: resolvedAgentId,
     spawnedBy: params.sessionEntry?.spawnedBy,
     messageProvider: channel,
     groupId,
@@ -117,34 +110,12 @@ export function resolveSkillDispatchTools(params: {
     senderUsername: params.message.senderUsername,
     senderE164: params.message.senderE164,
   });
-  const senderPolicy = resolveSenderToolPolicy({
-    config: params.cfg,
-    agentId: resolvedAgentId,
-    messageProvider: channel,
-    senderId: params.message.senderId ?? params.senderId,
-    senderName: params.message.senderName,
-    senderUsername: params.message.senderUsername,
-    senderE164: params.message.senderE164,
-  });
+  const { groupPolicy, senderPolicy, subagentPolicy, inheritedToolPolicy } = requesterPolicies;
   const sandboxRuntime = resolveSandboxRuntimeStatus({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
   });
   const sandboxPolicy = sandboxRuntime.sandboxed ? sandboxRuntime.toolPolicy : undefined;
-  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
-    cfg: params.cfg,
-  });
-  const subagentPolicy = isSubagentEnvelopeSession(params.sessionKey, {
-    cfg: params.cfg,
-    store: subagentStore,
-  })
-    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey, {
-        store: subagentStore,
-      })
-    : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(params.cfg, params.sessionKey, {
-    store: subagentStore,
-  });
   const explicitPolicyList = [
     profilePolicy,
     providerProfilePolicy,


### PR DESCRIPTION
Closes #109025

Alternative implementation to #109055.

AI-assisted: yes. I understand the authorization lineage and tool-policy changes in this PR.

## What Problem This Solves

Fixes an issue where users with an exact `toolsBySender` override could successfully use tools in the inbound parent run, but a spawned sender-less subagent would re-resolve the wildcard sender rule and silently lose filesystem/runtime tools.

The same context loss could affect trusted internal completion fallback, and separate tool-discovery consumers could otherwise disagree about the effective requester policy.

## Why This Change Was Made

This change centralizes requester tool-policy resolution. External requests resolve current global/group/sender policy normally. Verified internal descendants consume the stored effective requester projection, then intersect it with current agent, sandbox, profile, and subagent restrictions.

Delegation is accepted only from persisted spawned lineage or the private subagent-completion handoff with matching provenance. A new external sender targeting an existing child re-resolves sender policy, forged child-shaped keys fail closed, empty inherited projections remain meaningful, and the same rule now feeds conversation tools, Gateway/node tool resolution, web search, skill dispatch, compaction, and the Codex dynamic-tool surface.

Unlike a spawn-only propagation path, this also covers requester-agent fallback without copying or synthesizing public sender identity.

## User Impact

Delegated agents retain the tool authority of the external request that created them, subject to all ordinary child restrictions. Anonymous or newly external requests do not inherit that authority.

## Evidence

- Live A/B on Blacksmith Testbox `tbx_01kxshsbhgk1z0jt6ytw8rcc47`, real Gateway + qa-channel + `openai/gpt-5.4`: [Actions run](https://github.com/openclaw/openclaw/actions/runs/29627581013)
  - Fix commit `859fdd3b7f1`: scenario `issue-109025-sender-policy-live` passed; the parent wrote its proof, spawned a real child, and the child read the unpredictable marker.
  - Exact pre-fix parent `75e4103c57382ddbf16aab1aed8a6e72cfb39951`: the same scenario failed with `parentProof=PARENT_OK`, `childTools={}`, and no marker returned (`reproduced issue 109025`).
- Full changed-surface gate passed on Testbox: typecheck, lint, formatting, import cycles, dependency and plugin-boundary guards. [Actions run](https://github.com/openclaw/openclaw/actions/runs/29627205858)
- Focused Vitest coverage passed for requester policy, conversation capability profile, subagent announce delivery, Gateway plugin dispatch, Gateway tool resolution, skill dispatch, Codex dynamic tools, and embedded attempt tooling.
- `$autoreview --mode uncommitted` completed cleanly with no accepted/actionable findings.



## Authorization boundary review

Maintainer decision: senderless authenticated operator calls to a valid persisted child session are trusted resumptions inside the Gateway trusted-operator domain.

- Persisted lineage is authority-bearing only when the stored child envelope includes `spawnedBy` plus valid subagent metadata. Lineage and inherited-tool mutations through `sessions.patch` require `operator.admin`.
- The inherited sender projection is a spawn-time snapshot. Later `toolsBySender` edits are intentionally non-retroactive for that child, while current global, agent, provider, sandbox, and subagent restrictions continue to apply.
- A new external channel turn targeting an existing child re-resolves current sender policy. Sender identity and `external_user` provenance each independently force that path.
- Completion continuation additionally requires private in-process client metadata, `inter_session` + `subagent_announce` provenance, a source session, and a matching persisted lineage chain.
- Resolution records `current-request`, `persisted-child`, or `completion-handoff` for diagnostics.

Direct sibling Codex inspection completed at [`openai/codex@e98765c212d`](https://github.com/openai/codex/commit/e98765c212d04e7bced1d2d340e0cee61b6d7aa0): [`thread_processor.rs`](https://github.com/openai/codex/blob/e98765c212d04e7bced1d2d340e0cee61b6d7aa0/codex-rs/app-server/src/request_processors/thread_processor.rs#L1215-L1252) validates and passes the client-supplied dynamic-tool list into thread startup, while [`dynamic_tools.rs`](https://github.com/openai/codex/blob/e98765c212d04e7bced1d2d340e0cee61b6d7aa0/codex-rs/app-server/src/dynamic_tools.rs#L16-L50) relays tool responses. Codex does not reconstruct OpenClaw sender policy; OpenClaw owns authorization before supplying `dynamicTools`.