### PR TITLE
ci(release): tolerate historical script contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1332,31 +1332,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          pr_head="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" |
+              jq -r --arg repo "$GITHUB_REPOSITORY" --arg target "$TARGET_SHA" '
+                select(.state == "open" and .head.sha == $target and .base.repo.full_name == $repo)
+                | .head.sha
+              '
+          )"
+          if [[ "$pr_head" != "$TARGET_SHA" ]]; then
+            echo "release-gate pull request must be open and match the target head" >&2
+            exit 1
+          fi
+          # Freeze GitHub's canonical merge snapshot once it contains the exact head.
+          # Base freshness belongs to the landing gate; chasing moving main here can never converge.
           prepared=false
           for attempt in {1..6}; do
-            pr_info="$(
-              gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" |
-                jq -r --arg repo "$GITHUB_REPOSITORY" --arg target "$TARGET_SHA" '
-                  select(.state == "open" and .head.sha == $target and .base.repo.full_name == $repo)
-                  | [.base.sha, (if .mergeable == null then "unknown" else (.mergeable | tostring) end)]
-                  | @tsv
-                '
-            )"
-            if [[ -z "$pr_info" ]]; then
-              echo "release-gate pull request must be open and match the target head" >&2
-              exit 1
-            fi
-            IFS=$'\t' read -r base_sha mergeable <<<"$pr_info"
-            if [[ "$mergeable" == "false" ]]; then
-              echo "release-gate pull request is not mergeable" >&2
-              exit 1
-            fi
-            if [[ "$mergeable" == "true" ]] &&
-              timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags --depth=2 origin \
-                "+refs/pull/${PULL_REQUEST_NUMBER}/merge:refs/remotes/origin/ci-max-lines-merge"; then
+            if timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags --depth=2 origin \
+              "+refs/pull/${PULL_REQUEST_NUMBER}/merge:refs/remotes/origin/ci-max-lines-merge"; then
               merge_sha="$(git rev-parse refs/remotes/origin/ci-max-lines-merge)"
-              read -r merge_base merge_head extra_parent <<<"$(git show -s --format=%P "$merge_sha")"
-              if [[ "$merge_base" == "$base_sha" && "$merge_head" == "$TARGET_SHA" && -z "$extra_parent" ]]; then
+              read -r frozen_base_sha merge_head extra_parent <<<"$(git show -s --format=%P "$merge_sha")"
+              if [[ "$merge_head" == "$TARGET_SHA" && -z "$extra_parent" ]]; then
                 prepared=true
                 break
               fi
@@ -1366,11 +1361,11 @@ jobs:
             fi
           done
           if [[ "$prepared" != "true" ]]; then
-            echo "release-gate merge tree did not refresh to the current pull request base and head" >&2
+            echo "release-gate merge tree did not refresh to the target head" >&2
             exit 1
           fi
           git checkout --detach "$merge_sha"
-          echo "RATCHET_RELEASE_BASE_SHA=${base_sha}" >> "$GITHUB_ENV"
+          echo "RATCHET_RELEASE_BASE_SHA=${frozen_base_sha}" >> "$GITHUB_ENV"
           echo "RATCHET_RELEASE_MERGE_TREE=true" >> "$GITHUB_ENV"
 
       - name: Setup Node environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2027,7 +2027,14 @@ jobs:
           case "$TASK" in
             guards)
               pnpm check:no-conflict-markers
-              pnpm check:script-declarations
+              if has_package_script "check:script-declarations"; then
+                pnpm check:script-declarations
+              elif [[ "$HISTORICAL_TARGET" != "true" ]]; then
+                echo "Current CI targets must provide the check:script-declarations package script." >&2
+                exit 1
+              else
+                echo "[skip] historical target predates the script declaration contract"
+              fi
               pnpm tool-display:check
               pnpm check:host-env-policy:swift
               pnpm dup:check:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2723,7 +2723,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_macos_node == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-15' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-6vcpu-macos-15' || 'macos-15') }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-15' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-6vcpu-macos-15' || 'macos-15') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -2762,10 +2762,10 @@ jobs:
     name: "macos-swift"
     needs: [preflight]
     if: needs.preflight.outputs.run_macos_swift == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
-    # Release dispatches use the hosted runner and may still be finalizing large
-    # Swift caches after every test passes; keep that post-job work non-blocking.
-    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && 30 || 20 }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    # Hosted runs may still be finalizing large Swift caches after every test
+    # passes; keep that post-job work non-blocking.
+    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 30 || 20 }}
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
     steps:
@@ -2959,7 +2959,7 @@ jobs:
     name: "ios-build"
     needs: [preflight]
     if: needs.preflight.outputs.run_ios_build == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 45
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}

--- a/.github/workflows/ios-periphery.yml
+++ b/.github/workflows/ios-periphery.yml
@@ -84,7 +84,7 @@ jobs:
     name: Scan iOS dead code
     needs: scope
     if: ${{ needs.scope.outputs.should-scan == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/macos-periphery.yml
+++ b/.github/workflows/macos-periphery.yml
@@ -76,7 +76,7 @@ jobs:
     name: Scan macOS dead code
     needs: scope
     if: ${{ needs.scope.outputs.should-scan == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/shared-openclawkit-periphery.yml
+++ b/.github/workflows/shared-openclawkit-periphery.yml
@@ -81,7 +81,7 @@ jobs:
     name: Scan shared kit from iOS
     needs: scope
     if: ${{ needs.scope.outputs.should-scan == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -173,7 +173,7 @@ jobs:
     name: Scan shared kit from macOS
     needs: scope
     if: ${{ needs.scope.outputs.should-scan == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -522,6 +522,10 @@ const GITHUB_WORKFLOW_OWNER_TEST_TARGETS = new Map([
   ],
   [".github/workflows/ios-periphery.yml", ["test/scripts/ios-periphery-comment-workflow.test.ts"]],
   [
+    ".github/workflows/macos-periphery.yml",
+    ["test/scripts/ios-periphery-comment-workflow.test.ts"],
+  ],
+  [
     ".github/workflows/shared-openclawkit-periphery.yml",
     ["test/scripts/periphery-intersection.test.ts"],
   ],

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3511,21 +3511,27 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "release-gate pull request must be open and match the target head",
     );
     expect(releaseGateMerge.run).toContain("for attempt in {1..6}");
-    expect(releaseGateMerge.run).toContain('if [[ "$mergeable" == "false" ]]');
-    expect(releaseGateMerge.run).toContain("release-gate pull request is not mergeable");
-    expect(releaseGateMerge.run).toContain("sleep 5");
     expect(releaseGateMerge.run).toContain(
       '"+refs/pull/${PULL_REQUEST_NUMBER}/merge:refs/remotes/origin/ci-max-lines-merge"',
     );
+    expect(releaseGateMerge.run).toContain('"$merge_head" == "$TARGET_SHA"');
+    expect(releaseGateMerge.run).toContain('git show -s --format=%P "$merge_sha"');
     expect(releaseGateMerge.run).toContain(
       "timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags --depth=2 origin \\",
     );
     expect(releaseGateMerge.run).toContain(
-      "release-gate merge tree did not refresh to the current pull request base and head",
+      "Freeze GitHub's canonical merge snapshot once it contains the exact head",
     );
+    expect(releaseGateMerge.run).toContain(
+      "Base freshness belongs to the landing gate; chasing moving main here can never converge",
+    );
+    expect(releaseGateMerge.run).toContain(
+      "release-gate merge tree did not refresh to the target head",
+    );
+    expect(releaseGateMerge.run).not.toContain(".base.sha");
     expect(releaseGateMerge.run).toContain('git checkout --detach "$merge_sha"');
     expect(releaseGateMerge.run).toContain(
-      'echo "RATCHET_RELEASE_BASE_SHA=${base_sha}" >> "$GITHUB_ENV"',
+      'echo "RATCHET_RELEASE_BASE_SHA=${frozen_base_sha}" >> "$GITHUB_ENV"',
     );
     expect(releaseGateMerge.run).toContain(
       'echo "RATCHET_RELEASE_MERGE_TREE=true" >> "$GITHUB_ENV"',

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -869,6 +869,13 @@ describe("ci workflow guards", () => {
         "github.event_name == 'workflow_dispatch'",
       );
     }
+
+    for (const jobName of ["macos-node", "macos-swift", "ios-build"]) {
+      expect(
+        workflow.jobs[jobName]["runs-on"],
+        `${jobName} retries must escape stalled Blacksmith macOS capacity`,
+      ).toContain("github.run_attempt > 1");
+    }
   });
 
   it("keeps Testbox pull request validation off leased runner capacity", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3354,7 +3354,12 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
     expect(workflow).toContain("check-guards");
     expect(workflow).toContain("check-shrinkwrap");
+    expect(preflightGuards).toContain('has_package_script "check:script-declarations"');
     expect(preflightGuards).toContain("pnpm check:script-declarations");
+    expect(preflightGuards).toContain('[[ "$HISTORICAL_TARGET" != "true" ]]');
+    expect(preflightGuards).toContain(
+      "Current CI targets must provide the check:script-declarations package script.",
+    );
     expect(shrinkwrapGuards).toContain("pnpm deps:shrinkwrap:check");
     expect(preflightGuards).toContain("pnpm deps:patches:check");
     expect(parsedWorkflow.jobs.preflight.outputs.diff_base_revision).toBe(

--- a/test/scripts/ios-periphery-comment-workflow.test.ts
+++ b/test/scripts/ios-periphery-comment-workflow.test.ts
@@ -9,6 +9,7 @@ import { markdownToIR } from "../../packages/markdown-core/src/ir.js";
 
 const WORKFLOW_PATH = ".github/workflows/ios-periphery-comment.yml";
 const PRODUCER_WORKFLOW_PATH = ".github/workflows/ios-periphery.yml";
+const MACOS_PRODUCER_WORKFLOW_PATH = ".github/workflows/macos-periphery.yml";
 const ARTIFACT_NAME = "ios-periphery-dead-code-12345-2";
 
 type WorkflowStep = {
@@ -44,6 +45,7 @@ type ProducerWorkflow = {
       steps?: WorkflowStep[];
     };
     scan?: {
+      "runs-on"?: string;
       steps?: WorkflowStep[];
     };
   };
@@ -466,6 +468,13 @@ describe("iOS Periphery comment workflow", () => {
     expect(upload?.if).toBe("always()");
     expect(upload?.with?.path).toBe("${{ runner.temp }}/ios-periphery");
     expect(upload?.with?.["if-no-files-found"]).toBe("error");
+  });
+
+  it("uses hosted macOS capacity on retried scans", () => {
+    for (const workflowPath of [PRODUCER_WORKFLOW_PATH, MACOS_PRODUCER_WORKFLOW_PATH]) {
+      const workflow = parse(readFileSync(workflowPath, "utf8")) as ProducerWorkflow;
+      expect(workflow.jobs?.scan?.["runs-on"]).toContain("github.run_attempt > 1");
+    }
   });
 
   it("runs scope detection for PR transitions that can clear stale findings", () => {

--- a/test/scripts/periphery-intersection.test.ts
+++ b/test/scripts/periphery-intersection.test.ts
@@ -25,6 +25,7 @@ type Workflow = {
     {
       name?: string;
       needs?: string[] | string;
+      "runs-on"?: string;
       steps?: WorkflowStep[];
     }
   >;
@@ -97,6 +98,8 @@ describe("shared OpenClawKit Periphery workflow", () => {
     expect(workflow.jobs?.["scan-ios"]?.name).toBe("Scan shared kit from iOS");
     expect(workflow.jobs?.["scan-macos"]?.name).toBe("Scan shared kit from macOS");
     expect(workflow.jobs?.intersect?.needs).toEqual(["scope", "scan-ios", "scan-macos"]);
+    expect(workflow.jobs?.["scan-ios"]?.["runs-on"]).toContain("github.run_attempt > 1");
+    expect(workflow.jobs?.["scan-macos"]?.["runs-on"]).toContain("github.run_attempt > 1");
 
     const iosUpload = workflow.jobs?.["scan-ios"]?.steps?.find(
       (step) => step.name === "Upload iOS consumer report",


### PR DESCRIPTION
## What Problem This Solves

Current-main CI tooling runs against frozen release targets during full release validation. `release/2026.7.2` predates the new `check:script-declarations` package script, so the current harness failed before reaching product tests. Current main also had a stale generated Apple locale catalog, which made an unrelated `native-i18n` failure block the historical release candidate.

The required PR gate was also capacity-coupled to Blacksmith macOS runners. Six retried native jobs remained queued for more than 13 minutes without starting, even after an exact-head GitHub-hosted release gate completed all 133 jobs successfully in 16m17s.

Failure proof: https://github.com/openclaw/openclaw/actions/runs/29628298781/job/88037012120

## Why This Change Was Made

Feature-detect the new script for historical targets. Current targets still fail closed if the required script disappears. This preserves the new guard on main while preventing later harness additions from retroactively breaking frozen release candidates.

The branch also carries the canonical automation-generated Apple locale refresh from #110362. Combining the exact baseline repair avoids two serial full-CI/rebase cohorts while main is landing continuously.

Native macOS jobs now keep Blacksmith on the first attempt, but retries use GitHub-hosted macOS capacity. This preserves the fast/economic normal path and gives the required PR context a bounded capacity escape without rerunning successful jobs.

The exact-SHA release gate now freezes GitHub's canonical merge snapshot once it contains the requested head. It no longer compares that merge against the lagging REST `base.sha`, which caused false failures while `main` moved continuously; landing-time merge binding remains the freshness owner.

## User Impact

Release validation can test older/frozen candidates with current trusted CI tooling without backporting a large unrelated declaration-check implementation. Main's Apple locale inventory returns to generated consistency.

Maintainers can recover a capacity-stalled native gate with a failed-jobs-only retry instead of waiting indefinitely or rebasing onto a moving main branch.

## Evidence

- `actionlint .github/workflows/ci.yml`
- Testbox `tbx_01kxskja06732wkf21zbgrxsjf`: 83 workflow guard tests passed
- Testbox path-scoped `pnpm check:changed`: passed
- Apple refresh source PR #110362: exact-head `native-i18n` passed; identical delta previously passed `ios-build`
- Apple refresh macOS 26 runner wait exceeded 10 minutes with zero failures; serialized landing avoided
- Fresh combined-head autoreview: clean, 0.94
- Exact-head hosted fallback run: https://github.com/openclaw/openclaw/actions/runs/29629592932; 133/133 jobs passed in 16m17s
- Blacksmith macOS retry experiment: six jobs queued more than 13 minutes with zero execution before the new head superseded it
- Retry-capacity patch: `actionlint` passed for all four workflows
- Testbox `tbx_01kxsqwwcmqpxw42w35andfzxw`: 121 focused workflow tests passed in 11.25s
- Fresh retry-capacity autoreview: clean, 0.96
- Final exact-head normal CI: https://github.com/openclaw/openclaw/actions/runs/29631483212; green in 3m59s
- Final exact-head hosted release gate: https://github.com/openclaw/openclaw/actions/runs/29631485692; 133/133 jobs green in 17m45s
- Exact-head hosted native periphery: https://github.com/openclaw/openclaw/actions/runs/29631483229, https://github.com/openclaw/openclaw/actions/runs/29631483205, https://github.com/openclaw/openclaw/actions/runs/29631483237; all green
- Canonical merge-snapshot guard: 83 focused tests green on Testbox `tbx_01kxsrma5p1yzgn9ktm7v61wkp`; `actionlint` green
- Final merge-snapshot autoreview: clean, 0.91
