### PR TITLE
feat(feishu): route exact DMs with fail-closed enforcement

### DIFF
--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -81,17 +81,24 @@ does not create a route-only session entry just because a message was observed.
 
 Routing picks **one agent** for each inbound message:
 
-1. **Exact peer match** (`bindings` with `peer.kind` + `peer.id`).
-2. **Parent peer match** (thread inheritance).
-3. **Peer wildcard match** (`peer.id: "*"` for a peer kind).
-4. **Guild + roles match** (Discord) via `guildId` + `roles`.
-5. **Guild match** (Discord) via `guildId`.
-6. **Team match** (Slack) via `teamId`.
-7. **Account match** (`accountId` on the channel).
-8. **Channel match** (any account on that channel, `accountId: "*"`).
-9. **Default agent** (`agents.list[].default`, else first list entry, fallback to `main`).
+1. **Exact conversation match** (`bindings` with `conversationId`; route bindings only).
+2. **Exact peer match** (`bindings` with `peer.kind` + `peer.id`).
+3. **Parent peer match** (thread inheritance).
+4. **Peer wildcard match** (`peer.id: "*"` for a peer kind).
+5. **Guild + roles match** (Discord) via `guildId` + `roles`.
+6. **Guild match** (Discord) via `guildId`.
+7. **Team match** (Slack) via `teamId`.
+8. **Account match** (`accountId` on the channel).
+9. **Channel match** (any account on that channel, `accountId: "*"`).
+10. **Default agent** (`agents.list[].default`, else first list entry, fallback to `main`).
 
-When a binding includes multiple match fields (`peer`, `guildId`, `teamId`, `roles`), **all provided fields must match** for that binding to apply.
+When a binding includes multiple match fields (`conversationId`, `peer`, `guildId`, `teamId`, `roles`), **all provided fields must match** for that binding to apply. `conversationId` is an exact, literal provider conversation/chat ID; wildcard, regular-expression, and fuzzy matching are not supported.
+
+Unmatched routes keep the existing default-agent behavior. Channels may add a
+channel-owned post-routing policy; for example, Feishu can reject unmatched DMs
+after its configured and runtime conversation overlays by enabling
+[`channels.feishu.dmRouteFailClosed`](/channels/feishu#exact-fail-closed-dm-conversation-routing).
+That policy does not change routing for other channels.
 
 The matched agent determines which workspace and session store are used.
 

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -417,10 +417,64 @@ Use `bindings` to route Feishu/Lark DMs or groups to different agents.
 Routing fields:
 
 - `match.channel`: `"feishu"`
+- `match.accountId`: exact configured Feishu account ID
+- `match.conversationId`: exact Feishu `chat_id` for a route binding
 - `match.peer.kind`: `"direct"` (DM) or `"group"` (group chat)
 - `match.peer.id`: user Open ID (`ou_xxx`) or group ID (`oc_xxx`)
 
 See [Get group/user IDs](#get-groupuser-ids) for lookup tips.
+
+#### Exact fail-closed DM conversation routing
+
+A Feishu DM has both a sender Open ID and a chat ID. Peer routing uses the
+sender (`open_id`), so it can match the same person across their DMs. Use
+`match.conversationId` when one exact DM `chat_id` must route to a specialized
+agent without matching another conversation from the same sender.
+
+```json5
+{
+  agents: {
+    list: [
+      { id: "main" },
+      {
+        id: "purchase",
+        tools: {
+          allow: ["grasp_prepare_purchase_order"],
+        },
+      },
+    ],
+  },
+  channels: {
+    feishu: {
+      dmRouteFailClosed: true,
+    },
+  },
+  bindings: [
+    {
+      type: "route",
+      agentId: "purchase",
+      match: {
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_test_purchase_chat",
+      },
+    },
+  ],
+}
+```
+
+Conversation matching is literal and account-scoped. It does not accept
+wildcards, regular expressions, or fuzzy IDs. `dmRouteFailClosed` defaults to
+`false` and is also available as a per-account override. When enabled, Feishu
+first applies the core route plus existing configured and runtime ACP
+conversation overlays. It then rejects a DM instead of entering `main` when no
+exact route matched, the provider chat ID is missing, or the selected binding
+targets an agent absent from `agents.list`.
+
+This setting only affects Feishu DMs. Omitting it (or setting it to `false`)
+preserves existing Feishu fallback behavior, and other channels are unchanged.
+It does not replace Feishu `dmPolicy` or sender allowlists; ingress access
+control still runs independently.
 
 ## Per-user agent isolation (Dynamic Agent Creation)
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1,7 +1,7 @@
 // Feishu tests cover bot plugin behavior.
 import type * as ConversationRuntime from "openclaw/plugin-sdk/conversation-runtime";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentIdFromSessionKey, type ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
@@ -121,6 +121,8 @@ function createConfiguredFeishuRoute(): NonNullable<ConfiguredBindingRoute> {
         agentId: "codex",
       },
     },
+    boundSessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+    boundAgentId: "codex",
     route: {
       agentId: "codex",
       channel: "feishu",
@@ -150,6 +152,32 @@ function createBoundConversation(): NonNullable<BoundConversation> {
     },
     status: "active",
     boundAt: 0,
+  };
+}
+
+function createDirectBoundConversation(): NonNullable<BoundConversation> {
+  return {
+    bindingId: "default:ou_sender_1",
+    targetSessionKey: "agent:codex:acp:binding:feishu:default:feedface",
+    targetKind: "session",
+    conversation: {
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "ou_sender_1",
+    },
+    status: "active",
+    boundAt: 0,
+  };
+}
+
+function createPluginOwnedDirectBoundConversation(): NonNullable<BoundConversation> {
+  return {
+    ...createDirectBoundConversation(),
+    metadata: {
+      pluginBindingOwner: "plugin",
+      pluginId: "test-plugin",
+      pluginRoot: "/tmp/test-plugin",
+    },
   };
 }
 
@@ -386,12 +414,17 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
         return { bindingRecord: null, route: params.route };
       }
       mockTouchBinding(bindingRecord.bindingId);
+      if (bindingRecord.metadata?.pluginBindingOwner === "plugin") {
+        return { bindingRecord, route: params.route };
+      }
+      const boundAgentId = resolveAgentIdFromSessionKey(boundSessionKey) || params.route.agentId;
       return {
         bindingRecord,
         boundSessionKey,
-        boundAgentId: params.route.agentId,
+        boundAgentId,
         route: {
           ...params.route,
+          agentId: boundAgentId,
           sessionKey: boundSessionKey,
           lastRoutePolicy: boundSessionKey === params.route.mainSessionKey ? "main" : "session",
           matchedBy: "binding.channel",
@@ -492,12 +525,22 @@ describe("handleFeishuMessage ACP routing", () => {
 
   it("ensures configured ACP routes for Feishu DMs", async () => {
     mockResolveConfiguredBindingRoute.mockReturnValue(createConfiguredFeishuRoute());
+    const channelRuntime = createFeishuBotRuntime().channel;
 
     await dispatchMessage({
       cfg: {
+        agents: { list: [{ id: "main" }, { id: "codex" }] },
         session: { mainKey: "main", scope: "per-sender" },
-        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
       },
+      channelRuntime,
       event: {
         sender: { sender_id: { open_id: "ou_sender_1" } },
         message: {
@@ -512,6 +555,364 @@ describe("handleFeishuMessage ACP routing", () => {
 
     expect(mockResolveConfiguredBindingRoute).toHaveBeenCalledTimes(1);
     expect(mockEnsureConfiguredBindingRouteReady).toHaveBeenCalledTimes(1);
+    expect(channelRuntime.inbound.run).toHaveBeenCalledTimes(1);
+    expect(channelRuntime.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+      }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        conversationId: "oc_dm",
+        peer: { kind: "direct", id: "ou_sender_1" },
+      }),
+    );
+    expect(mockResolveAgentRoute.mock.invocationCallOrder[0]).toBeLessThan(
+      mockResolveConfiguredBindingRoute.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("preserves runtime ACP conversation overlays before the Feishu fail-closed gate", async () => {
+    mockResolveBoundConversation.mockReturnValue(createDirectBoundConversation());
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }, { id: "codex" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-runtime-overlay",
+          chat_id: "oc_test_runtime_overlay",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockResolveConfiguredBindingRoute).toHaveBeenCalledTimes(1);
+    expect(mockResolveBoundConversation).toHaveBeenCalledTimes(1);
+    expect(mockTouchBinding).toHaveBeenCalledWith("default:ou_sender_1");
+    expect(channelRuntime.inbound.run).toHaveBeenCalledTimes(1);
+    expect(channelRuntime.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:codex:acp:binding:feishu:default:feedface",
+      }),
+    );
+  });
+
+  it("rejects plugin-owned runtime bindings that do not route to an agent", async () => {
+    mockResolveBoundConversation.mockReturnValue(createPluginOwnedDirectBoundConversation());
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    const runtime = await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-plugin-owned-runtime-binding",
+          chat_id: "oc_test_plugin_owned_binding",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockTouchBinding).toHaveBeenCalledWith("default:ou_sender_1");
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("no_route (unmatched)"));
+    expect(channelRuntime.inbound.run).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an exact core conversation route when Feishu fail-closed is enabled", async () => {
+    mockResolveAgentRoute.mockReturnValue({
+      ...buildDefaultResolveRoute(),
+      agentId: "purchase",
+      bindingTargetAgentId: "purchase",
+      sessionKey: "agent:purchase:feishu:direct:ou_sender_1",
+      matchedBy: "binding.conversation",
+    });
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }, { id: "purchase" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-purchase-route",
+          chat_id: "oc_test_purchase_chat",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "purchase request" }),
+        },
+      },
+    });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        conversationId: "oc_test_purchase_chat",
+        peer: { kind: "direct", id: "ou_sender_1" },
+      }),
+    );
+    expect(channelRuntime.inbound.run).toHaveBeenCalledTimes(1);
+    expect(channelRuntime.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:purchase:feishu:direct:ou_sender_1",
+      }),
+    );
+  });
+
+  it("rejects an unmatched DM after configured and runtime overlays", async () => {
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    const runtime = await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }, { id: "purchase" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-route-unmatched",
+          chat_id: "oc_test_unmatched_chat",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "purchase request" }),
+        },
+      },
+    });
+
+    expect(mockResolveConfiguredBindingRoute).toHaveBeenCalledTimes(1);
+    expect(mockResolveBoundConversation).toHaveBeenCalledTimes(1);
+    expect(mockMaybeCreateDynamicAgent).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("no_route (unmatched)"));
+    expect(channelRuntime.inbound.run).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("rejects an exact DM binding whose target agent is missing", async () => {
+    mockResolveAgentRoute.mockReturnValue({
+      ...buildDefaultResolveRoute(),
+      bindingTargetAgentId: "missing-purchase",
+      matchedBy: "binding.conversation",
+    });
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    const runtime = await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-route-missing-agent",
+          chat_id: "oc_test_purchase_chat",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "purchase request" }),
+        },
+      },
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("no_route (agent_not_found)"),
+    );
+    expect(channelRuntime.inbound.run).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("rejects a fail-closed DM when the provider conversation id is missing", async () => {
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    const runtime = await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: true,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-route-missing-conversation",
+          chat_id: "",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "purchase request" }),
+        },
+      },
+    });
+
+    expect(mockResolveConfiguredBindingRoute).toHaveBeenCalledTimes(1);
+    expect(mockResolveBoundConversation).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("no_route (conversation_id_missing)"),
+    );
+    expect(channelRuntime.inbound.run).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("preserves the existing main fallback when Feishu fail-closed is disabled", async () => {
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: false,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-route-legacy-fallback",
+          chat_id: "oc_test_other_chat",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockMaybeCreateDynamicAgent).toHaveBeenCalledTimes(1);
+    expect(channelRuntime.inbound.run).toHaveBeenCalledTimes(1);
+    expect(channelRuntime.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:feishu:direct:ou_sender_1",
+      }),
+    );
+  });
+
+  it.each([
+    {
+      name: "enables rejection from the current config",
+      initialFailClosed: false,
+      currentFailClosed: true,
+      rejected: true,
+    },
+    {
+      name: "disables rejection from the current config",
+      initialFailClosed: true,
+      currentFailClosed: false,
+      rejected: false,
+    },
+  ])("$name instead of using the stale message snapshot", async (testCase) => {
+    const channelRuntime = createFeishuBotRuntime().channel;
+
+    const runtime = await dispatchMessage({
+      cfg: {
+        agents: { list: [{ id: "main" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: testCase.initialFailClosed,
+          },
+        },
+      },
+      currentCfg: {
+        agents: { list: [{ id: "main" }] },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            dmPolicy: "open",
+            dmRouteFailClosed: testCase.currentFailClosed,
+          },
+        },
+      },
+      channelRuntime,
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: `msg-route-current-${testCase.currentFailClosed}`,
+          chat_id: "oc_test_current_config",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    if (testCase.rejected) {
+      expect(mockMaybeCreateDynamicAgent).not.toHaveBeenCalled();
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("no_route (unmatched)"));
+      expect(channelRuntime.inbound.run).not.toHaveBeenCalled();
+    } else {
+      expect(mockMaybeCreateDynamicAgent).toHaveBeenCalledTimes(1);
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(channelRuntime.inbound.run).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("surfaces configured ACP initialization failures to the Feishu conversation", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -89,6 +89,25 @@ const groupNameCache = new Map<string, { name: string; expiresAt: number }>();
 const GROUP_NAME_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const GROUP_NAME_CACHE_MAX_SIZE = 500; // hard cap
 
+type FeishuRouteRejectionReason = "agent_not_found" | "conversation_id_missing" | "unmatched";
+
+class FeishuRouteRejectionError extends Error {
+  readonly code = "no_route";
+
+  constructor(readonly reason: FeishuRouteRejectionReason) {
+    super(`Feishu route rejected: no_route (${reason})`);
+    this.name = "FeishuRouteRejectionError";
+  }
+}
+
+function hasConfiguredRouteAgent(cfg: ClawdbotConfig, agentId: string): boolean {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const configuredAgentIds = (cfg.agents?.list ?? []).map((agent) => normalizeAgentId(agent.id));
+  return configuredAgentIds.length === 0
+    ? normalizedAgentId === "main"
+    : configuredAgentIds.includes(normalizedAgentId);
+}
+
 function shouldSendNoVisibleReplyFallback(dispatchResult: {
   counts: { final?: number };
   failedCounts?: { final?: number };
@@ -763,6 +782,7 @@ export async function handleFeishuMessage(params: {
       return {
         cfg: candidateCfg,
         dmPolicy: candidateDmPolicy,
+        dmRouteFailClosed: candidateAccount.config.dmRouteFailClosed === true,
         configAllowFrom: candidateConfigAllowFrom,
         ingress,
         shouldComputeCommandAuthorized: shouldComputeCommand,
@@ -811,6 +831,8 @@ export async function handleFeishuMessage(params: {
       return;
     }
     let effectiveDmPolicy = directAuthorization?.dmPolicy ?? dmPolicy;
+    let effectiveDmRouteFailClosed =
+      directAuthorization?.dmRouteFailClosed ?? feishuCfg.dmRouteFailClosed === true;
     let effectiveConfigAllowFrom = directAuthorization?.configAllowFrom ?? configAllowFrom;
     let effectiveDmIngress = dmIngress;
     let effectiveShouldComputeCommandAuthorized =
@@ -826,6 +848,7 @@ export async function handleFeishuMessage(params: {
         }
         effectiveCfg = currentCfg;
         effectiveDmPolicy = currentAuthorization.dmPolicy;
+        effectiveDmRouteFailClosed = currentAuthorization.dmRouteFailClosed;
         effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
         effectiveDmIngress = currentAuthorization.ingress;
         effectiveShouldComputeCommandAuthorized =
@@ -862,6 +885,7 @@ export async function handleFeishuMessage(params: {
       cfg: effectiveCfg,
       channel: "feishu",
       accountId: account.accountId,
+      conversationId: isGroup ? undefined : ctx.chatId,
       peer: {
         kind: isGroup ? "group" : "direct",
         id: peerId,
@@ -871,7 +895,7 @@ export async function handleFeishuMessage(params: {
 
     // Refresh a binding written after this request snapshot, or create the DM's
     // dynamic agent when the current account policy enables it.
-    if (!isGroup && route.matchedBy === "default") {
+    if (!isGroup && route.matchedBy === "default" && !effectiveDmRouteFailClosed) {
       const runtimeLocal = getFeishuRuntime();
       const result = await maybeCreateDynamicAgent({
         cfg: effectiveCfg,
@@ -895,6 +919,7 @@ export async function handleFeishuMessage(params: {
         }
         effectiveCfg = result.updatedCfg;
         effectiveDmPolicy = refreshedAuthorization.dmPolicy;
+        effectiveDmRouteFailClosed = refreshedAuthorization.dmRouteFailClosed;
         effectiveConfigAllowFrom = refreshedAuthorization.configAllowFrom;
         effectiveDmIngress = refreshedAuthorization.ingress;
         effectiveShouldComputeCommandAuthorized =
@@ -903,6 +928,7 @@ export async function handleFeishuMessage(params: {
           cfg: result.updatedCfg,
           channel: "feishu",
           accountId: account.accountId,
+          conversationId: ctx.chatId,
           peer: { kind: "direct", id: ctx.senderOpenId },
         });
         if (result.created) {
@@ -913,6 +939,9 @@ export async function handleFeishuMessage(params: {
       }
     }
 
+    const coreConversationBindingTargetAgentId =
+      route.matchedBy === "binding.conversation" ? route.bindingTargetAgentId : undefined;
+
     const commandAllowFrom = isGroup
       ? (groupConfig?.allowFrom ?? effectiveConfigAllowFrom)
       : (effectiveDmIngress?.senderAccess.effectiveAllowFrom ?? effectiveConfigAllowFrom);
@@ -920,6 +949,9 @@ export async function handleFeishuMessage(params: {
     const currentConversationId = peerId;
     const parentConversationId = isGroup ? (parentPeer?.id ?? ctx.chatId) : undefined;
     let configuredBinding = null;
+    let configuredConversationRouteMatched = false;
+    let runtimeConversationRouteMatched = false;
+    let overlayTargetAgentId: string | undefined;
     if (feishuAcpConversationSupported) {
       const configuredRoute = resolveConfiguredBindingRoute({
         cfg: effectiveCfg,
@@ -932,6 +964,8 @@ export async function handleFeishuMessage(params: {
         },
       });
       configuredBinding = configuredRoute.bindingResolution;
+      configuredConversationRouteMatched = Boolean(configuredRoute.boundAgentId?.trim());
+      overlayTargetAgentId = configuredRoute.boundAgentId;
       route = configuredRoute.route;
 
       // Bound Feishu conversations intentionally require an exact live conversation-id match.
@@ -947,6 +981,10 @@ export async function handleFeishuMessage(params: {
         },
       });
       route = runtimeRoute.route;
+      runtimeConversationRouteMatched = Boolean(runtimeRoute.boundAgentId?.trim());
+      overlayTargetAgentId = runtimeRoute.boundAgentId?.trim()
+        ? runtimeRoute.boundAgentId
+        : overlayTargetAgentId;
       if (runtimeRoute.bindingRecord) {
         configuredBinding = null;
         log(
@@ -954,6 +992,26 @@ export async function handleFeishuMessage(params: {
             ? `feishu[${account.accountId}]: routed via bound conversation ${currentConversationId} -> ${runtimeRoute.boundSessionKey}`
             : `feishu[${account.accountId}]: plugin-bound conversation ${currentConversationId}`,
         );
+      }
+    }
+
+    if (!isGroup && effectiveDmRouteFailClosed) {
+      if (!ctx.chatId.trim()) {
+        throw new FeishuRouteRejectionError("conversation_id_missing");
+      }
+      const overlayMatched = configuredConversationRouteMatched || runtimeConversationRouteMatched;
+      if (!coreConversationBindingTargetAgentId && !overlayMatched) {
+        throw new FeishuRouteRejectionError("unmatched");
+      }
+      const requiredAgentId = overlayMatched
+        ? (overlayTargetAgentId ?? route.agentId)
+        : coreConversationBindingTargetAgentId;
+      if (
+        !requiredAgentId ||
+        !hasConfiguredRouteAgent(effectiveCfg, requiredAgentId) ||
+        (!overlayMatched && normalizeAgentId(route.agentId) !== normalizeAgentId(requiredAgentId))
+      ) {
+        throw new FeishuRouteRejectionError("agent_not_found");
       }
     }
 

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -200,6 +200,35 @@ describe("FeishuConfigSchema replyInThread", () => {
   });
 });
 
+describe("FeishuConfigSchema dmRouteFailClosed", () => {
+  it("defaults to disabled when omitted", () => {
+    const result = FeishuConfigSchema.parse({});
+    expect(result.dmRouteFailClosed ?? false).toBe(false);
+  });
+
+  it("accepts top-level and account-level booleans", () => {
+    const result = FeishuConfigSchema.parse({
+      dmRouteFailClosed: true,
+      accounts: {
+        purchase: { dmRouteFailClosed: false },
+      },
+    });
+
+    expect(result.dmRouteFailClosed).toBe(true);
+    expect(result.accounts?.purchase?.dmRouteFailClosed).toBe(false);
+  });
+
+  it("rejects non-boolean values", () => {
+    const topLevel = FeishuConfigSchema.safeParse({ dmRouteFailClosed: "true" });
+    const accountLevel = FeishuConfigSchema.safeParse({
+      accounts: { purchase: { dmRouteFailClosed: "false" } },
+    });
+
+    expect(topLevel.success).toBe(false);
+    expect(accountLevel.success).toBe(false);
+  });
+});
+
 describe("FeishuConfigSchema optimization flags", () => {
   it("defaults top-level typingIndicator and resolveSenderNames to true", () => {
     const result = FeishuConfigSchema.parse({});

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -180,6 +180,7 @@ const FeishuSharedConfigShape = {
   capabilities: z.array(z.string()).optional(),
   markdown: MarkdownConfigSchema,
   configWrites: z.boolean().optional(),
+  dmRouteFailClosed: z.boolean().optional(),
   dmPolicy: DmPolicySchema.optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupPolicy: GroupPolicySchema.optional(),

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -472,6 +472,44 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts exact conversation route bindings", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "main" }, { id: "purchase" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "purchase",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "oc_test_purchase_chat",
+          },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects non-string conversation route identifiers", () => {
+    const res = validateConfigObject({
+      bindings: [
+        {
+          type: "route",
+          agentId: "purchase",
+          match: {
+            channel: "feishu",
+            conversationId: 12345,
+          },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
   it("accepts bindings that match normalized agents.list ids", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -215,6 +215,7 @@ const TARGET_KEYS = [
   "bindings[].match",
   "bindings[].match.channel",
   "bindings[].match.accountId",
+  "bindings[].match.conversationId",
   "bindings[].match.peer",
   "bindings[].match.peer.kind",
   "bindings[].match.peer.id",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -671,6 +671,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Channel/provider identifier this binding applies to, such as `telegram`, `discord`, or a plugin channel ID. Use the configured channel key exactly so binding evaluation works reliably.",
   "bindings[].match.accountId":
     "Optional account selector for multi-account channel setups so the binding applies only to one identity. Use this when account scoping is required for the route and leave unset otherwise.",
+  "bindings[].match.conversationId":
+    "Optional exact provider conversation/chat ID for route bindings. Use it for literal, account-scoped selection; wildcards, regular expressions, and fuzzy matching are not supported.",
   "bindings[].match.peer":
     "Optional peer matcher for specific conversations including peer kind and peer id. Use this when only one direct/group/channel target should be pinned to an agent.",
   "bindings[].match.peer.kind":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -415,6 +415,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "bindings[].match": "Binding Match Rule",
   "bindings[].match.channel": "Binding Channel",
   "bindings[].match.accountId": "Binding Account ID",
+  "bindings[].match.conversationId": "Binding Conversation ID",
   "bindings[].match.peer": "Binding Peer Match",
   "bindings[].match.peer.kind": "Binding Peer Kind",
   "bindings[].match.peer.id": "Binding Peer ID",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -44,6 +44,8 @@ export type AgentBindingMatch = {
    * - Any other string: matches that specific account id.
    */
   accountId?: string;
+  /** Exact provider conversation/chat id for route bindings. */
+  conversationId?: string;
   peer?: { kind: ChatType; id: string };
   guildId?: string;
   teamId?: string;
@@ -67,7 +69,7 @@ export type AgentAcpBinding = {
   type: "acp";
   agentId: string;
   comment?: string;
-  match: AgentBindingMatch;
+  match: Omit<AgentBindingMatch, "conversationId">;
   acp?: {
     mode?: "persistent" | "oneshot";
     label?: string;

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -36,6 +36,10 @@ const BindingMatchSchema = z
   })
   .strict();
 
+const RouteBindingMatchSchema = BindingMatchSchema.extend({
+  conversationId: z.string().trim().min(1).optional(),
+});
+
 const BindingSessionSchema = z
   .object({
     dmScope: z
@@ -54,7 +58,7 @@ const RouteBindingSchema = z
     type: z.literal("route").optional(),
     agentId: z.string(),
     comment: z.string().optional(),
-    match: BindingMatchSchema,
+    match: RouteBindingMatchSchema,
     session: BindingSessionSchema.optional(),
   })
   .strict();

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1,7 +1,10 @@
 // Route resolution tests cover resolving channel route targets from input.
 import { describe, expect, test, vi } from "vitest";
+import { resolveEffectiveToolPolicy } from "../agents/agent-tools.policy.js";
+import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as routingBindings from "./bindings.js";
+import { collectChannelRouteTargets } from "./channel-route-targets.js";
 import {
   deriveLastRoutePolicy,
   resolveAgentRoute,
@@ -114,6 +117,269 @@ describe("resolveAgentRoute", () => {
       lastRoutePolicy: "main",
       matchedBy: "default",
     });
+  });
+
+  test("routes only the exact Feishu account and conversation to the purchase agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "purchase" }, { id: "sender-agent" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "sender-agent",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "direct", id: "ou_test_sender" },
+          },
+        },
+        {
+          type: "route",
+          agentId: "purchase",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "oc_test_purchase_chat",
+          },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_test_purchase_chat",
+      peer: { kind: "direct", id: "ou_test_sender" },
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "purchase",
+      matchedBy: "binding.conversation",
+    });
+    expect(route.bindingTargetAgentId).toBe("purchase");
+
+    const otherAccountRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "secondary",
+      conversationId: "oc_test_purchase_chat",
+      peer: { kind: "direct", id: "ou_test_sender" },
+    });
+    expectResolvedRoute(otherAccountRoute, {
+      agentId: "main",
+      matchedBy: "default",
+    });
+  });
+
+  test.each([
+    {
+      name: "the same sender uses another conversation",
+      conversationId: "oc_test_other_chat",
+    },
+    {
+      name: "the provider conversation id is missing",
+      conversationId: undefined,
+    },
+  ])("does not match the purchase route when $name", ({ conversationId }) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "purchase" }, { id: "sender-agent" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "sender-agent",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "direct", id: "ou_test_sender" },
+          },
+        },
+        {
+          type: "route",
+          agentId: "purchase",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "oc_test_purchase_chat",
+          },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId,
+      peer: { kind: "direct", id: "ou_test_sender" },
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "sender-agent",
+      matchedBy: "binding.peer",
+    });
+  });
+
+  test("preserves the exact binding target when its agent is not configured", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "main" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "missing-purchase",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "oc_test_purchase_chat",
+          },
+        },
+      ],
+    } satisfies OpenClawConfig;
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_test_purchase_chat",
+      peer: { kind: "direct", id: "ou_test_sender" },
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "main",
+      matchedBy: "binding.conversation",
+    });
+    expect(route.bindingTargetAgentId).toBe("missing-purchase");
+  });
+
+  test("keeps channel/account-only diagnostic probes compatible", () => {
+    const cfg: OpenClawConfig = {
+      channels: { feishu: {} },
+      agents: { list: [{ id: "main" }, { id: "purchase" }] },
+      bindings: [
+        {
+          type: "route",
+          agentId: "purchase",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "oc_test_purchase_chat",
+          },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "main",
+      matchedBy: "default",
+    });
+    expect(collectChannelRouteTargets(cfg)).toEqual([
+      { agentId: "main", channels: ["feishu"] },
+      { agentId: "purchase", channels: ["feishu"] },
+    ]);
+  });
+
+  test("does not apply the Feishu-only fail-closed setting to other channels", () => {
+    const cfg = {
+      channels: {
+        feishu: { dmRouteFailClosed: true },
+      },
+      agents: {
+        list: [{ id: "main" }, { id: "discord-agent" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "discord-agent",
+          match: {
+            channel: "discord",
+            peer: { kind: "direct", id: "discord-user" },
+          },
+        },
+      ],
+    } as unknown as OpenClawConfig;
+
+    const matchedRoute = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "direct", id: "discord-user" },
+    });
+    expectResolvedRoute(matchedRoute, {
+      agentId: "discord-agent",
+      matchedBy: "binding.peer",
+    });
+
+    const fallbackRoute = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "direct", id: "other-user" },
+    });
+    expectResolvedRoute(fallbackRoute, {
+      agentId: "main",
+      matchedBy: "default",
+    });
+  });
+
+  test("reuses the routed agent tool allowlist for the purchase route", () => {
+    const disallowedTools = [
+      "grasp_query_bill",
+      "grasp_query_inventory",
+      "grasp_query_customer",
+      "grasp_query_product",
+      "grasp_prepare_bill",
+      "grasp_entry_message",
+    ];
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main" },
+          {
+            id: "purchase",
+            tools: {
+              allow: ["grasp_prepare_purchase_order"],
+              deny: disallowedTools,
+            },
+          },
+        ],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "purchase",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "oc_test_purchase_chat",
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_test_purchase_chat",
+      peer: { kind: "direct", id: "ou_test_sender" },
+    });
+    const policy = resolveEffectiveToolPolicy({
+      config: cfg,
+      agentId: route.agentId,
+    }).agentPolicy;
+
+    expect(isToolAllowedByPolicyName("grasp_prepare_purchase_order", policy)).toBe(true);
+    expect(disallowedTools.every((tool) => !isToolAllowedByPolicyName(tool, policy))).toBe(true);
   });
 
   test("uses the configured main session key for shared direct routes", () => {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -35,6 +35,8 @@ export type ResolveAgentRouteInput = {
   cfg: OpenClawConfig;
   channel: string;
   accountId?: string | null;
+  /** Provider conversation/chat id used only for exact route bindings. */
+  conversationId?: string | null;
   peer?: RoutePeer | null;
   /** Parent peer for threads — used for binding inheritance when peer doesn't match directly. */
   parentPeer?: RoutePeer | null;
@@ -46,6 +48,8 @@ export type ResolveAgentRouteInput = {
 
 export type ResolvedAgentRoute = {
   agentId: string;
+  /** Exact conversation binding target before legacy missing-agent fallback. */
+  bindingTargetAgentId?: string;
   channel: string;
   accountId: string;
   /** Effective direct-message scope after a matching binding override. */
@@ -58,6 +62,7 @@ export type ResolvedAgentRoute = {
   lastRoutePolicy: "main" | "session";
   /** Match description for debugging/logging. */
   matchedBy:
+    | "binding.conversation"
     | "binding.peer"
     | "binding.peer.parent"
     | "binding.peer.wildcard"
@@ -179,6 +184,7 @@ type NormalizedPeerConstraint =
 
 type NormalizedBindingMatch = {
   accountPattern: string;
+  conversationId: string | null;
   peer: NormalizedPeerConstraint;
   guildId: string | null;
   teamId: string | null;
@@ -192,6 +198,7 @@ type EvaluatedBinding = {
 };
 
 type BindingScope = {
+  conversationId: string;
   peer: RoutePeer | null;
   guildId: string;
   teamId: string;
@@ -219,6 +226,7 @@ const resolvedRouteCacheByCfg = new WeakMap<
 const MAX_RESOLVED_ROUTE_CACHE_KEYS = 4000;
 
 type EvaluatedBindingsIndex = {
+  byConversation: Map<string, EvaluatedBinding[]>;
   byPeer: Map<string, EvaluatedBinding[]>;
   byPeerWildcard: EvaluatedBinding[];
   byGuildWithRoles: Map<string, EvaluatedBinding[]>;
@@ -375,6 +383,7 @@ function collectPeerIndexedBindings(
 }
 
 function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBindingsIndex {
+  const byConversation = new Map<string, EvaluatedBinding[]>();
   const byPeer = new Map<string, EvaluatedBinding[]>();
   const byPeerWildcard: EvaluatedBinding[] = [];
   const byGuildWithRoles = new Map<string, EvaluatedBinding[]>();
@@ -384,6 +393,10 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
   const byChannel: EvaluatedBinding[] = [];
 
   for (const binding of bindings) {
+    if (binding.match.conversationId) {
+      pushToIndexMap(byConversation, binding.match.conversationId, binding);
+      continue;
+    }
     if (binding.match.peer.state === "valid") {
       for (const key of peerLookupKeys(binding.match.peer.kind, binding.match.peer.id)) {
         pushToIndexMap(byPeer, key, binding);
@@ -414,6 +427,7 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
   }
 
   return {
+    byConversation,
     byPeer,
     byPeerWildcard,
     byGuildWithRoles,
@@ -505,6 +519,7 @@ function normalizeBindingMatch(
   match:
     | {
         accountId?: string | undefined;
+        conversationId?: string | undefined;
         peer?: { kind?: string; id?: string } | undefined;
         guildId?: string | undefined;
         teamId?: string | undefined;
@@ -515,6 +530,7 @@ function normalizeBindingMatch(
   const rawRoles = match?.roles;
   return {
     accountPattern: (match?.accountId ?? "").trim(),
+    conversationId: normalizeId(match?.conversationId) || null,
     peer: normalizePeerConstraint(match?.peer),
     guildId: normalizeId(match?.guildId) || null,
     teamId: normalizeId(match?.teamId) || null,
@@ -568,6 +584,7 @@ function formatRoleIdsCacheKey(roleIds: string[]): string {
 function buildResolvedRouteCacheKey(params: {
   channel: string;
   accountId: string;
+  conversationId: string;
   peer: RoutePeer | null;
   parentPeer: RoutePeer | null;
   guildId: string;
@@ -575,7 +592,7 @@ function buildResolvedRouteCacheKey(params: {
   memberRoleIds: string[];
   dmScope: string;
 }): string {
-  return `${params.channel}\t${params.accountId}\t${formatRouteCachePeer(params.peer)}\t${formatRouteCachePeer(params.parentPeer)}\t${params.guildId || "-"}\t${params.teamId || "-"}\t${formatRoleIdsCacheKey(params.memberRoleIds)}\t${params.dmScope}`;
+  return `${params.channel}\t${params.accountId}\t${params.conversationId || "-"}\t${formatRouteCachePeer(params.peer)}\t${formatRouteCachePeer(params.parentPeer)}\t${params.guildId || "-"}\t${params.teamId || "-"}\t${formatRoleIdsCacheKey(params.memberRoleIds)}\t${params.dmScope}`;
 }
 
 function hasGuildConstraint(match: NormalizedBindingMatch): boolean {
@@ -591,6 +608,9 @@ function hasRolesConstraint(match: NormalizedBindingMatch): boolean {
 }
 
 function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope): boolean {
+  if (match.conversationId && match.conversationId !== scope.conversationId) {
+    return false;
+  }
   if (match.peer.state === "invalid") {
     return false;
   }
@@ -614,6 +634,7 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
+  const conversationId = normalizeId(input.conversationId);
   const peer = input.peer
     ? {
         kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
@@ -640,6 +661,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     ? buildResolvedRouteCacheKey({
         channel,
         accountId,
+        conversationId,
         peer,
         parentPeer,
         guildId,
@@ -682,6 +704,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     );
     const route = {
       agentId: resolvedAgentId,
+      ...(matchedBy === "binding.conversation"
+        ? { bindingTargetAgentId: normalizeAgentId(agentId) }
+        : {}),
       channel,
       accountId,
       dmScope: effectiveDmScope,
@@ -717,16 +742,17 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   if (shouldLogDebug) {
     logDebug(
-      `[routing] resolveAgentRoute: channel=${channel} accountId=${accountId} peer=${formatPeer(peer)} guildId=${guildId || "none"} teamId=${teamId || "none"} bindings=${bindings.length}`,
+      `[routing] resolveAgentRoute: channel=${channel} accountId=${accountId} conversationId=${conversationId ? "present" : "none"} peer=${formatPeer(peer)} guildId=${guildId || "none"} teamId=${teamId || "none"} bindings=${bindings.length}`,
     );
     for (const entry of bindings) {
       logDebug(
-        `[routing] binding: agentId=${entry.binding.agentId} accountPattern=${entry.match.accountPattern || "default"} peer=${formatNormalizedPeer(entry.match.peer)} guildId=${entry.match.guildId ?? "none"} teamId=${entry.match.teamId ?? "none"} roles=${entry.match.roles?.length ?? 0}`,
+        `[routing] binding: agentId=${entry.binding.agentId} accountPattern=${entry.match.accountPattern || "default"} conversationId=${entry.match.conversationId ? "present" : "none"} peer=${formatNormalizedPeer(entry.match.peer)} guildId=${entry.match.guildId ?? "none"} teamId=${entry.match.teamId ?? "none"} roles=${entry.match.roles?.length ?? 0}`,
       );
     }
   }
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
   const baseScope = {
+    conversationId,
     guildId,
     teamId,
     memberRoleIds: memberRoleIdSet,
@@ -739,6 +765,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     candidates: EvaluatedBinding[];
     predicate: (candidate: EvaluatedBinding) => boolean;
   }> = [
+    {
+      matchedBy: "binding.conversation",
+      enabled: Boolean(conversationId),
+      scopePeer: peer,
+      candidates: conversationId ? (bindingsIndex.byConversation.get(conversationId) ?? []) : [],
+      predicate: (candidate) => Boolean(candidate.match.conversationId),
+    },
     {
       matchedBy: "binding.peer",
       enabled: Boolean(peer),


### PR DESCRIPTION
Closes #110349

## What Problem This Solves

Resolves a problem where operators cannot bind one Feishu private conversation to a restricted agent without sender-scoped bindings also affecting the same sender in other conversations. For opt-in procurement-style workflows, an unmatched conversation, missing conversation ID, or unavailable target agent must stop before dispatch instead of reaching the main agent.

## Why This Change Was Made

This AI-assisted change adds exact literal `bindings[].match.conversationId` matching within the existing channel/account binding model and a Feishu-only `channels.feishu.dmRouteFailClosed` flag that defaults to `false` and follows existing account override behavior. The final DM gate runs after core routing, configured ACP overlays, and runtime ACP overlays; it does not add a global fallback switch, regex/fuzzy matching, a routing DSL, or changes to non-Feishu behavior.

## User Impact

Feishu operators can dedicate an exact private conversation to a restricted agent while keeping other conversations from the same sender isolated. When fail-closed mode is enabled, unmatched DMs, missing conversation IDs, missing agent targets, and plugin-owned runtime records without a core-routable agent are rejected before agent dispatch. Existing behavior remains unchanged when the flag is disabled.

## Evidence

Local/offline validation only:

- Focused routing, Feishu, schema, config metadata, and tool-policy tests: 4 shards, 250 tests passed.
- Final targeted Feishu bot test: 1 file, 100 tests passed.
- Final complete Feishu suite: 75 files, 1044 tests passed.
- Routing suite: 7 files, 197 tests passed.
- Config schema suites: 27 files, 297 tests passed.
- Doctor-related suites: 52 files, 801 tests passed.
- Full production build passed after the final fix.
- Changed-file gate passed 21/21 checks after the final fix, including core/core-test/extension/extension-test typechecks, core and extension lint, import-cycle checks, and routing boundary guards.
- Fresh local autoreview reported no accepted or actionable findings.
- `git diff --check` passed.

The local runtime reported Node 24.14.0 while the repository engine floor is Node 24.15.0; all commands above nevertheless completed successfully. No live Feishu route, deployment, runtime configuration change, OpenClaw restart, external tool invocation, purchase draft, BusinessQuery, BusinessProcess, GuanJiaPo API call, or ERP write was performed.