### PR TITLE
fix(model-selection): preserve pinned override when the model catalog is degraded

### DIFF
--- a/src/agents/model-catalog.runtime.ts
+++ b/src/agents/model-catalog.runtime.ts
@@ -1,2 +1,6 @@
 /** Runtime barrel for model catalog loading helpers. */
-export { loadManifestModelCatalog, loadModelCatalog } from "./model-catalog.js";
+export {
+  loadManifestModelCatalog,
+  loadModelCatalog,
+  loadModelCatalogSnapshot,
+} from "./model-catalog.js";

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -331,12 +331,20 @@ function mergeCatalogRouteVariants(
 function createModelCatalogSnapshot(
   entries: ModelCatalogEntry[],
   routeVariants: ModelCatalogRouteVariantCollector,
+  authoritative = true,
 ): ModelCatalogSnapshot {
   return {
     entries: sortModelCatalogEntries(entries),
     routeVariants: sortModelCatalogEntries(routeVariants.entries),
+    authoritative,
   };
 }
+
+const EMPTY_DEGRADED_MODEL_CATALOG_SNAPSHOT: ModelCatalogSnapshot = {
+  entries: [],
+  routeVariants: [],
+  authoritative: false,
+};
 
 export function loadManifestModelCatalog(params: {
   config: OpenClawConfig;
@@ -666,7 +674,8 @@ function loadReadOnlyStaticModelCatalog(params?: {
     mergeCatalogRouteVariants(routeVariants, configuredModels);
     mergeCatalogEntries(models, configuredModels, { preserveBaseName: true });
   }
-  return createModelCatalogSnapshot(models, routeVariants);
+  // Static-only catalog: discovery/persisted rows were unavailable, so this is degraded.
+  return createModelCatalogSnapshot(models, routeVariants, false);
 }
 
 /** Loads logical entries together with browse-only physical route provenance. */
@@ -675,8 +684,8 @@ export async function loadModelCatalogSnapshot(
 ): Promise<ModelCatalogSnapshot> {
   if (params?.cacheOnly === true) {
     return loadedModelCatalogGeneration === modelCatalogGeneration
-      ? (loadedModelCatalogSnapshot ?? { entries: [], routeVariants: [] })
-      : { entries: [], routeVariants: [] };
+      ? (loadedModelCatalogSnapshot ?? EMPTY_DEGRADED_MODEL_CATALOG_SNAPSHOT)
+      : EMPTY_DEGRADED_MODEL_CATALOG_SNAPSHOT;
   }
   const readOnly = params?.readOnly === true;
   if (readOnly) {
@@ -944,9 +953,9 @@ export async function loadModelCatalogSnapshot(
         modelCatalogPromise = null;
       }
       if (models.length > 0) {
-        return createModelCatalogSnapshot(models, routeVariants);
+        return createModelCatalogSnapshot(models, routeVariants, false);
       }
-      return { entries: [], routeVariants: [] };
+      return EMPTY_DEGRADED_MODEL_CATALOG_SNAPSHOT;
     }
   };
 

--- a/src/agents/model-catalog.types.ts
+++ b/src/agents/model-catalog.types.ts
@@ -30,4 +30,11 @@ export type ModelCatalogEntry = {
 export type ModelCatalogSnapshot = {
   entries: ModelCatalogEntry[];
   routeVariants: ModelCatalogEntry[];
+  /**
+   * `false` only when this snapshot came from a degraded load (discovery threw,
+   * static or empty fallback). Absent/`true` means authoritative — consumers that
+   * destroy durable state (e.g. resetting a pinned model override) must treat only
+   * an explicit `false` as degraded, so unrelated hand-built snapshots stay safe.
+   */
+  authoritative?: boolean;
 };

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -72,8 +72,15 @@ function hasOnlyModelDirective(directives: InlineDirectives): boolean {
 function formatModelOverrideResetEvent(params: {
   rejectedRef?: string;
   initialModelLabel: string;
-  reason?: "disallowed" | "stale";
+  reason?: "disallowed" | "stale" | "temporarily-unavailable";
 }): string {
+  if (params.reason === "temporarily-unavailable") {
+    // Non-destructive: the pin is preserved and comes back once the catalog reloads.
+    if (params.rejectedRef) {
+      return `Model override ${params.rejectedRef} is temporarily unavailable (model catalog is still loading); using ${params.initialModelLabel} for this turn. Your pinned model is unchanged.`;
+    }
+    return `Your pinned model override is temporarily unavailable (model catalog is still loading); using ${params.initialModelLabel} for this turn. Your pinned model is unchanged.`;
+  }
   if (params.reason === "stale") {
     if (params.rejectedRef) {
       return `Stored model override ${params.rejectedRef} is stale for this session; reverted to ${params.initialModelLabel}. Pick a model again with /model if you still want to override the default.`;
@@ -200,7 +207,9 @@ export async function applyInlineDirectiveOverrides(params: {
 
   let directiveAck: ReplyPayload | undefined;
 
-  if (modelState.resetModelOverride) {
+  // Fire on the reason, not the boolean: a temporarily-unavailable override
+  // surfaces a notice without destroying the pin, so resetModelOverride stays false.
+  if (modelState.resetModelOverrideReason) {
     enqueueSystemEvent(
       formatModelOverrideResetEvent({
         rejectedRef: modelState.resetModelOverrideRef,
@@ -255,7 +264,7 @@ export async function applyInlineDirectiveOverrides(params: {
     directives.hasQueueDirective ||
     directives.hasStatusDirective;
 
-  if (!hasAnyDirective && !modelState.resetModelOverride) {
+  if (!hasAnyDirective && !modelState.resetModelOverride && !modelState.resetModelOverrideReason) {
     return {
       kind: "continue",
       directives,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -17,17 +17,35 @@ import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/ses
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../../sessions/model-overrides.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 
+const DEFAULT_MOCK_CATALOG_ENTRIES = vi.hoisted(() => [
+  { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.5" },
+  { provider: "inferencer", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3" },
+  { provider: "kimi", id: "kimi-code", name: "Kimi Code" },
+  { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+  { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+  { provider: "xai", id: "grok-4", name: "Grok 4" },
+  { provider: "xai", id: "grok-4.20-reasoning", name: "Grok 4.20 (Reasoning)" },
+]);
+
+const catalogRuntimeMocks = vi.hoisted(() => {
+  const loadModelCatalog = vi.fn(
+    async (_params?: unknown): Promise<unknown[]> => DEFAULT_MOCK_CATALOG_ENTRIES,
+  );
+  return {
+    loadModelCatalog,
+    // Delegate to the entries mock so per-test `loadModelCatalog.mockResolvedValueOnce`
+    // still drives selection; tests that need a degraded snapshot override this directly.
+    loadModelCatalogSnapshot: vi.fn(async (params?: unknown) => {
+      const entries = await loadModelCatalog(params as never);
+      return { entries, routeVariants: entries, authoritative: true };
+    }),
+  };
+});
+
 vi.mock("../../agents/model-catalog.runtime.js", () => ({
   loadManifestModelCatalog: vi.fn(() => []),
-  loadModelCatalog: vi.fn(async () => [
-    { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.5" },
-    { provider: "inferencer", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3" },
-    { provider: "kimi", id: "kimi-code", name: "Kimi Code" },
-    { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
-    { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
-    { provider: "xai", id: "grok-4", name: "Grok 4" },
-    { provider: "xai", id: "grok-4.20-reasoning", name: "Grok 4.20 (Reasoning)" },
-  ]),
+  loadModelCatalog: catalogRuntimeMocks.loadModelCatalog,
+  loadModelCatalogSnapshot: catalogRuntimeMocks.loadModelCatalogSnapshot,
 }));
 
 vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
@@ -2063,4 +2081,106 @@ describe("createModelSelectionState resolveDefaultReasoningLevel", () => {
     await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("off");
   });
 });
+
+describe("createModelSelectionState degraded-catalog override preservation", () => {
+  const sessionKey = "agent:main:discord:channel:g1";
+  // The `anthropic/*` wildcard (a non-default provider) forces the live catalog
+  // load path (`needsModelCatalog`), which is the only path where a degraded
+  // catalog can transiently drop a pin. Every test must load the snapshot so its
+  // one-time mock is consumed and cannot leak into a sibling test.
+  //
+  // Allow-list without gpt-4o, so the pinned override reads as "not allowed"
+  // whenever the catalog cannot vouch for it. The authoritative flag then
+  // decides whether that reads as a genuine disallow or a transient outage.
+  const restrictiveCfg = {
+    agents: { defaults: { models: { "openai/gpt-4o-mini": {}, "anthropic/*": {} } } },
+  } as unknown as OpenClawConfig;
+  // Permissive allow-list that keeps gpt-4o allowed regardless of the catalog.
+  const permissiveCfg = {
+    agents: {
+      defaults: { models: { "openai/gpt-4o": {}, "openai/gpt-4o-mini": {}, "anthropic/*": {} } },
+    },
+  } as unknown as OpenClawConfig;
+
+  const makeOverrideEntry = (): SessionEntry => ({
+    sessionId: "session-id",
+    updatedAt: Date.now(),
+    providerOverride: "openai",
+    modelOverride: "gpt-4o",
+    modelOverrideSource: "user",
+  });
+
+  async function run(params: {
+    cfg: OpenClawConfig;
+    snapshotEntries: unknown[];
+    authoritative: boolean;
+  }): Promise<{
+    state: Awaited<ReturnType<typeof createModelSelectionState>>;
+    sessionEntry: SessionEntry;
+  }> {
+    catalogRuntimeMocks.loadModelCatalogSnapshot.mockResolvedValueOnce({
+      entries: params.snapshotEntries,
+      routeVariants: params.snapshotEntries,
+      authoritative: params.authoritative,
+    });
+    const sessionEntry = makeOverrideEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const state = await createModelSelectionState({
+      cfg: params.cfg,
+      agentCfg: params.cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      primaryProvider: "openai",
+      primaryModel: "gpt-4o-mini",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      hasModelDirective: false,
+    });
+    return { state, sessionEntry };
+  }
+
+  it("preserves a pin the degraded catalog cannot vouch for", async () => {
+    // Degraded snapshot: we cannot prove the pin is really disallowed, so keep it.
+    const { state, sessionEntry } = await run({
+      cfg: restrictiveCfg,
+      snapshotEntries: [],
+      authoritative: false,
+    });
+    expect(state.resetModelOverride).toBe(false);
+    expect(state.resetModelOverrideReason).toBe("temporarily-unavailable");
+    expect(state.resetModelOverrideRef).toBe("openai/gpt-4o");
+    // The pin is untouched and the turn falls back to primary.
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+    expect(state.model).toBe("gpt-4o-mini");
+  });
+
+  it("destroys a genuinely-disallowed pin on an authoritative catalog", async () => {
+    // Same disallowed pin, but an authoritative catalog proves it is gone.
+    const { state } = await run({
+      cfg: restrictiveCfg,
+      snapshotEntries: [{ provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" }],
+      authoritative: true,
+    });
+    expect(state.resetModelOverrideReason).toBe("disallowed");
+    expect(state.resetModelOverride).toBe(true);
+  });
+
+  it("keeps a configured pin that is present on an authoritative catalog", async () => {
+    const { state } = await run({
+      cfg: permissiveCfg,
+      snapshotEntries: [
+        { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+        { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+      ],
+      authoritative: true,
+    });
+    expect(state.resetModelOverride).toBe(false);
+    expect(state.resetModelOverrideReason).toBeUndefined();
+    expect(state.model).toBe("gpt-4o");
+  });
+});
+
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -66,7 +66,7 @@ type ModelSelectionState = {
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resetModelOverrideRef?: string;
-  resetModelOverrideReason?: "disallowed" | "stale";
+  resetModelOverrideReason?: "disallowed" | "stale" | "temporarily-unavailable";
   resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
   resolveDefaultThinkingLevel: (selection?: ThinkingDefaultSelection) => Promise<ThinkLevel>;
   hasConfiguredThinkingDefault?: boolean;
@@ -212,9 +212,12 @@ export async function createModelSelectionState(params: {
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
   });
   let modelCatalog: ModelCatalog | null = null;
+  // Whether the loaded catalog is a complete/live snapshot. A degraded catalog
+  // (discovery threw, static/empty fallback) must not destroy a pinned override.
+  let catalogAuthoritative = true;
   let resetModelOverride = false;
   let resetModelOverrideRef: string | undefined;
-  let resetModelOverrideReason: "disallowed" | "stale" | undefined;
+  let resetModelOverrideReason: "disallowed" | "stale" | "temporarily-unavailable" | undefined;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
   const normalizedDirectStoredOverride = normalizeStoredOverrideModel({
     providerOverride: sessionEntry?.providerOverride,
@@ -272,8 +275,16 @@ export async function createModelSelectionState(params: {
     staleLegacyAutoFallbackWithoutOrigin;
 
   if (needsModelCatalog) {
-    modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
-    logStage("catalog-loaded", `entries=${modelCatalog.length}`);
+    const catalogSnapshot = await (
+      await loadModelCatalogRuntime()
+    ).loadModelCatalogSnapshot({ config: cfg });
+    modelCatalog = catalogSnapshot.entries;
+    // Only an explicit false is degraded; absent means authoritative.
+    catalogAuthoritative = catalogSnapshot.authoritative !== false;
+    logStage(
+      "catalog-loaded",
+      `entries=${modelCatalog.length} authoritative=${catalogAuthoritative}`,
+    );
     visibilityPolicy = createModelVisibilityPolicy({
       cfg,
       catalog: modelCatalog,
@@ -319,7 +330,19 @@ export async function createModelSelectionState(params: {
       directStoredOverride.model,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-    if (staleDirectStoredOverride || !visibilityPolicy.allowsKey(key)) {
+    const overrideAllowed = visibilityPolicy.allowsKey(key);
+    // A degraded catalog (discovery failed, static/empty fallback) makes the
+    // allow-list unreliable, so `!allowsKey` cannot prove a pin is really
+    // disallowed. Never destroy the pin for that: the turn already falls back to
+    // the primary via the allowsKey gate below, and the override is re-evaluated
+    // once discovery recovers. Stale is a config fact (override model absent from
+    // config), catalog-independent, so it still resets.
+    const overrideTemporarilyUnavailable =
+      !staleDirectStoredOverride && !overrideAllowed && !catalogAuthoritative;
+    if (overrideTemporarilyUnavailable) {
+      resetModelOverrideRef = key;
+      resetModelOverrideReason = "temporarily-unavailable";
+    } else if (staleDirectStoredOverride || !overrideAllowed) {
       const initialSessionEntry = { ...sessionEntry };
       const nextSessionEntry = { ...sessionEntry };
       const { updated } = applyModelOverrideToSessionEntry({


### PR DESCRIPTION
Related: #97517

## What Problem This Solves

Fixes an issue where switching an active session to a model served by a slow-to-start runtime (e.g. `/model codex/gpt-5.5` behind a local app-server/proxy) would, on the first turn or two, show a misleading rejection and silently unpin the user's chosen model:

```
Model override codex/gpt-5.5 is not allowed for this agent; reverted to <fallback>.
Add codex/gpt-5.5 to agents.defaults.models or pick an allowed model with /model list.
```

The model **is** allowed — it is inherited from `agents.defaults.models`. The real trigger is a transient cold-start/discovery failure: for that one turn the live model catalog fails to load, so the pinned model looks disallowed. Worse, the reset was **persisted**, permanently unpinning the model, and the notice told the user to "add it to agents.defaults.models" — advice that is wrong and does not help. This is symptom #1 of #97517.

## Why This Change Was Made

The per-turn model catalog can load in a degraded state (discovery threw, or it fell back to a static/empty catalog). A degraded catalog cannot prove a pin is truly disallowed, yet the reset path treated a degraded `allowsKey() === false` identically to a genuine, authoritative rejection — destroying durable session state on a transient signal.

This change threads authoritative-vs-degraded provenance through `ModelCatalogSnapshot` (`authoritative?: boolean`; only degraded loads set `false`). When a pin is rejected **only** because the catalog is degraded, the override is preserved: the turn still falls back to the primary model (unchanged behavior, via the existing `allowsKey` gate), and a non-destructive "temporarily unavailable" notice is shown instead of the destructive "not allowed; add to config" message. The pin is re-evaluated once discovery recovers.

Genuine disallow (authoritative catalog proves the model is gone) and stale overrides (a catalog-independent config fact) keep today's destructive reset — both are reliable signals, so their behavior is unchanged.

Scope: this addresses symptom #1 (the false "not allowed; reverted" misreport). Symptom #2 in the issue (`/status` runtime label lagging the live-switched harness) is a separate persisted-snapshot path and is not touched here.

## User Impact

- A pinned model served by a slow-starting runtime is no longer silently unpinned during its cold-start window. Once the runtime finishes its first handshake, the pin is simply used.
- During the transient window the user sees an accurate, non-alarming notice ("temporarily unavailable; using <primary> for this turn; your pinned model is unchanged") instead of a misleading allow-list rejection with unhelpful config advice.
- No change for genuinely disallowed or stale overrides — those still reset as before.

## Evidence

**Unit tests** (`src/auto-reply/reply/model-selection.test.ts`) — new `degraded-catalog override preservation` block, all green, covering the three branches that differ only by catalog provenance:
- degraded catalog + pin the catalog cannot vouch for → **preserved**, reason `temporarily-unavailable`, pin untouched, turn falls back to primary;
- authoritative catalog proving the pin is gone → **destructive reset**, reason `disallowed` (unchanged);
- authoritative catalog containing the pin → no reset, pin used.

**Live, real code + real key** (no mocks):
- `loadModelCatalogSnapshot({ readOnly: true })` → real static-fallback path returns `authoritative: false` (degraded) — verified.
- Real OpenAI key → real discovery → `authoritative !== false` with real `openai` catalog entries present — verified against the live provider (this is the exact per-turn catalog-load path the gateway runs). Discovery-failure with no credentials likewise returns `authoritative: false`, confirming degraded marking end-to-end.

The transient degraded **window itself** cannot be triggered on demand through a live message (it depends on a runtime cold-start race), so that branch is covered by the unit tests plus the verified real-code provenance marking rather than a live message round-trip.

**Static checks:** `tsgo` typecheck clean, `oxfmt`/`oxlint` clean, autoreview (uncommitted diff) clean — no accepted/actionable findings.
