### PR TITLE
fix(ios): sync stale Apple localization catalog

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",


### PR DESCRIPTION
Closes #110367

## What Problem This Solves

Fixes an issue where pull requests would fail the required compact tooling shard because the iOS localization catalog on `main` was stale.

## Why This Change Was Made

The repository-owned Apple localization generator was run with `sync-ios --write`. This adds the missing `Show reasoning & tool activity` entry to the iOS catalog and regenerates the contradiction report, removing four contradictions that no longer exist.

## User Impact

Maintainers can pass the Apple i18n tooling gate again. The existing localized reasoning/tool-activity setting is now present in the generated iOS catalog.

## Evidence

- Before: exact-head CI run 29628452375 failed twice in `test/scripts/apple-app-i18n.test.ts` because `apps/ios/Resources/Localizable.xcstrings` was stale.
- After: `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` passed all 13 tests.
- Generator result: 1,439 iOS keys, 84 InfoPlist files, 1,201 remaining tracked contradictions.
- `git diff --check` passed.
- Autoreview: clean; no accepted/actionable findings.

AI-assisted: yes. The generated diff and proof were reviewed by the author.
