### PR TITLE
fix: failed cloud dispatch leaks the session's managed worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cloud dispatch cleanup:** snapshot and remove session-owned managed worktrees during session deletion so failed cloud dispatches cannot leak worktrees, and disable the New Session cloud target with an explanatory reason when the configured agent runtime is not OpenClaw.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cloud dispatch cleanup:** snapshot and remove session-owned managed worktrees during session deletion so failed cloud dispatches cannot leak worktrees, and disable the New Session cloud target with an explanatory reason when the configured agent runtime is not OpenClaw.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -390,8 +390,8 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
     const archivedTranscripts = deletion.archivedTranscripts;
     const archived = archivedTranscripts.map((entryLocal) => entryLocal.archivedPath);
 
-    // Dirty or unpushed worktrees survive session deletion; tell the caller so
-    // operator UIs can point at the preserved checkout instead of orphaning it.
+    // Session deletion ends worktree ownership. Snapshot before removal so
+    // inherited unpushed history or local edits do not leave an ownerless checkout.
     let worktreePreserved: { id: string; branch: string; path: string } | undefined;
     if (deleted) {
       // requestedAgentId wins: "global" canonical keys resolve to the default store
@@ -400,12 +400,16 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
         target.canonicalKey ?? key,
         requestedAgentId ?? resolveSessionStoreAgentId(cfg, target.canonicalKey ?? key),
       );
+      let worktree: ReturnType<typeof managedWorktrees.findLiveByOwner> = undefined;
       try {
-        const worktree = managedWorktrees.findLiveByOwner("session", target.canonicalKey);
-        if (worktree && !(await managedWorktrees.removeIfLossless(worktree.id))) {
-          worktreePreserved = { id: worktree.id, branch: worktree.branch, path: worktree.path };
+        worktree = managedWorktrees.findLiveByOwner("session", target.canonicalKey);
+        if (worktree) {
+          await managedWorktrees.remove({ id: worktree.id, reason: "session-delete" });
         }
       } catch (error) {
+        if (worktree) {
+          worktreePreserved = { id: worktree.id, branch: worktree.branch, path: worktree.path };
+        }
         sessionLog.warn(
           `failed to clean up worktree for deleted session ${target.canonicalKey}: ${formatErrorMessage(error)}`,
         );

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -118,7 +118,7 @@ function expectThreadBindingsUnbound(targetSessionKey: string) {
   });
 }
 
-test("sessions.delete removes clean session worktrees and keeps dirty ones", async () => {
+test("sessions.delete snapshots and removes session worktrees", async () => {
   const root = await fs.mkdtemp(
     path.join(await fs.realpath(os.tmpdir()), "openclaw-delete-worktree-"),
   );
@@ -131,9 +131,12 @@ test("sessions.delete removes clean session worktrees and keeps dirty ones", asy
   let dirtyWorktreeId: string | undefined;
   try {
     const adminClient = { connect: { scopes: ["operator.admin"] } } as never;
+    await fs.writeFile(path.join(workspace, "local-base.txt"), "inherited local commit\n");
+    await execFileAsync("git", ["-C", workspace, "add", "local-base.txt"]);
+    await execFileAsync("git", ["-C", workspace, "commit", "-m", "local base"]);
     const clean = await directSessionReq<{
       key: string;
-      worktree: { id: string; path: string };
+      worktree: { id: string; path: string; branch: string };
     }>("sessions.create", { agentId: "main", worktree: true }, { client: adminClient });
     expect(clean.ok).toBe(true);
     const cleanKey = clean.payload?.key;
@@ -148,10 +151,26 @@ test("sessions.delete removes clean session worktrees and keeps dirty ones", asy
       removedAt: expect.any(Number),
       snapshotRef: expect.stringMatching(/^refs\/openclaw\/snapshots\//),
     });
+    const registered = await execFileAsync("git", [
+      "-C",
+      workspace,
+      "worktree",
+      "list",
+      "--porcelain",
+    ]);
+    expect(registered.stdout).not.toContain(cleanWorktree!.path);
+    const branch = await execFileAsync("git", [
+      "-C",
+      workspace,
+      "branch",
+      "--list",
+      cleanWorktree!.branch,
+    ]);
+    expect(branch.stdout.trim()).toBe("");
 
     const dirty = await directSessionReq<{
       key: string;
-      worktree: { id: string; path: string };
+      worktree: { id: string; path: string; branch: string };
     }>("sessions.create", { agentId: "main", worktree: true }, { client: adminClient });
     expect(dirty.ok).toBe(true);
     const dirtyKey = dirty.payload?.key;
@@ -161,8 +180,12 @@ test("sessions.delete removes clean session worktrees and keeps dirty ones", asy
 
     await expectSessionDeleteSucceeds({ key: dirtyKey! });
 
-    await expect(fs.access(dirtyWorktree!.path)).resolves.toBeUndefined();
-    expect(getRegistryWorktree(process.env, dirtyWorktree!.id)?.removedAt).toBeUndefined();
+    await expect(fs.access(dirtyWorktree!.path)).rejects.toThrow();
+    expect(getRegistryWorktree(process.env, dirtyWorktree!.id)).toMatchObject({
+      removedAt: expect.any(Number),
+      snapshotRef: expect.stringMatching(/^refs\/openclaw\/snapshots\//),
+    });
+    dirtyWorktreeId = undefined;
   } finally {
     if (
       dirtyWorktreeId &&

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -479,6 +479,8 @@ export const en: TranslationMap = {
     cloudWorker: "Cloud · {profile}",
     cloudWorkerProvider: "Cloud worker provider: {provider}",
     cloudRequiresWorktree: "Cloud workers require a managed worktree",
+    cloudRequiresOpenClawRuntime:
+      "Cloud workers require the OpenClaw runtime; {runtime} is selected.",
     cloudSecureContextRequired:
       "Cloud workers need a secure browser context so recovery can protect your task.",
     cloudStartFailed: "The session was created locally, but cloud startup failed: {error}",

--- a/ui/src/pages/new-session/cloud-target.test.ts
+++ b/ui/src/pages/new-session/cloud-target.test.ts
@@ -1,8 +1,12 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   deleteCloudDraftSession,
   deleteRecoveredCloudDraftSession,
+  renderCloudProfileMenuItems,
   startCloudInitialTurn,
 } from "./cloud-target.ts";
 
@@ -595,5 +599,26 @@ describe("cloud session startup", () => {
       "sessions.send",
       expect.objectContaining({ idempotencyKey: "recovery-message-1" }),
     );
+  });
+});
+
+describe("cloud target menu", () => {
+  it("disables cloud profiles with the runtime preflight reason", () => {
+    const container = document.createElement("div");
+    render(
+      renderCloudProfileMenuItems({
+        profiles: [{ id: "aws", providerId: "crabbox" }],
+        selectedId: "",
+        submitting: false,
+        disabled: true,
+        disabledReason: "Cloud workers require the OpenClaw runtime; codex is selected.",
+        onSelect: vi.fn(),
+      }),
+      container,
+    );
+
+    const button = container.querySelector<HTMLButtonElement>('[data-value="cloud:aws"]');
+    expect(button?.disabled).toBe(true);
+    expect(button?.title).toBe("Cloud workers require the OpenClaw runtime; codex is selected.");
   });
 });

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -464,6 +464,7 @@ export function renderCloudProfileMenuItems(params: {
   selectedId: string;
   submitting: boolean;
   disabled?: boolean;
+  disabledReason?: string;
   onSelect: (profileId: string) => void;
 }) {
   return params.profiles.map((profile) =>
@@ -473,7 +474,10 @@ export function renderCloudProfileMenuItems(params: {
         label: t("newSession.cloudWorker", { profile: profile.id }),
         checked: params.selectedId === profile.id,
         disabled: params.disabled,
-        title: t("newSession.cloudWorkerProvider", { provider: profile.providerId }),
+        title:
+          params.disabled && params.disabledReason
+            ? params.disabledReason
+            : t("newSession.cloudWorkerProvider", { provider: profile.providerId }),
         onSelect: () => params.onSelect(profile.id),
       },
       params.submitting,

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { NewSessionModelControl } from "./model-control.ts";
+
+function contextWith(models: ModelCatalogEntry[], runtime = "openclaw"): ApplicationContext {
+  return {
+    gateway: {
+      snapshot: {
+        connected: true,
+        client: { request: vi.fn().mockResolvedValue({ models }) },
+      },
+    },
+    sessions: {
+      state: {
+        result: {
+          defaults: {
+            model: "openai/gpt-5.6-luna",
+            modelProvider: "openai",
+            agentRuntime: { id: runtime, source: "defaults" },
+          },
+        },
+      },
+    },
+  } as unknown as ApplicationContext;
+}
+
+describe("new-session model runtime", () => {
+  it("uses model catalog runtime metadata for an explicit cloud target", async () => {
+    const context = contextWith([
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        agentRuntime: { id: "codex", source: "model" },
+      },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+    control.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(context.gateway.snapshot.client?.request).toHaveBeenCalledWith("chat.metadata", {
+        agentId: "main",
+      }),
+    );
+    await vi.waitFor(() => {
+      control.selected = "openai/gpt-5.6-luna";
+      expect(control.resolveAgentRuntimeId({ context })).toBe("codex");
+    });
+  });
+
+  it("falls back to the selected agent runtime for its default model", () => {
+    const context = contextWith([]);
+    const agent = {
+      id: "main",
+      agentRuntime: { id: "claude-cli", source: "agent" },
+    } satisfies GatewayAgentRow;
+    const control = new NewSessionModelControl(() => undefined);
+
+    expect(control.resolveAgentRuntimeId({ agent, context })).toBe("claude-cli");
+  });
+
+  it("does not apply default runtime metadata to an explicit model", async () => {
+    const context = contextWith(
+      [{ id: "sonnet-4.6", name: "Sonnet 4.6", provider: "anthropic" }],
+      "codex",
+    );
+    const control = new NewSessionModelControl(() => undefined);
+    control.load(context, "main", true);
+    control.selected = "anthropic/sonnet-4.6";
+
+    await vi.waitFor(() => expect(control.resolveAgentRuntimeId({ context })).toBeUndefined());
+  });
+});

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -3,12 +3,13 @@ import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { NewSessionModelControl } from "./model-control.ts";
 
-function contextWith(models: ModelCatalogEntry[], runtime = "openclaw"): ApplicationContext {
-  return {
+function contextWith(models: ModelCatalogEntry[], runtime = "openclaw") {
+  const request = vi.fn().mockResolvedValue({ models });
+  const context = {
     gateway: {
       snapshot: {
         connected: true,
-        client: { request: vi.fn().mockResolvedValue({ models }) },
+        client: { request },
       },
     },
     sessions: {
@@ -23,11 +24,12 @@ function contextWith(models: ModelCatalogEntry[], runtime = "openclaw"): Applica
       },
     },
   } as unknown as ApplicationContext;
+  return { context, request };
 }
 
 describe("new-session model runtime", () => {
   it("uses model catalog runtime metadata for an explicit cloud target", async () => {
-    const context = contextWith([
+    const { context, request } = contextWith([
       {
         id: "gpt-5.6-luna",
         name: "GPT-5.6 Luna",
@@ -38,7 +40,7 @@ describe("new-session model runtime", () => {
     const control = new NewSessionModelControl(() => undefined);
     control.load(context, "main", true);
     await vi.waitFor(() =>
-      expect(context.gateway.snapshot.client?.request).toHaveBeenCalledWith("chat.metadata", {
+      expect(request).toHaveBeenCalledWith("chat.metadata", {
         agentId: "main",
       }),
     );
@@ -49,7 +51,7 @@ describe("new-session model runtime", () => {
   });
 
   it("falls back to the selected agent runtime for its default model", () => {
-    const context = contextWith([]);
+    const { context } = contextWith([]);
     const agent = {
       id: "main",
       agentRuntime: { id: "claude-cli", source: "agent" },
@@ -60,7 +62,7 @@ describe("new-session model runtime", () => {
   });
 
   it("does not apply default runtime metadata to an explicit model", async () => {
-    const context = contextWith(
+    const { context } = contextWith(
       [{ id: "sonnet-4.6", name: "Sonnet 4.6", provider: "anthropic" }],
       "codex",
     );

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -61,6 +61,16 @@ describe("new-session model runtime", () => {
     expect(control.resolveAgentRuntimeId({ agent, context })).toBe("claude-cli");
   });
 
+  it.each(["auto", "default"])(
+    "leaves the %s runtime selector unresolved for server-side policy",
+    (runtime) => {
+      const { context } = contextWith([], runtime);
+      const control = new NewSessionModelControl(() => undefined);
+
+      expect(control.resolveAgentRuntimeId({ context })).toBeUndefined();
+    },
+  );
+
   it("does not apply default runtime metadata to an explicit model", async () => {
     const { context } = contextWith(
       [{ id: "sonnet-4.6", name: "Sonnet 4.6", provider: "anthropic" }],

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -107,6 +107,33 @@ export class NewSessionModelControl {
       });
   }
 
+  resolveAgentRuntimeId(options: {
+    agent?: GatewayAgentRow;
+    context: ApplicationContext | undefined;
+  }): string | undefined {
+    const defaults = options.context?.sessions.state.result?.defaults;
+    const agentDefaultModel = options.agent?.model?.primary;
+    if (this.selected) {
+      // Agent/default runtime metadata belongs to its default model. An explicit
+      // model without per-model metadata is unknown, not an inherited runtime.
+      return resolveDraftModelTarget(
+        this.selected,
+        undefined,
+        this.catalog,
+      )?.entry?.agentRuntime?.id.trim();
+    }
+    const defaultTarget = resolveDraftModelTarget(
+      agentDefaultModel ?? defaults?.model,
+      agentDefaultModel ? undefined : defaults?.modelProvider,
+      this.catalog,
+    );
+    return (
+      defaultTarget?.entry?.agentRuntime?.id.trim() ??
+      options.agent?.agentRuntime?.id.trim() ??
+      defaults?.agentRuntime?.id.trim()
+    );
+  }
+
   render(options: {
     agent?: GatewayAgentRow;
     agentId: string;

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -127,11 +127,13 @@ export class NewSessionModelControl {
       agentDefaultModel ? undefined : defaults?.modelProvider,
       this.catalog,
     );
-    return (
+    const runtime =
       defaultTarget?.entry?.agentRuntime?.id.trim() ??
       options.agent?.agentRuntime?.id.trim() ??
-      defaults?.agentRuntime?.id.trim()
-    );
+      defaults?.agentRuntime?.id.trim();
+    // Default selectors need server-side model/provider policy before they are
+    // concrete, so the UI must leave Cloud eligibility to the dispatch gate.
+    return runtime === "auto" || runtime === "default" ? undefined : runtime;
   }
 
   render(options: {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -589,6 +589,16 @@ class NewSessionPage extends OpenClawLightDomElement {
     return this.pendingCloud.sessionKey ? this.pendingCloud.profileId : this.cloudProfileId;
   }
 
+  private cloudRuntimeUnsupportedReason(): string | undefined {
+    const runtime = this.modelControl.resolveAgentRuntimeId({
+      agent: this.selectedAgent(),
+      context: this.context,
+    });
+    return runtime && runtime !== "openclaw"
+      ? t("newSession.cloudRequiresOpenClawRuntime", { runtime })
+      : undefined;
+  }
+
   private canSubmit(): boolean {
     const pendingCloud = Boolean(this.pendingCloud.sessionKey);
     const cloudProfileId = this.cloudProfileForSubmission();
@@ -639,7 +649,8 @@ class NewSessionPage extends OpenClawLightDomElement {
         !gateway.snapshot.client.recoveryScopeReady ||
         !this.cloudProfilesHydrated ||
         !this.worktree ||
-        !this.cloudProfiles.some((profile) => profile.id === cloudProfileId))
+        !this.cloudProfiles.some((profile) => profile.id === cloudProfileId) ||
+        Boolean(this.cloudRuntimeUnsupportedReason()))
     ) {
       return false;
     }
@@ -1186,6 +1197,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       syncFolder: this.folder.trim() || this.workspacePath(),
       worktree: this.worktree,
       worktreeAvailable: this.worktreeAvailable(),
+      cloudDisabledReason: this.cloudRuntimeUnsupportedReason(),
       customFolder: this.usesCustomFolder(),
       branches: this.branches,
       branchesLoading: this.branchesLoading,

--- a/ui/src/pages/new-session/target-controls.ts
+++ b/ui/src/pages/new-session/target-controls.ts
@@ -92,6 +92,7 @@ export function renderWhereSelect(params: {
   syncFolder: string;
   worktree: boolean;
   worktreeAvailable: boolean;
+  cloudDisabledReason?: string;
   customFolder: boolean;
   branches: DraftBranches | null;
   branchesLoading: boolean;
@@ -194,7 +195,8 @@ export function renderWhereSelect(params: {
               profiles: params.cloudProfiles,
               selectedId: params.cloudProfileId,
               submitting: params.submitting,
-              disabled: !params.worktreeAvailable,
+              disabled: !params.worktreeAvailable || Boolean(params.cloudDisabledReason),
+              disabledReason: params.cloudDisabledReason,
               onSelect: params.onSelectCloudProfile,
             })}
             ${params.cloudProfileId && !activeProfile


### PR DESCRIPTION
Related: #110224

## What Problem This Solves

Fixes an issue where choosing a Cloud target in the New Session composer and hitting a dispatch rejection (for example "cloud worker dispatch requires the OpenClaw runtime, not codex") would clean up the just-created session but permanently leak its session-owned managed worktree and branch on disk, with no owning session left in the session list. It also lets operators hit that runtime rejection blind: the Cloud target was offered even when the configured agent runtime can never dispatch.

Found during a live stress test of cloud workers on a dev gateway with the bundled crabbox provider (see the linked issue for the full session log).

## Why This Change Was Made

Two bounded changes:

1. Session deletion now snapshots and removes session-owned managed worktrees instead of relying on the lossless check. The previous `removeIfLossless` gate can never pass in a workspace repo with no git remote (its `git log HEAD --not --remotes` treats the entire inherited history as unpushed), so every session delete preserved an ownerless checkout. `remove()` already snapshots the working tree into `refs/openclaw/snapshots/<id>` before removal, so content stays restorable; on cleanup failure the preserved checkout is still reported.
2. The New Session composer resolves the effective agent runtime from configured model metadata and disables the Cloud target with an explanatory tooltip ("Cloud workers require the OpenClaw runtime; {runtime} is selected.") and blocks submission when it is not `openclaw`. Note the limitation: implicit provider-side routing (e.g. OpenAI models auto-routing to the Codex runtime without any configured `agentRuntime`) is not visible to the UI, so the server-side dispatch check remains the authority; this pre-check catches the configured cases.

## User Impact

Failed cloud dispatches no longer litter the workspace with orphaned worktrees/branches, and session deletion reliably cleans up its worktree while keeping a restorable snapshot. Operators with a configured non-OpenClaw runtime see why Cloud is unavailable up front instead of a post-creation failure banner.

## Evidence

- Live repro before the fix: dispatch rejected with the codex-runtime error left `wt-3f8d623c` + branch `openclaw/wt-3f8d623c` on disk with no owning session.
- Focused tests: `node scripts/run-vitest.mjs src/gateway/server.sessions.delete-lifecycle.test.ts ui/src/pages/new-session/cloud-target.test.ts ui/src/pages/new-session/model-control.test.ts` — gateway shard 24 passed, UI shard 34 passed. The lifecycle test now proves the worktree registration and branch are gone after delete and a `refs/openclaw/snapshots/` ref is recorded.
- Structured autoreview (codex, gpt-5.6-sol): clean, no actionable findings.
