### PR TITLE
fix(qa): Active Memory live migration fails before model turns

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -186,6 +186,7 @@ describe("qa scenario catalog", () => {
       );
 
     expect(scenarios.map((scenario) => scenario.id).toSorted()).toEqual([
+      "active-memory-preprompt-recall",
       "cron-model-created-one-shot-recurring",
       "kitchen-sink-live-openai",
       "matrix-post-restart-room-continue",

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -43,6 +43,8 @@ scenario:
     kind: flow
     summary: Verify Active Memory stays off when session-toggled off, runs memory search/get when enabled, and helps a live model answer with the recalled preference in the first visible reply.
     channel: qa-channel
+    suiteIsolation: isolated
+    isolationReason: Mutates legacy Active Memory state and runs doctor while the Gateway is stopped, then restarts the Gateway.
     config:
       baselineConversationId: qa-active-memory-off
       activeConversationId: qa-active-memory-on
@@ -84,31 +86,37 @@ flow:
         - set: activeSessionKey
           value:
             expr: "'agent:qa:qa-channel:direct:active-memory-on'"
-        - set: toggleStorePath
+        - set: doctorOutputPath
           value:
-            expr: "path.join(env.gateway.tempRoot, 'state', 'plugins', 'active-memory', 'session-toggles.json')"
-        - call: fs.rm
+            expr: "path.join(env.gateway.tempRoot, 'active-memory-doctor-output.txt')"
+        - assert:
+            expr: "typeof env.gateway.restartAfterStateMutation === 'function'"
+            message: qa gateway child does not expose restartAfterStateMutation
+        - call: env.gateway.restartAfterStateMutation
           args:
-            - ref: toggleStorePath
-            - force: true
-        - call: fs.mkdir
-          args:
-            - expr: "path.dirname(toggleStorePath)"
-            - recursive: true
-        - call: fs.writeFile
-          args:
-            - ref: toggleStorePath
-            - expr: "`${JSON.stringify({ sessions: { [baselineSessionKey]: { disabled: true, updatedAt: Date.now() } } }, null, 2)}\\n`"
-            - utf8
-        - call: runQaCli
-          saveAs: doctorFixOutput
+            - lambda:
+                async: true
+                params: [ctx]
+                expr: |-
+                  (async () => {
+                    const toggleStorePath = path.join(ctx.stateDir, "plugins", "active-memory", "session-toggles.json");
+                    await fs.rm(toggleStorePath, { force: true });
+                    await fs.mkdir(path.dirname(toggleStorePath), { recursive: true });
+                    await fs.writeFile(toggleStorePath, `${JSON.stringify({ sessions: { [baselineSessionKey]: { disabled: true, updatedAt: Date.now() } } }, null, 2)}\n`, "utf8");
+                    const doctorFixOutput = await runQaCli(env, ["doctor", "--fix", "--yes"], {
+                      timeoutMs: liveTurnTimeoutMs(env, 60000),
+                    });
+                    await fs.writeFile(doctorOutputPath, doctorFixOutput, "utf8");
+                  })()
+        - call: waitForGatewayHealthy
           args:
             - ref: env
-            - - doctor
-              - --fix
-              - --yes
-            - timeoutMs:
-                expr: liveTurnTimeoutMs(env, 60000)
+            - 120000
+        - call: fs.readFile
+          saveAs: doctorFixOutput
+          args:
+            - ref: doctorOutputPath
+            - utf8
         - assert:
             expr: "String(doctorFixOutput).includes('Migrated 1 Active Memory session toggle entry')"
             message:


### PR DESCRIPTION
Closes #110343

## What Problem This Solves

Fixes an issue where maintainers running the live Active Memory regression scenario would get a failure before either model turn because the scenario attempted its legacy state migration while the QA Gateway still owned SQLite.

## Why This Change Was Made

The scenario now uses the existing isolated Gateway state-mutation lifecycle: stop the Gateway, write the legacy toggle fixture, run doctor, persist the ephemeral doctor output for the assertion, restart the Gateway, and wait for health before continuing. The catalog test now requires this scenario to remain in the isolated restart set.

## User Impact

No end-user behavior changes. Maintainers regain real-model regression coverage for disabled and enabled Active Memory recall.

## Evidence

- Live OpenAI run passed the complete scenario on Blacksmith: [run 29628102972](https://github.com/openclaw/openclaw/actions/runs/29628102972). This covered doctor migration, Gateway replacement, the disabled baseline turn, the enabled Active Memory turn, memory search/get evidence, and first-reply recall.
- Focused scenario catalog test: 44/44 passed.
- Full fail-safe changed gate passed on Blacksmith: [run 29628204307](https://github.com/openclaw/openclaw/actions/runs/29628204307). This included formatting, full project typecheck, lint across core/extensions/scripts, import-cycle checks, and repository guards.
- Autoreview: clean; no accepted/actionable findings.

AI-assisted: yes. The implementation and proof were reviewed by the author.
