### PR TITLE
fix(config): compaction.enabled field rejected by config schema despite being read by the runtime

### DIFF
--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -94,4 +94,22 @@ describe("config compaction settings", () => {
 
     expect(compaction?.qualityGuard?.maxRetries).toBe(99);
   });
+
+  it("accepts compaction.enabled toggle", () => {
+    // Regression: the config schema rejected compaction.enabled because
+    // the .strict() Zod object omitted it, even though the runtime reads
+    // it (settings-manager.ts:667). Users trying to disable auto-compaction
+    // got "Invalid config" for a field the code was written to accept.
+    const compaction = materializeCompactionConfig({
+      enabled: false,
+    });
+    expect(compaction?.enabled).toBe(false);
+  });
+
+  it("defaults compaction.enabled to undefined when absent", () => {
+    // Absent compaction entirely must not fail config validation, and
+    // the runtime's `?? true` default path correctly enables compaction.
+    const compaction = materializeCompactionConfig({});
+    expect(compaction?.enabled).toBeUndefined();
+  });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -244,6 +244,38 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  // Regression: the .strict() compaction schema rejected `enabled` even
+  // though the settings manager (settings-manager.ts:667) reads it to
+  // control auto-compaction on/off. Users trying `compaction.enabled: false`
+  // got their entire config rejected as invalid.
+  it("accepts agents.defaults.compaction.enabled", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("still rejects unknown compaction fields to maintain strictness", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            nonexistentField: true,
+          },
+        },
+      },
+    } as unknown as Record<string, unknown>);
+
+    expect(res.ok).toBe(false);
+  });
+
   it("accepts Matrix queue byChannel overrides", () => {
     const res = validateConfigObject({
       messages: {

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -120,6 +120,8 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
   "agents.defaults.compaction":
     "Compaction tuning for when context nears token limits, including history share, reserve headroom, and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",
+  "agents.defaults.compaction.enabled":
+    "Whether automatic context compaction is allowed for this agent session. When false, the runtime skips auto-compaction entirely regardless of token usage. Use this as a workaround while tuning premature-compaction thresholds. Default: true.",
   "agents.defaults.compaction.mode":
     'Compaction strategy mode: "default" uses baseline behavior, while "safeguard" applies stricter guardrails to preserve recent context. Keep "default" unless you observe aggressive history loss near limit boundaries.',
   "agents.defaults.compaction.provider":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -519,6 +519,8 @@ export type AgentCompactionMidTurnPrecheckConfig = {
 };
 
 export type AgentCompactionConfig = {
+  /** Whether auto-compaction is enabled. When false, the runtime skips compaction entirely. Default: true. */
+  enabled?: boolean;
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
   /** Embedded OpenClaw reserve target before floor and context-window caps. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -158,6 +158,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
+        enabled: z.boolean().optional(),
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         provider: z.string().optional(),
         reserveTokens: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
Closes #110065

## What Problem This Solves

Fixes an issue where users could not disable auto-compaction through configuration. The session runtime reads `compaction.enabled` to control auto-compaction on/off (`settings-manager.ts:667`: `this.settings.compaction?.enabled ?? true`), but both the config schema's Zod `.strict()` object and the `AgentCompactionConfig` TypeScript type omitted the `enabled` field. Setting `enabled: false` in `openclaw.json` caused the entire config to be rejected as invalid with `agents.defaults.compaction: Invalid input`.

Users experiencing premature compaction had no `enabled: false` workaround while waiting for underlying usage-accounting fixes.

## Why This Change Was Made

Added `enabled: z.boolean().optional()` to the compaction Zod schema and the `enabled?: boolean` property to the `AgentCompactionConfig` TS type — matching the runtime's existing `?? true` default. The field is optional: absent means enabled (the existing default), `false` disables auto-compaction entirely as the settings manager intended. The schema stays `.strict()` so truly unknown fields are still rejected. A new schema help entry documents the field.

## User Impact

Users can now set `compaction.enabled: false` in `openclaw.json` (or via `openclaw config set`) to disable automatic context compaction. Absent configurations behave exactly as before (`enabled` defaults to true).

## Evidence

### Real runtime behavior proof (production Zod AgentDefaultsSchema)

Loading the production `AgentDefaultsSchema` (the same Zod schema used by `openclaw validate`, `openclaw status`, and every config-load path) with `compaction.enabled: false`:

```
[proof] enabled=false accepted by real Zod schema: true
[proof] unknown field rejected (strictness preserved): true
[proof] full compaction config with enabled=false accepted: true
[proof] Zod parse output: {"compaction":{"enabled":false}}
[proof] ON MAIN: this same Zod.safeParse call returns success=false -- config rejected as invalid
[proof] PROOF COMPLETE -- production AgentDefaultsSchema now accepts compaction.enabled
```

The `.strict()` guard still fires for truly unknown keys -- the schema accepts exactly the field the runtime reads and nothing else.

### Schema validation regression (real `validateConfigObject`)

- `validateConfigObject({ agents: { defaults: { compaction: { enabled: false } } } })` -- passes with the fix; fails against unfixed `main` (the `.strict()` schema rejects `enabled` as an unrecognized key).
- `validateConfigObject({ agents: { defaults: { compaction: { nonexistentField: true } } } })` -- still fails in both states, proving the `.strict()` guard stays intact.

### Unit regression coverage

- `config.compaction-settings.test.ts`: 7 tests pass (2 new: compaction.enabled toggle accepted; absent defaults to undefined for runtime `?? true`).
- `config.schema-regressions.test.ts`: 36 tests pass (2 new, including the strictness-preservation test).
- `pnpm tsgo:core:test` -- passed (no type errors).
- `node scripts/run-vitest.mjs` on both test files -- 43 passed.
- Scoped `oxlint`, `oxfmt`, and `git diff --check` pass on the five changed files.

### Unrelated CI failures

`checks-node-compact-small-5` and `checks-node-compact-small-6` fail in `test/scripts/apple-app-i18n.test.ts` ("Apple catalog apps/ios/Resources/Localizable.xcstrings is stale") -- an iOS localization catalog staleness issue on `main` unrelated to this PR's config schema change.

`check-test-types` was fixed in a21f752 by adding `enabled` to the `AgentCompactionConfig` TS type.

AI-assisted.
