### PR TITLE
fix(mxc): reject oversized sandbox policy files

### DIFF
--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -225,6 +225,9 @@ baseline:
 - A configured policy file that does not exist on the host is an error
   (`Configured sandbox policy file <path> does not exist. Remove it from
 mxcPolicyPaths or create the file.`), not a silent skip.
+- A policy file larger than 1 MiB is rejected before parsing. If an existing
+  policy exceeds this limit, remove unnecessary whitespace or split it into
+  multiple files listed in `mxcPolicyPaths`; files are layered in array order.
 - A policy file that is malformed JSON or includes an unsupported field fails
   with an error naming the policy file path and the invalid field.
 - Every `filesystem.additionalReadonlyPaths` and

--- a/extensions/mxc/src/sandbox-policy-loader.ts
+++ b/extensions/mxc/src/sandbox-policy-loader.ts
@@ -67,6 +67,8 @@ const SandboxPolicyLayerSchema = z
   })
   .strict();
 
+const MAX_SANDBOX_POLICY_FILE_BYTES = 1024 * 1024;
+
 export function loadSandboxBaselinePolicy(
   options: SandboxPolicyLoaderOptions = {},
 ): LoadedSandboxBaselinePolicy {
@@ -93,6 +95,12 @@ export function loadSandboxBaselinePolicy(
 function readSandboxPolicyFile(policyPath: string): SandboxPolicyLayer {
   let parsed: unknown;
   try {
+    const fileSize = statSync(policyPath).size;
+    if (fileSize > MAX_SANDBOX_POLICY_FILE_BYTES) {
+      throw new Error(
+        `Sandbox policy file exceeds ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes (${fileSize} bytes).`,
+      );
+    }
     parsed = JSON.parse(readFileSync(policyPath, "utf-8"));
   } catch (err) {
     throw policyFileError(policyPath, err);

--- a/extensions/mxc/src/sandbox-policy-loader.ts
+++ b/extensions/mxc/src/sandbox-policy-loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readSync, statSync } from "node:fs";
 import { win32 } from "node:path";
 import { z } from "zod";
 import {
@@ -68,6 +68,7 @@ const SandboxPolicyLayerSchema = z
   .strict();
 
 const MAX_SANDBOX_POLICY_FILE_BYTES = 1024 * 1024;
+const SANDBOX_POLICY_READ_CHUNK_BYTES = 64 * 1024;
 
 export function loadSandboxBaselinePolicy(
   options: SandboxPolicyLoaderOptions = {},
@@ -95,13 +96,7 @@ export function loadSandboxBaselinePolicy(
 function readSandboxPolicyFile(policyPath: string): SandboxPolicyLayer {
   let parsed: unknown;
   try {
-    const fileSize = statSync(policyPath).size;
-    if (fileSize > MAX_SANDBOX_POLICY_FILE_BYTES) {
-      throw new Error(
-        `Sandbox policy file exceeds ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes (${fileSize} bytes).`,
-      );
-    }
-    parsed = JSON.parse(readFileSync(policyPath, "utf-8"));
+    parsed = JSON.parse(readSandboxPolicyFileContents(policyPath));
   } catch (err) {
     throw policyFileError(policyPath, err);
   }
@@ -110,6 +105,42 @@ function readSandboxPolicyFile(policyPath: string): SandboxPolicyLayer {
     return parseSandboxPolicyLayer(parsed, policyPath);
   } catch (err) {
     throw policyFileError(policyPath, err);
+  }
+}
+
+function readSandboxPolicyFileContents(policyPath: string): string {
+  let fd: number | undefined;
+  try {
+    // Keep the size check and bounded read on one descriptor so replacing or
+    // growing the configured path cannot bypass the startup memory limit.
+    fd = openSync(policyPath, "r");
+    const fileSize = fstatSync(fd).size;
+    if (fileSize > MAX_SANDBOX_POLICY_FILE_BYTES) {
+      throw new Error(
+        `Sandbox policy file exceeds ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes (${fileSize} bytes).`,
+      );
+    }
+
+    const chunks: Buffer[] = [];
+    const scratch = Buffer.allocUnsafe(SANDBOX_POLICY_READ_CHUNK_BYTES);
+    let totalBytes = 0;
+    while (true) {
+      const bytesRead = readSync(fd, scratch, 0, scratch.length, null);
+      if (bytesRead === 0) {
+        return Buffer.concat(chunks, totalBytes).toString("utf-8");
+      }
+      totalBytes += bytesRead;
+      if (totalBytes > MAX_SANDBOX_POLICY_FILE_BYTES) {
+        throw new Error(
+          `Sandbox policy file exceeds ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes while being read.`,
+        );
+      }
+      chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
+    }
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd);
+    }
   }
 }
 

--- a/extensions/mxc/test/sandbox-policy-loader.test.ts
+++ b/extensions/mxc/test/sandbox-policy-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -41,6 +41,18 @@ function expectPolicyFileFailure(policyPath: string, action: () => unknown, deta
   }
   throw new Error("Expected policy loader failure.");
 }
+
+test("rejects oversized policy files before reading them", () => {
+  const policyPath = join(makeTestDir(), "oversized-policy.json");
+  writeFileSync(policyPath, "", "utf-8");
+  truncateSync(policyPath, 1024 * 1024 + 1);
+
+  expectPolicyFileFailure(
+    policyPath,
+    () => loadSandboxBaselinePolicy({ policyPaths: [policyPath] }),
+    "exceeds 1048576 bytes",
+  );
+});
 
 describeOnWindows("loadSandboxBaselinePolicy", () => {
   test("resolves no configured policy files with the default baseline", () => {

--- a/extensions/mxc/test/sandbox-policy-loader.test.ts
+++ b/extensions/mxc/test/sandbox-policy-loader.test.ts
@@ -54,6 +54,13 @@ test("rejects oversized policy files before reading them", () => {
   );
 });
 
+test("accepts policy files at the size limit", () => {
+  const policyPath = join(makeTestDir(), "maximum-policy.json");
+  writeFileSync(policyPath, `{${" ".repeat(1024 * 1024 - 2)}}`, "utf-8");
+
+  expect(loadSandboxBaselinePolicy({ policyPaths: [policyPath] }).process.timeoutSeconds).toBe(300);
+});
+
 describeOnWindows("loadSandboxBaselinePolicy", () => {
   test("resolves no configured policy files with the default baseline", () => {
     const policy = loadSandboxBaselinePolicy();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who configured an unexpectedly large file in `plugins.entries.mxc.config.mxcPolicyPaths` would have the entire file read and parsed synchronously when an MXC sandbox backend was created. A mistaken path to a large JSON file could therefore cause a large memory spike during gateway startup before the policy was rejected.

## Why This Change Was Made

MXC now opens each sandbox policy once, checks and bounded-reads that same descriptor, and rejects files larger than 1 MiB before JSON parsing. The compatibility risk is that an unusually large but valid policy now fails closed; the documented upgrade path is to remove unnecessary whitespace or split it into multiple policy files, and boundary coverage verifies that a policy exactly at 1 MiB remains accepted.

## User Impact

MXC operators get an actionable error for oversized sandbox policy files instead of allowing an unbounded synchronous allocation during sandbox initialization.

## Evidence

**Real-machine production-path proof:** Linux `6.8.0-134-generic` x86_64, Node `v24.18.0`. The same harness directly imported the production `loadSandboxBaselinePolicy`, created a real 64 MiB JSON file on disk, invoked the loader, recorded process RSS, and then loaded a normal `{}` policy as a negative control. No filesystem or loader mocks were used.

**Before:** On pre-fix `upstream/main` at `d45e024dcabfd01abec24bf195fc2a6f0984cfef`, the production loader read and parsed all 64 MiB before schema validation rejected the extra field. RSS increased by 135,368,704 bytes and peak resident memory reached 223,332 KiB:

```text
{"sourceHead":"d45e024dcabfd01abec24bf195fc2a6f0984cfef","policyBytes":67108864,"oversizedError":"Failed to load sandbox policy file at <temp>/oversized-policy.json: Sandbox policy field <temp>/oversized-policy.json.padding is not supported.","rssBefore":92536832,"rssAfter":227905536,"rssDelta":135368704,"normalPolicyTimeoutSeconds":300}
Maximum resident set size (kbytes): 223332
```

Latest main at PR creation was `1aa0d73823a80e4674648328ff63bc162daed58e`; its loader blob is identical to the tested pre-fix source:

```text
d45e024dc:extensions/mxc/src/sandbox-policy-loader.ts  36cda6a4051482dd32c14e66b9764f46a1a222a8
1aa0d73823a:extensions/mxc/src/sandbox-policy-loader.ts  36cda6a4051482dd32c14e66b9764f46a1a222a8
```

**Premise:** `createMxcSandboxBackendHandle` synchronously calls `loadSandboxBaselinePolicy({ policyPaths: params.config.mxcPolicyPaths })`. Before this change, `readSandboxPolicyFile` passed each configured path directly to `readFileSync(..., "utf-8")` and then `JSON.parse`, so neither the existing `try/catch` nor schema validation bounded the allocation.

**After / negative control:** On commit `6bbe0ec8312e8786dfe1e786925e0b327db1409a`, the same production-path harness rejected the file from its 67,108,864-byte metadata before reading it. The size check and bounded read share one open descriptor, and the read loop independently enforces the cap if the opened file grows. RSS did not increase in this run, peak resident memory was 76,936 KiB, and the normal policy still loaded with the default 300-second timeout:

```bash
SOURCE_HEAD=$(git rev-parse HEAD) POLICY_BYTES=67108864 \
  /usr/bin/time -f 'max_rss_kb=%M elapsed=%e exit=%x' \
  node --import tsx /tmp/openclaw-mxc-policy-proof.mts
```

```text
{"sourceHead":"6bbe0ec8312e8786dfe1e786925e0b327db1409a","policyBytes":67108864,"oversizedError":"Failed to load sandbox policy file at <temp>/oversized-policy.json: Sandbox policy file exceeds 1048576 bytes (67108864 bytes).","rssBefore":78651392,"rssAfter":78651392,"rssDelta":0,"normalPolicyTimeoutSeconds":300}
max_rss_kb=76936 elapsed=0.12 exit=0
```

**Focused validation on the rebased patch:**

```bash
node scripts/run-vitest.mjs extensions/mxc
```

```text
Test Files  9 passed | 1 skipped (10)
Tests       53 passed | 54 skipped (107)
```

The focused suite includes an accepted file exactly at the 1 MiB boundary. Targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check upstream/main..HEAD` also passed. The full extension type/check lanes were not run locally because `pnpm test:extension mxc` attempted dependency reconciliation in the isolated linked worktree; fork CI remains the wide validation path.

AI-assisted: Codex helped inspect and implement the change; the production-path proof and focused validation above were run manually.
