### PR TITLE
fix(doctor): warn when maxActiveTranscriptBytes is set without truncateAfterCompaction

### DIFF
--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -81,7 +81,7 @@ export async function runCoreContributionHealth(
   }
 }
 
-function formatHealthFindings(findings: readonly HealthFinding[]): string {
+export function formatHealthFindings(findings: readonly HealthFinding[]): string {
   return findings
     .map((finding) => {
       const lines = [`- ${finding.message}`];

--- a/src/flows/doctor-health-contribution-runners.state.ts
+++ b/src/flows/doctor-health-contribution-runners.state.ts
@@ -1,6 +1,9 @@
 import { isLegacyParentWritableUpdateDoctorPass } from "../commands/doctor/shared/update-phase.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { formatHealthFindings } from "./doctor-health-contribution-core.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
+import type { HealthFinding } from "./health-checks.js";
 
 const loadDoctorStateIntegrityModule = async () =>
   await import("../commands/doctor-state-integrity.js");
@@ -150,4 +153,49 @@ export async function runSandboxHealth(ctx: DoctorHealthFlowContext): Promise<vo
   await maybeRepairSandboxRegistryFiles(ctx.prompter);
   ctx.cfg = await maybeRepairSandboxImages(ctx.cfg, ctx.runtime, ctx.prompter);
   noteSandboxScopeWarnings(ctx.cfg);
+}
+
+export async function collectCompactionByteGuardFindings(
+  cfg: OpenClawConfig,
+): Promise<readonly HealthFinding[]> {
+  const compaction = cfg.agents?.defaults?.compaction;
+  if (!compaction) {
+    return [];
+  }
+
+  const configured = compaction.maxActiveTranscriptBytes;
+  if (configured === undefined || configured === null) {
+    return [];
+  }
+
+  const str = String(configured).trim();
+  if (str === "" || str === "0") {
+    return [];
+  }
+
+  const truncateEnabled = compaction.truncateAfterCompaction === true;
+  if (truncateEnabled) {
+    return [];
+  }
+
+  return [
+    {
+      checkId: "core/doctor/inactive-compaction-byte-guard",
+      severity: "warning",
+      message: `agents.defaults.compaction.maxActiveTranscriptBytes is set to "${str}" but truncateAfterCompaction is not enabled, so the byte guard has no effect.`,
+      path: "agents.defaults.compaction",
+      requirement: "truncateAfterCompaction enabled when maxActiveTranscriptBytes is configured",
+      fixHint:
+        "Set agents.defaults.compaction.truncateAfterCompaction to true or remove maxActiveTranscriptBytes.",
+    },
+  ];
+}
+
+export async function runCompactionByteGuardHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const findings = await collectCompactionByteGuardFindings(ctx.cfg);
+  if (findings.length === 0) {
+    return;
+  }
+  const { note } = await import("../../packages/terminal-core/src/note.js");
+  note(formatHealthFindings(findings), "Compaction byte guard");
 }

--- a/src/flows/doctor-health-contribution-runners.state.ts
+++ b/src/flows/doctor-health-contribution-runners.state.ts
@@ -1,4 +1,5 @@
 import { isLegacyParentWritableUpdateDoctorPass } from "../commands/doctor/shared/update-phase.js";
+import { parseNonNegativeByteSize } from "../config/byte-size.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { formatHealthFindings } from "./doctor-health-contribution-core.js";
@@ -168,8 +169,8 @@ export async function collectCompactionByteGuardFindings(
     return [];
   }
 
-  const str = String(configured).trim();
-  if (str === "" || str === "0") {
+  const effectiveBytes = parseNonNegativeByteSize(configured);
+  if (effectiveBytes === null || effectiveBytes <= 0) {
     return [];
   }
 
@@ -178,11 +179,12 @@ export async function collectCompactionByteGuardFindings(
     return [];
   }
 
+  const displayValue = String(configured).trim();
   return [
     {
       checkId: "core/doctor/inactive-compaction-byte-guard",
       severity: "warning",
-      message: `agents.defaults.compaction.maxActiveTranscriptBytes is set to "${str}" but truncateAfterCompaction is not enabled, so the byte guard has no effect.`,
+      message: `agents.defaults.compaction.maxActiveTranscriptBytes is set to "${displayValue}" but truncateAfterCompaction is not enabled, so the byte guard has no effect.`,
       path: "agents.defaults.compaction",
       requirement: "truncateAfterCompaction enabled when maxActiveTranscriptBytes is configured",
       fixHint:

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -353,7 +353,6 @@ export function resolveInitialDoctorHealthContributions(params: {
         id: "core/doctor/inactive-compaction-byte-guard",
         description:
           "Warn when maxActiveTranscriptBytes is configured but truncateAfterCompaction is not enabled, leaving the byte guard inactive.",
-        defaultEnabled: false,
         detect: async (ctx) => collectCompactionByteGuardFindings(ctx.cfg),
       },
       run: runCompactionByteGuardHealth,

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -3,8 +3,10 @@ import {
   runCommandOwnerHealth,
 } from "./doctor-health-contribution-runners.gateway.js";
 import {
+  collectCompactionByteGuardFindings,
   runChannelIngressDeadLettersHealth,
   runCodexSessionRouteHealth,
+  runCompactionByteGuardHealth,
   runConfigAuditScrubHealth,
   runDatabaseBloatHealth,
   runDiskSpaceHealth,
@@ -343,6 +345,18 @@ export function resolveInitialDoctorHealthContributions(params: {
       label: "Legacy cron",
       healthCheckIds: ["core/doctor/legacy-whatsapp-crontab", "core/doctor/legacy-cron-store"],
       run: runLegacyCronHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:compaction-byte-guard",
+      label: "Compaction byte guard",
+      healthChecks: {
+        id: "core/doctor/inactive-compaction-byte-guard",
+        description:
+          "Warn when maxActiveTranscriptBytes is configured but truncateAfterCompaction is not enabled, leaving the byte guard inactive.",
+        defaultEnabled: false,
+        detect: async (ctx) => collectCompactionByteGuardFindings(ctx.cfg),
+      },
+      run: runCompactionByteGuardHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:sandbox",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1803,6 +1803,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
     expect(contributionIds).toContain("core/doctor/channel-preview-warnings");
     expect(contributionIds).toContain("core/doctor/systemd-linger");
+    expect(contributionIds).toContain("core/doctor/inactive-compaction-byte-guard");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
 
@@ -1869,6 +1870,119 @@ describe("doctor health contributions", () => {
       });
     });
     expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
+  });
+
+  it("warns when maxActiveTranscriptBytes is set but truncateAfterCompaction is not enabled", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const check = contributionChecks.find(
+      (entry) => entry.id === "core/doctor/inactive-compaction-byte-guard",
+    );
+    expect(check).toMatchObject({ defaultEnabled: false });
+    expect(check).toBeDefined();
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "100MB",
+              truncateAfterCompaction: false,
+            },
+          },
+        },
+      },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+
+    // defaultEnabled=false → skipped unless explicitly included
+    await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [check!],
+        onlyIds: ["core/doctor/inactive-compaction-byte-guard"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/inactive-compaction-byte-guard",
+          severity: "warning",
+          path: "agents.defaults.compaction",
+        }),
+      ],
+    });
+  });
+
+  it("stays silent when truncateAfterCompaction is enabled", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const check = contributionChecks.find(
+      (entry) => entry.id === "core/doctor/inactive-compaction-byte-guard",
+    );
+    expect(check).toBeDefined();
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "100MB",
+              truncateAfterCompaction: true,
+            },
+          },
+        },
+      },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [check!],
+        onlyIds: ["core/doctor/inactive-compaction-byte-guard"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [],
+    });
+  });
+
+  it("stays silent when maxActiveTranscriptBytes is not configured", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const check = contributionChecks.find(
+      (entry) => entry.id === "core/doctor/inactive-compaction-byte-guard",
+    );
+    expect(check).toBeDefined();
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: false,
+            },
+          },
+        },
+      },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [check!],
+        onlyIds: ["core/doctor/inactive-compaction-byte-guard"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [],
+    });
   });
 
   it("keeps stale plugin-runtime symlinks opt-in for structured lint selection", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2032,6 +2032,44 @@ describe("doctor health contributions", () => {
     expect(mocks.collectStalePluginRuntimeSymlinkHealthFindings).toHaveBeenCalledTimes(1);
   });
 
+  it("stays silent for zero-value byte sizes like 0, 0mb, or 0kb", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const check = contributionChecks.find(
+      (entry) => entry.id === "core/doctor/inactive-compaction-byte-guard",
+    );
+    expect(check).toBeDefined();
+
+    const zeroValues: Array<unknown> = [0, "0", "0mb", "0MB", "0kb", "0gb", "0b"];
+
+    for (const value of zeroValues) {
+      const ctx = {
+        cfg: {
+          agents: {
+            defaults: {
+              compaction: {
+                maxActiveTranscriptBytes: value,
+                truncateAfterCompaction: false,
+              },
+            },
+          },
+        },
+        mode: "lint",
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      } as const;
+
+      await expect(
+        runDoctorLintChecks(ctx, {
+          checks: [check!],
+          onlyIds: ["core/doctor/inactive-compaction-byte-guard"],
+        }),
+      ).resolves.toMatchObject({
+        checksRun: 1,
+        checksSkipped: 0,
+        findings: [],
+      });
+    }
+  });
+
   it("keeps legacy plugin dependency lint opt-in and read-only", async () => {
     const openClawState = await createOpenClawTestState({
       layout: "state-only",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2039,7 +2039,7 @@ describe("doctor health contributions", () => {
     );
     expect(check).toBeDefined();
 
-    const zeroValues: Array<unknown> = [0, "0", "0mb", "0MB", "0kb", "0gb", "0b"];
+    const zeroValues: Array<string | number> = [0, "0", "0mb", "0MB", "0kb", "0gb", "0b"];
 
     for (const value of zeroValues) {
       const ctx = {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1877,8 +1877,8 @@ describe("doctor health contributions", () => {
     const check = contributionChecks.find(
       (entry) => entry.id === "core/doctor/inactive-compaction-byte-guard",
     );
-    expect(check).toMatchObject({ defaultEnabled: false });
     expect(check).toBeDefined();
+    expect(check).not.toHaveProperty("defaultEnabled", false);
 
     const ctx = {
       cfg: {
@@ -1895,17 +1895,8 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
     } as const;
 
-    // defaultEnabled=false → skipped unless explicitly included
+    // Default doctor lint runs the check without needing --only.
     await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
-      checksRun: 0,
-      checksSkipped: 1,
-    });
-    await expect(
-      runDoctorLintChecks(ctx, {
-        checks: [check!],
-        onlyIds: ["core/doctor/inactive-compaction-byte-guard"],
-      }),
-    ).resolves.toMatchObject({
       checksRun: 1,
       checksSkipped: 0,
       findings: [


### PR DESCRIPTION
## What Problem This Solves
Fixes #100529
- **Problem:** `resolveMaxActiveTranscriptBytes()` at `src/auto-reply/reply/memory-flush.ts:27-29` returns `undefined` when `truncateAfterCompaction` is not `true`, even when `maxActiveTranscriptBytes` is configured with a positive value. The byte guard silently has no effect, and no diagnostic warns the operator.
- **Solution:** Add a Doctor health check (`core/doctor/inactive-compaction-byte-guard`) that runs in the default `openclaw doctor --lint` path. It warns when `maxActiveTranscriptBytes` resolves to a positive effective byte limit while `truncateAfterCompaction` is not enabled. Uses `parseNonNegativeByteSize` to normalize values so zero-value forms (`"0mb"`, `0`, etc.) do not produce false-positive warnings.

## What changed

- `src/flows/doctor-health-contributions.ts` — added `collectCompactionByteGuardFindings` (uses `parseNonNegativeByteSize`), `runCompactionByteGuardHealth`, and the `doctor:compaction-byte-guard` contribution. Runs in the default Doctor lint path (no `defaultEnabled: false` gate).
- `src/flows/doctor-health-contributions.test.ts` — 4 test cases covering all config states plus zero-value forms.

## Evidence

All cases below run the built `openclaw doctor --lint` against a minimal `openclaw.json` config. The check runs in the default path (22 core checks, no `--only` filtering). Output is JSON mode (stdout not a TTY).

### Case A: Warning — `maxActiveTranscriptBytes=100MB`, `truncateAfterCompaction=false`

Config: `{"agents":{"defaults":{"compaction":{"maxActiveTranscriptBytes":"100MB","truncateAfterCompaction":false}}}}`

```
$ OPENCLAW_CONFIG_PATH=/tmp/proof-warn.json OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 node openclaw.mjs doctor --lint
{"ok":false,"checksRun":22,"checksSkipped":31,"findings":[
  ...,
  {"checkId":"core/doctor/inactive-compaction-byte-guard","severity":"warning","message":"agents.defaults.compaction.maxActiveTranscriptBytes is set to \"100MB\" but truncateAfterCompaction is not enabled, so the byte guard has no effect.","path":"agents.defaults.compaction","requirement":"truncateAfterCompaction enabled when maxActiveTranscriptBytes is configured","fixHint":"Set agents.defaults.compaction.truncateAfterCompaction to true or remove maxActiveTranscriptBytes."}
]}
```

→ `inactive-compaction-byte-guard` warning present. Exit code 1 (findings exist).

### Case B: Silent — `maxActiveTranscriptBytes=0mb`, `truncateAfterCompaction=false` (zero-value)

Config: `{"agents":{"defaults":{"compaction":{"maxActiveTranscriptBytes":"0mb","truncateAfterCompaction":false}}}}`

```
$ OPENCLAW_CONFIG_PATH=/tmp/proof-silent-zero.json OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 node openclaw.mjs doctor --lint
{"ok":false,"checksRun":22,"checksSkipped":31,"findings":[...]}
```

→ No `inactive-compaction-byte-guard` finding. Zero-value forms ("0mb", "0", etc.) do not trigger false positives.

### Case C: Silent — `maxActiveTranscriptBytes=100MB`, `truncateAfterCompaction=true` (guard active)

Config: `{"agents":{"defaults":{"compaction":{"maxActiveTranscriptBytes":"100MB","truncateAfterCompaction":true}}}}`

```
$ OPENCLAW_CONFIG_PATH=/tmp/proof-silent-truncate.json OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 node openclaw.mjs doctor --lint
{"ok":false,"checksRun":22,"checksSkipped":31,"findings":[...]}
```

→ No `inactive-compaction-byte-guard` finding. Truncation enabled → guard works → warning suppressed.

### Test Suite

```
$ node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts
 Test Files  1 passed (1)
      Tests  94 passed (94)
```