### PR TITLE
fix: generated media posts only once after completion

### DIFF
--- a/src/agents/agent-command-restart-recovery.test.ts
+++ b/src/agents/agent-command-restart-recovery.test.ts
@@ -115,7 +115,22 @@ describe("constrainRestartRecoveryDeliveryPayloads", () => {
         ],
         [" /tmp/missing.png ", "/tmp/missing.png"],
       ),
-    ).toEqual([{ text: "ready" }, { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true }]);
+    ).toEqual([{ text: "ready", mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true }]);
+  });
+
+  it("strips duplicate MEDIA directives before attaching the host-owned media", () => {
+    expect(
+      constrainRestartRecoveryDeliveryPayloads(
+        [{ text: "Fresh from the decks\nMEDIA:/tmp/generated.png" }],
+        ["/tmp/generated.png"],
+      ),
+    ).toEqual([
+      {
+        text: "Fresh from the decks",
+        mediaUrls: ["/tmp/generated.png"],
+        trustedLocalMedia: true,
+      },
+    ]);
   });
 
   it("strips all model media from a text-only notice", () => {

--- a/src/agents/agent-command-restart-recovery.ts
+++ b/src/agents/agent-command-restart-recovery.ts
@@ -1,6 +1,7 @@
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../config/sessions/restart-recovery-types.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { splitMediaFromOutput } from "../media/parse.js";
 import type { DeliveryContext } from "../utils/delivery-context.shared.js";
 import {
   collectDeliveredMediaUrls,
@@ -47,7 +48,10 @@ export function constrainRestartRecoveryDeliveryPayloads(
   for (const payload of payloads ?? []) {
     const constrainedPayload: ReplyPayload = {};
     if (!suppressText && typeof payload.text === "string") {
-      constrainedPayload.text = payload.text;
+      // The host appends the canonical media set below. Strip model-emitted
+      // MEDIA directives first or the outbound parser re-materializes the same
+      // attachment in both this caption payload and the host-owned payload.
+      constrainedPayload.text = splitMediaFromOutput(payload.text).text;
     }
     if (payload.isError === true) {
       constrainedPayload.isError = true;
@@ -78,7 +82,18 @@ export function constrainRestartRecoveryDeliveryPayloads(
     new Set(mediaUrls.map((url) => url.trim()).filter((url) => url.length > 0)),
   );
   if (exactMediaUrls.length > 0) {
-    constrained.push({ mediaUrls: exactMediaUrls, trustedLocalMedia: true });
+    const captionIndex = constrained.findIndex(
+      (payload) => payload.isReasoning !== true && Boolean(payload.text?.trim()),
+    );
+    if (captionIndex >= 0) {
+      constrained[captionIndex] = {
+        ...constrained[captionIndex],
+        mediaUrls: exactMediaUrls,
+        trustedLocalMedia: true,
+      };
+    } else {
+      constrained.push({ mediaUrls: exactMediaUrls, trustedLocalMedia: true });
+    }
   }
   return constrained;
 }

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -2854,12 +2854,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       "delivery params",
     );
     expect(requireRecord(deliveryParams.result, "delivery result").payloads).toEqual([
-      { text: "ready" },
-      { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
+      { text: "ready", mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
     ]);
     expect(deliveryParams.payloads).toEqual([
-      { text: "ready" },
-      { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
+      { text: "ready", mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
     ]);
     expect(
       state.persistSessionEntryMock.mock.calls.some((call) => {

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1880,6 +1880,30 @@ describe("deliverAgentCommandResult payload normalization", () => {
     expect(outcome?.stage).toBe("platform_send");
   });
 
+  it("accepts an already-owned internal delivery intent during replay", async () => {
+    deliverOutboundPayloadsMock.mockRejectedValueOnce(
+      new Error("Stable delivery intent is already queued: image:task-1:generated-media-direct"),
+    );
+
+    const delivered = await deliverMediaReplyForTest(
+      {
+        key: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+      } as never,
+      { internalDeliveryIdempotencyKey: "image:task-1:generated-media-direct" },
+    );
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "suppressed",
+      succeeded: true,
+      reason: "delivery_intent_already_owned",
+      resultCount: 0,
+    });
+  });
+
   it("marks no-payload deliveryStatus as terminal delivery success", async () => {
     const delivered = await deliverAgentCommandResult({
       cfg: {} as OpenClawConfig,

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -941,6 +941,12 @@ export async function deliverAgentCommandResult(
           threadId: resolvedThreadTarget ?? null,
           bestEffort: bestEffortDeliver,
           durability: bestEffortDeliver ? "best_effort" : "required",
+          ...(opts.internalDeliveryIdempotencyKey
+            ? {
+                deliveryIntentId: opts.internalDeliveryIdempotencyKey,
+                completionRetention: "permanent" as const,
+              }
+            : {}),
           signal: restartAbort.signal,
           onDeliveryIntent: restartAbort.dispose,
           onError: logDeliveryError,
@@ -953,8 +959,25 @@ export async function deliverAgentCommandResult(
       if (restartAbort.signal?.aborted && send.status === "failed") {
         throw restartAbort.signal.reason;
       }
-      deliveryStatus = deliveryStatusFromDurableSend(send);
-      if (!bestEffortDeliver && (send.status === "failed" || send.status === "partial_failed")) {
+      const stableIntentAlreadyOwned =
+        send.status === "failed" &&
+        Boolean(opts.internalDeliveryIdempotencyKey) &&
+        /Stable delivery intent is already queued:/i.test(formatErrorMessage(send.error));
+      deliveryStatus = stableIntentAlreadyOwned
+        ? {
+            requested: true,
+            attempted: true,
+            status: "suppressed",
+            succeeded: true,
+            reason: "delivery_intent_already_owned",
+            resultCount: 0,
+          }
+        : deliveryStatusFromDurableSend(send);
+      if (
+        !stableIntentAlreadyOwned &&
+        !bestEffortDeliver &&
+        (send.status === "failed" || send.status === "partial_failed")
+      ) {
         emitJsonEnvelope(deliveryStatus);
         captureDeliveryResult(
           buildDeliveryResult({
@@ -967,7 +990,8 @@ export async function deliverAgentCommandResult(
         );
         throw send.error;
       }
-      deliverySucceeded = send.status === "sent" || send.status === "suppressed";
+      deliverySucceeded =
+        stableIntentAlreadyOwned || send.status === "sent" || send.status === "suppressed";
     }
   }
   if (deliver && !deliveryStatus) {

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -153,6 +153,7 @@ export type AgentCommandOpts = {
   forceRestartSafeTools?: boolean;
   /** Host-owned exact media set for a scoped automatic recovery delivery. */
   internalDeliveryMediaUrls?: string[];
+  internalDeliveryIdempotencyKey?: string;
   internalDeliverySuppressText?: boolean;
   /** Gateway ingress that already persisted visible activity can skip the duplicate pre-run touch. */
   skipInitialSessionTouch?: boolean;

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3428,6 +3428,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         content: "The generated music is ready.",
         mediaUrls: ["/tmp/generated-night-drive.mp3"],
         idempotencyKey: "announce-dm-fallback-empty:generated-media-direct",
+        deliveryIntentId: "announce-dm-fallback-empty:generated-media-direct",
+        completionRetention: "permanent",
       }),
     );
   });
@@ -3905,6 +3907,46 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         content: "The generated music is ready.",
         mediaUrls: ["/tmp/generated-night-drive.mp3"],
         idempotencyKey: "announce-dm-fallback-empty:generated-media-direct",
+      }),
+    );
+  });
+
+  it("treats a shared generated-media delivery intent as already delivered", async () => {
+    const callGateway = createGatewayMock({
+      result: { payloads: [{ text: "The track is ready." }] },
+    });
+    const sendMessage = vi.fn(async () => {
+      throw new Error(
+        "Stable delivery intent is already queued: announce-dm-fallback-empty:generated-media-direct",
+      );
+    }) as unknown as typeof runtimeSendMessage;
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "music_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.",
+          mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          replyInstruction: "Deliver the generated music.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(generatedMediaWakeMocks.wakeSessionForGeneratedMediaDirectDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaLabel: "music",
+        contextKey: "announce-dm-fallback-empty:generated-media-direct",
       }),
     );
   });
@@ -4850,7 +4892,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expect.objectContaining({
         kind: "agentTurn",
         sessionKey: "agent:main:slack:channel:C123",
-        message: expect.stringContaining("generated-locked.png"),
+        message: expect.stringMatching(
+          /generated-locked\.png[\s\S]*completion delivery system owns the generated media/,
+        ),
         messageId: "announce-channel-media-handoff-locked:agent-loop",
         route: {
           channel: "slack",
@@ -4863,8 +4907,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           sourceChannel: "webchat",
           sourceTool: "image_generate",
         },
-        sourceReplyDeliveryMode: "message_tool_only",
+        sourceReplyDeliveryMode: "automatic",
         expectedMediaUrls: ["/tmp/generated-locked.png"],
+        deliveryIdempotencyKey: "announce-channel-media-handoff-locked:generated-media-direct",
         idempotencyKey: "announce-channel-media-handoff-locked:agent-loop",
       }),
       expect.any(Number),

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1056,6 +1056,8 @@ async function deliverGeneratedMediaCompletionDirect(params: {
       content: params.content ?? `The generated ${mediaLabel} is ready.`,
       mediaUrls: Array.from(params.mediaUrls),
       idempotencyKey,
+      deliveryIntentId: idempotencyKey,
+      completionRetention: "permanent",
       mirror: {
         sessionKey: params.requesterSessionKey,
         agentId,
@@ -1082,6 +1084,24 @@ async function deliverGeneratedMediaCompletionDirect(params: {
       path: "direct",
     };
   } catch (err) {
+    if (/Stable delivery intent is already queued:/i.test(summarizeDeliveryError(err))) {
+      if (params.wakeAfterDelivery) {
+        wakeSessionForGeneratedMediaDirectDelivery({
+          cfg: params.cfg,
+          sessionKey: params.requesterSessionKey,
+          mediaLabel,
+          status: params.status ?? "ok",
+          deliveryContext: {
+            channel: params.deliveryTarget.channel,
+            to: params.deliveryTarget.to,
+            accountId: params.deliveryTarget.accountId,
+            threadId: params.deliveryTarget.threadId,
+          },
+          contextKey: idempotencyKey,
+        });
+      }
+      return { delivered: true, path: "direct" };
+    }
     const terminal = hasAnnounceSendEvidence(err);
     return {
       delivered: false,
@@ -2202,36 +2222,26 @@ export async function deliverSubagentAnnouncement(params: {
         directOrigin: params.directOrigin,
         requesterSessionOrigin: params.requesterSessionOrigin,
       });
-      const { requesterSessionOrigin, effectiveDirectOrigin } = resolveCompletionDeliveryOrigins({
-        expectsCompletionMessage: params.expectsCompletionMessage,
-        completionDirectOrigin: params.completionDirectOrigin,
-        directOrigin: params.directOrigin,
-        requesterSessionOrigin: params.requesterSessionOrigin,
-      });
-      const requesterEntry = subagentAnnounceDeliveryDeps.loadRequesterSessionEntry(
-        params.targetRequesterSessionKey,
-      ).entry;
-      // No external route exists for an internal-only handoff. Let the normal
-      // agent final enter the owning transcript instead of requiring a message tool target.
-      const sourceReplyDeliveryMode =
-        queuedRoute.route.channel === INTERNAL_MESSAGE_CHANNEL
-          ? "automatic"
-          : completionRequiresMessageToolDelivery({
-                cfg,
-                requesterSessionKey: params.requesterSessionKey,
-                targetRequesterSessionKey: canonicalSessionKey,
-                requesterEntry,
-                directOrigin: effectiveDirectOrigin,
-                requesterSessionOrigin,
-              })
-            ? "message_tool_only"
-            : "automatic";
+      // Durable generated-media handoffs are host-owned: the model supplies
+      // only caption text while the queue fixes the route and exact attachment.
+      // Replay dispatch also enforces disableMessageTool=true.
+      const sourceReplyDeliveryMode = "automatic";
       const queued = await enqueueClaimedSessionDelivery(
         {
           kind: "agentTurn",
           sessionKey: canonicalSessionKey,
           message:
-            formatAgentInternalEventsForPrompt(params.internalEvents) || params.triggerMessage,
+            formatAgentInternalEventsForPrompt(
+              params.internalEvents?.map((event) =>
+                event.status === "ok" && collectExpectedMediaFromInternalEvents([event]).length > 0
+                  ? {
+                      ...event,
+                      replyInstruction:
+                        "The completion delivery system owns the generated media and will attach it exactly once to this reply. Do not call the message tool and do not include MEDIA lines or otherwise resend the attachment. Write only the short caption or normal conversational reply.",
+                    }
+                  : event,
+              ),
+            ) || params.triggerMessage,
           messageId: `${params.directIdempotencyKey}:agent-loop`,
           route: queuedRoute.route,
           ...(queuedRoute.deliveryContext ? { deliveryContext: queuedRoute.deliveryContext } : {}),
@@ -2243,6 +2253,7 @@ export async function deliverSubagentAnnouncement(params: {
           },
           sourceReplyDeliveryMode,
           expectedMediaUrls: collectExpectedMediaFromInternalEvents(params.internalEvents),
+          deliveryIdempotencyKey: `${params.directIdempotencyKey}:generated-media-direct`,
           idempotencyKey: `${params.directIdempotencyKey}:agent-loop`,
         },
         resolveSubagentAnnounceTimeoutMs(cfg) + 5_000,

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1084,6 +1084,8 @@ describe("createMediaGenerationTaskLifecycle", () => {
     const announceParams = subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mock
       .calls[0]?.[0] as { triggerMessage?: string; internalEvents?: unknown[] } | undefined;
     expect(announceParams?.triggerMessage).toContain("MEDIA:/tmp/generated-night-drive.mp3");
+    expect(announceParams?.triggerMessage).toContain('call message(action="send")');
+    expect(announceParams?.triggerMessage).toContain("final-reply MEDIA lines");
     expect(announceParams?.internalEvents).toEqual([
       expect.objectContaining({
         mediaUrls: ["/tmp/generated-night-drive.mp3"],

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -359,6 +359,7 @@ export function startAgentRunExecution(params: {
           disableMessageTool: params.request.disableMessageTool,
           forceRestartSafeTools: params.request.forceRestartSafeTools,
           internalDeliveryMediaUrls: params.client?.internal?.internalDeliveryMediaUrls,
+          internalDeliveryIdempotencyKey: params.client?.internal?.internalDeliveryIdempotencyKey,
           internalDeliverySuppressText: params.client?.internal?.internalDeliverySuppressText,
           suppressPromptPersistence:
             params.requestedPromptPersistenceSuppression ||

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -862,6 +862,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           gatewayClientScopes: client?.connect?.scopes ?? [],
           silent: request.silent,
           formatting: request.parseMode ? { parseMode: request.parseMode } : undefined,
+          deliveryIntentId: idem,
           mirror: outboundSessionKey
             ? {
                 sessionKey: outboundSessionKey,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -82,6 +82,7 @@ export type GatewayClient = {
     agentRunTracking?: "plugin_subagent";
     /** Host-owned exact media set for a scoped automatic recovery delivery. */
     internalDeliveryMediaUrls?: string[];
+    internalDeliveryIdempotencyKey?: string;
     internalDeliverySuppressText?: boolean;
     /** Plugin-owned tools authorized for this internal subagent run. */
     runtimePluginToolGrant?: RuntimePluginToolGrant;

--- a/src/gateway/server-plugin-runtime-client.ts
+++ b/src/gateway/server-plugin-runtime-client.ts
@@ -17,6 +17,7 @@ export function createSyntheticPluginRuntimeClient(params?: {
   agentRunTracking?: "plugin_subagent";
   cronRunContinuation?: boolean;
   internalDeliveryMediaUrls?: string[];
+  internalDeliveryIdempotencyKey?: string;
   internalDeliverySuppressText?: boolean;
   pluginRuntimeOwnerId?: string;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
@@ -45,6 +46,9 @@ export function createSyntheticPluginRuntimeClient(params?: {
       ...(params?.cronRunContinuation === true ? { cronRunContinuation: true } : {}),
       ...(params?.internalDeliveryMediaUrls
         ? { internalDeliveryMediaUrls: [...params.internalDeliveryMediaUrls] }
+        : {}),
+      ...(params?.internalDeliveryIdempotencyKey
+        ? { internalDeliveryIdempotencyKey: params.internalDeliveryIdempotencyKey }
         : {}),
       ...(params?.internalDeliverySuppressText === true
         ? { internalDeliverySuppressText: true }

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -241,6 +241,7 @@ type DispatchGatewayMethodInProcessOptions = {
   expectFinal?: boolean;
   forceSyntheticClient?: boolean;
   internalDeliveryMediaUrls?: string[];
+  internalDeliveryIdempotencyKey?: string;
   internalDeliverySuppressText?: boolean;
   onAccepted?: (payload: unknown) => void;
   pluginRuntimeOwnerId?: string;
@@ -280,6 +281,7 @@ export async function dispatchGatewayMethodInProcessRaw(
     agentRunTracking: options?.agentRunTracking,
     cronRunContinuation: options?.allowSyntheticCronRunContinuation === true,
     internalDeliveryMediaUrls: options?.internalDeliveryMediaUrls,
+    internalDeliveryIdempotencyKey: options?.internalDeliveryIdempotencyKey,
     internalDeliverySuppressText: options?.internalDeliverySuppressText,
     ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
     ...(options?.runtimePluginToolGrant

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -317,6 +317,7 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
   }
 
   const queuedRunId = resolveQueuedAgentRunId(entry);
+  const deliveryIdempotencyKey = entry.deliveryIdempotencyKey;
   const deliveryMode = resolveDurableCompletionDeliveryMode(entry.sourceReplyDeliveryMode);
   if (deliveryMode === "host_owned" && route.channel === INTERNAL_MESSAGE_CHANNEL) {
     return await deadLetterSessionDelivery(
@@ -439,6 +440,9 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
         expectFinal: true,
         forceSyntheticClient: true,
         internalDeliveryMediaUrls: entry.expectedMediaUrls ?? [],
+        ...(deliveryIdempotencyKey
+          ? { internalDeliveryIdempotencyKey: deliveryIdempotencyKey }
+          : {}),
         ...(entry.suppressTextDelivery === true ? { internalDeliverySuppressText: true } : {}),
         onAccepted: () => {
           accepted = true;

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1163,6 +1163,7 @@ describe("scheduleRestartSentinelWake", () => {
         },
         sourceReplyDeliveryMode: "automatic",
         expectedMediaUrls: ["/tmp/proof.png"],
+        deliveryIdempotencyKey: "image:task-automatic:generated-media-direct",
         suppressTextDelivery: true,
       },
     });
@@ -1178,6 +1179,7 @@ describe("scheduleRestartSentinelWake", () => {
         expectFinal: true,
         forceSyntheticClient: true,
         internalDeliveryMediaUrls: ["/tmp/proof.png"],
+        internalDeliveryIdempotencyKey: "image:task-automatic:generated-media-direct",
         internalDeliverySuppressText: true,
         onAccepted: expect.any(Function),
       },

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -777,6 +777,8 @@ type DeliverOutboundPayloadsCoreParams = {
   deliveryQueueId?: string;
   /** @internal Stable producer id used to make queue creation idempotent across crashes. */
   deliveryIntentId?: string;
+  /** @internal Preserve the completed producer receipt for permanent deduplication. */
+  completionRetention?: "permanent";
   /** @internal Serializable owner state finalized after live or recovered delivery. */
   deliveryCompletion?: DurableDeliveryCompletion;
   /** @internal Channel-valid id reserved before a correlated conversation turn is sent. */
@@ -1591,6 +1593,7 @@ export async function deliverOutboundPayloadsInternal(
         session: params.session,
         gatewayClientScopes: params.gatewayClientScopes,
         preparedMessageId: params.preparedMessageId,
+        completionRetention: params.completionRetention,
         deliveryCompletion: params.deliveryCompletion,
       };
       if (params.deliveryIntentId) {

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -349,6 +349,7 @@ describe("sendMessage", () => {
       queuePolicy: "required",
       requireUnknownSendReconciliation: false,
       deliveryIntentId: "operation-1",
+      completionRetention: "permanent",
       deliveryCompletion: {
         kind: "conversation",
         agentId: "main",
@@ -361,6 +362,7 @@ describe("sendMessage", () => {
     const deliveryParams = expectDeliveryCallFields({
       queuePolicy: "required",
       deliveryIntentId: "operation-1",
+      completionRetention: "permanent",
       deliveryCompletion: {
         kind: "conversation",
         agentId: "main",

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -98,6 +98,8 @@ type MessageSendParams = {
   gatewayOwnedDelivery?: boolean;
   /** @internal Stable producer id for idempotent durable queue creation. */
   deliveryIntentId?: string;
+  /** @internal Preserve the completed producer receipt for permanent deduplication. */
+  completionRetention?: "permanent";
   /** @internal Serializable owner state finalized by live send or recovery. */
   deliveryCompletion?: DurableDeliveryCompletion;
   /** @internal Override provider unknown-send reconciliation independently from queue durability. */
@@ -444,6 +446,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       formatting: params.parseMode ? { parseMode: params.parseMode } : undefined,
       preparedMessageId: params.preparedMessageId,
       deliveryIntentId: params.deliveryIntentId,
+      completionRetention: params.completionRetention,
       deliveryCompletion: params.deliveryCompletion,
       ...(params.onDeliveryIntent ? { onDeliveryIntent: params.onDeliveryIntent } : {}),
       ...(params.onDeliveryResult ? { onDeliveryResult: params.onDeliveryResult } : {}),

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -64,6 +64,8 @@ export type QueuedSessionDeliveryPayload =
       inputProvenance?: InputProvenance;
       sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
       expectedMediaUrls?: string[];
+      /** Stable outbound ownership shared with generated-media direct fallback. */
+      deliveryIdempotencyKey?: string;
       suppressTextDelivery?: true;
       idempotencyKey?: string;
     } & SessionDeliveryRetryPolicy);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving background-generated media could see the same attachment posted multiple times after one successful generation.

## Why This Change Was Made

The duplicate was not caused by the handoff retry ladder itself. Restart-safe delivery preserved the model's `MEDIA:` directive and then appended the same host-owned attachment as a second payload, while the completion prompt could separately tell the requester session to resend it.

This change strips model-emitted media directives before attaching the canonical host-owned media, gives queued/automatic/direct delivery one permanently retained intent ID, treats an already-owned intent as successful replay evidence, disables message-tool ownership for the host-owned turn, and rewrites only that queued completion action to say the media is already owned and must not be resent.

AI-assisted; I reviewed the resulting delivery and recovery flow.

## User Impact

Each generated attachment is delivered once, with its caption, even when completion delivery crosses restart recovery or direct fallback paths.

## Evidence

- Focused Vitest suites: 801 tests passed; replay-focused follow-up: 451 tests passed.
- `pnpm check:changed`: passed (format, core/core-test typecheck, lint, import-cycle and repository guards).
- `autoreview`: clean; no accepted/actionable findings.
- Added regression coverage for duplicate `MEDIA:` materialization, shared direct/queued ownership, permanent completion receipts, replay collisions, and host-owned completion instructions.

<details>
<summary>Incident evidence and provenance</summary>

Observed in Discord channel `1456744319972282449` on 2026-07-18 (UTC):

- `01:27:38.376` — message `1527849296597090436`: caption “Fresh from the decks” plus `dj-molty.png` (1,781,418 bytes).
- `01:27:39.204` — message `1527849300070109386`: bare, byte-identical `dj-molty.png`.
- `01:29:10` — message `1527849684826194132`: requester-session resend after the internal completion action instructed it to send the media again.

The first pair maps to one host-owned batch containing both model-rematerialized media and the canonical attachment. The third maps to the stale completion instruction, not another retry-ladder send.

</details>
