### PR TITLE
fix: remove dead 'think-hard' alias from high-level array in normalizeThinkLevel

### DIFF
--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -98,7 +98,7 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
     return "medium";
   }
-  if (["high", "ultrathink", "think-hard", "thinkhardest", "highest"].includes(key)) {
+  if (["high", "ultrathink", "thinkhardest", "highest"].includes(key)) {
     return "high";
   }
   if (["think"].includes(key)) {

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -50,7 +50,7 @@ export function normalizeThinkLevel(raw?: string | null): string | undefined {
   if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
     return "medium";
   }
-  if (["high", "ultrathink", "think-hard", "thinkhardest", "highest"].includes(key)) {
+  if (["high", "ultrathink", "thinkhardest", "highest"].includes(key)) {
     return "high";
   }
   if (key === "think") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `normalizeThinkLevel` function contained a misleading dead-code entry. The string `"think-hard"` appeared in both the `"low"` and `"high"` alias arrays. Because the `"low"` check runs first, the `"high"` entry could never be reached — it was dead code that misled readers into thinking `"think-hard"` might map to `"high"` under some path.

## Why This Change Was Made

The `"think-hard"` alias is the kebab-case variant of `"thinkhard"` and correctly belongs to `"low"` — consistent with the `"think_hard"` (underscore) variant in the same array. The `"high"` array entry was a copy-paste error present since the first commit of this code. The Swift native implementation never included this duplicate alias, confirming it has no legitimate purpose in the `"high"` array. The fix removes only the dead entry from the `"high"` array; the live `"low"` entry is untouched.

## User Impact

No user-visible behavior change. This is a dead-code cleanup with zero external impact — input `"think-hard"` continues to normalize to `"low"` as before.

## Evidence

- **Root cause analysis**: git history traced to first commit (`05b76281f7`), confirmed by cross-referencing naming conventions and Swift (`ChatViewModel+Thinking.swift:453`) which never included the duplicate
- **Full codebase search**: `"think-hard"` appears only in the two TypeScript normalization files (4 occurrences: `shared.ts:95`/`101`, `ui/thinking.ts:47`/`53`). No tests, docs, or config files reference it
- **Focused test suite**:
  - `src/auto-reply/thinking.test.ts` — 63 tests passed
  - `ui/src/lib/chat/thinking.test.ts` — 4 tests passed
- **Diff**: 2 files, 2 lines changed, each removing one string literal — no behavioral change
- **Runtime proof** — after-fix terminal output from both the core and UI paths confirming `"think-hard"` still normalizes to `"low"`:

  ```
  === Core path (src/auto-reply/thinking) ===
  normalizeThinkLevel("think-hard") → "low"   ✓ PASS

  === UI path (ui/src/lib/chat/thinking) ===
  normalizeThinkLevel("think-hard") → "low"   ✓ PASS

  === Full alias matrix (both paths identical) ===
  "think-hard"       → "low"
  "think-harder"     → "medium"
  "thinkhard"        → "low"
  "think_hard"       → "low"
  "ultrathink"       → "high"
  "thinkhardest"     → "high"
  "highest"          → "high"
  ```

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
