### PR TITLE
ci(release): enforce reusable permission ceiling

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -389,7 +389,8 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
+      pull-requests: read
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
       ref: ${{ needs.resolve_target.outputs.sha }}

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -207,6 +207,7 @@ describe("release validation no-push transport", () => {
 
   it("keeps every local reusable-workflow permission request within its caller ceiling", () => {
     const readOnlyCalls = [
+      [FULL_RELEASE, "prepare_release_candidate"],
       [PLUGIN_PRERELEASE, "plugin-prerelease-docker-suite"],
       [RELEASE_CHECKS, "live_repo_e2e_release_checks"],
       [RELEASE_CHECKS, "docker_e2e_release_checks"],


### PR DESCRIPTION
## What Problem This Solves

The beta-profile dry validation run failed before scheduling any job because the new shared-candidate reusable-workflow caller omitted the callee's required `pull-requests: read` permission. The caller also retained unnecessary package write access.

Failed startup proof: https://github.com/openclaw/openclaw/actions/runs/29627864974

## Why This Change Was Made

Grant the exact read-only permission ceiling required by the reusable workflow, reduce `packages` from write to read, and include this caller in the reusable-permission contract test so future drift fails CI before dispatch.

## User Impact

Full release validation can schedule its shared-candidate preparation job. No product behavior or release artifact changes.

## Evidence

- `actionlint .github/workflows/full-release-validation.yml`
- Testbox `tbx_01kxsjh3zzz2465zweyx1q3ezh`: 14 focused tests passed
- Testbox path-scoped `pnpm check:changed`: passed
- Fresh autoreview: clean
