### PR TITLE
fix(feishu): restore lifecycle tests after inbound runtime refactor

### DIFF
--- a/extensions/feishu/src/lifecycle.test-support.ts
+++ b/extensions/feishu/src/lifecycle.test-support.ts
@@ -8,9 +8,6 @@ type BoundConversation = {
 };
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 type AsyncUnknownMock = Mock<(...args: unknown[]) => Promise<unknown>>;
-type FinalizeInboundContextMock = Mock<
-  (ctx: Record<string, unknown>, opts?: unknown) => Record<string, unknown>
->;
 type DispatchReplyCounts = {
   final: number;
   block?: number;
@@ -21,12 +18,14 @@ type DispatchReplyContext = Record<string, unknown> & {
 };
 type DispatchReplyDispatcher = {
   sendFinalReply: (payload: { text: string }) => unknown;
+  waitForIdle?: () => Promise<void>;
+  markComplete?: () => void;
   getFailedCounts?: UnknownMock;
 };
 type FeishuReplyDispatcherMockValue = {
-  dispatcher: DispatchReplyDispatcher;
+  dispatcherOptions: Record<string, never>;
+  delivery: { deliver: AsyncUnknownMock };
   replyOptions: Record<string, never>;
-  markDispatchIdle: () => unknown;
   ensureNoVisibleReplyFallback?: AsyncUnknownMock;
 };
 type CreateFeishuReplyDispatcherMock = Mock<(params?: unknown) => FeishuReplyDispatcherMockValue>;
@@ -56,7 +55,6 @@ type FeishuLifecycleTestMocks = {
   ensureConfiguredBindingRouteReadyMock: UnknownMock;
   dispatchReplyFromConfigMock: DispatchReplyFromConfigMock;
   withReplyDispatcherMock: WithReplyDispatcherMock;
-  finalizeInboundContextMock: FinalizeInboundContextMock;
   getMessageFeishuMock: AsyncUnknownMock;
   listFeishuThreadMessagesMock: AsyncUnknownMock;
   sendMessageFeishuMock: AsyncUnknownMock;
@@ -77,7 +75,6 @@ const feishuLifecycleTestMocks = vi.hoisted(
     ensureConfiguredBindingRouteReadyMock: vi.fn(),
     dispatchReplyFromConfigMock: vi.fn(),
     withReplyDispatcherMock: vi.fn(),
-    finalizeInboundContextMock: vi.fn((ctx) => ctx),
     getMessageFeishuMock: vi.fn(async () => null),
     listFeishuThreadMessagesMock: vi.fn(async () => []),
     sendMessageFeishuMock: vi.fn(async () => ({ messageId: "om_sent", chatId: "chat_default" })),
@@ -98,7 +95,20 @@ export function resetFeishuLifecycleTestMocks(): void {
   feishuLifecycleTestMocks.monitorWebhookMock.mockResolvedValue(undefined);
   feishuLifecycleTestMocks.createFeishuThreadBindingManagerMock.mockReturnValue({ stop: vi.fn() });
   feishuLifecycleTestMocks.resolveBoundConversationMock.mockReturnValue(null);
-  feishuLifecycleTestMocks.finalizeInboundContextMock.mockImplementation((ctx) => ctx);
+  feishuLifecycleTestMocks.withReplyDispatcherMock.mockImplementation(
+    async ({ dispatcher, onSettled, run }) => {
+      try {
+        return await run();
+      } finally {
+        dispatcher?.markComplete?.();
+        try {
+          await dispatcher?.waitForIdle?.();
+        } finally {
+          await onSettled?.();
+        }
+      }
+    },
+  );
   feishuLifecycleTestMocks.getMessageFeishuMock.mockResolvedValue(null);
   feishuLifecycleTestMocks.listFeishuThreadMessagesMock.mockResolvedValue([]);
   feishuLifecycleTestMocks.sendMessageFeishuMock.mockResolvedValue({
@@ -126,31 +136,6 @@ const {
   sendMessageFeishuMock,
   sendCardFeishuMock,
 } = feishuLifecycleTestMocks;
-
-vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
-    "openclaw/plugin-sdk/reply-runtime",
-  );
-  return {
-    ...actual,
-    dispatchInboundMessage: (params: {
-      ctx: DispatchReplyContext;
-      dispatcher: DispatchReplyDispatcher;
-      onSettled?: () => unknown;
-    }) => {
-      const ctx = feishuLifecycleTestMocks.finalizeInboundContextMock(params.ctx);
-      return feishuLifecycleTestMocks.withReplyDispatcherMock({
-        dispatcher: params.dispatcher,
-        onSettled: params.onSettled,
-        run: () =>
-          feishuLifecycleTestMocks.dispatchReplyFromConfigMock({
-            ctx,
-            dispatcher: params.dispatcher,
-          }),
-      });
-    },
-  };
-});
 
 vi.mock("./client.js", () => {
   return {

--- a/extensions/feishu/src/monitor.acp-init-failure.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.acp-init-failure.lifecycle.test-support.ts
@@ -22,7 +22,6 @@ const {
   createEventDispatcherMock,
   dispatchReplyFromConfigMock,
   ensureConfiguredBindingRouteReadyMock,
-  finalizeInboundContextMock,
   resolveAgentRouteMock,
   resolveBoundConversationMock,
   resolveConfiguredBindingRouteMock,
@@ -145,11 +144,8 @@ describe("Feishu ACP-init failure lifecycle", () => {
       queuedFinal: false,
       counts: { final: 0 },
     });
-    withReplyDispatcherMock.mockImplementation(async ({ run }) => await run());
-
     installFeishuLifecycleReplyRuntime({
       resolveAgentRouteMock,
-      finalizeInboundContextMock,
       dispatchReplyFromConfigMock,
       withReplyDispatcherMock,
       storePath: "/tmp/feishu-acp-failure-sessions.json",

--- a/extensions/feishu/src/monitor.bot-menu.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.bot-menu.lifecycle.test-support.ts
@@ -25,7 +25,6 @@ const {
   createEventDispatcherMock,
   createFeishuReplyDispatcherMock,
   dispatchReplyFromConfigMock,
-  finalizeInboundContextMock,
   resolveAgentRouteMock,
   resolveBoundConversationMock,
   sendCardFeishuMock,
@@ -113,11 +112,8 @@ describe("Feishu bot-menu lifecycle", () => {
       replyText: "menu reply once",
     });
 
-    withReplyDispatcherMock.mockImplementation(async ({ run }) => await run());
-
     installFeishuLifecycleReplyRuntime({
       resolveAgentRouteMock,
-      finalizeInboundContextMock,
       dispatchReplyFromConfigMock,
       withReplyDispatcherMock,
       storePath: "/tmp/feishu-bot-menu-sessions.json",
@@ -181,11 +177,13 @@ describe("Feishu bot-menu lifecycle", () => {
         replyToMessageId: undefined,
       }),
     );
-    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+    expect(dispatchReplyFromConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        AccountId: "acct-menu",
-        SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
-        MessageSid: "bot-menu:quick-actions:1700000000001",
+        ctx: expect.objectContaining({
+          AccountId: "acct-menu",
+          SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+          MessageSid: "bot-menu:quick-actions:1700000000001",
+        }),
       }),
     );
     expect(touchBindingMock).toHaveBeenCalledWith("binding-menu");

--- a/extensions/feishu/src/monitor.broadcast.reply-once.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.broadcast.reply-once.lifecycle.test-support.ts
@@ -24,7 +24,6 @@ const {
   createEventDispatcherMock,
   createFeishuReplyDispatcherMock,
   dispatchReplyFromConfigMock,
-  finalizeInboundContextMock,
   resolveAgentRouteMock,
   resolveBoundConversationMock,
   withReplyDispatcherMock,
@@ -161,11 +160,8 @@ describe("Feishu broadcast reply-once lifecycle", () => {
         (ctx as { SessionKey: string }).SessionKey.includes("agent:main:"),
     });
 
-    withReplyDispatcherMock.mockImplementation(async ({ run }) => await run());
-
     installFeishuLifecycleReplyRuntime({
       resolveAgentRouteMock,
-      finalizeInboundContextMock,
       dispatchReplyFromConfigMock,
       withReplyDispatcherMock,
       storePath: "/tmp/feishu-broadcast-sessions.json",
@@ -212,16 +208,16 @@ describe("Feishu broadcast reply-once lifecycle", () => {
       }),
     );
 
-    const sessionKeys = finalizeInboundContextMock.mock.calls.map(
-      (call) => (call[0] as { SessionKey?: string }).SessionKey,
+    const sessionKeys = dispatchReplyFromConfigMock.mock.calls.map(
+      (call) => (call[0].ctx as { SessionKey?: string }).SessionKey,
     );
     expect(sessionKeys).toContain("agent:main:feishu:group:oc_broadcast_group");
     expect(sessionKeys).toContain("agent:susan:feishu:group:oc_broadcast_group");
 
-    const activeDispatcher = createFeishuReplyDispatcherMock.mock.results[0]?.value.dispatcher as {
-      sendFinalReply: ReturnType<typeof vi.fn>;
+    const activeDelivery = createFeishuReplyDispatcherMock.mock.results[0]?.value.delivery as {
+      deliver: ReturnType<typeof vi.fn>;
     };
-    expect(activeDispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(activeDelivery.deliver).toHaveBeenCalledTimes(1);
   });
 
   it("does not duplicate delivery after a post-send failure on the first account", async () => {
@@ -257,9 +253,9 @@ describe("Feishu broadcast reply-once lifecycle", () => {
     expect(runtimesByAccount.get("account-B")?.error).not.toHaveBeenCalled();
     expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(2);
 
-    const activeDispatcher = createFeishuReplyDispatcherMock.mock.results[0]?.value.dispatcher as {
-      sendFinalReply: ReturnType<typeof vi.fn>;
+    const activeDelivery = createFeishuReplyDispatcherMock.mock.results[0]?.value.delivery as {
+      deliver: ReturnType<typeof vi.fn>;
     };
-    expect(activeDispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(activeDelivery.deliver).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
@@ -26,7 +26,6 @@ const {
   createEventDispatcherMock,
   createFeishuReplyDispatcherMock,
   dispatchReplyFromConfigMock,
-  finalizeInboundContextMock,
   resolveAgentRouteMock,
   resolveBoundConversationMock,
   sendCardFeishuMock,
@@ -129,11 +128,11 @@ function latestReplyDispatcherParams() {
 }
 
 function latestFinalizedContext() {
-  const call = finalizeInboundContextMock.mock.calls.at(-1);
+  const call = dispatchReplyFromConfigMock.mock.calls.at(-1);
   if (!call) {
     throw new Error("expected finalized inbound context call");
   }
-  return call[0] as {
+  return call[0].ctx as {
     AccountId?: string;
     SessionKey?: string;
     MessageSid?: string;
@@ -170,11 +169,8 @@ describe("Feishu card-action lifecycle", () => {
       replyText: "card action reply once",
     });
 
-    withReplyDispatcherMock.mockImplementation(async ({ run }) => await run());
-
     installFeishuLifecycleReplyRuntime({
       resolveAgentRouteMock,
-      finalizeInboundContextMock,
       dispatchReplyFromConfigMock,
       withReplyDispatcherMock,
       storePath: "/tmp/feishu-card-action-sessions.json",
@@ -318,11 +314,13 @@ describe("Feishu card-action lifecycle", () => {
         replyToMessageId: "om_card_v2_nested",
       }),
     );
-    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+    expect(dispatchReplyFromConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        AccountId: "acct-card",
-        SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
-        MessageSid: "card-action-tok-card-v2-nested-operator",
+        ctx: expect.objectContaining({
+          AccountId: "acct-card",
+          SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+          MessageSid: "card-action-tok-card-v2-nested-operator",
+        }),
       }),
     );
   });

--- a/extensions/feishu/src/test-support/lifecycle-test-support.ts
+++ b/extensions/feishu/src/test-support/lifecycle-test-support.ts
@@ -12,7 +12,6 @@ type InboundDebouncerParams<T> = {
   onFlush?: (items: T[]) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
 };
-type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 type AsyncUnknownMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 type FeishuDispatchReplyCounts = {
   final: number;
@@ -31,18 +30,15 @@ type FeishuDispatchReplyMock = Mock<
     dispatcher: FeishuDispatchReplyDispatcher;
   }) => Promise<{ queuedFinal: boolean; counts: FeishuDispatchReplyCounts }>
 >;
+type RuntimeReplyDispatcher = NonNullable<
+  Parameters<PluginRuntime["channel"]["reply"]["withReplyDispatcher"]>[0]["dispatcher"]
+>;
 type FeishuLifecycleReplyDispatcher = {
-  dispatcher: {
-    sendToolResult: UnknownMock;
-    sendBlockReply: UnknownMock;
-    sendFinalReply: AsyncUnknownMock;
-    waitForIdle: AsyncUnknownMock;
-    getQueuedCounts: UnknownMock;
-    getFailedCounts: UnknownMock;
-    markComplete: UnknownMock;
+  dispatcherOptions: Record<string, never>;
+  delivery: {
+    deliver: AsyncUnknownMock;
   };
   replyOptions: Record<string, never>;
-  markDispatchIdle: UnknownMock;
   ensureNoVisibleReplyFallback: AsyncUnknownMock;
 };
 
@@ -66,17 +62,9 @@ const FEISHU_PREFETCHED_BOT_OPEN_ID_SOURCE = {
 
 export function createFeishuLifecycleReplyDispatcher(): FeishuLifecycleReplyDispatcher {
   return {
-    dispatcher: {
-      sendToolResult: vi.fn(() => false),
-      sendBlockReply: vi.fn(() => false),
-      sendFinalReply: vi.fn(async () => true),
-      waitForIdle: vi.fn(async () => {}),
-      getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
-      getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
-      markComplete: vi.fn(),
-    },
+    dispatcherOptions: {},
+    delivery: { deliver: vi.fn(async () => {}) },
     replyOptions: {},
-    markDispatchIdle: vi.fn(),
     ensureNoVisibleReplyFallback: vi.fn(async () => false),
   };
 }
@@ -100,7 +88,6 @@ function createImmediateInboundDebounce() {
 
 function installFeishuLifecycleRuntime(params: {
   resolveAgentRoute: PluginRuntime["channel"]["routing"]["resolveAgentRoute"];
-  finalizeInboundContext: PluginRuntime["channel"]["reply"]["finalizeInboundContext"];
   dispatchReplyFromConfig: PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"];
   withReplyDispatcher: PluginRuntime["channel"]["reply"]["withReplyDispatcher"];
   resolveStorePath: PluginRuntime["channel"]["session"]["resolveStorePath"];
@@ -124,7 +111,35 @@ function installFeishuLifecycleRuntime(params: {
       reply: {
         resolveEnvelopeFormatOptions: vi.fn(() => ({})),
         formatAgentEnvelope: vi.fn((value: { body: string }) => value.body),
-        finalizeInboundContext: params.finalizeInboundContext,
+        dispatchReplyWithBufferedBlockDispatcher: async ({ cfg, ctx, dispatcherOptions }) => {
+          // ReplyDispatcher enqueue methods are synchronous; settlement owns async delivery.
+          const pendingDeliveries: Promise<unknown>[] = [];
+          const dispatcher: RuntimeReplyDispatcher = {
+            sendToolResult: () => false,
+            sendBlockReply: () => false,
+            sendFinalReply: (payload) => {
+              pendingDeliveries.push(
+                Promise.resolve(dispatcherOptions.deliver(payload, { kind: "final" })),
+              );
+              return true;
+            },
+            waitForIdle: async () => {
+              await Promise.all(pendingDeliveries);
+            },
+            getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+            getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+            markComplete: () => {},
+          };
+          return await params.withReplyDispatcher({
+            dispatcher,
+            run: () =>
+              params.dispatchReplyFromConfig({
+                cfg,
+                ctx: ctx as Parameters<typeof params.dispatchReplyFromConfig>[0]["ctx"],
+                dispatcher,
+              }),
+          });
+        },
         dispatchReplyFromConfig: params.dispatchReplyFromConfig,
         withReplyDispatcher: params.withReplyDispatcher,
       },
@@ -153,7 +168,6 @@ function installFeishuLifecycleRuntime(params: {
 
 export function installFeishuLifecycleReplyRuntime(params: {
   resolveAgentRouteMock: unknown;
-  finalizeInboundContextMock: unknown;
   dispatchReplyFromConfigMock: unknown;
   withReplyDispatcherMock: unknown;
   storePath: string;
@@ -161,8 +175,6 @@ export function installFeishuLifecycleReplyRuntime(params: {
   return installFeishuLifecycleRuntime({
     resolveAgentRoute:
       params.resolveAgentRouteMock as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
-    finalizeInboundContext:
-      params.finalizeInboundContextMock as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
     dispatchReplyFromConfig:
       params.dispatchReplyFromConfigMock as PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"],
     withReplyDispatcher:
@@ -405,10 +417,10 @@ export async function expectFeishuReplyPipelineDedupedAfterPostSendFailure(param
 export function expectFeishuReplyDispatcherSentFinalReplyOnce(params: {
   createFeishuReplyDispatcherMock: ReturnType<typeof vi.fn>;
 }) {
-  const dispatcher = params.createFeishuReplyDispatcherMock.mock.results[0]?.value.dispatcher as {
-    sendFinalReply: ReturnType<typeof vi.fn>;
+  const delivery = params.createFeishuReplyDispatcherMock.mock.results[0]?.value.delivery as {
+    deliver: ReturnType<typeof vi.fn>;
   };
-  expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  expect(delivery.deliver).toHaveBeenCalledTimes(1);
 }
 
 async function loadMonitorSingleAccount() {


### PR DESCRIPTION
Related: #110095

## What Problem This Solves

Feishu lifecycle tests fail 12 of 16 scenarios after inbound turn execution moved into core. The harness still returns the retired dispatcher shape and mocks the retired reply-runtime entry point, so current core dispatch sees no delivery adapter.

## Why This Change Was Made

Model the current `dispatcherOptions` and `delivery` return contract, bridge the current buffered-dispatch seam, and delete the obsolete finalize-context compatibility mock. The test dispatcher now queues async deliveries and waits for settlement, preserving the production lifecycle invariant.

## User Impact

No production behavior change. Feishu replay, card-action, bot-menu, broadcast, and ACP lifecycle regressions are testable again, unblocking affected PR CI.

## Evidence

- Current `main` at `19296b003b55`: `node scripts/run-vitest.mjs extensions/feishu/src/monitor.lifecycle.test.ts` failed 12/16.
- Fixed branch after final rebase: same command passed 16/16.
- Hosted changed gate: extension and extension-test typechecks passed; formatting, SDK baseline, plugin boundaries, and static guards passed. Final targeted lint passed after deleting the obsolete alias.
- Testbox type/check evidence: https://github.com/openclaw/openclaw/actions/runs/29627963069
- Autoreview: first pass caught unawaited delivery settlement; fixed. Final pass clean, 0.86 confidence.

AI-assisted maintainer repair discovered while landing #110326.
