### PR TITLE
fix(msteams): preserve inbound activities before webhook ack

### DIFF
--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -93,7 +93,7 @@ async function runMessageActivity(params: {
   deps?: MSTeamsMessageHandlerDeps;
 }) {
   const deps = params.deps ?? createDeps();
-  let messageHandler: ((context: unknown, next: () => Promise<void>) => Promise<void>) | undefined;
+  let messageHandler: Parameters<MSTeamsActivityHandler["onMessage"]>[0] | undefined;
   const handler: MSTeamsActivityHandler = {
     onMessage: (callback) => {
       messageHandler = callback;

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -6,12 +6,17 @@ import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
 import { createMSTeamsReactionHandler } from "./monitor-handler/reaction-handler.js";
+import type { MSTeamsIngressDispatchResult, MSTeamsIngressLifecycle } from "./msteams-ingress.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 import { buildGroupWelcomeText, buildWelcomeCard } from "./welcome-card.js";
 
 export type MSTeamsActivityHandler = {
   onMessage: (
-    handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
+    handler: (
+      context: unknown,
+      next: () => Promise<void>,
+      turnAdoptionLifecycle?: MSTeamsIngressLifecycle,
+    ) => Promise<MSTeamsIngressDispatchResult | void>,
   ) => MSTeamsActivityHandler;
   onMembersAdded: (
     handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
@@ -22,7 +27,10 @@ export type MSTeamsActivityHandler = {
   onReactionsRemoved: (
     handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
   ) => MSTeamsActivityHandler;
-  run?: (context: unknown) => Promise<void>;
+  run?: (
+    context: unknown,
+    turnAdoptionLifecycle?: MSTeamsIngressLifecycle,
+  ) => Promise<MSTeamsIngressDispatchResult | void>;
 };
 
 async function isInvokeAuthorized(params: {
@@ -139,7 +147,7 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
   // Wrap the original run method to intercept invokes
   const originalRun = handler.run;
   if (originalRun) {
-    handler.run = async (context: unknown) => {
+    handler.run = async (context: unknown, turnAdoptionLifecycle?: MSTeamsIngressLifecycle) => {
       const ctx = context as MSTeamsTurnContext;
       // Non-poll adaptiveCard/action invokes get dispatched here as text so the
       // agent can react. Poll votes are intercepted in monitor.ts's
@@ -147,29 +155,38 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "adaptiveCard/action") {
         const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
         if (text) {
-          await handleTeamsMessage({
-            ...ctx,
-            activity: {
-              ...ctx.activity,
-              type: "message",
-              text,
+          return await handleTeamsMessage(
+            {
+              ...ctx,
+              activity: {
+                ...ctx.activity,
+                type: "message",
+                text,
+              },
             },
-          });
+            turnAdoptionLifecycle,
+          );
         }
         return;
       }
 
-      return originalRun.call(handler, context);
+      return originalRun.call(handler, context, turnAdoptionLifecycle);
     };
   }
 
-  handler.onMessage(async (context, next) => {
+  handler.onMessage(async (context, next, turnAdoptionLifecycle) => {
     try {
-      await handleTeamsMessage(context as MSTeamsTurnContext);
+      const result = await handleTeamsMessage(context as MSTeamsTurnContext, turnAdoptionLifecycle);
+      await next();
+      return result;
     } catch (err) {
+      if (turnAdoptionLifecycle) {
+        throw err;
+      }
       deps.runtime.error(`msteams handler failed: ${formatUnknownError(err)}`);
     }
     await next();
+    return undefined;
   });
 
   handler.onMembersAdded(async (context, next) => {

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -175,9 +175,14 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
   }
 
   handler.onMessage(async (context, next, turnAdoptionLifecycle) => {
+    let nextRan = false;
+    const runNext = async () => {
+      nextRan = true;
+      await next();
+    };
     try {
       const result = await handleTeamsMessage(context as MSTeamsTurnContext, turnAdoptionLifecycle);
-      await next();
+      await runNext();
       return result;
     } catch (err) {
       if (turnAdoptionLifecycle) {
@@ -185,7 +190,9 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       }
       deps.runtime.error(`msteams handler failed: ${formatUnknownError(err)}`);
     }
-    await next();
+    if (!nextRan) {
+      await runNext();
+    }
     return undefined;
   });
 

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -1,0 +1,159 @@
+// Microsoft Teams tests cover durable claim ownership through inbound debounce.
+import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../runtime-api.js";
+import type { MSTeamsIngressLifecycle } from "../msteams-ingress.js";
+import type { MSTeamsTurnContext } from "../sdk-types.js";
+import "./message-handler-mock-support.test-support.js";
+import { getRuntimeApiMockState } from "./message-handler-mock-support.test-support.js";
+import { createMSTeamsMessageHandler } from "./message-handler.js";
+import { buildChannelActivity, createMessageHandlerDeps } from "./message-handler.test-support.js";
+
+const runtimeApiMockState = getRuntimeApiMockState();
+
+function createLifecycle(): MSTeamsIngressLifecycle & {
+  adoptedCount: () => number;
+  abandonedCount: () => number;
+} {
+  let adopted = 0;
+  let abandoned = 0;
+  return {
+    abortSignal: new AbortController().signal,
+    onAdopted: async () => {
+      adopted += 1;
+    },
+    onDeferred: () => {},
+    onAdoptionFinalizing: () => {},
+    onAbandoned: async () => {
+      abandoned += 1;
+    },
+    adoptedCount: () => adopted,
+    abandonedCount: () => abandoned,
+  };
+}
+
+function context(activity: MSTeamsTurnContext["activity"]): MSTeamsTurnContext {
+  return {
+    activity,
+    sendActivity: vi.fn(async () => ({ id: "sent" })),
+    sendActivities: vi.fn(async () => []),
+    updateActivity: vi.fn(async () => ({ id: "updated" })),
+    deleteActivity: vi.fn(async () => {}),
+  };
+}
+
+function directActivity(id: string, text: string): MSTeamsTurnContext["activity"] {
+  return {
+    ...buildChannelActivity({
+      id,
+      text,
+      conversation: { id: "dm-conversation", conversationType: "personal" },
+      channelData: {},
+      entities: [],
+    }),
+  } as MSTeamsTurnContext["activity"];
+}
+
+function createHandler(cfg: OpenClawConfig) {
+  const { deps } = createMessageHandlerDeps(cfg, {
+    createInboundDebouncer,
+    resolveInboundDebounceMs: vi.fn(() => 40),
+  });
+  return createMSTeamsMessageHandler(deps);
+}
+
+describe("Microsoft Teams drain claim ownership", () => {
+  beforeEach(() => {
+    runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mockClear();
+  });
+
+  it("defers a claimed activity and binds completion to reply adoption", async () => {
+    const handler = createHandler({
+      channels: { msteams: { dmPolicy: "open", allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    const lifecycle = createLifecycle();
+
+    const result = await handler(context(directActivity("activity-one", "hello")), lifecycle);
+
+    expect(result).toEqual({ kind: "deferred" });
+    await vi.waitFor(
+      () => {
+        expect(
+          runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher,
+        ).toHaveBeenCalledTimes(1);
+        expect(lifecycle.adoptedCount()).toBe(1);
+      },
+      { timeout: 5_000 },
+    );
+    const dispatchParams = runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock
+      .calls[0]?.[0] as
+      | { replyOptions?: { turnAdoptionLifecycle?: { admission?: string } } }
+      | undefined;
+    expect(dispatchParams?.replyOptions?.turnAdoptionLifecycle).toMatchObject({
+      admission: "exclusive",
+    });
+    expect(lifecycle.abandonedCount()).toBe(0);
+  });
+
+  it("fans merged-flush adoption to every constituent claim", async () => {
+    const handler = createHandler({
+      messages: { inbound: { debounceMs: 40 } },
+      channels: { msteams: { dmPolicy: "open", allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    const first = createLifecycle();
+    const second = createLifecycle();
+
+    const results = [
+      await handler(context(directActivity("activity-first", "part one")), first),
+      await handler(context(directActivity("activity-second", "part two")), second),
+    ];
+
+    expect(results).toEqual([{ kind: "deferred" }, { kind: "deferred" }]);
+    await vi.waitFor(
+      () => {
+        expect(
+          runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher,
+        ).toHaveBeenCalledTimes(1);
+        expect(first.adoptedCount()).toBe(1);
+        expect(second.adoptedCount()).toBe(1);
+      },
+      { timeout: 5_000 },
+    );
+    const dispatchParams = runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock
+      .calls[0]?.[0] as { ctxPayload?: { BodyForAgent?: string } } | undefined;
+    expect(dispatchParams?.ctxPayload?.BodyForAgent).toContain("part one\npart two");
+    expect(first.abandonedCount()).toBe(0);
+    expect(second.abandonedCount()).toBe(0);
+  });
+
+  it("completes a gated no-dispatch turn instead of stalling its claim", async () => {
+    const { deps } = createMessageHandlerDeps(
+      {
+        channels: {
+          msteams: {
+            groupPolicy: "open",
+            requireMention: true,
+          },
+        },
+      } as OpenClawConfig,
+      {
+        createInboundDebouncer,
+        resolveInboundDebounceMs: vi.fn(() => 20),
+      },
+    );
+    const handler = createMSTeamsMessageHandler(deps);
+    const lifecycle = createLifecycle();
+    const gatedActivity = buildChannelActivity({
+      id: "activity-gated",
+      text: "not for the bot",
+      entities: [],
+    }) as MSTeamsTurnContext["activity"];
+
+    const result = await handler(context(gatedActivity), lifecycle);
+
+    expect(result).toEqual({ kind: "deferred" });
+    await vi.waitFor(() => expect(lifecycle.adoptedCount()).toBe(1), { timeout: 5_000 });
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+    expect(lifecycle.abandonedCount()).toBe(0);
+  });
+});

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -64,7 +64,7 @@ function createHandler(cfg: OpenClawConfig) {
 
 describe("Microsoft Teams drain claim ownership", () => {
   beforeEach(() => {
-    runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mockClear();
+    runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
   });
 
   it("defers a claimed activity and binds completion to reply adoption", async () => {
@@ -78,14 +78,14 @@ describe("Microsoft Teams drain claim ownership", () => {
     expect(result).toEqual({ kind: "deferred" });
     await vi.waitFor(
       () => {
-        expect(
-          runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher,
-        ).toHaveBeenCalledTimes(1);
+        expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(
+          1,
+        );
         expect(lifecycle.adoptedCount()).toBe(1);
       },
       { timeout: 5_000 },
     );
-    const dispatchParams = runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock
+    const dispatchParams = runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mock
       .calls[0]?.[0] as
       | { replyOptions?: { turnAdoptionLifecycle?: { admission?: string } } }
       | undefined;
@@ -111,17 +111,17 @@ describe("Microsoft Teams drain claim ownership", () => {
     expect(results).toEqual([{ kind: "deferred" }, { kind: "deferred" }]);
     await vi.waitFor(
       () => {
-        expect(
-          runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher,
-        ).toHaveBeenCalledTimes(1);
+        expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(
+          1,
+        );
         expect(first.adoptedCount()).toBe(1);
         expect(second.adoptedCount()).toBe(1);
       },
       { timeout: 5_000 },
     );
-    const dispatchParams = runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock
-      .calls[0]?.[0] as { ctxPayload?: { BodyForAgent?: string } } | undefined;
-    expect(dispatchParams?.ctxPayload?.BodyForAgent).toContain("part one\npart two");
+    const dispatchParams = runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mock
+      .calls[0]?.[0] as { ctx?: { BodyForAgent?: string } } | undefined;
+    expect(dispatchParams?.ctx?.BodyForAgent).toContain("part one\npart two");
     expect(first.abandonedCount()).toBe(0);
     expect(second.abandonedCount()).toBe(0);
   });
@@ -153,7 +153,7 @@ describe("Microsoft Teams drain claim ownership", () => {
 
     expect(result).toEqual({ kind: "deferred" });
     await vi.waitFor(() => expect(lifecycle.adoptedCount()).toBe(1), { timeout: 5_000 });
-    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+    expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     expect(lifecycle.abandonedCount()).toBe(0);
   });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -11,6 +11,7 @@ import {
   hasFinalInboundReplyDispatch,
   resolveInboundReplyDispatchCounts,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import {
   filterSupplementalContextItems,
   resolveChannelContextVisibilityMode,
@@ -80,6 +81,7 @@ function extractTextFromHtmlAttachments(attachments: MSTeamsAttachmentLike[]): s
 }
 
 import type { MSTeamsMessageHandlerDeps } from "../monitor-handler.types.js";
+import type { MSTeamsIngressLifecycle } from "../msteams-ingress.js";
 import { resolveMSTeamsAllowlistMatch, resolveMSTeamsReplyPolicy } from "../policy.js";
 import { extractMSTeamsPollVote } from "../polls.js";
 import { createMSTeamsReplyDispatcher } from "../reply-dispatcher.js";
@@ -216,6 +218,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     attachments: MSTeamsAttachmentLike[];
     wasMentioned: boolean;
     implicitMentionKinds: Array<"reply_to_bot">;
+    turnAdoptionLifecycle?: MSTeamsIngressLifecycle;
   };
 
   const handleTeamsMessageNow = async (params: MSTeamsDebounceEntry) => {
@@ -989,7 +992,12 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
             },
             dispatcherOptions,
             delivery,
-            replyOptions,
+            replyOptions: {
+              ...replyOptions,
+              ...(params.turnAdoptionLifecycle
+                ? bindIngressLifecycleToReplyOptions(params.turnAdoptionLifecycle)
+                : {}),
+            },
           }),
         },
       });
@@ -1010,6 +1018,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     } catch (err) {
       log.error("dispatch failed", { error: formatUnknownError(err) });
       runtime.error(`msteams dispatch failed: ${formatUnknownError(err)}`);
+      if (params.turnAdoptionLifecycle) {
+        throw err;
+      }
       try {
         await context.sendActivity("⚠️ Something went wrong. Please try again.");
       } catch {
@@ -1017,6 +1028,63 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       }
     }
   };
+
+  // One debounced turn owns every constituent queue claim. Fan adoption and
+  // abandonment to all of them; otherwise merged messages replay after restart.
+  function buildFlushIngressLifecycle(entries: MSTeamsDebounceEntry[]): {
+    lifecycle: MSTeamsIngressLifecycle | undefined;
+    settle: () => Promise<void>;
+  } {
+    const lifecycles = entries
+      .map((entry) => entry.turnAdoptionLifecycle)
+      .filter((lifecycle) => lifecycle !== undefined);
+    const [firstLifecycle] = lifecycles;
+    if (!firstLifecycle) {
+      return { lifecycle: undefined, settle: async () => {} };
+    }
+    let handedOff = false;
+    const adoptAll = async () => {
+      for (const lifecycle of lifecycles) {
+        await lifecycle.onAdopted();
+      }
+    };
+    return {
+      lifecycle: {
+        abortSignal:
+          lifecycles.length === 1
+            ? firstLifecycle.abortSignal
+            : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+        onAdopted: async () => {
+          handedOff = true;
+          await adoptAll();
+        },
+        onDeferred: () => {
+          handedOff = true;
+          for (const lifecycle of lifecycles) {
+            lifecycle.onDeferred();
+          }
+        },
+        onAdoptionFinalizing: () => {
+          for (const lifecycle of lifecycles) {
+            lifecycle.onAdoptionFinalizing();
+          }
+        },
+        onAbandoned: async () => {
+          handedOff = true;
+          for (const lifecycle of lifecycles) {
+            await lifecycle.onAbandoned();
+          }
+        },
+      },
+      // Gated, blank, and other terminal no-dispatch turns are handled work.
+      // Tombstone them instead of leaving deferred claims to stall-watchdog.
+      settle: async () => {
+        if (!handedOff) {
+          await adoptAll();
+        }
+      },
+    };
+  }
 
   const inboundDebouncer = core.channel.debounce.createInboundDebouncer<MSTeamsDebounceEntry>({
     debounceMs: inboundDebounceMs,
@@ -1045,38 +1113,50 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       if (!last) {
         return;
       }
-      if (entries.length === 1) {
-        await handleTeamsMessageNow(last);
-        return;
+      const { lifecycle, settle } = buildFlushIngressLifecycle(entries);
+      try {
+        if (entries.length === 1) {
+          await handleTeamsMessageNow(
+            lifecycle ? { ...last, turnAdoptionLifecycle: lifecycle } : last,
+          );
+        } else {
+          const combinedText = entries
+            .map((entry) => entry.text)
+            .filter(Boolean)
+            .join("\n");
+          if (combinedText.trim()) {
+            const combinedRawText = entries
+              .map((entry) => entry.rawText)
+              .filter(Boolean)
+              .join("\n");
+            const wasMentioned = entries.some((entry) => entry.wasMentioned);
+            const implicitMentionKinds = entries.flatMap((entry) => entry.implicitMentionKinds);
+            await handleTeamsMessageNow({
+              context: last.context,
+              rawText: combinedRawText,
+              text: combinedText,
+              attachments: [],
+              wasMentioned,
+              implicitMentionKinds,
+              ...(lifecycle ? { turnAdoptionLifecycle: lifecycle } : {}),
+            });
+          }
+        }
+        await settle();
+      } catch (err) {
+        await lifecycle?.onAbandoned();
+        throw err;
       }
-      const combinedText = entries
-        .map((entry) => entry.text)
-        .filter(Boolean)
-        .join("\n");
-      if (!combinedText.trim()) {
-        return;
-      }
-      const combinedRawText = entries
-        .map((entry) => entry.rawText)
-        .filter(Boolean)
-        .join("\n");
-      const wasMentioned = entries.some((entry) => entry.wasMentioned);
-      const implicitMentionKinds = entries.flatMap((entry) => entry.implicitMentionKinds);
-      await handleTeamsMessageNow({
-        context: last.context,
-        rawText: combinedRawText,
-        text: combinedText,
-        attachments: [],
-        wasMentioned,
-        implicitMentionKinds,
-      });
     },
     onError: (err) => {
       runtime.error(`msteams debounce flush failed: ${formatUnknownError(err)}`);
     },
   });
 
-  return async function handleTeamsMessage(context: MSTeamsTurnContext) {
+  return async function handleTeamsMessage(
+    context: MSTeamsTurnContext,
+    turnAdoptionLifecycle?: MSTeamsIngressLifecycle,
+  ) {
     const activity = context.activity;
     const attachments = Array.isArray(activity.attachments)
       ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
@@ -1103,7 +1183,14 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       attachments,
       wasMentioned,
       implicitMentionKinds,
+      turnAdoptionLifecycle,
     });
+    if (turnAdoptionLifecycle) {
+      // Keep the durable claim held across the debounce window. The merged
+      // flush completes it only when the reply lane adopts (or terminally skips).
+      return { kind: "deferred" } as const;
+    }
+    return undefined;
   };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/msteams/src/monitor-ingress-mock.test-support.ts
+++ b/extensions/msteams/src/monitor-ingress-mock.test-support.ts
@@ -42,3 +42,26 @@ vi.mock("./msteams-ingress.js", () => ({
     return instance;
   },
 }));
+
+/** Gate accept on a promise, then fire dispatch detached with a stub lifecycle. */
+export function gateIngressAcceptThenDispatch(
+  ingress: ReturnType<typeof getMSTeamsIngressMockState>["instances"][number],
+  appendWork: Promise<void>,
+): void {
+  ingress.accept.mockImplementationOnce(async (activity: unknown, context?: unknown) => {
+    await appendWork;
+    void Promise.resolve(
+      ingress.options.dispatch(
+        activity,
+        {
+          abortSignal: new AbortController().signal,
+          onAdopted: vi.fn(),
+          onDeferred: vi.fn(),
+          onAdoptionFinalizing: vi.fn(),
+          onAbandoned: vi.fn(),
+        },
+        context,
+      ),
+    ).catch(() => undefined);
+  });
+}

--- a/extensions/msteams/src/monitor-ingress-mock.test-support.ts
+++ b/extensions/msteams/src/monitor-ingress-mock.test-support.ts
@@ -1,5 +1,6 @@
 // Microsoft Teams monitor tests inject a durable-ingress boundary without ambient state.
 import { vi } from "vitest";
+import type { Mock } from "vitest";
 
 type IngressDispatch = (
   activity: unknown,
@@ -9,7 +10,7 @@ type IngressDispatch = (
 
 const ingressMockState = vi.hoisted(() => ({
   instances: [] as Array<{
-    accept: ReturnType<typeof vi.fn>;
+    accept: Mock<(activity: unknown, context?: unknown) => Promise<void>>;
     start: ReturnType<typeof vi.fn>;
     stop: ReturnType<typeof vi.fn>;
     options: { dispatch: IngressDispatch };

--- a/extensions/msteams/src/monitor-ingress-mock.test-support.ts
+++ b/extensions/msteams/src/monitor-ingress-mock.test-support.ts
@@ -1,0 +1,43 @@
+// Microsoft Teams monitor tests inject a durable-ingress boundary without ambient state.
+import { vi } from "vitest";
+
+type IngressDispatch = (
+  activity: unknown,
+  lifecycle: unknown,
+  context?: unknown,
+) => Promise<unknown>;
+
+const ingressMockState = vi.hoisted(() => ({
+  instances: [] as Array<{
+    accept: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    options: { dispatch: IngressDispatch };
+  }>,
+}));
+
+export function getMSTeamsIngressMockState() {
+  return ingressMockState;
+}
+
+vi.mock("./msteams-ingress.js", () => ({
+  createMSTeamsIngress: (options: { dispatch: IngressDispatch }) => {
+    const lifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(),
+    };
+    const instance = {
+      accept: vi.fn(async (activity: unknown, context?: unknown) => {
+        void options.dispatch(activity, lifecycle, context).catch(() => undefined);
+      }),
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      options,
+    };
+    ingressMockState.instances.push(instance);
+    return instance;
+  },
+}));

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -803,22 +803,24 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     const appendWork = new Promise<void>((resolve) => {
       releaseAppend = resolve;
     });
-    ingress.accept.mockImplementationOnce(async (activity: unknown, context?: unknown) => {
-      await appendWork;
-      void Promise.resolve(
-        ingress.options.dispatch(
-          activity,
-          {
-            abortSignal: new AbortController().signal,
-            onAdopted: vi.fn(),
-            onDeferred: vi.fn(),
-            onAdoptionFinalizing: vi.fn(),
-            onAbandoned: vi.fn(),
-          },
-          context,
-        ),
-      ).catch(() => undefined);
-    });
+    ingress.accept.mockImplementationOnce(
+      (activity: unknown, context?: unknown): Promise<void> =>
+        appendWork.then(() => {
+          void Promise.resolve(
+            ingress.options.dispatch(
+              activity,
+              {
+                abortSignal: new AbortController().signal,
+                onAdopted: vi.fn(),
+                onDeferred: vi.fn(),
+                onAdoptionFinalizing: vi.fn(),
+                onAbandoned: vi.fn(),
+              },
+              context,
+            ),
+          ).catch(() => undefined);
+        }),
+    );
 
     const responseWork = cardActionHandler({
       activity: {

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -805,8 +805,8 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     });
     ingress.accept.mockImplementationOnce(async (activity: unknown, context?: unknown) => {
       await appendWork;
-      void ingress.options
-        .dispatch(
+      void Promise.resolve(
+        ingress.options.dispatch(
           activity,
           {
             abortSignal: new AbortController().signal,
@@ -816,8 +816,8 @@ describe("monitorMSTeamsProvider lifecycle", () => {
             onAbandoned: vi.fn(),
           },
           context,
-        )
-        .catch(() => undefined);
+        ),
+      ).catch(() => undefined);
     });
 
     const responseWork = cardActionHandler({

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import type { MSTeamsActivityHandler } from "./monitor-handler.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import { getMSTeamsIngressMockState } from "./monitor-ingress-mock.test-support.js";
 import type { MSTeamsPollStore } from "./polls.js";
 
 type FakeServer = EventEmitter & {
@@ -297,6 +298,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     isSigninInvokeAuthorized.mockReset().mockResolvedValue(true);
     isCardActionInvokeAuthorized.mockReset().mockResolvedValue(true);
     runMSTeamsFileConsentInvokeHandler.mockReset().mockResolvedValue(undefined);
+    getMSTeamsIngressMockState().instances.length = 0;
     ssoTokenStore.get.mockClear();
     ssoTokenStore.save.mockClear();
     ssoTokenStore.remove.mockClear();
@@ -761,7 +763,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await task;
   });
 
-  it("acks non-poll card actions before agent dispatch settles", async () => {
+  it("acks non-poll card actions after durable admission, before agent dispatch settles", async () => {
     const abort = new AbortController();
     const task = monitorMSTeamsProvider({
       cfg: createConfig(0),
@@ -790,24 +792,56 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     if (!registeredHandler) {
       throw new Error("expected registered Teams handler");
     }
-    let releaseDispatch: (() => void) | undefined;
-    const dispatchWork = new Promise<void>((resolve) => {
-      releaseDispatch = resolve;
-    });
+    const dispatchWork = new Promise<void>(() => {});
     const run = vi.spyOn(registeredHandler, "run").mockReturnValueOnce(dispatchWork);
 
-    const response = await cardActionHandler({
+    const ingress = getMSTeamsIngressMockState().instances[0];
+    if (!ingress) {
+      throw new Error("expected Teams ingress");
+    }
+    let releaseAppend: (() => void) | undefined;
+    const appendWork = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    ingress.accept.mockImplementationOnce(async (activity: unknown, context?: unknown) => {
+      await appendWork;
+      void ingress.options
+        .dispatch(
+          activity,
+          {
+            abortSignal: new AbortController().signal,
+            onAdopted: vi.fn(),
+            onDeferred: vi.fn(),
+            onAdoptionFinalizing: vi.fn(),
+            onAbandoned: vi.fn(),
+          },
+          context,
+        )
+        .catch(() => undefined);
+    });
+
+    const responseWork = cardActionHandler({
       activity: {
+        id: "activity-card-action",
         type: "invoke",
         name: "adaptiveCard/action",
+        conversation: { id: "conversation-card-action", conversationType: "personal" },
         value: { action: { data: { action: "nonPoll" } } },
       },
     });
 
+    let responseSettled = false;
+    void responseWork.then(() => {
+      responseSettled = true;
+    });
+    await Promise.resolve();
+    expect(responseSettled).toBe(false);
+
+    releaseAppend?.();
+    const response = await responseWork;
+
     expect(response).toMatchObject({ statusCode: 200, value: "OK" });
     expect(run).toHaveBeenCalledTimes(1);
-    releaseDispatch?.();
-    await dispatchWork;
 
     abort.abort();
     await task;

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -6,7 +6,10 @@ import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import type { MSTeamsActivityHandler } from "./monitor-handler.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
-import { getMSTeamsIngressMockState } from "./monitor-ingress-mock.test-support.js";
+import {
+  getMSTeamsIngressMockState,
+  gateIngressAcceptThenDispatch,
+} from "./monitor-ingress-mock.test-support.js";
 import type { MSTeamsPollStore } from "./polls.js";
 
 type FakeServer = EventEmitter & {
@@ -803,22 +806,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     const appendWork = new Promise<void>((resolve) => {
       releaseAppend = resolve;
     });
-    ingress.accept.mockImplementationOnce(async (activity: unknown, context?: unknown) => {
-      await appendWork;
-      void Promise.resolve(
-        ingress.options.dispatch(
-          activity,
-          {
-            abortSignal: new AbortController().signal,
-            onAdopted: vi.fn(),
-            onDeferred: vi.fn(),
-            onAdoptionFinalizing: vi.fn(),
-            onAbandoned: vi.fn(),
-          },
-          context,
-        ),
-      ).catch(() => undefined);
-    });
+    gateIngressAcceptThenDispatch(ingress, appendWork);
 
     const responseWork = cardActionHandler({
       activity: {

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -803,24 +803,22 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     const appendWork = new Promise<void>((resolve) => {
       releaseAppend = resolve;
     });
-    ingress.accept.mockImplementationOnce(
-      (activity: unknown, context?: unknown): Promise<void> =>
-        appendWork.then(() => {
-          void Promise.resolve(
-            ingress.options.dispatch(
-              activity,
-              {
-                abortSignal: new AbortController().signal,
-                onAdopted: vi.fn(),
-                onDeferred: vi.fn(),
-                onAdoptionFinalizing: vi.fn(),
-                onAbandoned: vi.fn(),
-              },
-              context,
-            ),
-          ).catch(() => undefined);
-        }),
-    );
+    ingress.accept.mockImplementationOnce(async (activity: unknown, context?: unknown) => {
+      await appendWork;
+      void Promise.resolve(
+        ingress.options.dispatch(
+          activity,
+          {
+            abortSignal: new AbortController().signal,
+            onAdopted: vi.fn(),
+            onDeferred: vi.fn(),
+            onAdoptionFinalizing: vi.fn(),
+            onAbandoned: vi.fn(),
+          },
+          context,
+        ),
+      ).catch(() => undefined);
+    });
 
     const responseWork = cardActionHandler({
       activity: {

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -16,7 +16,7 @@ import type { MSTeamsConversationStore } from "./conversation-store.js";
 import { formatUnknownError } from "./errors.js";
 import { runMSTeamsFeedbackInvokeHandler } from "./feedback-invoke.js";
 import { runMSTeamsFileConsentInvokeHandler } from "./file-consent-invoke.js";
-import { normalizeMSTeamsConversationId } from "./inbound.js";
+import { extractMSTeamsConversationMessageId, normalizeMSTeamsConversationId } from "./inbound.js";
 import {
   isCardActionInvokeAuthorized,
   isSigninInvokeAuthorized,
@@ -24,6 +24,7 @@ import {
   type MSTeamsActivityHandler,
 } from "./monitor-handler.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import { createMSTeamsIngress } from "./msteams-ingress.js";
 import {
   createMSTeamsPollStoreState,
   extractMSTeamsPollVote,
@@ -36,6 +37,11 @@ import {
   resolveMSTeamsUserAllowlist,
 } from "./resolve-allowlist.js";
 import { getMSTeamsRuntime } from "./runtime.js";
+import {
+  deleteMSTeamsActivityWithReference,
+  sendMSTeamsActivityWithReference,
+  updateMSTeamsActivityWithReference,
+} from "./sdk-proactive.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 import {
   createMSTeamsExpressAdapter,
@@ -292,6 +298,17 @@ export async function monitorMSTeamsProvider(
   };
   registerMSTeamsHandlers(handler, handlerDeps);
 
+  const ingress = createMSTeamsIngress({
+    accountId: appId,
+    runtime,
+    dispatch: async (activity, lifecycle, liveContext) => {
+      const context =
+        liveContext ??
+        createMSTeamsReplayContext(activity, app, resolveMSTeamsSdkCloudOptions(msteamsCfg));
+      return await handler.run!(context, lifecycle);
+    },
+  });
+
   // Handle adaptiveCard/action invokes (Action.Execute Universal Action Model).
   // We must return an InvokeResponse-shaped value so Teams updates the card UI;
   // returning nothing or letting the catch-all process it makes Teams report
@@ -375,11 +392,9 @@ export async function monitorMSTeamsProvider(
           };
         }
       }
-      // Non-poll card actions may dispatch into the agent. Acknowledge the
-      // invoke immediately so Teams does not time out while that work runs.
-      void handler.run!(adaptedCtx).catch((err: unknown) => {
-        log.error("msteams card.action dispatch failed", { error: formatUnknownError(err) });
-      });
+      // The SDK has already authenticated this invoke. Acknowledge only after
+      // the raw activity is durable; agent work drains independently.
+      await ingress.accept(activity, adaptedCtx);
       return {
         statusCode: 200,
         type: "application/vnd.microsoft.activity.message",
@@ -512,36 +527,43 @@ export async function monitorMSTeamsProvider(
   // handler dispatch system. The SDK has already validated JWT and parsed the
   // activity by this point.
   app.on("activity", async (ctx) => {
-    try {
-      const adaptedCtx = adaptSdkContext(ctx, app);
-      const activity = adaptedCtx.activity;
-      // Skip invokes that have dedicated typed routes above.
-      if (activity?.type === "invoke") {
-        if (activity?.name === "adaptiveCard/action") {
-          return;
-        }
-        if (activity?.name === "fileConsent/invoke") {
-          return;
-        }
-        if (activity?.name === "signin/tokenExchange" || activity?.name === "signin/verifyState") {
-          return;
-        }
+    const adaptedCtx = adaptSdkContext(ctx, app);
+    const activity = adaptedCtx.activity;
+    // Skip invokes that have dedicated typed routes above.
+    if (activity?.type === "invoke") {
+      if (activity?.name === "adaptiveCard/action") {
+        return;
       }
+      if (activity?.name === "fileConsent/invoke") {
+        return;
+      }
+      if (activity?.name === "signin/tokenExchange" || activity?.name === "signin/verifyState") {
+        return;
+      }
+    }
+    if (activity?.type === "message") {
+      // Throwing rejects the SDK route, so a failed SQLite append is never acked.
+      await ingress.accept(activity, adaptedCtx);
+      return;
+    }
+    try {
       await handler.run!(adaptedCtx);
     } catch (err) {
-      log.error("msteams webhook failed", { error: formatUnknownError(err) });
+      log.error("msteams non-turn activity failed", { error: formatUnknownError(err) });
     }
   });
 
   // Initialize the SDK App — registers the POST route on Express and sets up
   // JWT validation middleware internally.
   await app.initialize();
+  ingress.start();
 
   // Start listening and fail fast if bind/listen fails.
   const httpServer = await new Promise<Server>((resolve, reject) => {
     const server = expressApp.listen(port, (err) => (err ? reject(err) : resolve(server)));
-  }).catch((err: unknown) => {
+  }).catch(async (err: unknown) => {
     log.error("msteams server error", { error: formatUnknownError(err) });
+    await ingress.stop();
     throw err;
   });
   log.info(`msteams provider started on port ${port}`);
@@ -553,7 +575,7 @@ export async function monitorMSTeamsProvider(
 
   const shutdown = async () => {
     log.info("shutting down msteams provider");
-    return new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       httpServer.close((err) => {
         if (err) {
           log.debug?.("msteams server close error", { error: formatUnknownError(err) });
@@ -561,6 +583,7 @@ export async function monitorMSTeamsProvider(
         resolve();
       });
     });
+    await ingress.stop();
   };
 
   // Keep this task alive until close so gateway runtime does not treat startup as exit.
@@ -579,7 +602,8 @@ export async function monitorMSTeamsProvider(
  */
 function buildActivityHandler(): MSTeamsActivityHandler {
   type Handler = (context: unknown, next: () => Promise<void>) => Promise<void>;
-  const messageHandlers: Handler[] = [];
+  type MessageHandler = Parameters<MSTeamsActivityHandler["onMessage"]>[0];
+  const messageHandlers: MessageHandler[] = [];
   const membersAddedHandlers: Handler[] = [];
   const reactionsAddedHandlers: Handler[] = [];
   const reactionsRemovedHandlers: Handler[] = [];
@@ -601,14 +625,17 @@ function buildActivityHandler(): MSTeamsActivityHandler {
       reactionsRemovedHandlers.push(cb);
       return handler;
     },
-    async run(context: unknown) {
+    async run(context, turnAdoptionLifecycle) {
       const ctx = context as { activity?: { type?: string } };
       const activityType = ctx?.activity?.type;
       const noop = async () => {};
 
       if (activityType === "message") {
         for (const h of messageHandlers) {
-          await h(context, noop);
+          const result = await h(context, noop, turnAdoptionLifecycle);
+          if (result) {
+            return result;
+          }
         }
       } else if (activityType === "conversationUpdate") {
         for (const h of membersAddedHandlers) {
@@ -629,10 +656,70 @@ function buildActivityHandler(): MSTeamsActivityHandler {
           }
         }
       }
+      return undefined;
     },
   };
 
   return handler;
+}
+
+function createMSTeamsReplayContext(
+  activity: MSTeamsTurnContext["activity"],
+  app: MSTeamsApp,
+  serviceUrlBoundary: ReturnType<typeof resolveMSTeamsSdkCloudOptions>,
+): MSTeamsTurnContext {
+  const rawConversationId = activity.conversation?.id ?? "";
+  const conversationId = normalizeMSTeamsConversationId(rawConversationId);
+  const conversationType = activity.conversation?.conversationType ?? "personal";
+  const threadActivityId =
+    conversationType.toLowerCase() === "channel"
+      ? (extractMSTeamsConversationMessageId(rawConversationId) ?? activity.replyToId)
+      : undefined;
+  const tenantId = activity.channelData?.tenant?.id ?? activity.conversation?.tenantId;
+  const reference = {
+    activityId: activity.id,
+    user: activity.from,
+    agent: activity.recipient,
+    conversation: {
+      id: conversationId,
+      conversationType,
+      ...(tenantId ? { tenantId } : {}),
+    },
+    channelId: activity.channelId,
+    serviceUrl: activity.serviceUrl,
+    locale: activity.locale,
+    ...(tenantId ? { tenantId } : {}),
+    ...(activity.from?.aadObjectId ? { aadObjectId: activity.from.aadObjectId } : {}),
+  };
+  const proactiveOptions = {
+    ...(threadActivityId ? { threadActivityId } : {}),
+    serviceUrlBoundary,
+  };
+  const sendActivity: MSTeamsTurnContext["sendActivity"] = (outbound) =>
+    sendMSTeamsActivityWithReference(app, reference, outbound, proactiveOptions);
+  return {
+    activity,
+    sendActivity,
+    sendActivities: async (activities) => {
+      const results: unknown[] = [];
+      for (const outbound of activities) {
+        results.push(await sendActivity(outbound));
+      }
+      return results;
+    },
+    updateActivity: async (outbound) =>
+      (await updateMSTeamsActivityWithReference(
+        app,
+        reference,
+        typeof outbound.id === "string" ? outbound.id : "",
+        outbound,
+        proactiveOptions,
+      )) as { id?: string } | void,
+    deleteActivity: async (activityId) => {
+      await deleteMSTeamsActivityWithReference(app, reference, activityId, proactiveOptions);
+    },
+    getTeamDetails: (teamId) => app.api.teams.getById(teamId),
+  };
 }
 
 /**

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -302,6 +302,12 @@ export async function monitorMSTeamsProvider(
     accountId: appId,
     runtime,
     dispatch: async (activity, lifecycle, liveContext) => {
+      // The journaled activity is the dispatch payload; the live context only
+      // supplies the transport surface. A duplicate delivery's context must
+      // not swap in its own (possibly mutated) activity object.
+      if (liveContext) {
+        liveContext.activity = activity;
+      }
       const context =
         liveContext ??
         createMSTeamsReplayContext(activity, app, resolveMSTeamsSdkCloudOptions(msteamsCfg));

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -1,0 +1,361 @@
+// Microsoft Teams tests cover durable admission, replay, taxonomy, and redelivery dedupe.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMSTeamsIngress } from "./msteams-ingress.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+type IngressQueue = NonNullable<Parameters<typeof createMSTeamsIngress>[0]["queue"]>;
+type IngressPayload = Parameters<IngressQueue["enqueue"]>[1];
+type IngressDispatch = Parameters<typeof createMSTeamsIngress>[0]["dispatch"];
+
+function activity(params?: {
+  id?: string;
+  type?: string;
+  name?: string;
+  conversationId?: string;
+  text?: string;
+}): MSTeamsTurnContext["activity"] {
+  return {
+    id: params?.id ?? "activity-1",
+    type: params?.type ?? "message",
+    ...(params?.name ? { name: params.name } : {}),
+    text: params?.text ?? "hello",
+    from: { id: "user-1", aadObjectId: "aad-user-1", name: "User" },
+    recipient: { id: "bot-1", name: "Bot" },
+    conversation: {
+      id: params?.conversationId ?? "conversation-1",
+      conversationType: "personal",
+    },
+    channelId: "msteams",
+    serviceUrl: "https://smba.trafficmanager.net/emea/",
+  };
+}
+
+function runtime() {
+  return { error: vi.fn(), log: vi.fn() };
+}
+
+function makeIngress(queue: IngressQueue, dispatch: IngressDispatch) {
+  return createMSTeamsIngress({
+    accountId: "app-id",
+    queue,
+    dispatch,
+    runtime: runtime(),
+  });
+}
+
+async function withQueue<T>(fn: (queue: IngressQueue) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-ingress-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<IngressPayload>({
+    channelId: "msteams",
+    accountId: "app-id",
+    stateDir,
+  });
+  try {
+    return await fn(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+async function waitForVerdict(
+  queue: IngressQueue,
+  eventId: string,
+  expected: "completed" | "failed",
+): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const verdict = await queue.enqueue(eventId, {} as IngressPayload);
+      expect(verdict.kind).toBe(expected);
+    },
+    { timeout: 5_000 },
+  );
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("Microsoft Teams durable ingress", () => {
+  it("propagates durable append failure before scheduling dispatch", async () => {
+    await withQueue(async (queue) => {
+      const appendError = new Error("sqlite unavailable");
+      const failingQueue: ChannelIngressQueue<IngressPayload> = {
+        ...queue,
+        enqueue: vi.fn().mockRejectedValue(appendError),
+      };
+      const dispatch = vi.fn();
+      const ingress = makeIngress(failingQueue, dispatch);
+
+      await expect(ingress.accept(activity())).rejects.toBe(appendError);
+      expect(dispatch).not.toHaveBeenCalled();
+      await ingress.stop();
+    });
+  });
+
+  it("recovers an uncompleted append with a fresh drain and dispatches exactly once", async () => {
+    await withQueue(async (queue) => {
+      const incoming = activity({ id: "activity-restart" });
+      const interrupted = makeIngress(queue, vi.fn());
+      await interrupted.accept(incoming);
+      await interrupted.stop();
+
+      const recoveredDispatch = vi.fn(async (_activity, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const recovered = makeIngress(queue, recoveredDispatch);
+      recovered.start();
+      try {
+        await waitForVerdict(queue, "activity-restart", "completed");
+        expect(recoveredDispatch).toHaveBeenCalledTimes(1);
+        expect(recoveredDispatch).toHaveBeenCalledWith(incoming, expect.any(Object), undefined);
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("keeps a completion tombstone and rejects a post-completion duplicate", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_activity, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = makeIngress(queue, dispatch);
+      const incoming = activity({ id: "activity-duplicate" });
+      ingress.start();
+      try {
+        await ingress.accept(incoming);
+        await waitForVerdict(queue, "activity-duplicate", "completed");
+        await ingress.accept(incoming);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("deduplicates a concrete Bot Framework redelivery by activity.id", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_activity, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = makeIngress(queue, dispatch);
+      const first = activity({ id: "bot-framework-redelivery", text: "original" });
+      const redelivery = activity({ id: "bot-framework-redelivery", text: "redelivered copy" });
+      ingress.start();
+      try {
+        await ingress.accept(first);
+        await waitForVerdict(queue, "bot-framework-redelivery", "completed");
+        await ingress.accept(redelivery);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(dispatch.mock.calls[0]?.[0]).toMatchObject({ text: "original" });
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("stores raw activity JSON and uses the exact conversation.id as its lane", async () => {
+    await withQueue(async (queue) => {
+      const deliveredText: string[] = [];
+      const ingress = makeIngress(queue, async (delivered, lifecycle) => {
+        deliveredText.push(delivered.text ?? "");
+        await lifecycle.onAdopted();
+      });
+      const incoming = activity({
+        id: "activity-raw",
+        conversationId: "19:channel@thread.tacv2;messageid=thread-root",
+        text: "before",
+      });
+      await ingress.accept(incoming);
+      const pending = await queue.listPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0]).toMatchObject({
+        id: "activity-raw",
+        laneKey: "19:channel@thread.tacv2;messageid=thread-root",
+        payload: { version: 1, rawActivity: JSON.stringify(incoming) },
+      });
+      incoming.text = "after";
+
+      ingress.start();
+      try {
+        await waitForVerdict(queue, "activity-raw", "completed");
+        expect(deliveredText).toEqual(["before"]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("journals only message turns and adaptive-card agent turns", async () => {
+    await withQueue(async (queue) => {
+      const ingress = makeIngress(queue, vi.fn());
+      await ingress.accept(activity({ id: "message", type: "message" }));
+      await ingress.accept(
+        activity({ id: "adaptive", type: "invoke", name: "adaptiveCard/action" }),
+      );
+      await ingress.accept(activity({ id: "edit", type: "messageUpdate" }));
+      await ingress.accept(activity({ id: "reaction", type: "messageReaction" }));
+      await ingress.accept(
+        activity({ id: "feedback", type: "invoke", name: "message/submitAction" }),
+      );
+      await ingress.accept(
+        activity({ id: "file-consent", type: "invoke", name: "fileConsent/invoke" }),
+      );
+
+      expect(
+        (await queue.listPending({ limit: "all" })).map((entry) => entry.id).toSorted(),
+      ).toEqual(["adaptive", "message"]);
+      await ingress.stop();
+    });
+  });
+
+  it("dead-letters malformed persisted JSON without dispatch", async () => {
+    await withQueue(async (queue) => {
+      await queue.enqueue(
+        "activity-malformed",
+        { version: 1, receivedAt: Date.now(), rawActivity: "{" },
+        { laneKey: "conversation-1" },
+      );
+      const dispatch = vi.fn();
+      const ingress = makeIngress(queue, dispatch);
+      ingress.start();
+      try {
+        await waitForVerdict(queue, "activity-malformed", "failed");
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("releases transient dispatch failures for retry", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_activity, lifecycle) => {
+        if (dispatch.mock.calls.length === 1) {
+          throw new Error("temporary dispatch outage");
+        }
+        await lifecycle.onAdopted();
+      });
+      const ingress = makeIngress(queue, dispatch);
+      ingress.start();
+      try {
+        await ingress.accept(activity({ id: "activity-retry" }));
+        await waitForVerdict(queue, "activity-retry", "completed");
+        expect(dispatch).toHaveBeenCalledTimes(2);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters permanent authentication failures without retry", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async () => {
+        throw Object.assign(new Error("invalid Bot Framework credentials"), { statusCode: 401 });
+      });
+      const ingress = makeIngress(queue, dispatch);
+      ingress.start();
+      try {
+        await ingress.accept(activity({ id: "activity-auth-failed" }));
+        await waitForVerdict(queue, "activity-auth-failed", "failed");
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        const verdict = await queue.enqueue("activity-auth-failed", {} as IngressPayload);
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("authentication-failed");
+        }
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("caps active deliveries across repeated drain pumps", async () => {
+    await withQueue(async (queue) => {
+      let releaseDeliveries: (() => void) | undefined;
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDeliveries = resolve;
+      });
+      let active = 0;
+      let maxActive = 0;
+      const dispatch = vi.fn(async (_activity, lifecycle) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await lifecycle.onAdopted();
+        try {
+          await deliveryGate;
+        } finally {
+          active -= 1;
+        }
+      });
+      const ingress = makeIngress(queue, dispatch);
+      ingress.start();
+      try {
+        for (let index = 0; index < 9; index += 1) {
+          await ingress.accept(
+            activity({ id: `activity-concurrency-${index}`, conversationId: `lane-${index}` }),
+          );
+        }
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(8));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
+        expect(dispatch).toHaveBeenCalledTimes(8);
+        expect(maxActive).toBe(8);
+
+        releaseDeliveries?.();
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(9));
+        expect(maxActive).toBe(8);
+      } finally {
+        releaseDeliveries?.();
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("waits for active delivery to finish before stopping", async () => {
+    await withQueue(async (queue) => {
+      let releaseDelivery: (() => void) | undefined;
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      const ingress = makeIngress(queue, async (_activity, lifecycle) => {
+        await lifecycle.onAdopted();
+        await deliveryGate;
+      });
+      ingress.start();
+      await ingress.accept(activity({ id: "activity-stop" }));
+      await waitForVerdict(queue, "activity-stop", "completed");
+
+      let stopped = false;
+      const stopping = ingress.stop().then(() => {
+        stopped = true;
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(stopped).toBe(false);
+
+      releaseDelivery?.();
+      await stopping;
+      expect(stopped).toBe(true);
+    });
+  });
+});

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -103,6 +103,44 @@ describe("Microsoft Teams durable ingress", () => {
     });
   });
 
+  it("does not dispatch a failed append's stale live context on retry", async () => {
+    await withQueue(async (queue) => {
+      let failNext = true;
+      const enqueue = queue.enqueue.bind(queue);
+      queue.enqueue = async (...args) => {
+        if (failNext) {
+          failNext = false;
+          throw new Error("sqlite busy");
+        }
+        return await enqueue(...args);
+      };
+      const contexts: unknown[] = [];
+      const ingress = createMSTeamsIngress({
+        accountId: "default",
+        queue,
+        runtime: runtime(),
+        dispatch: async (_activity, lifecycle, liveContext) => {
+          contexts.push(liveContext);
+          await lifecycle.onAdopted();
+        },
+      });
+      const staleContext = { id: "stale" } as never;
+      const retryContext = { id: "retry" } as never;
+      const retryActivity = activity({ id: "activity-ctx-retry" });
+      try {
+        ingress.start();
+        await expect(ingress.accept(retryActivity, staleContext)).rejects.toThrow("sqlite busy");
+        // The failed append must uninstall its context; the retry's own
+        // context is the one a claim may consume.
+        await ingress.accept(retryActivity, retryContext);
+        await vi.waitFor(() => expect(contexts).toHaveLength(1));
+        expect(contexts[0]).toBe(retryContext);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
   it("recovers an uncompleted append with a fresh drain and dispatches exactly once", async () => {
     await withQueue(async (queue) => {
       const incoming = activity({ id: "activity-restart" });

--- a/extensions/msteams/src/msteams-ingress.ts
+++ b/extensions/msteams/src/msteams-ingress.ts
@@ -257,18 +257,32 @@ export function createMSTeamsIngress(options: MSTeamsIngressOptions): MSTeamsIng
       if (liveContext && installedLiveContext) {
         liveContexts.set(facts.eventId, liveContext);
       }
-      const result = await queue.enqueue(
-        facts.eventId,
-        {
-          version: MSTEAMS_INGRESS_VERSION,
-          receivedAt,
-          rawActivity: JSON.stringify(activity),
-        },
-        { receivedAt, laneKey: facts.laneKey },
-      );
-      if (installedLiveContext && !(result.kind === "accepted" || result.kind === "pending")) {
-        // Tombstoned duplicate: no claim will ever consume this context.
-        liveContexts.delete(facts.eventId);
+      // Identity-guarded uninstall: only remove OUR context so a concurrent
+      // redelivery's fresh install is never clobbered. A failed or
+      // tombstoned-duplicate append leaves no claim to consume the entry, and
+      // a later retry must not dispatch this request's stale context.
+      const uninstallLiveContext = () => {
+        if (installedLiveContext && liveContexts.get(facts.eventId) === liveContext) {
+          liveContexts.delete(facts.eventId);
+        }
+      };
+      let result;
+      try {
+        result = await queue.enqueue(
+          facts.eventId,
+          {
+            version: MSTEAMS_INGRESS_VERSION,
+            receivedAt,
+            rawActivity: JSON.stringify(activity),
+          },
+          { receivedAt, laneKey: facts.laneKey },
+        );
+      } catch (error) {
+        uninstallLiveContext();
+        throw error;
+      }
+      if (!(result.kind === "accepted" || result.kind === "pending")) {
+        uninstallLiveContext();
       }
       requestDrain();
     },

--- a/extensions/msteams/src/msteams-ingress.ts
+++ b/extensions/msteams/src/msteams-ingress.ts
@@ -250,6 +250,13 @@ export function createMSTeamsIngress(options: MSTeamsIngressOptions): MSTeamsIng
         failedMaxEntries: MSTEAMS_INGRESS_FAILED_MAX_ENTRIES,
       });
       const receivedAt = Date.now();
+      // Install before the durable append: the drain can claim and consume the
+      // entry the moment the insert commits; a set afterwards would leak. A
+      // duplicate delivery must not clobber the first delivery's context.
+      const installedLiveContext = Boolean(liveContext) && !liveContexts.has(facts.eventId);
+      if (liveContext && installedLiveContext) {
+        liveContexts.set(facts.eventId, liveContext);
+      }
       const result = await queue.enqueue(
         facts.eventId,
         {
@@ -259,8 +266,9 @@ export function createMSTeamsIngress(options: MSTeamsIngressOptions): MSTeamsIng
         },
         { receivedAt, laneKey: facts.laneKey },
       );
-      if (liveContext && (result.kind === "accepted" || result.kind === "pending")) {
-        liveContexts.set(facts.eventId, liveContext);
+      if (installedLiveContext && !(result.kind === "accepted" || result.kind === "pending")) {
+        // Tombstoned duplicate: no claim will ever consume this context.
+        liveContexts.delete(facts.eventId);
       }
       requestDrain();
     },

--- a/extensions/msteams/src/msteams-ingress.ts
+++ b/extensions/msteams/src/msteams-ingress.ts
@@ -1,0 +1,294 @@
+// Microsoft Teams plugin owns durable Bot Framework activity admission and draining.
+import {
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { classifyMSTeamsSendError } from "./errors.js";
+import { getMSTeamsRuntime } from "./runtime.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const MSTEAMS_INGRESS_VERSION = 1;
+const MSTEAMS_INGRESS_DRAIN_INTERVAL_MS = 500;
+const MSTEAMS_INGRESS_MAX_CONCURRENT_DELIVERIES = 8;
+const MSTEAMS_INGRESS_SCAN_LIMIT = 100;
+const MSTEAMS_INGRESS_TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60_000;
+const MSTEAMS_INGRESS_COMPLETED_MAX_ENTRIES = 20_000;
+const MSTEAMS_INGRESS_FAILED_MAX_ENTRIES = 4096;
+
+type MSTeamsIngressActivity = MSTeamsTurnContext["activity"];
+
+type MSTeamsIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  rawActivity: string;
+};
+
+export type MSTeamsIngressLifecycle = {
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onAdoptionFinalizing: () => void;
+  onAbandoned: () => void | Promise<void>;
+};
+
+export type MSTeamsIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type MSTeamsIngressOptions = {
+  accountId: string;
+  runtime: Pick<RuntimeEnv, "error" | "log">;
+  dispatch: (
+    activity: MSTeamsIngressActivity,
+    lifecycle: MSTeamsIngressLifecycle,
+    liveContext?: MSTeamsTurnContext,
+  ) => Promise<MSTeamsIngressDispatchResult | void> | MSTeamsIngressDispatchResult | void;
+  queue?: ChannelIngressQueue<MSTeamsIngressPayload>;
+};
+
+type MSTeamsIngress = {
+  accept: (activity: MSTeamsIngressActivity, liveContext?: MSTeamsTurnContext) => Promise<void>;
+  start: () => void;
+  stop: () => Promise<void>;
+};
+
+class MSTeamsIngressPayloadError extends Error {
+  constructor(
+    readonly reason: "invalid-activity" | "invalid-json" | "unsupported-activity",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "MSTeamsIngressPayloadError";
+  }
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isDispatchableActivity(activity: MSTeamsIngressActivity): boolean {
+  return (
+    activity.type === "message" ||
+    (activity.type === "invoke" && activity.name === "adaptiveCard/action")
+  );
+}
+
+function inspectMSTeamsIngressActivity(activity: MSTeamsIngressActivity): {
+  eventId: string;
+  laneKey: string;
+} | null {
+  if (!isDispatchableActivity(activity)) {
+    return null;
+  }
+  // @microsoft/teams.api's Activity contract defines id as unique on the
+  // channel. The queue is bot-account scoped, so the raw activity id is the
+  // stable redelivery key; composing mutable message fields would weaken it.
+  const eventId = nonEmptyString(activity.id);
+  if (!eventId) {
+    throw new MSTeamsIngressPayloadError(
+      "invalid-activity",
+      "Microsoft Teams dispatchable activity is missing activity.id.",
+    );
+  }
+  const laneKey = nonEmptyString(activity.conversation?.id);
+  if (!laneKey) {
+    throw new MSTeamsIngressPayloadError(
+      "invalid-activity",
+      "Microsoft Teams dispatchable activity is missing conversation.id.",
+    );
+  }
+  return { eventId, laneKey };
+}
+
+function parseClaimedActivity(
+  payload: MSTeamsIngressPayload,
+  claimedId: string,
+): MSTeamsIngressActivity {
+  if (
+    payload.version !== MSTEAMS_INGRESS_VERSION ||
+    typeof payload.rawActivity !== "string" ||
+    !Number.isFinite(payload.receivedAt)
+  ) {
+    throw new MSTeamsIngressPayloadError(
+      "invalid-activity",
+      "Microsoft Teams ingress payload is invalid.",
+    );
+  }
+  let activity: unknown;
+  try {
+    activity = JSON.parse(payload.rawActivity);
+  } catch (error) {
+    throw new MSTeamsIngressPayloadError(
+      "invalid-json",
+      "Microsoft Teams ingress activity JSON is invalid.",
+      { cause: error },
+    );
+  }
+  if (!activity || typeof activity !== "object" || Array.isArray(activity)) {
+    throw new MSTeamsIngressPayloadError(
+      "invalid-activity",
+      "Microsoft Teams ingress activity must be an object.",
+    );
+  }
+  const parsed = activity as MSTeamsIngressActivity;
+  const facts = inspectMSTeamsIngressActivity(parsed);
+  if (!facts) {
+    throw new MSTeamsIngressPayloadError(
+      "unsupported-activity",
+      "Microsoft Teams ingress row is not an agent-turn activity.",
+    );
+  }
+  if (facts.eventId !== claimedId) {
+    throw new MSTeamsIngressPayloadError(
+      "invalid-activity",
+      "Microsoft Teams activity id changed after durable admission.",
+    );
+  }
+  return parsed;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createMSTeamsIngress(options: MSTeamsIngressOptions): MSTeamsIngress {
+  const queue =
+    options.queue ??
+    getMSTeamsRuntime().state.openChannelIngressQueue<MSTeamsIngressPayload>({
+      accountId: options.accountId,
+    });
+  const shutdown = new AbortController();
+  const liveContexts = new Map<string, MSTeamsTurnContext>();
+  const activeDeliveries = new Set<Promise<MSTeamsIngressDispatchResult | void>>();
+  const drain = createChannelIngressDrain<MSTeamsIngressPayload>({
+    queue,
+    abortSignal: shutdown.signal,
+    orderBy: "received",
+    scanLimit: MSTEAMS_INGRESS_SCAN_LIMIT,
+    startLimit: MSTEAMS_INGRESS_MAX_CONCURRENT_DELIVERIES,
+    retryPolicy: {
+      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+    },
+    resolveNonRetryableFailure: (error) => {
+      if (error instanceof MSTeamsIngressPayloadError) {
+        return { reason: error.reason, message: error.message };
+      }
+      const classification = classifyMSTeamsSendError(error);
+      return classification.kind === "auth"
+        ? { reason: "authentication-failed", message: errorText(error) }
+        : null;
+    },
+    onLog: (message) => options.runtime.error?.(`msteams: ${message}`),
+    dispatchClaimedEvent: async (claimed, lifecycle) => {
+      const activity = parseClaimedActivity(claimed.payload, claimed.id);
+      const liveContext = liveContexts.get(claimed.id);
+      liveContexts.delete(claimed.id);
+      const delivery = Promise.resolve(options.dispatch(activity, lifecycle, liveContext));
+      activeDeliveries.add(delivery);
+      try {
+        return await delivery;
+      } finally {
+        activeDeliveries.delete(delivery);
+      }
+    },
+  });
+  let running = false;
+  let stopped = false;
+  let drainRequested = false;
+  let drainTask: Promise<void> | undefined;
+  let drainTimer: ReturnType<typeof setInterval> | undefined;
+
+  const requestDrain = (): void => {
+    if (!running || shutdown.signal.aborted) {
+      return;
+    }
+    drainRequested = true;
+    if (drainTask) {
+      return;
+    }
+    drainTask = (async () => {
+      while (drainRequested && !shutdown.signal.aborted) {
+        if (!running) {
+          break;
+        }
+        drainRequested = false;
+        await drain.drainOnce({
+          shouldStop: () =>
+            !running ||
+            shutdown.signal.aborted ||
+            activeDeliveries.size >= MSTEAMS_INGRESS_MAX_CONCURRENT_DELIVERIES,
+        });
+      }
+    })()
+      .catch((error: unknown) => {
+        options.runtime.error?.(`msteams ingress drain failed: ${errorText(error)}`);
+      })
+      .finally(() => {
+        drainTask = undefined;
+        if (running && drainRequested && !shutdown.signal.aborted) {
+          requestDrain();
+        }
+      });
+  };
+
+  return {
+    accept: async (activity, liveContext) => {
+      const facts = inspectMSTeamsIngressActivity(activity);
+      if (!facts) {
+        return;
+      }
+      await queue.prune({
+        completedTtlMs: MSTEAMS_INGRESS_TOMBSTONE_TTL_MS,
+        completedMaxEntries: MSTEAMS_INGRESS_COMPLETED_MAX_ENTRIES,
+        failedTtlMs: MSTEAMS_INGRESS_TOMBSTONE_TTL_MS,
+        failedMaxEntries: MSTEAMS_INGRESS_FAILED_MAX_ENTRIES,
+      });
+      const receivedAt = Date.now();
+      const result = await queue.enqueue(
+        facts.eventId,
+        {
+          version: MSTEAMS_INGRESS_VERSION,
+          receivedAt,
+          rawActivity: JSON.stringify(activity),
+        },
+        { receivedAt, laneKey: facts.laneKey },
+      );
+      if (liveContext && (result.kind === "accepted" || result.kind === "pending")) {
+        liveContexts.set(facts.eventId, liveContext);
+      }
+      requestDrain();
+    },
+    start: () => {
+      if (running || stopped) {
+        return;
+      }
+      running = true;
+      requestDrain();
+      drainTimer = setInterval(requestDrain, MSTEAMS_INGRESS_DRAIN_INTERVAL_MS);
+      drainTimer.unref?.();
+    },
+    stop: async () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      running = false;
+      if (drainTimer) {
+        clearInterval(drainTimer);
+        drainTimer = undefined;
+      }
+      await drainTask;
+      await Promise.allSettled(activeDeliveries);
+      await drain.waitForIdle();
+      shutdown.abort();
+      drain.dispose();
+      liveContexts.clear();
+    },
+  };
+}


### PR DESCRIPTION
Related: #109657

AI-assisted implementation; maintainer-reviewed and validated.

## What Problem This Solves

Fixes an issue where Microsoft Teams users could silently lose inbound agent activities when the process stopped after Bot Framework received a webhook but before detached processing adopted the turn. The webhook returned success without durable admission, so Bot Framework had no reason to retry; severity was HIGH because the loss was silent.

## Why This Change Was Made

Microsoft Teams now adopts the shared durable channel-ingress drain. Dispatchable activities use `activity.id` as the event ID, matching the `@microsoft/teams.api` contract that it uniquely identifies an activity on the channel, and `conversation.id` as the serialization lane. The webhook acknowledgement waits for durable append, while downstream work uses deferred claims and merged-debounce fan-out adoption following the proven Signal pattern.

The adapter journals message turns and adaptive-card agent turns only. `messageUpdate`, poll votes, file consent, reactions, and other dedicated non-agent workflows remain outside the ingress journal.

Landing review also fixed live-context payload substitution, an install/append race and leak, duplicate `next()` invocation, stale context after failed append, and the test seam renamed when `main` retired the settled dispatcher.

## User Impact

Accepted Microsoft Teams agent activities survive process interruption and replay after restart instead of disappearing after an early webhook acknowledgement. Conversation ordering remains serialized, debounced turns settle every constituent claim, and non-agent Teams workflows retain their existing behavior.

## Evidence

- Post-rebase full Microsoft Teams suite: 1,113 tests passed, including the loopback lifecycle tests that an earlier sandbox could not run.
- Dedicated durability proof: 14-case ingress matrix plus 3 lifecycle tests covering deferred claims, merged fan-out adoption, and gated no-dispatch completion.
- Current exact-head changed-surface rerun: 39 tests passed across `msteams-ingress`, message-handler ingress lifecycle, monitor lifecycle, and adaptive-card handling.
- Hard-zero gates: `node scripts/check-deadcode-exports.mjs` and `node scripts/check-deadcode-unused-files.mjs` both reported zero entries; `git diff --check` passed.
- The original autoreview build-stage attempt was blocked by sandbox networking. Manual review found and drove the on-branch context, lifecycle, and dispatcher-seam fixes listed above; all prior findings were adjudicated and resolved.

