### PR TITLE
improve: speed up Control UI async test polling

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -18,6 +18,7 @@ import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts"
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
+import { waitForFast } from "../test-helpers/wait-for.ts";
 import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
 import "./app-sidebar.ts";
 import {
@@ -684,8 +685,8 @@ describe("AppSidebar agent chip", () => {
     expect(sidebar.querySelector(".sidebar-recent-session--child")).toBeNull();
 
     toggle?.click();
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledOnce());
-    await vi.waitFor(() =>
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledOnce());
+    await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),
     );
 
@@ -759,8 +760,8 @@ describe("AppSidebar agent chip", () => {
         ],
       },
     });
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() =>
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
+    await waitForFast(() =>
       expect(
         sidebar.querySelector('[data-session-key="agent:main:child-one"] [aria-label="Done"]'),
       ).not.toBeNull(),
@@ -810,12 +811,12 @@ describe("AppSidebar agent chip", () => {
     await sidebar.updateComplete;
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
 
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
     expect(harness.list.mock.calls[1]?.[0]).toMatchObject({
       spawnedBy: "agent:main:parent",
       offset: 20,
     });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),
     );
   });
@@ -871,12 +872,12 @@ describe("AppSidebar agent chip", () => {
     await sidebar.updateComplete;
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
 
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
     expect(sidebar.querySelector(".sidebar-recent-session--child")).toBeNull();
 
     publishParent(11);
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledTimes(3));
-    await vi.waitFor(() =>
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(3));
+    await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),
     );
   });
@@ -905,7 +906,7 @@ describe("AppSidebar agent chip", () => {
     });
     await sidebar.updateComplete;
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
-    await vi.waitFor(() => expect(original.list).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(original.list).toHaveBeenCalledOnce());
 
     const replacement = createSessionsHarness("main", ["agent:main:parent"]);
     replacement.list.mockResolvedValue({
@@ -940,7 +941,7 @@ describe("AppSidebar agent chip", () => {
       },
     });
     provider.setContext(createContext(gateway, replacement.sessions));
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
     );
 
@@ -992,15 +993,15 @@ describe("AppSidebar agent chip", () => {
     context.agentSelection.state.scopeId = "worker";
     (sidebar as unknown as { activeRouteId: string }).activeRouteId = "chat";
     sidebar.sessionKey = "agent:worker:child";
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("sessions.describe", {
         key: "agent:worker:child",
       }),
     );
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(sidebar.querySelectorAll('[data-session-key="agent:worker:child"]')).toHaveLength(1),
     );
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledOnce());
 
     expect(sidebar.querySelectorAll(".sidebar-recent-session")).toHaveLength(2);
     expect(sidebar.querySelectorAll('[data-session-key="agent:worker:child"]')).toHaveLength(1);
@@ -1026,7 +1027,7 @@ describe("AppSidebar agent chip", () => {
     sidebar.sessionKey = "agent:main:parent";
     await sidebar.updateComplete;
     sidebar.sessionKey = "agent:worker:child";
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
     );
   });
@@ -1068,13 +1069,13 @@ describe("AppSidebar agent chip", () => {
     });
     await sidebar.updateComplete;
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledOnce());
 
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
     await sidebar.updateComplete;
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(sidebar.textContent).toContain("Recovered child"));
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(sidebar.textContent).toContain("Recovered child"));
   });
 
   it("restores a directly opened child whose parent is outside the root page", async () => {
@@ -1102,8 +1103,8 @@ describe("AppSidebar agent chip", () => {
     (sidebar as unknown as { activeRouteId: string }).activeRouteId = "chat";
     sidebar.sessionKey = "agent:worker:child";
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() =>
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() =>
       expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
     );
     expect(
@@ -1158,9 +1159,9 @@ describe("AppSidebar agent chip", () => {
     });
     (sidebar as unknown as { activeRouteId: string }).activeRouteId = "chat";
     sidebar.sessionKey = "agent:worker:child";
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
-    await vi.waitFor(() => expect(harness.list).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledOnce());
 
     described.resolve({
       session: {
@@ -1172,7 +1173,7 @@ describe("AppSidebar agent chip", () => {
         status: "running",
       },
     });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),
     );
     expect(sidebar.textContent).toContain("Loaded sibling");
@@ -3579,14 +3580,14 @@ describe("AppSidebar session mutation feedback", () => {
     const menu = await openSessionMenu(sidebar, row.key);
     menu.querySelector<HTMLElement>('[value="stop-cloud-worker"]')?.click();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     expect(confirm).toHaveBeenCalledWith('Stop the cloud worker for "a"?');
     expect(request).toHaveBeenCalledWith(
       "sessions.reclaim",
       { key: "agent:main:a", agentId: "main" },
       { timeoutMs: 10 * 60_000 },
     );
-    await vi.waitFor(() => expect(harness.refreshReplacement).toHaveBeenCalledWith("main"));
+    await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledWith("main"));
   });
 
   it("shows and dismisses a fixed sidebar error when a session patch is rejected", async () => {
@@ -3597,7 +3598,7 @@ describe("AppSidebar session mutation feedback", () => {
       const menu = await openSessionMenu(sidebar, "agent:main:a");
       menu.querySelector<HTMLButtonElement>('[data-shortcut="r"]')?.click();
 
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
           "rename rejected by Gateway",
         );
@@ -3633,7 +3634,7 @@ describe("AppSidebar session mutation feedback", () => {
       await menu?.updateComplete;
       menu?.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
 
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
           "agent:main:b: permission denied",
         );
@@ -3649,7 +3650,7 @@ describe("AppSidebar session mutation feedback", () => {
     harness.patch.mockImplementationOnce(() => pending.promise);
     const menu = await openSessionMenu(sidebar, "agent:main:a");
     menu.querySelector<HTMLButtonElement>('[data-shortcut="p"]')?.click();
-    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
 
     gateway.publish({ connected: false, reconnecting: true });
     gateway.publish({ connected: true, reconnecting: false });
@@ -3674,7 +3675,7 @@ describe("AppSidebar session mutation feedback", () => {
     const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
     await menu?.updateComplete;
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
-    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
 
     gateway.publish({ connected: false, reconnecting: true });
     gateway.publish({ connected: true, reconnecting: false });
@@ -3701,17 +3702,17 @@ describe("AppSidebar session mutation feedback", () => {
     let menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
     await menu?.updateComplete;
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
-    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
 
     row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     await sidebar.updateComplete;
     menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
     await menu?.updateComplete;
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="u"]')?.click();
-    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(3));
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(3));
 
     firstPatch.resolve(successfulSessionPatch("agent:main:a"));
-    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(4));
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(4));
     expect(harness.patch.mock.calls.map(([, patch]) => patch)).toEqual(
       expect.arrayContaining([
         { archived: true },
@@ -3743,7 +3744,7 @@ describe("AppSidebar session mutation feedback", () => {
     try {
       const menu = await openSessionMenu(sidebar, "agent:main:a");
       menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
-      await vi.waitFor(() => expect(confirmations).toBe(2));
+      await waitForFast(() => expect(confirmations).toBe(2));
 
       expect(request).not.toHaveBeenCalled();
     } finally {
@@ -3866,7 +3867,7 @@ describe("AppSidebar multi-select", () => {
     expect(menu.querySelector('[data-shortcut="r"]')).toBeNull();
     menu.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
 
-    await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
     expect(harness.patch).toHaveBeenNthCalledWith(
       1,
       "agent:main:a",
@@ -3895,7 +3896,7 @@ describe("AppSidebar multi-select", () => {
       const menu = await sessionMenu(sidebar);
       menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
 
-      await vi.waitFor(() => expect(harness.deleteMany).toHaveBeenCalledOnce());
+      await waitForFast(() => expect(harness.deleteMany).toHaveBeenCalledOnce());
       expect(confirmSpy).toHaveBeenCalledOnce();
       expect(confirmSpy.mock.calls[0]?.[0]).toContain("2");
       expect(harness.deleteMany).toHaveBeenCalledWith([
@@ -4423,7 +4424,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     const menu = await openGroupMenu(sidebar);
     const rename = menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0];
     rename?.click();
-    await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
+    await waitForFast(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
     await Promise.resolve();
     await Promise.resolve();
 
@@ -4438,7 +4439,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Beta");
     const menu = await openGroupMenu(sidebar);
     menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0]?.click();
-    await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
+    await waitForFast(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
     await Promise.resolve();
     await Promise.resolve();
 
@@ -4459,7 +4460,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Beta");
     const menu = await openGroupMenu(sidebar);
     menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0]?.click();
-    await vi.waitFor(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
+    await waitForFast(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
 
     gatewayHarness.publish({ connected: false });
     gatewayHarness.publish({ connected: true });
@@ -4479,7 +4480,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     const menu = await openGroupMenu(sidebar);
     const items = menu.querySelectorAll<HTMLButtonElement>(".session-menu__item");
     items[items.length - 1]?.click();
-    await vi.waitFor(() => expect(harness.groupsDelete).toHaveBeenCalledWith("Alpha"));
+    await waitForFast(() => expect(harness.groupsDelete).toHaveBeenCalledWith("Alpha"));
     await Promise.resolve();
     await Promise.resolve();
 
@@ -4495,7 +4496,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     const menu = await openGroupMenu(sidebar);
     const items = menu.querySelectorAll<HTMLButtonElement>(".session-menu__item");
     items[items.length - 1]?.click();
-    await vi.waitFor(() => expect(harness.groupsDelete).toHaveBeenCalledWith("Alpha"));
+    await waitForFast(() => expect(harness.groupsDelete).toHaveBeenCalledWith("Alpha"));
     await Promise.resolve();
     await Promise.resolve();
 

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
 
 type CreateOptions = {
@@ -103,7 +104,7 @@ async function startPanelWithPendingOpen() {
   panel.available = true;
   document.body.append(panel);
   panel.toggle();
-  await vi.waitFor(() =>
+  await waitForFast(() =>
     expect(requests.some(({ method }) => method === "terminal.open")).toBe(true),
   );
   return { createOptions: createOptions!, open, requests };
@@ -139,7 +140,7 @@ describe("OpenClawTerminalPanel", () => {
     customElements.define(tagName, LazyUpgradeTerminalPanel);
     const panel = element as unknown as OpenClawTerminalPanel;
     await panel.updateComplete;
-    await vi.waitFor(() => expect((panel as unknown as { open: boolean }).open).toBe(true));
+    await waitForFast(() => expect((panel as unknown as { open: boolean }).open).toBe(true));
   });
 
   it("opens new sessions for the selected agent", async () => {
@@ -171,7 +172,7 @@ describe("OpenClawTerminalPanel", () => {
 
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests[0]).toEqual({
         method: "terminal.open",
         params: { agentId: "ops", cols: 100, rows: 30 },
@@ -184,7 +185,7 @@ describe("OpenClawTerminalPanel", () => {
       : [OpenClawTerminalPanel.styles];
     const styles = styleResults.map((style) => style.cssText).join("\n");
     expect(styles).toMatch(/\.tabstrip-new\s*\{[^}]*align-self:\s*center/u);
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests).toContainEqual({
         method: "terminal.resize",
         params: { sessionId: "session-1", cols: 100, rows: 30 },
@@ -193,7 +194,7 @@ describe("OpenClawTerminalPanel", () => {
 
     createOptions?.onData?.(new TextEncoder().encode("pwd\n"));
     createOptions?.onResize?.({ columns: 120, rows: 40 });
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests).toContainEqual({
         method: "terminal.input",
         params: { sessionId: "session-1", data: "pwd\n" },
@@ -224,7 +225,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
     panel.toggle();
 
-    await vi.waitFor(() => expect(createOptions?.parent.isConnected).toBe(true));
+    await waitForFast(() => expect(createOptions?.parent.isConnected).toBe(true));
     controller.fit.mockClear();
     controller.terminal.renderer.render.mockClear();
 
@@ -267,7 +268,7 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.some(({ method }) => method === "terminal.resize")).toBe(true);
     });
 
@@ -277,7 +278,7 @@ describe("OpenClawTerminalPanel", () => {
       payload: { sessionId: "session-1", seq: query.length, data: query },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests).toContainEqual({
         method: "terminal.input",
         params: {
@@ -303,7 +304,7 @@ describe("OpenClawTerminalPanel", () => {
 
     open.resolve(terminalOpenResult("session-1"));
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(requests.filter(({ method }) => method === "terminal.input")).toHaveLength(2),
     );
     expect(requests.slice(1)).toEqual([
@@ -325,7 +326,7 @@ describe("OpenClawTerminalPanel", () => {
 
     open.resolve(terminalOpenResult("session-1"));
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(requests.some(({ method }) => method === "terminal.input")).toBe(true),
     );
     expect(requests.filter(({ method }) => method === "terminal.input")).toEqual([
@@ -339,7 +340,7 @@ describe("OpenClawTerminalPanel", () => {
 
     open.reject(new Error("terminal open refused"));
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const panel = document.querySelector(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
       expect(panel.renderRoot.querySelector(".tp-error")?.textContent).toContain(
         "terminal open refused",
@@ -394,7 +395,7 @@ describe("OpenClawTerminalPanel", () => {
 
     panel.handleToggleRequest(new CustomEvent("openclaw:terminal-toggle", { detail: { catalog } }));
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.filter((entry) => entry.method === "terminal.attach")).toHaveLength(1);
       expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(1);
     });
@@ -432,7 +433,7 @@ describe("OpenClawTerminalPanel", () => {
 
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");
     });
     expect(requests.filter((entry) => entry.method === "terminal.list")).toHaveLength(1);
@@ -479,7 +480,7 @@ describe("OpenClawTerminalPanel", () => {
 
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");
     });
     expect(requests.filter((entry) => entry.method === "terminal.attach")).toHaveLength(1);
@@ -523,7 +524,7 @@ describe("OpenClawTerminalPanel", () => {
 
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(1);
     });
     expect(requests.filter((entry) => entry.method === "terminal.list")).toHaveLength(2);
@@ -602,14 +603,14 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.some((request) => request.method === "terminal.open")).toBe(true);
     });
 
     (
       panel.renderRoot.querySelector('[aria-label="Terminal sessions"]') as HTMLButtonElement
     ).click();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(panel.renderRoot.querySelector(".tp-session-menu")?.textContent).toContain(
         "detached-agent",
       );
@@ -628,7 +629,7 @@ describe("OpenClawTerminalPanel", () => {
       panel as unknown as { attachPickedSession: (sessionId: string) => Promise<void> }
     ).attachPickedSession("detached-1");
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests).toContainEqual({
         method: "terminal.attach",
         params: { sessionId: "detached-1" },
@@ -672,14 +673,14 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => expect(panel.renderRoot.querySelector(".tp-actions")).not.toBeNull());
+    await waitForFast(() => expect(panel.renderRoot.querySelector(".tp-actions")).not.toBeNull());
 
     (
       panel.renderRoot.querySelector('[aria-label="Terminal sessions"]') as HTMLButtonElement
     ).click();
-    await vi.waitFor(() => expect(listCount).toBe(1));
+    await waitForFast(() => expect(listCount).toBe(1));
     (panel.renderRoot.querySelector(".tp-session-refresh") as HTMLButtonElement).click();
-    await vi.waitFor(() => expect(listCount).toBe(2));
+    await waitForFast(() => expect(listCount).toBe(2));
 
     secondList.resolve({
       sessions: [
@@ -691,7 +692,7 @@ describe("OpenClawTerminalPanel", () => {
         },
       ],
     });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(panel.renderRoot.querySelector(".tp-session-menu")?.textContent).toContain(
         "new-agent",
       ),
@@ -736,7 +737,7 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe(
         JSON.stringify(["current-1"]),
       );
@@ -778,13 +779,13 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => expect(createGhosttyTerminalMock).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(createGhosttyTerminalMock).toHaveBeenCalledOnce());
     const catalog = { catalogId: "codex", hostId: "node:mac", threadId: "thread" };
 
     panel.handleToggleRequest(new CustomEvent("openclaw:terminal-toggle", { detail: { catalog } }));
     firstBoot.resolve(createTerminalController());
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests).toContainEqual({
         method: "terminal.open",
         params: { agentId: undefined, cols: 100, rows: 30, catalog },
@@ -817,7 +818,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
 
     // No toggle: the terminal-only document opens its session on mount.
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.some((entry) => entry.method === "terminal.open")).toBe(true);
     });
     await panel.updateComplete;
@@ -876,7 +877,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
 
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(1);
     });
 
@@ -889,7 +890,7 @@ describe("OpenClawTerminalPanel", () => {
 
     await panel.updateComplete;
     (panel.renderRoot.querySelector(".tabstrip-tab__close") as HTMLElement).click();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests).toContainEqual({
         method: "terminal.close",
         params: { sessionId: "session-1" },
@@ -899,7 +900,7 @@ describe("OpenClawTerminalPanel", () => {
     expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe("[]");
 
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(2);
     });
     expect(requests.some((entry) => entry.method === "terminal.attach")).toBe(false);
@@ -941,13 +942,13 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toContain("old-session");
     });
     panel.client = newClient;
     await panel.updateComplete;
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");
     });
     expect(oldRequests.filter((method) => method === "terminal.open")).toHaveLength(1);
@@ -980,7 +981,7 @@ describe("OpenClawTerminalPanel", () => {
     document.body.append(panel);
     panel.toggle();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(createGhosttyTerminalMock).toHaveBeenCalledOnce();
     });
     const staleOptions = createGhosttyTerminalMock.mock.calls[0]![0] as CreateOptions;
@@ -993,12 +994,12 @@ describe("OpenClawTerminalPanel", () => {
     expect(requests.filter((method) => method === "terminal.open")).toHaveLength(0);
     staleBoot.resolve(staleController);
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(createGhosttyTerminalMock).toHaveBeenCalledTimes(2);
       expect(requests.filter((method) => method === "terminal.open")).toHaveLength(1);
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(staleController.dispose).toHaveBeenCalledOnce();
     });
     expect(staleHost.isConnected).toBe(false);
@@ -1072,7 +1073,7 @@ describe("OpenClawTerminalPanel", () => {
     panel.available = true;
     document.body.append(panel);
     panel.toggle();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toContain("session-1");
     });
 

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -6,6 +6,7 @@ import {
   type GatewayHelloOk,
 } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createSessionCapability, reconcileSessionRunTerminal } from "./index.ts";
 
 function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
@@ -140,7 +141,7 @@ describe("createSessionCapability", () => {
 
     await sessions.groupsLoad();
 
-    await vi.waitFor(() => expect(sessions.state.groups).toEqual(["Recovered"]));
+    await waitForFast(() => expect(sessions.state.groups).toEqual(["Recovered"]));
     expect(groupsCalls).toBe(2);
     sessions.dispose();
   });
@@ -287,7 +288,7 @@ describe("createSessionCapability", () => {
         operation === "rename"
           ? sessions.groupsRename("Alpha", "Beta")
           : sessions.groupsDelete("Alpha");
-      await vi.waitFor(() =>
+      await waitForFast(() =>
         expect(request).toHaveBeenCalledWith("sessions.list", expect.any(Object)),
       );
       publish(false);
@@ -331,11 +332,11 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability(gateway);
 
     const firstLoad = sessions.groupsLoad();
-    await vi.waitFor(() => expect(groupsCalls).toBe(1));
+    await waitForFast(() => expect(groupsCalls).toBe(1));
     emitEvent({ type: "event", event: "sessions.changed", payload: { reason: "groups" } });
-    await vi.waitFor(() => expect(groupsCalls).toBe(2));
+    await waitForFast(() => expect(groupsCalls).toBe(2));
     currentGroups.resolve({ groups: [{ name: "Current" }] });
-    await vi.waitFor(() => expect(sessions.state.groups).toEqual(["Current"]));
+    await waitForFast(() => expect(sessions.state.groups).toEqual(["Current"]));
     firstGroups.reject(new Error("stale catalog failure"));
     await firstLoad;
 
@@ -451,14 +452,14 @@ describe("createSessionCapability", () => {
     const staleRefresh = sessions.refresh({ force: true });
     publish(false);
     publish(true);
-    await vi.waitFor(() => expect(listCalls).toBe(2));
+    await waitForFast(() => expect(listCalls).toBe(2));
 
     staleList.resolve(sessionsResult([{ key: "stale", kind: "direct", updatedAt: 1 }], 1));
     await staleRefresh;
     expect(sessions.state.result).toBeNull();
 
     currentList.resolve(sessionsResult([{ key: "current", kind: "direct", updatedAt: 2 }], 2));
-    await vi.waitFor(() => expect(sessions.state.result?.sessions[0]?.key).toBe("current"));
+    await waitForFast(() => expect(sessions.state.result?.sessions[0]?.key).toBe("current"));
     sessions.dispose();
   });
 
@@ -516,7 +517,7 @@ describe("createSessionCapability", () => {
     expect(sessions.state.loading).toBe(true);
 
     const created = sessions.create({ agentId: "main" });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("sessions.create", { agentId: "main" }),
     );
 
@@ -950,11 +951,11 @@ describe("createSessionCapability", () => {
 
     emitEvent(sessionChangedEvent(hiddenKey));
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(sessions.state.result?.sessions.map((row) => row.key)).toEqual([visibleKey]);
     expect(publishedKeys.some((keys) => keys.includes(hiddenKey))).toBe(false);
     refreshed.resolve(sessionsResult([{ key: visibleKey, kind: "direct", updatedAt: 1 }], 2));
-    await vi.waitFor(() => expect(sessions.state.loading).toBe(false));
+    await waitForFast(() => expect(sessions.state.loading).toBe(false));
     sessions.dispose();
   });
 
@@ -986,10 +987,10 @@ describe("createSessionCapability", () => {
       payload: { sessionKey: visibleKey, reason: "delete" },
     });
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(deletedSnapshots.some((keys) => keys.includes(visibleKey))).toBe(true);
     refreshed.resolve(sessionsResult([], 2));
-    await vi.waitFor(() => expect(sessions.state.loading).toBe(false));
+    await waitForFast(() => expect(sessions.state.loading).toBe(false));
     sessions.dispose();
   });
 
@@ -1019,7 +1020,7 @@ describe("createSessionCapability", () => {
 
     emitEvent(sessionChangedEvent(hiddenKey));
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(sessions.state.result?.sessions.map((row) => row.key)).not.toContain(hiddenKey);
     sessions.dispose();
   });
@@ -1065,7 +1066,7 @@ describe("createSessionCapability", () => {
       payload: { sessionKey: key, updatedAt: 1, status: "done" },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(sessions.state.result?.sessions[0]).toMatchObject({
         key,
         hasActiveRun: false,

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -7,6 +7,7 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { UiSettings } from "../../app/settings.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   getChatAttachmentDataUrl,
   getChatAttachmentPreviewUrl,
@@ -1595,7 +1596,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main",
       sessionStatus: "done",
     });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request.mock.calls.some(([method]) => method === "sessions.list")).toBe(true),
     );
     expect(host.sessionsResult).toBe(archivedSessions);
@@ -1740,7 +1741,7 @@ describe("handleSendChat", () => {
 
     const send = handleSendChat(host);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(eventPayloads(host, "control-ui.chat.send").map((payload) => payload.phase)).toEqual(
         expect.arrayContaining(["pending-visible", "request-start", "pending-painted"]),
       ),
@@ -1841,7 +1842,7 @@ describe("handleSendChat", () => {
 
     thinkingUpdate.resolve({});
     await thinkingPatch;
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request.mock.calls.filter(([method]) => method === "sessions.patch")).toHaveLength(2),
     );
     expect(request.mock.calls.some(([method]) => method === "chat.send")).toBe(false);
@@ -2901,7 +2902,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, retryItem.sessionKey, retryItem)).toBe(true);
 
     const foreground = handleSendChat(host);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(1));
     await retryQueuedChatMessage(host, "retry-send");
 
     expect(request).toHaveBeenCalledTimes(1);
@@ -2909,7 +2910,7 @@ describe("handleSendChat", () => {
 
     foregroundAck.resolve({ runId: "foreground-run", status: "error" });
     await foreground;
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(2),
     );
 
@@ -2976,7 +2977,7 @@ describe("handleSendChat", () => {
 
     host.chatMessage = "independent foreground send";
     const foreground = handleSendChat(host);
-    await vi.waitFor(() => expect(sendPayloads).toHaveLength(1));
+    await waitForFast(() => expect(sendPayloads).toHaveLength(1));
     expect(sendPayloads[0]?.sessionKey).toBe("agent:main");
 
     settingsPatch.resolve(true);
@@ -3265,7 +3266,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "chat.send",
         expect.objectContaining({
@@ -3277,7 +3278,7 @@ describe("handleSendChat", () => {
       ),
     );
     expect(host.chatRunId).toBe("run-1");
-    await vi.waitFor(() => expect(host.chatQueue[0]?.kind).toBe("steered"));
+    await waitForFast(() => expect(host.chatQueue[0]?.kind).toBe("steered"));
     expect(host.chatQueue[0]?.pendingRunId).toBe("run-1");
   });
 
@@ -3298,7 +3299,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+    await waitForFast(() => expect(request).toHaveBeenCalled());
     const payload = findRequestPayload(
       request as unknown as MockCallSource,
       "chat.send",
@@ -3328,7 +3329,7 @@ describe("handleSendChat", () => {
 
       await handleSendChat(host);
 
-      await vi.waitFor(() =>
+      await waitForFast(() =>
         expect(request).toHaveBeenCalledWith(
           "chat.send",
           expect.objectContaining({
@@ -3338,7 +3339,7 @@ describe("handleSendChat", () => {
           }),
         ),
       );
-      await vi.waitFor(() => expect(host.chatQueue).toHaveLength(0));
+      await waitForFast(() => expect(host.chatQueue).toHaveLength(0));
     },
   );
 
@@ -3362,7 +3363,7 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "chat.send",
         expect.objectContaining({
@@ -3484,7 +3485,7 @@ describe("handleSendChat", () => {
     const secondHost = makeHost({ client });
 
     const firstSend = handleSendChat(firstHost, "first pane turn");
-    await vi.waitFor(() => expect(sendPayloads).toHaveLength(1));
+    await waitForFast(() => expect(sendPayloads).toHaveLength(1));
     const secondSend = handleSendChat(secondHost, "second pane turn");
     await Promise.resolve();
 
@@ -3551,7 +3552,7 @@ describe("handleSendChat", () => {
 
     const resume = retryReconnectableQueuedChatSends(host);
 
-    await vi.waitFor(() => expect(sentSessions).toContain(readyItem.sessionKey));
+    await waitForFast(() => expect(sentSessions).toContain(readyItem.sessionKey));
     expect(sentSessions).not.toContain(slowItem.sessionKey);
     slowHistory.resolve({
       messages: [],
@@ -3594,7 +3595,7 @@ describe("handleSendChat", () => {
     });
 
     const visibleSend = handleSendChat(host, "visible pending send");
-    await vi.waitFor(() => expect(sentSessions).toContain(visibleSessionKey));
+    await waitForFast(() => expect(sentSessions).toContain(visibleSessionKey));
     expect(host.chatSending).toBe(true);
 
     const inactiveItem = {
@@ -3610,7 +3611,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, inactiveSessionKey, inactiveItem)).toBe(true);
     const resume = retryReconnectableQueuedChatSends(host);
 
-    await vi.waitFor(() => expect(sentSessions).toContain(inactiveSessionKey));
+    await waitForFast(() => expect(sentSessions).toContain(inactiveSessionKey));
     expect(host.chatSending).toBe(true);
 
     const visibleRunId = host.chatQueue[0]?.sendRunId;
@@ -3812,7 +3813,7 @@ describe("handleSendChat", () => {
     admitHostQueueItems(visibleHost);
 
     const visibleDrain = retryReconnectableQueuedChatSends(visibleHost);
-    await vi.waitFor(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
     const inactiveDrain = retryReconnectableQueuedChatSends(inactiveHost);
     firstCommand.resolve({ content: "Thinking level set." });
     await Promise.all([visibleDrain, inactiveDrain]);
@@ -3850,7 +3851,7 @@ describe("handleSendChat", () => {
 
     try {
       const draining = retryReconnectableQueuedChatSends(host);
-      await vi.waitFor(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
+      await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
       stopPeer = subscribeChatOutboxProjection(peer);
 
       expect(host.chatQueue[0]?.sendState).toBe("executing-command");
@@ -3915,7 +3916,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
 
     const draining = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
 
     host.sessionKey = "agent:main:second";
     host.chatMessages = [{ role: "assistant", content: "Second session transcript" }];
@@ -3971,7 +3972,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
 
     const draining = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
 
     host.client = {
       request: vi.fn(async (method: string) => {
@@ -4571,7 +4572,7 @@ describe("handleSendChat", () => {
     const sendingHost = makeHost({ client });
     const staleHost = makeHost({ client });
     const send = handleSendChat(sendingHost, "delete before ack");
-    await vi.waitFor(() => expect(sendingHost.chatQueue[0]?.sendState).toBe("sending"));
+    await waitForFast(() => expect(sendingHost.chatQueue[0]?.sendState).toBe("sending"));
     const id = sendingHost.chatQueue[0]?.id ?? "missing";
     const runId = sendingHost.chatQueue[0]?.sendRunId;
     staleHost.chatQueue = loadChatComposerSnapshot(staleHost, staleHost.sessionKey)?.queue ?? [];
@@ -4796,7 +4797,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
 
     const send = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1),
     );
     const runId = host.chatQueue[0]?.sendRunId;
@@ -5276,7 +5277,7 @@ describe("handleSendChat", () => {
     });
 
     const sending = handleSendChat(host);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     host.chatMessage = "newer composer input";
     firstAttempt.reject(new Error("send rejected"));
     await sending;
@@ -5317,7 +5318,7 @@ describe("handleSendChat", () => {
     });
 
     const firstSend = handleSendChat(host);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     const volatileId = host.chatQueue[0]?.id;
     const volatileRunId = host.chatQueue[0]?.sendRunId;
 
@@ -5484,9 +5485,9 @@ describe("handleSendChat", () => {
 
     expect(host.connected).toBe(true);
     expect(host.chatQueue[0]).toMatchObject({ sendAttempts: 0, sendState: "waiting-reconnect" });
-    await vi.waitFor(() => expect(sendAttempts).toBe(2));
+    await waitForFast(() => expect(sendAttempts).toBe(2));
     expect(sendRunIds[1]).toBe(sendRunIds[0]);
-    await vi.waitFor(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]));
+    await waitForFast(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]));
   });
 
   it("retries reconnect history after a retryable response without a socket close", async () => {
@@ -5528,9 +5529,9 @@ describe("handleSendChat", () => {
 
     expect(historyAttempts).toBe(1);
     expect(sendAttempts).toBe(0);
-    await vi.waitFor(() => expect(sendAttempts).toBe(1));
+    await waitForFast(() => expect(sendAttempts).toBe(1));
     expect(historyAttempts).toBeGreaterThanOrEqual(2);
-    await vi.waitFor(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]));
+    await waitForFast(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]));
   });
 
   it("persists queueable local commands entered while disconnected", async () => {
@@ -5613,7 +5614,7 @@ describe("handleSendChat", () => {
     host.client = { request } as unknown as ChatHost["client"];
     host.connected = true;
     const replay = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() => expect(historyRequests).toBe(1));
+    await waitForFast(() => expect(historyRequests).toBe(1));
     expect(executeSlashCommandMock).not.toHaveBeenCalled();
 
     startupHistory.resolve({
@@ -5832,7 +5833,9 @@ describe("handleSendChat", () => {
     admitHostQueueItems(host);
 
     const retry = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("chat.history", expect.anything()));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("chat.history", expect.anything()),
+    );
     host.connectionEpoch = 2;
     history.resolve({
       messages: [],
@@ -5881,7 +5884,7 @@ describe("handleSendChat", () => {
     admitHostQueueItems(host);
 
     const staleRetry = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() => expect(historyRequests).toBe(1));
+    await waitForFast(() => expect(historyRequests).toBe(1));
     host.connectionEpoch = 2;
     const reconnectRetry = retryReconnectableQueuedChatSends(host);
     staleHistory.resolve({
@@ -5932,7 +5935,7 @@ describe("handleSendChat", () => {
     admitHostQueueItems(host);
 
     const initialDrain = retryReconnectableQueuedChatSends(host);
-    await vi.waitFor(() => expect(historyRequests).toBe(1));
+    await waitForFast(() => expect(historyRequests).toBe(1));
     const terminalWakeup = flushChatQueueForEvent(host);
     activeHistory.resolve({
       messages: [],
@@ -6634,7 +6637,7 @@ describe("handleSendChat", () => {
     ]);
 
     const clearing = handleSendChat(host);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("sessions.reset", { key: sourceSessionKey }),
     );
     host.chatQueueByScope = { [queueScopeKey(host, sourceSessionKey)]: host.chatQueue };
@@ -6683,7 +6686,7 @@ describe("handleSendChat", () => {
     ]);
 
     const clearing = handleSendChat(host);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("sessions.reset", { key: sourceSessionKey }),
     );
     host.chatQueueByScope = { [queueScopeKey(host, sourceSessionKey)]: host.chatQueue };
@@ -6721,7 +6724,7 @@ describe("handleSendChat", () => {
     });
 
     const clearing = handleSendChat(host);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("sessions.reset", { key: "agent:main" }),
     );
     const queuedId = host.chatQueue[0]?.id ?? "missing-clear";
@@ -6782,7 +6785,7 @@ describe("handleSendChat", () => {
     });
 
     const clearing = handleSendChat(host);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("sessions.reset", {
         key: "agent:work:main",
         agentId: "work",
@@ -6998,7 +7001,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
 
     const steering = steerQueuedChatMessage(host, original.id);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     clearPendingQueueItemsForRun(host, "active-run");
     host.chatRunId = null;
     resolveRequest({ status: "started", runId: "steer-run" });
@@ -7048,13 +7051,13 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
 
     const steering = steerQueuedChatMessage(host, original.id);
-    await vi.waitFor(() => expect(sends).toBe(1));
+    await waitForFast(() => expect(sends).toBe(1));
     clearPendingQueueItemsForRun(host, "active-run");
     host.chatRunId = null;
     await flushChatQueueForEvent(host);
     resolveSteer({ status: "error", runId: "steer-error" });
     await steering;
-    await vi.waitFor(() => expect(sends).toBe(2));
+    await waitForFast(() => expect(sends).toBe(2));
 
     expect(listStoredChatOutboxes(host)).toEqual([]);
     expect(host.chatQueue).toEqual([]);
@@ -7100,7 +7103,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
 
     const steering = steerQueuedChatMessage(host, original.id);
-    await vi.waitFor(() => expect(sends).toBe(1));
+    await waitForFast(() => expect(sends).toBe(1));
     const originalScopeKey = storedChatOutboxScopeKey(
       resolveStoredChatOutboxScope(host, host.sessionKey),
     );
@@ -7115,8 +7118,8 @@ describe("handleSendChat", () => {
     expect(sends).toBe(1);
     resolveSteer({ status: "error", runId: "steer-error" });
     await steering;
-    await vi.waitFor(() => expect(sends).toBe(2));
-    await vi.waitFor(() => expect(listStoredChatOutboxes(host)).toEqual([]));
+    await waitForFast(() => expect(sends).toBe(2));
+    await waitForFast(() => expect(listStoredChatOutboxes(host)).toEqual([]));
 
     expect(host.chatQueue).toEqual([]);
     expect(host.chatQueueByScope[originalScopeKey]).toBeUndefined();
@@ -7181,15 +7184,15 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
 
     const steering = steerQueuedChatMessage(host, original.id);
-    await vi.waitFor(() => expect(sendPayloads).toHaveLength(1));
+    await waitForFast(() => expect(sendPayloads).toHaveLength(1));
     clearPendingQueueItemsForRun(host, "active-run");
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
     host.chatRunId = null;
     await flushChatQueueForEvent(host);
     resolveSteer({ status: "error", runId: "steer-error" });
     await steering;
-    await vi.waitFor(() => expect(sendPayloads).toHaveLength(2));
-    await vi.waitFor(() => expect(listStoredChatOutboxes(host)).toEqual([]));
+    await waitForFast(() => expect(sendPayloads).toHaveLength(2));
+    await waitForFast(() => expect(listStoredChatOutboxes(host)).toEqual([]));
 
     const replayAttachments = sendPayloads[1]?.attachments as Array<Record<string, unknown>>;
     expect(replayAttachments).toHaveLength(1);
@@ -7227,7 +7230,7 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
 
     const steering = steerQueuedChatMessage(host, original.id);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     const originalScopeKey = storedChatOutboxScopeKey(
       resolveStoredChatOutboxScope(host, host.sessionKey),
     );
@@ -7277,7 +7280,7 @@ describe("handleSendChat", () => {
       expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
 
       const steering = steerQueuedChatMessage(host, original.id);
-      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      await waitForFast(() => expect(request).toHaveBeenCalledOnce());
       const originalScopeKey = storedChatOutboxScopeKey(
         resolveStoredChatOutboxScope(host, host.sessionKey),
       );
@@ -7347,7 +7350,7 @@ describe("handleSendChat", () => {
 
     try {
       const steering = steerQueuedChatMessage(host, original.id);
-      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      await waitForFast(() => expect(request).toHaveBeenCalledOnce());
       expect(host.chatQueue).toHaveLength(1);
       expect(host.chatQueue[0]?.pendingRunId).toBe("active-run");
       expect(peer.chatQueue).toHaveLength(1);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -21,6 +21,7 @@ import {
   createSessionsListResult,
   DEFAULT_CHAT_MODEL_CATALOG,
 } from "../../test-helpers/chat-model.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload as registerStoredChatAttachmentPayload,
@@ -3276,7 +3277,7 @@ describe("chat attachment picker", () => {
     const allowed = textarea.dispatchEvent(event);
 
     expect(allowed).toBe(false);
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
       expect(attachments).toHaveLength(1);
       expect(attachments[0]?.fileName).toMatch(/^pasted-text-\d+\.txt$/u);
@@ -3432,7 +3433,7 @@ describe("chat attachment picker", () => {
         new ProgressEvent("load"),
       );
 
-      await vi.waitFor(() => expect(attachments).toHaveLength(2));
+      await waitForFast(() => expect(attachments).toHaveLength(2));
       expect(attachments.map((attachment) => attachment.fileName)).toEqual([
         expect.stringMatching(/^pasted-text-\d+\.txt$/u),
         "brief.pdf",
@@ -3601,7 +3602,7 @@ describe("chat attachment picker", () => {
     });
     textarea.dispatchEvent(event);
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(onAttachmentsChange).toHaveBeenCalled();
     });
     const attachment = expectDefined(
@@ -3740,7 +3741,7 @@ describe("chat attachment picker", () => {
     });
     input.dispatchEvent(new Event("change", { bubbles: true }));
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
       expect(attachments).toHaveLength(1);
       expect(attachments[0]?.fileName).toBe("camera.jpg");
@@ -3772,7 +3773,7 @@ describe("chat attachment picker", () => {
     });
     input!.dispatchEvent(new Event("change", { bubbles: true }));
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
       expect(attachments).toHaveLength(1);
       expect(attachments[0]?.fileName).toBe("brief.pdf");
@@ -4389,7 +4390,7 @@ describe("chat model controls", () => {
     expect(defaultOption?.getAttribute("aria-selected")).toBe("false");
     defaultOption?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(onModelSelect).toHaveBeenCalledWith("", sessionKey);
     });
   });
@@ -4426,7 +4427,7 @@ describe("chat model controls", () => {
     expect(defaultOption?.getAttribute("aria-selected")).toBe("true");
     defaultOption?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(onModelSelect).toHaveBeenCalledWith("", sessionKey);
     });
   });
@@ -4702,11 +4703,11 @@ describe("chat model controls", () => {
     expect(patches).toEqual([{ model: "openai/gpt-5.6-sol" }]);
     modelPatch.resolve(patchResult);
     await expect(modelSwitch).resolves.toBe(true);
-    await vi.waitFor(() => expect(patches).toHaveLength(2));
+    await waitForFast(() => expect(patches).toHaveLength(2));
     expect(patches.at(-1)).toEqual({ thinkingLevel: "ultra" });
     thinkingUpdate.resolve(patchResult);
     await expect(thinkingPatch).resolves.toBe(true);
-    await vi.waitFor(() => expect(patches).toHaveLength(4));
+    await waitForFast(() => expect(patches).toHaveLength(4));
     await expect(Promise.all([fastModePatch, laterModelSwitch])).resolves.toEqual([true, true]);
     expect(patches.at(-1)).toEqual({ model: "google/gemini-3-pro" });
     expect(patches).toEqual([
@@ -4861,12 +4862,12 @@ describe("chat model controls", () => {
     } as unknown as Parameters<typeof switchChatFastMode>[0];
 
     const first = switchChatFastMode(host, "on");
-    await vi.waitFor(() => expect(pendingPatches).toHaveLength(1));
+    await waitForFast(() => expect(pendingPatches).toHaveLength(1));
     const second = switchChatFastMode(host, "off");
 
     pendingPatches[0]?.reject(new Error("boom"));
     await expect(first).resolves.toBe(false);
-    await vi.waitFor(() => expect(pendingPatches).toHaveLength(2));
+    await waitForFast(() => expect(pendingPatches).toHaveLength(2));
     pendingPatches[1]?.resolve();
     await expect(second).resolves.toBe(true);
 
@@ -4896,7 +4897,7 @@ describe("chat model controls", () => {
       .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
       ?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(onModelSelect).toHaveBeenCalledWith("openai/gpt-5.4", "main");
     });
     render(renderChatModelControls(props), container);
@@ -4971,7 +4972,7 @@ describe("chat model controls", () => {
     expect(reset?.disabled).toBe(false);
     reset?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(request).toHaveBeenCalledWith("sessions.patch", {
         key: "main",
         thinkingLevel: null,
@@ -4997,7 +4998,7 @@ describe("chat model controls", () => {
     expect(slider?.classList.contains("chat-controls__reasoning-range--unanchored")).toBe(true);
     slider?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(request).toHaveBeenCalledWith("sessions.patch", {
         key: "main",
         thinkingLevel: "off",
@@ -5042,7 +5043,7 @@ describe("chat model controls", () => {
     expect(only?.getAttribute("aria-pressed")).toBe("false");
     only?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(request).toHaveBeenCalledWith("sessions.patch", {
         key: "main",
         thinkingLevel: "adaptive",

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -424,7 +425,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
     await transport.start();
     pumpMicrophone(new Float32Array(4096));
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(onStatus).toHaveBeenCalledWith("error", "Unknown realtime relay session"),
     );
     pumpMicrophone(new Float32Array(4096));
@@ -570,7 +571,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const toolCall = vi
         .mocked(client["request"])
         .mock.calls.find((call) => call[0] === "talk.client.toolCall");
@@ -587,7 +588,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       },
     });
 
-    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith("listening"));
+    await waitForFast(() => expect(onStatus).toHaveBeenCalledWith("listening"));
     expect(client["request"]).toHaveBeenCalledWith("talk.session.submitToolResult", {
       sessionId: "relay-1",
       callId: "call-1",
@@ -632,7 +633,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
     emitGatewayFrame({
       event: "chat",
       payload: {
@@ -641,7 +644,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         message: { text: "All systems green." },
       },
     });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(requestCallsFor(client, "talk.session.submitToolResult")).toHaveLength(1),
     );
     emitGatewayFrame({
@@ -656,7 +659,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     expect(onStatus).not.toHaveBeenCalledWith("listening");
     expect(requestCallsFor(client, "chat.abort")).toHaveLength(0);
     resolveSubmission();
-    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith("listening"));
+    await waitForFast(() => expect(onStatus).toHaveBeenCalledWith("listening"));
     transport.stop();
   });
 
@@ -689,7 +692,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
     emitGatewayFrame({
       event: "chat",
       payload: {
@@ -699,7 +704,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(onStatus).toHaveBeenCalledWith("error", "Provider rejected the tool result"),
     );
     expect(onStatus).toHaveBeenLastCalledWith("error", "Provider rejected the tool result");
@@ -735,7 +740,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.session.submitToolResult", {
         sessionId: "relay-1",
         callId: "call-1",
@@ -785,7 +790,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
     emitGatewayFrame({
       event: "chat",
       payload: { runId: "run-1", state: "final", message: { text: "ready" } },
@@ -797,7 +804,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       payload: { relaySessionId: "relay-1", type: "clear" },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.session.submitToolResult", {
         sessionId: "relay-1",
         callId: "call-1",
@@ -841,7 +848,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
     emitGatewayFrame({
       event: "chat",
       payload: { runId: "run-1", state: "final", message: { text: "ready" } },
@@ -901,7 +910,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(requestCallsFor(client, "talk.session.submitToolResult")).toHaveLength(1),
     );
     expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(0);
@@ -950,7 +959,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
 
     pumpMicrophone(speech);
     pumpMicrophone(speech);
@@ -1054,7 +1065,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
     emitGatewayFrame({
       event: "chat",
       payload: { runId: "run-1", state: "final", message: { text: "ready" } },
@@ -1098,7 +1111,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
 
     emitGatewayFrame({
       event: "talk.event",
@@ -1138,7 +1153,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("chat.abort", {
         sessionKey: "main",
         runId: "run-1",
@@ -1173,7 +1188,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    await waitForFast(() =>
+      expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1),
+    );
 
     emitGatewayFrame({
       event: "chat",
@@ -1183,7 +1200,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       },
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.session.submitToolResult", {
         sessionId: "relay-1",
         callId: "call-1",
@@ -1225,7 +1242,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         args: { question: "status?" },
       },
     });
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const toolCall = requestCallsFor(client, "talk.client.toolCall")[0];
       const params = toolCall?.[1] as
         | {
@@ -1244,7 +1261,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     });
 
     transport.stop();
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("chat.abort", {
         sessionKey: "main",
         runId: "run-1",

--- a/ui/src/pages/chat/realtime-talk-google-live.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.test.ts
@@ -1,5 +1,6 @@
 // Control UI tests cover realtime talk google live behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -345,7 +346,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     ws.emitMessage(encodeJsonFrame({ setupComplete: {} }));
 
     expect(ws.binaryType).toBe("arraybuffer");
-    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith("listening"));
+    await waitForFast(() => expect(onStatus).toHaveBeenCalledWith("listening"));
     const readyEvent = requireFirstTalkEvent(onTalkEvent);
     expect(readyEvent.type).toBe("session.ready");
     expect(readyEvent.sessionId).toBe("main:google:provider-websocket");
@@ -373,7 +374,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     await transport.start();
     latestWebSocket().emitMessage(new Blob([JSON.stringify({ setupComplete: {} })]));
 
-    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith("listening"));
+    await waitForFast(() => expect(onStatus).toHaveBeenCalledWith("listening"));
   });
 
   it("stops queued output when Google Live sends interruption", async () => {
@@ -391,12 +392,12 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    await waitForFast(() => expect(createdSources).toHaveLength(1));
 
     const source = createdSources[0];
     ws.emitMessage(encodeJsonFrame({ serverContent: { interrupted: true } }));
 
-    await vi.waitFor(() => expect(source?.stop).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(source?.stop).toHaveBeenCalledTimes(1));
     const cancelledEvent = onTalkEvent.mock.calls.find(
       ([event]) => event.type === "turn.cancelled",
     )?.[0];
@@ -426,7 +427,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       }),
     );
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
         "transcript.done",
         "output.text.delta",
@@ -501,15 +502,15 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(onStatus).toHaveBeenCalledWith("thinking", undefined));
-    await vi.waitFor(() => expect(listeners.size).toBe(1));
+    await waitForFast(() => expect(onStatus).toHaveBeenCalledWith("thinking", undefined));
+    await waitForFast(() => expect(listeners.size).toBe(1));
 
     transport.stop();
     for (const listener of listeners) {
       listener({ event: "chat", payload: { runId, state: "final", message: { text: "done" } } });
     }
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(client["request"]).toHaveBeenCalledWith("chat.abort", { sessionKey: "main", runId });
     });
     expect(onStatus).not.toHaveBeenCalledWith("listening");
@@ -544,7 +545,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(listeners.size).toBe(1));
+    await waitForFast(() => expect(listeners.size).toBe(1));
     for (const listener of listeners) {
       listener({
         event: "chat",
@@ -552,7 +553,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       });
     }
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(ws.sent.map((payload) => JSON.parse(payload))).toContainEqual({
         toolResponse: {
           functionResponses: [
@@ -605,7 +606,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       }),
     );
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(onStatus).toHaveBeenCalledWith("error", "Google Live socket rejected the tool result"),
     );
     expect(
@@ -664,7 +665,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    await waitForFast(() => expect(createdSources).toHaveLength(1));
     ws.emitMessage(
       encodeJsonFrame({
         toolCall: {
@@ -678,7 +679,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.client.toolCall", expect.any(Object)),
     );
 
@@ -690,7 +691,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       }),
     );
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     expect(createdSources[0]?.stop).toHaveBeenCalledTimes(1);
@@ -737,7 +738,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    await waitForFast(() => expect(createdSources).toHaveLength(1));
     ws.emitMessage(
       encodeJsonFrame({
         toolCall: {
@@ -751,7 +752,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.client.toolCall", expect.any(Object)),
     );
 
@@ -763,7 +764,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       }),
     );
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     expect(createdSources[0]?.stop).toHaveBeenCalledTimes(1);
@@ -810,7 +811,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    await waitForFast(() => expect(createdSources).toHaveLength(1));
     ws.emitMessage(
       encodeJsonFrame({
         toolCall: {
@@ -824,7 +825,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         },
       }),
     );
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.client.toolCall", expect.any(Object)),
     );
 
@@ -836,7 +837,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       }),
     );
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(client["request"]).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     expect(createdSources[0]?.stop).toHaveBeenCalledTimes(1);

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
@@ -142,7 +143,7 @@ async function startActiveConsult(
     dispatchRealtimeEvent(peer, { type: "response.created" });
   }
   dispatchConsultToolCall(peer);
-  await vi.waitFor(() =>
+  await waitForFast(() =>
     expect(request).toHaveBeenCalledWith("talk.client.toolCall", expect.any(Object)),
   );
 
@@ -276,7 +277,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
           rejectOffer = reject;
         }),
     );
-    await vi.waitFor(() => expect(createOfferSpy).toHaveBeenCalled());
+    await waitForFast(() => expect(createOfferSpy).toHaveBeenCalled());
     transport.stop();
     rejectOffer(new Error("closed peer rejected offer creation"));
 
@@ -350,7 +351,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       (error: unknown) => error,
     );
 
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(offerSignal?.aborted).toBe(false);
 
     await vi.runAllTimersAsync();
@@ -385,7 +386,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const transport = createOpenAiTransport();
 
     const startResult = transport.start();
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     transport.stop();
 
@@ -681,7 +682,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         }),
       }),
     );
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(1));
     expect(request).toHaveBeenCalledWith("talk.client.toolCall", {
       sessionKey: "main",
       callId: "call-1",
@@ -691,7 +692,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
     transport.stop();
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("chat.abort", { sessionKey: "main", runId: "run-1" }),
     );
     expect(listeners.size).toBe(0);
@@ -721,7 +722,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
     dispatchTranscription(peer, "status");
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     const sent = sentRealtimeEvents(peer);
@@ -756,7 +757,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
     dispatchTranscription(peer, "status");
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     let sent = sentRealtimeEvents(peer);
@@ -798,7 +799,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
     dispatchTranscription(peer, "actually focus on WebUI");
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     const sent = sentRealtimeEvents(peer);
@@ -835,7 +836,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
     dispatchTranscription(peer, "cancel that");
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.client.steer", expect.any(Object)),
     );
     const sent = sentRealtimeEvents(peer);
@@ -888,7 +889,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         }),
       }),
     );
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.client.toolCall", expect.any(Object)),
     );
 
@@ -960,7 +961,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       }),
     );
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.client.steer", {
         sessionKey: "main",
         text: "revísalo en WebUI",
@@ -1011,7 +1012,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       arguments: JSON.stringify({ text: "status", mode: "status" }),
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(onStatus).toHaveBeenCalledWith(
         "error",
         "OpenAI data channel rejected the tool result",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -11,6 +11,7 @@ import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
 } from "../../test-helpers/application-context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./custodian-page.ts";
 
 type TestCustodianPage = HTMLElement & {
@@ -152,7 +153,7 @@ describe("custodian page", () => {
     const { context } = createContext(request);
     const { page } = await mountPage(context);
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
     const card = page.querySelector("openclaw-option-card")!;
     await card.updateComplete;
@@ -161,7 +162,7 @@ describe("custodian page", () => {
     );
     page.querySelector<HTMLButtonElement>('[data-option-value="Connect WhatsApp"]')!.click();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
     expect(request.mock.calls[0]?.[0]).toBe("openclaw.chat");
     expect(request.mock.calls[0]?.[1]).toMatchObject({ welcomeVariant: "onboarding" });
@@ -188,7 +189,7 @@ describe("custodian page", () => {
       .mockRejectedValueOnce(new Error("Request failed"));
     const { context } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
     const input = page.querySelector<HTMLInputElement>(
       '.custodian__composer input[type="password"]',
@@ -198,8 +199,8 @@ describe("custodian page", () => {
     await page.updateComplete;
     page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
     await page.updateComplete;
     expect(page.querySelector('.custodian__composer input[type="password"]')).not.toBeNull();
     expect(page.textContent).toContain("Sensitive reply sent");
@@ -214,7 +215,7 @@ describe("custodian page", () => {
     });
     const { context, setGatewaySnapshot } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
 
     setGatewaySnapshot({ client: null, connected: false, reconnecting: true });
@@ -239,7 +240,7 @@ describe("custodian page", () => {
     const { context, setGatewaySnapshot, setGatewayDeviceToken } = createContext(request);
     setGatewayDeviceToken("stored-device-token");
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Device-token conversation."));
+    await waitForFast(() => expect(page.textContent).toContain("Device-token conversation."));
 
     // Transient drop: the retrying client stays but hello is cleared.
     setGatewaySnapshot({ client: null, connected: false, reconnecting: true, hello: null });
@@ -276,17 +277,17 @@ describe("custodian page", () => {
       });
     const { context, setGatewaySnapshot } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
 
     setGatewaySnapshot({ client: { request } as unknown as GatewayBrowserClient });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector('[role="alert"]')?.textContent).toContain(
         "Gateway connection changed",
       ),
     );
     page.querySelector<HTMLButtonElement>('[role="alert"] button')!.click();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(page.textContent).toContain("Hello after reconnect."));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(page.textContent).toContain("Hello after reconnect."));
   });
 
   it("clears the prior conversation when the gateway changes while offline", async () => {
@@ -297,11 +298,11 @@ describe("custodian page", () => {
     });
     const { context, setGatewaySnapshot, setGatewayUrl } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Gateway A conversation."));
+    await waitForFast(() => expect(page.textContent).toContain("Gateway A conversation."));
 
     setGatewayUrl("ws://gateway-b.test/control");
     setGatewaySnapshot({ client: null, connected: false, reconnecting: true });
-    await vi.waitFor(() => expect(page.textContent).not.toContain("Gateway A conversation."));
+    await waitForFast(() => expect(page.textContent).not.toContain("Gateway A conversation."));
 
     expect(page.querySelector('[role="alert"] button')).toBeNull();
   });
@@ -321,7 +322,7 @@ describe("custodian page", () => {
       });
     const { context, setGatewaySnapshot, setGatewayToken } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Operator A conversation."));
+    await waitForFast(() => expect(page.textContent).toContain("Operator A conversation."));
 
     setGatewayToken("test-token-placeholder");
     setGatewaySnapshot({
@@ -330,7 +331,7 @@ describe("custodian page", () => {
       reconnecting: false,
     });
 
-    await vi.waitFor(() => expect(page.textContent).toContain("Operator B welcome."));
+    await waitForFast(() => expect(page.textContent).toContain("Operator B welcome."));
     expect(page.textContent).not.toContain("Operator A conversation.");
     expect(request).toHaveBeenCalledTimes(2);
     expect(request.mock.calls[1]?.[1]).toMatchObject({ welcomeVariant: "onboarding" });
@@ -352,7 +353,7 @@ describe("custodian page", () => {
       });
     const { context, setGatewaySnapshot, setGatewayBootstrapToken } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Paired device conversation."));
+    await waitForFast(() => expect(page.textContent).toContain("Paired device conversation."));
 
     setGatewayBootstrapToken("test-token-placeholder");
     setGatewaySnapshot({
@@ -361,7 +362,7 @@ describe("custodian page", () => {
       reconnecting: false,
     });
 
-    await vi.waitFor(() => expect(page.textContent).toContain("Re-paired welcome."));
+    await waitForFast(() => expect(page.textContent).toContain("Re-paired welcome."));
     expect(page.textContent).not.toContain("Paired device conversation.");
   });
 
@@ -380,7 +381,7 @@ describe("custodian page", () => {
       });
     const { context, setGatewaySnapshot, setGatewayDeviceToken } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Device A conversation."));
+    await waitForFast(() => expect(page.textContent).toContain("Device A conversation."));
 
     setGatewayDeviceToken("test-token-placeholder");
     setGatewaySnapshot({
@@ -389,7 +390,7 @@ describe("custodian page", () => {
       reconnecting: false,
     });
 
-    await vi.waitFor(() => expect(page.textContent).toContain("Device B welcome."));
+    await waitForFast(() => expect(page.textContent).toContain("Device B welcome."));
     expect(page.textContent).not.toContain("Device A conversation.");
     expect(request).toHaveBeenCalledTimes(2);
   });
@@ -415,14 +416,14 @@ describe("custodian page", () => {
       });
     const { context, setGatewaySnapshot, setGatewayDeviceToken } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Paste your token."));
+    await waitForFast(() => expect(page.textContent).toContain("Paste your token."));
 
     const composer = page.querySelector<HTMLInputElement>('input[type="password"]')!;
     composer.value = "test-token-placeholder";
     composer.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await page.updateComplete;
     page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
 
     setGatewayDeviceToken("test-token-placeholder");
     setGatewaySnapshot({
@@ -431,7 +432,7 @@ describe("custodian page", () => {
       reconnecting: false,
     });
 
-    await vi.waitFor(() => expect(page.textContent).toContain("New operator welcome."));
+    await waitForFast(() => expect(page.textContent).toContain("New operator welcome."));
     expect(page.textContent).not.toContain("Paste your token.");
     expect(page.textContent).not.toContain("Sensitive reply sent");
     expect(page.querySelector('[role="alert"]')).toBeNull();
@@ -449,7 +450,7 @@ describe("custodian page", () => {
       .mockRejectedValueOnce(new Error("gateway timeout"));
     const { context } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Welcome."));
+    await waitForFast(() => expect(page.textContent).toContain("Welcome."));
 
     const composer = page.querySelector<HTMLTextAreaElement>("textarea")!;
     composer.value = "install everything";
@@ -457,7 +458,7 @@ describe("custodian page", () => {
     await page.updateComplete;
     page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector('[role="alert"]')?.textContent).toContain("gateway timeout"),
     );
     expect(page.querySelector('[role="alert"] button')).toBeNull();
@@ -479,7 +480,7 @@ describe("custodian page", () => {
       });
     const { context } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(page.textContent).toContain("Paste your API key."));
+    await waitForFast(() => expect(page.textContent).toContain("Paste your API key."));
 
     const composer = page.querySelector<HTMLInputElement>('input[type="password"]')!;
     const sensitiveValue = ["", "test-token-placeholder", ""].join(" ");
@@ -488,9 +489,9 @@ describe("custodian page", () => {
     await page.updateComplete;
     page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: sensitiveValue });
-    await vi.waitFor(() => expect(page.textContent).toContain("Key accepted."));
+    await waitForFast(() => expect(page.textContent).toContain("Key accepted."));
     expect(page.textContent).not.toContain("test-token-placeholder");
   });
 
@@ -517,12 +518,12 @@ describe("custodian page", () => {
       });
     const { context } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
 
     page.querySelector<HTMLButtonElement>(".option-card__skip")!.click();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "Skip for now" });
     expect(page.querySelector("openclaw-option-card")).toBeNull();
@@ -551,7 +552,7 @@ describe("custodian page", () => {
       });
     const { context } = createContext(request);
     const { page } = await mountPage(context);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
     const input = page.querySelector<HTMLTextAreaElement>(".custodian__composer textarea")!;
     input.value = "Something else";
@@ -560,7 +561,7 @@ describe("custodian page", () => {
 
     page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "Something else" });
     expect(page.querySelector<HTMLButtonElement>('[data-option-value="Ask first"]')?.disabled).toBe(
@@ -576,7 +577,7 @@ describe("custodian page", () => {
     });
     const { context } = createContext(request);
     const { page } = await mountPage(context, { onboarding: false });
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
 
     // The onboarding variant seeds the first-run setup proposal; permanent
@@ -588,7 +589,7 @@ describe("custodian page", () => {
     composer.dispatchEvent(new Event("input"));
     await page.updateComplete;
     page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(request.mock.calls[1]?.[1]).not.toHaveProperty("welcomeVariant");
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "status" });
   });
@@ -608,11 +609,11 @@ describe("custodian page", () => {
       });
     const { context } = createContext(request);
     const { page } = await mountPage(context, { onboarding: false });
-    await vi.waitFor(() => expect(page.textContent).toContain("Normal caretaker conversation."));
+    await waitForFast(() => expect(page.textContent).toContain("Normal caretaker conversation."));
 
     page.onboarding = true;
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(page.textContent).toContain("Onboarding proposal."));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(page.textContent).toContain("Onboarding proposal."));
 
     expect(page.textContent).not.toContain("Normal caretaker conversation.");
     expect(request.mock.calls[1]?.[1]).toMatchObject({ welcomeVariant: "onboarding" });
@@ -628,7 +629,7 @@ describe("custodian page", () => {
     const { context } = createContext(request);
     const { page } = await mountPage(context);
     page.onboarding = true;
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
 
     page.querySelector<HTMLButtonElement>(".custodian__header button")!.click();

--- a/ui/src/pages/plugin/plugin-page.test.ts
+++ b/ui/src/pages/plugin/plugin-page.test.ts
@@ -4,6 +4,7 @@ import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts"
 import type { RouteId } from "../../app-route-paths.ts";
 import type { ApplicationConfigCapability } from "../../app/config.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { getLogbookState, stopLogbookPolling } from "./logbook-controller.ts";
 import { renderLogbook } from "./logbook-view.ts";
 import { PluginPage } from "./plugin-page.ts";
@@ -170,11 +171,11 @@ describe("PluginPage", () => {
       expect(page.querySelector("iframe")).toBeNull();
 
       pendingRefresh.resolve(externalPluginConfig());
-      await vi.waitFor(() => expect(page.probeCalls).toEqual(["/plugins/external/panel"]));
+      await waitForFast(() => expect(page.probeCalls).toEqual(["/plugins/external/panel"]));
       expect(page.querySelector("iframe")).toBeNull();
 
       pendingProbe.resolve(true);
-      await vi.waitFor(() =>
+      await waitForFast(() =>
         expect(page.querySelector("iframe")?.getAttribute("src")).toBe("/plugins/external/panel"),
       );
     } finally {
@@ -188,7 +189,7 @@ describe("PluginPage", () => {
     page.probeResults = [Promise.resolve(false)];
     document.body.append(page);
     try {
-      await vi.waitFor(() => expect(page.textContent).toContain("Plugin panel unavailable"));
+      await waitForFast(() => expect(page.textContent).toContain("Plugin panel unavailable"));
       expect(page.probeCalls).toEqual(["/plugins/external/panel"]);
       expect(page.querySelector("iframe")).toBeNull();
     } finally {
@@ -202,7 +203,7 @@ describe("PluginPage", () => {
     const page = createExternalPluginPage(refresh, true, path);
     document.body.append(page);
     try {
-      await vi.waitFor(() => expect(page.querySelector("iframe")?.getAttribute("src")).toBe(path));
+      await waitForFast(() => expect(page.querySelector("iframe")?.getAttribute("src")).toBe(path));
       expect(page.probeCalls).toEqual([path]);
     } finally {
       page.remove();
@@ -214,7 +215,7 @@ describe("PluginPage", () => {
     const page = createExternalPluginPage(refresh);
     document.body.append(page);
     try {
-      await vi.waitFor(() => expect(page.textContent).toContain("Plugin panel unavailable"));
+      await waitForFast(() => expect(page.textContent).toContain("Plugin panel unavailable"));
       expect(page.querySelector("iframe")).toBeNull();
       expect(refresh).toHaveBeenCalledOnce();
     } finally {
@@ -347,7 +348,7 @@ describe("PluginPage", () => {
     const page = createExternalPluginPage(refresh);
     document.body.append(page);
     try {
-      await vi.waitFor(() => expect(page.querySelector("iframe")).not.toBeNull());
+      await waitForFast(() => expect(page.querySelector("iframe")).not.toBeNull());
       const context = (page as unknown as { context: ApplicationContext<RouteId> }).context;
       const gateway = context.gateway;
       const snapshot = gateway.snapshot as { connected: boolean };
@@ -367,7 +368,7 @@ describe("PluginPage", () => {
           updateGatewaySource: (source: ApplicationContext<RouteId>["gateway"]) => void;
         }
       ).updateGatewaySource(gateway);
-      await vi.waitFor(() => expect(page.querySelector("iframe")).not.toBeNull());
+      await waitForFast(() => expect(page.querySelector("iframe")).not.toBeNull());
       expect(refresh).toHaveBeenCalledTimes(2);
     } finally {
       page.remove();
@@ -441,7 +442,7 @@ describe("PluginPage", () => {
     document.body.append(page);
     try {
       bundledView.resolve({ render: () => "Logbook view", stop });
-      await vi.waitFor(() => expect(page.textContent).toContain("Logbook view"));
+      await waitForFast(() => expect(page.textContent).toContain("Logbook view"));
       const previousHost = bundledViewHost(page);
 
       hello.controlUiTabs = [];
@@ -509,7 +510,7 @@ describe("PluginPage", () => {
       createContext(firstRequest);
     document.body.append(page);
     try {
-      await vi.waitFor(() => expect(firstRequest).toHaveBeenCalled());
+      await waitForFast(() => expect(firstRequest).toHaveBeenCalled());
       const firstHost = bundledViewHost(page);
       expect(getLogbookState(firstHost).pollTimer).not.toBeNull();
 
@@ -518,7 +519,7 @@ describe("PluginPage", () => {
       page.requestUpdate();
       await page.updateComplete;
 
-      await vi.waitFor(() => expect(secondRequest).toHaveBeenCalledWith("logbook.status", {}));
+      await waitForFast(() => expect(secondRequest).toHaveBeenCalledWith("logbook.status", {}));
       expect(bundledViewHost(page)).not.toBe(firstHost);
       expect(getLogbookState(firstHost).pollTimer).toBeNull();
     } finally {
@@ -599,7 +600,7 @@ describe("PluginPage", () => {
     } as unknown as ApplicationContext<RouteId>;
     document.body.append(page);
     try {
-      await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+      await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
       const staleHost = bundledViewHost(page);
 
       snapshot.connected = false;
@@ -612,14 +613,14 @@ describe("PluginPage", () => {
       staleStatus.resolve(responseFor("logbook.status"));
       staleDays.resolve(responseFor("logbook.days"));
       staleTimeline.resolve(responseFor("logbook.timeline"));
-      await vi.waitFor(() => expect(getLogbookState(staleHost).timeline).not.toBeNull());
+      await waitForFast(() => expect(getLogbookState(staleHost).timeline).not.toBeNull());
       expect(getLogbookState(disconnectedHost).timeline).toBeNull();
 
       snapshot.connected = true;
       listener?.(snapshot);
       await page.updateComplete;
       expect(bundledViewHost(page)).not.toBe(disconnectedHost);
-      await vi.waitFor(() => expect(getLogbookState(bundledViewHost(page)).status).not.toBeNull());
+      await waitForFast(() => expect(getLogbookState(bundledViewHost(page)).status).not.toBeNull());
     } finally {
       page.remove();
     }
@@ -670,7 +671,7 @@ describe("PluginPage", () => {
       await page.updateComplete;
 
       currentWorkspaceLoad.resolve({ render: () => "current workspace view", stop: vi.fn() });
-      await vi.waitFor(() => expect(page.textContent).toContain("current workspace view"));
+      await waitForFast(() => expect(page.textContent).toContain("current workspace view"));
 
       firstWorkspaceLoad.resolve({ render: () => "stale workspace view", stop: vi.fn() });
       await Promise.resolve();

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -18,6 +18,7 @@ import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
 } from "../../test-helpers/application-context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
 import "./plugins-page.ts";
 
@@ -302,7 +303,7 @@ describe("PluginsPage", () => {
       routeData,
     );
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(
         page.querySelector('[data-plugin-id="remote-icon"] img.plugins-icon')?.getAttribute("src"),
       ).toBe("blob:firecrawl-icon");
@@ -365,7 +366,7 @@ describe("PluginsPage", () => {
       },
     );
 
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(fetchMock).toHaveBeenCalledOnce());
     expect(createObjectURL).not.toHaveBeenCalled();
     expect(
       page.querySelector('[data-plugin-id="unsafe-icon"] .plugins-tile--fallback')?.textContent,
@@ -460,7 +461,7 @@ describe("PluginsPage", () => {
     harness.emit(client, false);
     harness.emit(client, true);
 
-    await vi.waitFor(() => expect(page.result?.plugins[0]?.enabled).toBe(true));
+    await waitForFast(() => expect(page.result?.plugins[0]?.enabled).toBe(true));
     expect(request).toHaveBeenCalledWith("plugins.list", {});
   });
 
@@ -542,8 +543,8 @@ describe("PluginsPage", () => {
 
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
 
-    await vi.waitFor(() => expect(page.result?.plugins[0]?.enabled).toBe(true));
-    await vi.waitFor(() => expect(refreshConfig).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(page.result?.plugins[0]?.enabled).toBe(true));
+    await waitForFast(() => expect(refreshConfig).toHaveBeenCalledOnce());
     expect(refreshConfig).toHaveBeenCalledWith();
     expect(runtimeConfigState.configFormDirty).toBe(true);
     expect(calls).toContainEqual(["plugins.setEnabled", { pluginId: "workboard", enabled: true }]);
@@ -574,12 +575,12 @@ describe("PluginsPage", () => {
     );
 
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector('[role="alert"]')?.textContent).toContain("Enable failed"),
     );
 
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const calls = request.mock.calls.filter(([method]) => method === "plugins.setEnabled");
       expect(calls).toHaveLength(2);
       expect(calls.map(([, params]) => params)).toEqual([
@@ -666,7 +667,7 @@ describe("PluginsPage", () => {
     expect(page.loading).toBe(true);
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
 
-    await vi.waitFor(() => expect(page.busy["plugin:workboard"]).toBeUndefined());
+    await waitForFast(() => expect(page.busy["plugin:workboard"]).toBeUndefined());
     expect(page.loading).toBe(false);
     expect(page.querySelector<HTMLButtonElement>(".plugins-refresh")?.disabled).toBe(false);
     manualRefresh.resolve(createResult());
@@ -707,14 +708,14 @@ describe("PluginsPage", () => {
     );
 
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector(".plugins-page-error")?.textContent).toContain(
         "Could not refresh Control UI configuration: config.get failed",
       ),
     );
 
     page.querySelector<HTMLButtonElement>(".plugins-page-error button")?.click();
-    await vi.waitFor(() => expect(page.querySelector(".plugins-page-error")).toBeNull());
+    await waitForFast(() => expect(page.querySelector(".plugins-page-error")).toBeNull());
     expect(refreshConfig).toHaveBeenCalledTimes(2);
   });
 
@@ -759,7 +760,7 @@ describe("PluginsPage", () => {
     expect(page.busy["plugin:workboard"]).toBe(true);
 
     harness.emit(replacementClient, true);
-    await vi.waitFor(() => expect(replacementListCount).toBe(1));
+    await waitForFast(() => expect(replacementListCount).toBe(1));
     await page.updateComplete;
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     expect(page.busy["plugin:workboard"]).toBe(true);
@@ -769,7 +770,7 @@ describe("PluginsPage", () => {
     expect(page.busy["plugin:workboard"]).toBe(true);
 
     freshMutation.resolve({ ok: true, plugin: enabledPlugin, restartRequired: false });
-    await vi.waitFor(() => expect(page.busy["plugin:workboard"]).toBeUndefined());
+    await waitForFast(() => expect(page.busy["plugin:workboard"]).toBeUndefined());
   });
 
   it("uninstalls a removable plugin after inline confirmation", async () => {
@@ -818,10 +819,10 @@ describe("PluginsPage", () => {
       )
       ?.click();
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(calls).toContainEqual(["plugins.uninstall", { pluginId: "community-thing" }]),
     );
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector(".plugins-page-notice")?.textContent).toContain(
         "Removed community-thing",
       ),
@@ -874,7 +875,7 @@ describe("PluginsPage", () => {
       "https://mcp.context7.com/mcp";
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 
-    await vi.waitFor(() => expect(configHarness.runtimeConfig.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(configHarness.runtimeConfig.patch).toHaveBeenCalledOnce());
     const patchArgs = expectDefined(
       expectDefined(configHarness.runtimeConfig.patch.mock.calls[0], "MCP add patch call")[0],
       "MCP add patch payload",
@@ -890,7 +891,7 @@ describe("PluginsPage", () => {
         },
       },
     });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector('[role="status"].plugins-row-message')?.textContent).toContain(
         "Added MCP server context7",
       ),
@@ -937,7 +938,7 @@ describe("PluginsPage", () => {
     expect(page.querySelector('[data-mcp-name="github"]')).not.toBeNull();
     await clickRowAction(page, '[data-mcp-name="github"]', "Remove");
 
-    await vi.waitFor(() => expect(configHarness.runtimeConfig.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(configHarness.runtimeConfig.patch).toHaveBeenCalledOnce());
     const patchArgs = expectDefined(
       expectDefined(configHarness.runtimeConfig.patch.mock.calls[0], "MCP remove patch call")[0],
       "MCP remove patch payload",
@@ -983,7 +984,7 @@ describe("PluginsPage", () => {
       )
       ?.click();
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(
         page.querySelector('[data-connector-id="context7"] [role="alert"]')?.textContent,
       ).toContain("rate limit exceeded"),
@@ -1025,7 +1026,7 @@ describe("PluginsPage", () => {
     form.querySelector<HTMLInputElement>('[name="mcp-target"]')!.value = "https://x.example/mcp";
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector('[role="alert"].plugins-row-message')?.textContent).toContain(
         "Server names use",
       ),

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./worktrees-page.ts";
 
 type WorktreesPageTestElement = HTMLElement & {
@@ -177,11 +178,11 @@ describe("WorktreesPage lifecycle", () => {
       gatewayWithClient({ request } as unknown as GatewayBrowserClient),
     );
     document.body.append(page);
-    await vi.waitFor(() => expect(page.records).toEqual([record]));
-    await vi.waitFor(() => expect(page.loading).toBe(false));
+    await waitForFast(() => expect(page.records).toEqual([record]));
+    await waitForFast(() => expect(page.loading).toBe(false));
 
     const refreshing = page.load();
-    await vi.waitFor(() => expect(listRequests).toBe(2));
+    await waitForFast(() => expect(listRequests).toBe(2));
     await page.updateComplete;
 
     const deleteButton = page.querySelector<HTMLButtonElement>("button.danger");
@@ -244,7 +245,7 @@ describe("WorktreesPage lifecycle", () => {
     );
 
     document.body.append(page);
-    await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(firstRequest).toHaveBeenCalledOnce());
     expect(page.loading).toBe(true);
 
     page.remove();
@@ -253,8 +254,8 @@ describe("WorktreesPage lifecycle", () => {
     );
     document.body.append(page);
 
-    await vi.waitFor(() => expect(secondRequest).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(page.loading).toBe(false));
+    await waitForFast(() => expect(secondRequest).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(page.loading).toBe(false));
 
     resolveFirst({ worktrees: [] });
     await Promise.resolve();
@@ -276,10 +277,10 @@ describe("WorktreesPage lifecycle", () => {
     );
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     document.body.append(page);
-    await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(firstRequest).toHaveBeenCalledWith("worktrees.list", {}));
 
     const removing = page.removeWorktree(worktree());
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(firstRequest).toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1" }),
     );
 
@@ -315,7 +316,7 @@ describe("WorktreesPage lifecycle", () => {
     );
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     document.body.append(page);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
 
     await page.removeWorktree(worktree());
 
@@ -338,10 +339,10 @@ describe("WorktreesPage lifecycle", () => {
     const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
     page.context = contextWithGateway(source.gateway);
     document.body.append(page);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
 
     const restoring = page.restore(worktree());
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("worktrees.restore", { id: "worktree-1" }),
     );
     source.emit(false);
@@ -371,8 +372,8 @@ describe("WorktreesPage lifecycle", () => {
       gatewayWithClient({ request } as unknown as GatewayBrowserClient),
     );
     document.body.append(page);
-    await vi.waitFor(() => expect(listRequests).toBe(1));
-    await vi.waitFor(() => expect(page.loading).toBe(false));
+    await waitForFast(() => expect(listRequests).toBe(1));
+    await waitForFast(() => expect(page.loading).toBe(false));
 
     await page.restore(record);
 
@@ -401,8 +402,8 @@ describe("WorktreesPage lifecycle", () => {
       gatewayWithClient({ request } as unknown as GatewayBrowserClient),
     );
     document.body.append(page);
-    await vi.waitFor(() => expect(listRequests).toBe(1));
-    await vi.waitFor(() => expect(page.loading).toBe(false));
+    await waitForFast(() => expect(listRequests).toBe(1));
+    await waitForFast(() => expect(page.loading).toBe(false));
 
     await page.restore(record);
 
@@ -425,10 +426,10 @@ describe("WorktreesPage lifecycle", () => {
     page.context = contextWithGateway(source.gateway);
     page.createRepoRoot = "/tmp/repo";
     document.body.append(page);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
 
     const creating = page.createWorktree();
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("worktrees.create", { repoRoot: "/tmp/repo" }),
     );
     expect(page.creating).toBe(true);
@@ -460,8 +461,8 @@ describe("WorktreesPage lifecycle", () => {
     page.createName = "submitted-name";
     page.createBaseRef = "main";
     document.body.append(page);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
-    await vi.waitFor(() => expect(page.loading).toBe(false));
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(page.loading).toBe(false));
 
     const toggleButton = Array.from(page.querySelectorAll<HTMLButtonElement>("button")).find(
       (button) => button.textContent?.trim() === "New worktree",
@@ -469,7 +470,7 @@ describe("WorktreesPage lifecycle", () => {
     const creating = page.createWorktree();
     toggleButton?.click();
     expect(page.createOpen).toBe(true);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("worktrees.create", {
         baseRef: "main",
         name: "submitted-name",
@@ -519,7 +520,7 @@ describe("WorktreesPage lifecycle", () => {
       runtimeConfigStub({ maxCount: 25, maxTotalSizeGb: 50 }),
     );
     document.body.append(withConfig);
-    await vi.waitFor(() => expect(withConfig.cleanupLoaded).toBe(true));
+    await waitForFast(() => expect(withConfig.cleanupLoaded).toBe(true));
     await withConfig.updateComplete;
 
     expect(withConfig.cleanupMaxCount).toBe(25);
@@ -720,11 +721,11 @@ describe("WorktreesPage lifecycle", () => {
     );
     page.createRepoRoot = "/tmp/repo";
     document.body.append(page);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
 
     page.loadCreateBranches();
 
-    await vi.waitFor(() => expect(page.createBranches).toEqual(["main"]));
+    await waitForFast(() => expect(page.createBranches).toEqual(["main"]));
     expect(page.createBaseRef).toBe("main");
   });
 
@@ -746,11 +747,11 @@ describe("WorktreesPage lifecycle", () => {
     );
     page.createRepoRoot = "/tmp/repo";
     document.body.append(page);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
 
     page.loadCreateBranches();
     page.loadCreateBranches();
-    await vi.waitFor(() => expect(page.createBranches).toEqual(["main"]));
+    await waitForFast(() => expect(page.createBranches).toEqual(["main"]));
     expect(page.createBaseRef).toBe("main");
 
     firstBranches.reject(new Error("stale branch failure"));

--- a/ui/src/test-helpers/wait-for.ts
+++ b/ui/src/test-helpers/wait-for.ts
@@ -1,0 +1,7 @@
+import { vi } from "vitest";
+
+type WaitForOptions = Exclude<Parameters<typeof vi.waitFor>[1], number | undefined>;
+
+export function waitForFast<T>(assertion: () => T | Promise<T>, options: WaitForOptions = {}) {
+  return vi.waitFor(assertion, { interval: 1, ...options });
+}


### PR DESCRIPTION
## What Problem This Solves

Control UI test suites spend seconds idling on Vitest's default polling interval while waiting for mocked, immediately scheduled async updates. This slows developer and CI feedback without adding coverage.

## Why This Change Was Made

Adds a test-only fast polling helper with a 1 ms default and migrates 301 waits across the 12 highest-polling Control UI suites. Caller-supplied options still take precedence. Runtime code and CI configuration are unchanged.

AI-assisted with Codex.

## User Impact

No product behavior changes. Maintainers get faster focused Control UI tests and shorter CI feedback for these suites.

## Evidence

- Same warm Blacksmith Testbox, same 12-file order, 672 tests:
  - before: 4.52 s wall, 10.70 s aggregate test bodies
  - after: 2.78 s wall, 4.56 s aggregate test bodies
  - improvement: 38.5% wall, 57.4% aggregate test-body time
- Focused target: 12 files passed, 672 tests passed.
- Changed-scope gate: formatting, conflict and dependency guards, Control UI i18n, core-test and UI typechecks, and serialized core/UI lint all passed.
- Autoreview: clean, no accepted or actionable findings.
- No workflow or CI configuration files changed.
