### PR TITLE
fix: derived caches wedge cloud-worker reconciliation and reclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cloud worker derived workspace caches:** exclude Python caches, dependency trees, and macOS metadata symmetrically from outbound sync and inbound reconciliation so local cache rewrites cannot fence later cloud results or worker reclaim.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -607,6 +607,11 @@ describe("worker tunnel manager", () => {
       fs.writeFile(path.join(plainPath, "hello.txt"), "plain\n"),
       fs.writeFile(path.join(plainPath, "nested/.git/config"), "private metadata\n"),
     ]);
+    await fs.mkdir(path.join(plainPath, "__pycache__"));
+    await Promise.all([
+      fs.writeFile(path.join(plainPath, "__pycache__/fizzbuzz.pyc"), "derived\n"),
+      fs.writeFile(path.join(plainPath, ".mypy_cache"), "derived name file\n"),
+    ]);
     await git(gitPath, "init");
     await git(gitPath, "config", "user.name", "Worker Sync Test");
     await git(gitPath, "config", "user.email", "worker-sync@example.invalid");
@@ -641,6 +646,10 @@ describe("worker tunnel manager", () => {
       await expect(
         fs.access(path.join(plain.remoteWorkspaceDir, "nested/.git/config")),
       ).rejects.toThrow();
+      await expect(
+        fs.access(path.join(plain.remoteWorkspaceDir, "__pycache__/fizzbuzz.pyc")),
+      ).rejects.toThrow();
+      await expect(fs.access(path.join(plain.remoteWorkspaceDir, ".mypy_cache"))).rejects.toThrow();
 
       await expect(
         handle.syncWorkspace({

--- a/src/gateway/worker-environments/workspace-manifest.ts
+++ b/src/gateway/worker-environments/workspace-manifest.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
 
 export type WorkerWorkspaceManifestEntry =
   | { path: string; type: "file"; mode: number; size: number; sha256: string }
@@ -145,10 +146,11 @@ function validateAndProjectEntries(values: unknown[]): {
   }
   return {
     entries: rawEntries.filter(
-      (entry): entry is WorkerWorkspaceManifestEntry => entry.type !== "directory",
+      (entry): entry is WorkerWorkspaceManifestEntry =>
+        entry.type !== "directory" && !isDerivedWorkspacePath(entry.path),
     ),
     directories: rawEntries
-      .filter((entry) => entry.type === "directory")
+      .filter((entry) => entry.type === "directory" && !isDerivedWorkspacePath(entry.path))
       .map((entry) => entry.path),
   };
 }

--- a/src/gateway/worker-environments/workspace-path-exclusions.ts
+++ b/src/gateway/worker-environments/workspace-path-exclusions.ts
@@ -1,0 +1,28 @@
+export const DERIVED_WORKSPACE_DIRECTORY_NAMES = [
+  "__pycache__",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".ruff_cache",
+  "node_modules",
+] as const;
+
+export const DERIVED_WORKSPACE_FILE_NAMES = [".DS_Store"] as const;
+export const DERIVED_WORKSPACE_FILE_SUFFIXES = [".pyc", ".pyo"] as const;
+
+// Derived caches must never fence workspace reconciliation. Keep every sync,
+// manifest, divergence, apply, and recovery path on this single predicate.
+export function isDerivedWorkspacePath(relativePath: string): boolean {
+  const segments = relativePath.split("/");
+  return segments.some(
+    (segment) =>
+      (DERIVED_WORKSPACE_DIRECTORY_NAMES as readonly string[]).includes(segment) ||
+      (DERIVED_WORKSPACE_FILE_NAMES as readonly string[]).includes(segment) ||
+      DERIVED_WORKSPACE_FILE_SUFFIXES.some((suffix) => segment.endsWith(suffix)),
+  );
+}
+
+export const DERIVED_WORKSPACE_RSYNC_EXCLUDES = [
+  ...DERIVED_WORKSPACE_DIRECTORY_NAMES,
+  ...DERIVED_WORKSPACE_FILE_NAMES,
+  ...DERIVED_WORKSPACE_FILE_SUFFIXES.map((suffix) => `*${suffix}`),
+] as const;

--- a/src/gateway/worker-environments/workspace-reconcile-derived-paths.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-derived-paths.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { FsSafeError, root as openFsSafeRoot, type Root } from "../../infra/fs-safe.js";
+import type { WorkerWorkspaceManifestEntry } from "./workspace-manifest.js";
+import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
+
+export function reconciliationEntries(
+  entries: readonly WorkerWorkspaceManifestEntry[],
+): WorkerWorkspaceManifestEntry[] {
+  return entries.filter((entry) => !isDerivedWorkspacePath(entry.path));
+}
+
+export function reconciliationDirectories(directories: readonly string[] | undefined): string[] {
+  return (directories ?? []).filter((directory) => !isDerivedWorkspacePath(directory));
+}
+
+function localPath(root: string, relative: string): string {
+  return path.join(root, ...relative.split("/"));
+}
+
+async function removeDerivedWorkspaceDescendants(
+  root: Root,
+  relativeDirectory: string,
+): Promise<void> {
+  for (const entry of await root.list(relativeDirectory, { withFileTypes: true })) {
+    const child = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name;
+    if (isDerivedWorkspacePath(child)) {
+      await removeDerivedWorkspaceEntry(root, child, entry.isDirectory);
+      continue;
+    }
+    if (entry.isDirectory) {
+      await removeDerivedWorkspaceDescendants(root, child);
+    }
+  }
+}
+
+async function removeDerivedWorkspaceEntry(
+  root: Root,
+  relativePath: string,
+  isDirectory: boolean,
+): Promise<void> {
+  if (isDirectory) {
+    let entries;
+    try {
+      entries = await root.list(relativePath, { withFileTypes: true });
+    } catch (error) {
+      if (!(error instanceof FsSafeError) || !["not-found", "path-alias"].includes(error.code)) {
+        throw error;
+      }
+      entries = undefined;
+    }
+    for (const entry of entries ?? []) {
+      await removeDerivedWorkspaceEntry(root, `${relativePath}/${entry.name}`, entry.isDirectory);
+    }
+  }
+  await root.remove(relativePath).catch((error: unknown) => {
+    if (!(error instanceof FsSafeError) || error.code !== "not-found") {
+      throw error;
+    }
+  });
+}
+
+async function hasWorkspaceSymlinkAncestor(root: string, relativePath: string): Promise<boolean> {
+  const segments = relativePath.split("/");
+  for (let index = 1; index < segments.length; index += 1) {
+    const stats = await fs
+      .lstat(localPath(root, segments.slice(0, index).join("/")))
+      .catch(() => undefined);
+    if (stats?.isSymbolicLink()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function prepareNonDirectoryTargets(
+  root: string,
+  entries: readonly WorkerWorkspaceManifestEntry[],
+): Promise<void> {
+  const workspaceRoot = await openFsSafeRoot(root);
+  for (const entry of reconciliationEntries(entries)) {
+    if (await hasWorkspaceSymlinkAncestor(root, entry.path)) {
+      continue;
+    }
+    let stats;
+    try {
+      stats = await workspaceRoot.stat(entry.path);
+    } catch (error) {
+      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
+        continue;
+      }
+      throw error;
+    }
+    if (stats.isDirectory) {
+      // Excluded descendants cannot fence a namespace replacement, but Git
+      // cannot replace their still-nonempty parent until they are removed.
+      // fs-safe binds traversal/removal to root-relative directory handles, so
+      // a symlink swap cannot redirect cleanup outside this workspace.
+      await removeDerivedWorkspaceDescendants(workspaceRoot, entry.path);
+      if ((await workspaceRoot.list(entry.path)).length === 0) {
+        await workspaceRoot.remove(entry.path);
+      }
+    }
+  }
+}

--- a/src/gateway/worker-environments/workspace-reconcile-derived-paths.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-derived-paths.ts
@@ -30,6 +30,12 @@ async function removeDerivedWorkspaceDescendants(
     }
     if (entry.isDirectory) {
       await removeDerivedWorkspaceDescendants(root, child);
+      if ((await root.list(child)).length === 0) {
+        // This traversal only runs beneath a manifest non-directory replacing
+        // relativeDirectory. Every empty descendant belongs to that old namespace,
+        // and pruning it unconditionally keeps interrupted cleanup resumable.
+        await root.remove(child);
+      }
     }
   }
 }

--- a/src/gateway/worker-environments/workspace-reconcile-fs.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-fs.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runCommandBuffered } from "../../process/exec.js";
+import {
+  gitFileMode,
+  MAX_RECONCILIATION_FILE_BYTES,
+  type WorkerWorkspaceManifestEntry,
+} from "./workspace-manifest.js";
+import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
+
+const PATCH_TIMEOUT_MS = 10 * 60_000;
+
+export function localPath(root: string, relative: string): string {
+  return path.join(root, ...relative.split("/"));
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+export async function absoluteEntryMatches(
+  absolute: string,
+  entry: WorkerWorkspaceManifestEntry,
+): Promise<boolean> {
+  const stats = await fs.lstat(absolute).catch(() => undefined);
+  if (!stats) {
+    return false;
+  }
+  if (entry.type === "symlink") {
+    return stats.isSymbolicLink() && (await fs.readlink(absolute)) === entry.target;
+  }
+  return (
+    stats.isFile() &&
+    !stats.isSymbolicLink() &&
+    gitFileMode(stats.mode & 0o777) === entry.mode &&
+    stats.size === entry.size &&
+    (await sha256File(absolute)) === entry.sha256
+  );
+}
+
+export async function entryMatches(
+  root: string,
+  entry: WorkerWorkspaceManifestEntry,
+): Promise<boolean> {
+  return await absoluteEntryMatches(localPath(root, entry.path), entry);
+}
+
+export async function readWorkspaceTreeFile(params: {
+  repositoryRoot: string;
+  tree: string;
+  entry: Extract<WorkerWorkspaceManifestEntry, { type: "file" }>;
+}): Promise<Uint8Array> {
+  const listed = await runCommandBuffered(
+    [
+      "git",
+      "--literal-pathspecs",
+      "-C",
+      params.repositoryRoot,
+      "ls-tree",
+      "-z",
+      "--full-tree",
+      params.tree,
+      "--",
+      params.entry.path,
+    ],
+    {
+      timeoutMs: PATCH_TIMEOUT_MS,
+      maxOutputBytes: 1024 * 1024,
+    },
+  );
+  if (listed.termination !== "exit" || listed.code !== 0) {
+    throw new Error(listed.stderr.toString("utf8").trim() || "git ls-tree failed");
+  }
+  const record = listed.stdout;
+  const terminator = record.indexOf(0);
+  const separator = record.indexOf(9);
+  if (terminator !== record.byteLength - 1 || separator < 0 || separator > terminator) {
+    throw new Error(`Cloud workspace recovery snapshot is missing: ${params.entry.path}`);
+  }
+  const metadata = record.subarray(0, separator).toString("utf8");
+  const match = /^100(?:644|755) blob ([a-f0-9]{40})$/u.exec(metadata);
+  const listedPath = record.subarray(separator + 1, terminator);
+  if (!match || !listedPath.equals(Buffer.from(params.entry.path))) {
+    throw new Error(`Cloud workspace recovery snapshot is invalid: ${params.entry.path}`);
+  }
+  const blob = await runCommandBuffered(
+    ["git", "-C", params.repositoryRoot, "cat-file", "blob", match[1]!],
+    {
+      timeoutMs: PATCH_TIMEOUT_MS,
+      maxOutputBytes: MAX_RECONCILIATION_FILE_BYTES + 1,
+    },
+  );
+  if (blob.termination !== "exit" || blob.code !== 0) {
+    throw new Error(blob.stderr.toString("utf8").trim() || "git cat-file failed");
+  }
+  return blob.stdout;
+}
+
+export async function directoryContainsOnlyJournalPaths(
+  root: string,
+  directory: string,
+  paths: ReadonlySet<string>,
+  directories: ReadonlySet<string>,
+): Promise<boolean> {
+  for (const name of await fs.readdir(localPath(root, directory))) {
+    const child = `${directory}/${name}`;
+    if (isDerivedWorkspacePath(child)) {
+      continue;
+    }
+    const stats = await fs.lstat(localPath(root, child));
+    if (stats.isDirectory() && !stats.isSymbolicLink()) {
+      if (!directories.has(child)) {
+        return false;
+      }
+      if (!(await directoryContainsOnlyJournalPaths(root, child, paths, directories))) {
+        return false;
+      }
+    } else if (!paths.has(child)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function directoryContainsOnlyDerivedWorkspaceEntries(
+  root: string,
+  directory: string,
+): Promise<boolean> {
+  const names = await fs.readdir(localPath(root, directory));
+  return names.length > 0 && names.every((name) => isDerivedWorkspacePath(`${directory}/${name}`));
+}
+
+export async function clearTemporaryWorkspace(repositoryRoot: string): Promise<void> {
+  for (const name of await fs.readdir(repositoryRoot)) {
+    if (name !== ".git") {
+      await fs.rm(path.join(repositoryRoot, name), { recursive: true, force: true });
+    }
+  }
+}

--- a/src/gateway/worker-environments/workspace-reconcile-fs.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-fs.ts
@@ -133,7 +133,24 @@ export async function directoryContainsOnlyDerivedWorkspaceEntries(
   directory: string,
 ): Promise<boolean> {
   const names = await fs.readdir(localPath(root, directory));
-  return names.length > 0 && names.every((name) => isDerivedWorkspacePath(`${directory}/${name}`));
+  let foundDerivedEntry = false;
+  for (const name of names) {
+    const child = `${directory}/${name}`;
+    if (isDerivedWorkspacePath(child)) {
+      foundDerivedEntry = true;
+      continue;
+    }
+    const stats = await fs.lstat(localPath(root, child));
+    if (
+      !stats.isDirectory() ||
+      stats.isSymbolicLink() ||
+      !(await directoryContainsOnlyDerivedWorkspaceEntries(root, child))
+    ) {
+      return false;
+    }
+    foundDerivedEntry = true;
+  }
+  return foundDerivedEntry;
 }
 
 export async function clearTemporaryWorkspace(repositoryRoot: string): Promise<void> {

--- a/src/gateway/worker-environments/workspace-reconcile.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.test.ts
@@ -179,12 +179,58 @@ describe("worker workspace reconciliation", () => {
     ).rejects.toThrow("local-only path");
   });
 
+  it("ignores derived-cache divergence but still rejects real file divergence", async () => {
+    const local = await temporaryDirectory("workspace-derived-local");
+    const staged = await temporaryDirectory("workspace-derived-staged");
+    await gitInit(local);
+    await Promise.all([
+      fs.mkdir(path.join(local, "__pycache__")),
+      fs.mkdir(path.join(staged, "__pycache__")),
+    ]);
+    await Promise.all([
+      fs.writeFile(path.join(local, "real.txt"), "base"),
+      fs.writeFile(path.join(local, "__pycache__/fizzbuzz.pyc"), "base cache"),
+      fs.writeFile(path.join(staged, "real.txt"), "base"),
+      fs.writeFile(path.join(staged, "__pycache__/fizzbuzz.pyc"), "worker cache"),
+    ]);
+    const base = await manifestFor(local);
+    const current = await manifestFor(staged);
+    await fs.writeFile(path.join(local, "__pycache__/fizzbuzz.pyc"), "local cache");
+
+    await applyWorkspace({ root: local, stagingRoot: staged, base, current });
+    await expect(fs.readFile(path.join(local, "__pycache__/fizzbuzz.pyc"), "utf8")).resolves.toBe(
+      "local cache",
+    );
+
+    await fs.writeFile(path.join(local, "real.txt"), "local divergence");
+    await expect(
+      applyWorkspace({ root: local, stagingRoot: staged, base, current }),
+    ).rejects.toThrow("Gateway workspace changed after cloud dispatch: real.txt");
+  });
+
   it("allows a remote file to replace an unchanged base directory", async () => {
     const local = await temporaryDirectory("workspace-directory-replacement");
     const staged = await temporaryDirectory("workspace-directory-replacement-staged");
     await gitInit(local);
     await fs.mkdir(path.join(local, "src"));
     await fs.writeFile(path.join(local, "src", "old.txt"), "base");
+    const base = await manifestFor(local);
+    await fs.mkdir(path.join(local, "src", "__pycache__"));
+    await fs.writeFile(path.join(local, "src", "__pycache__", "old.pyc"), "local cache");
+    await fs.writeFile(path.join(staged, "src"), "replacement");
+    const current = await manifestFor(staged);
+
+    await applyWorkspace({ root: local, stagingRoot: staged, base, current });
+
+    await expect(fs.readFile(path.join(local, "src"), "utf8")).resolves.toBe("replacement");
+  });
+
+  it("allows a remote file to replace a base directory containing only derived entries", async () => {
+    const local = await temporaryDirectory("workspace-derived-directory-replacement");
+    const staged = await temporaryDirectory("workspace-derived-directory-replacement-staged");
+    await gitInit(local);
+    await fs.mkdir(path.join(local, "src", "__pycache__"), { recursive: true });
+    await fs.writeFile(path.join(local, "src", "__pycache__", "old.pyc"), "local cache");
     const base = await manifestFor(local);
     await fs.writeFile(path.join(staged, "src"), "replacement");
     const current = await manifestFor(staged);
@@ -219,30 +265,64 @@ describe("worker workspace reconciliation", () => {
     await expect(fs.readFile(path.join(local, "src", "old.txt"), "utf8")).resolves.toBe("base");
   });
 
+  it("restores a file over a directory containing only derived descendants", async () => {
+    const local = await temporaryDirectory("workspace-directory-recovery-cache");
+    const staged = await temporaryDirectory("workspace-directory-recovery-cache-staged");
+    await gitInit(local);
+    await fs.writeFile(path.join(local, "src"), "base");
+    const base = await manifestFor(local);
+    await fs.mkdir(path.join(staged, "src"));
+    const current = await manifestFor(staged);
+    let journal: WorkerWorkspaceReconciliationJournal | undefined;
+    await applyWorkspace({
+      root: local,
+      stagingRoot: staged,
+      base,
+      current,
+      begin: (value) => {
+        journal = value;
+      },
+    });
+    await fs.mkdir(path.join(local, "src", "__pycache__"), { recursive: true });
+    await fs.writeFile(path.join(local, "src", "__pycache__", "remote.pyc"), "local cache");
+
+    await recoverWorkerWorkspaceReconciliation({ root: local, journal: journal! });
+
+    await expect(fs.readFile(path.join(local, "src"), "utf8")).resolves.toBe("base");
+  });
+
   it("does not follow a base symlink while replacing it with a directory", async () => {
     const local = await temporaryDirectory("workspace-symlink-replacement");
     const staged = await temporaryDirectory("workspace-symlink-replacement-staged");
     await gitInit(local);
     await fs.mkdir(path.join(local, "target"));
+    await fs.mkdir(path.join(local, "target", "nested", "__pycache__"), { recursive: true });
     await fs.writeFile(path.join(local, "target", "file.txt"), "base target");
+    await fs.writeFile(
+      path.join(local, "target", "nested", "__pycache__", "cache.pyc"),
+      "outside cache",
+    );
     await fs.symlink("target", path.join(local, "entry"));
     const base = await manifestFor(local);
 
     await fs.mkdir(path.join(staged, "target"));
     await fs.writeFile(path.join(staged, "target", "file.txt"), "base target");
     await fs.mkdir(path.join(staged, "entry"));
-    await fs.writeFile(path.join(staged, "entry", "file.txt"), "remote directory");
+    await fs.writeFile(path.join(staged, "entry", "nested"), "remote directory");
     const current = await manifestFor(staged);
 
     await applyWorkspace({ root: local, stagingRoot: staged, base, current });
 
     expect((await fs.lstat(path.join(local, "entry"))).isDirectory()).toBe(true);
-    await expect(fs.readFile(path.join(local, "entry", "file.txt"), "utf8")).resolves.toBe(
+    await expect(fs.readFile(path.join(local, "entry", "nested"), "utf8")).resolves.toBe(
       "remote directory",
     );
     await expect(fs.readFile(path.join(local, "target", "file.txt"), "utf8")).resolves.toBe(
       "base target",
     );
+    await expect(
+      fs.readFile(path.join(local, "target", "nested", "__pycache__", "cache.pyc"), "utf8"),
+    ).resolves.toBe("outside cache");
   });
 
   it("rolls back atomically when durable manifest acceptance fails", async () => {
@@ -311,6 +391,54 @@ describe("worker workspace reconciliation", () => {
     await expect(fs.access(path.join(local, "file.txt"))).rejects.toThrow();
   });
 
+  it("ignores derived paths in a journal created before the exclusion", async () => {
+    const local = await temporaryDirectory("workspace-derived-recovery");
+    const staged = await temporaryDirectory("workspace-derived-recovery-staged");
+    await gitInit(local);
+    await Promise.all([
+      fs.writeFile(path.join(local, "file.txt"), "base"),
+      fs.writeFile(path.join(local, ":literal.ts"), "base literal"),
+    ]);
+    const base = await manifestFor(local);
+    await Promise.all([
+      fs.writeFile(path.join(staged, "file.txt"), "remote"),
+      fs.writeFile(path.join(staged, ":literal.ts"), "remote literal"),
+    ]);
+    const current = await manifestFor(staged);
+    let journal: WorkerWorkspaceReconciliationJournal | undefined;
+    await applyWorkspace({
+      root: local,
+      stagingRoot: staged,
+      base,
+      current,
+      begin: (value) => {
+        journal = value;
+      },
+    });
+    expect(journal).toBeDefined();
+    expect(journal!.baseEntries.map((entry) => entry.path)).toContain(":literal.ts");
+    expect(await fs.readFile(path.join(local, ":literal.ts"), "utf8")).toBe("remote literal");
+    const legacyJournal = {
+      ...journal!,
+      baseEntries: journal!.baseEntries.map((entry) =>
+        entry.path === "file.txt" ? { ...entry, path: "__pycache__/file.pyc" } : entry,
+      ),
+      appliedEntries: journal!.appliedEntries.map((entry) =>
+        entry.path === "file.txt" ? { ...entry, path: "__pycache__/file.pyc" } : entry,
+      ),
+    } satisfies WorkerWorkspaceReconciliationJournal;
+    await fs.mkdir(path.join(local, "__pycache__"));
+    await fs.writeFile(path.join(local, "__pycache__/file.pyc"), "local cache");
+
+    await recoverWorkerWorkspaceReconciliation({ root: local, journal: legacyJournal });
+
+    expect(await fs.readFile(path.join(local, "file.txt"), "utf8")).toBe("remote");
+    expect(await fs.readFile(path.join(local, ":literal.ts"), "utf8")).toBe("base literal");
+    await expect(fs.readFile(path.join(local, "__pycache__/file.pyc"), "utf8")).resolves.toBe(
+      "local cache",
+    );
+  });
+
   it("does not follow a symlink-raced ancestor during Git patch application", async () => {
     const local = await temporaryDirectory("workspace-symlink-race");
     const staged = await temporaryDirectory("workspace-symlink-race-staged");
@@ -352,6 +480,24 @@ describe("worker workspace reconciliation", () => {
     expect(parseWorkerWorkspaceManifest(encoded.raw, encoded.ref).entries).toEqual([
       { path: "dir/file", type: "file", mode: 0o644, size: 1, sha256: "a".repeat(64) },
     ]);
+    const legacyDerived = encodeManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [
+        { path: "__pycache__", type: "directory", mode: 0o700 },
+        {
+          path: "__pycache__/fizzbuzz.pyc",
+          type: "file",
+          mode: 0o600,
+          size: 1,
+          sha256: "b".repeat(64),
+        },
+      ],
+    });
+    expect(parseWorkerWorkspaceManifest(legacyDerived.raw, legacyDerived.ref)).toMatchObject({
+      entries: [],
+      directories: [],
+    });
     expect(() => parseWorkerWorkspaceManifest(`${encoded.raw} `, encoded.ref)).toThrow("digest");
     for (const target of ["../outside", "..\\outside", "C:/outside"]) {
       const invalid = encodeManifest({

--- a/src/gateway/worker-environments/workspace-reconcile.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.test.ts
@@ -418,14 +418,18 @@ describe("worker workspace reconciliation", () => {
     expect(journal).toBeDefined();
     expect(journal!.baseEntries.map((entry) => entry.path)).toContain(":literal.ts");
     expect(await fs.readFile(path.join(local, ":literal.ts"), "utf8")).toBe("remote literal");
+    const withLegacyDerivedPath = (entry: WorkerWorkspaceManifestEntry) => {
+      if (entry.path !== "file.txt") {
+        return entry;
+      }
+      const legacyEntry = structuredClone(entry);
+      legacyEntry.path = "__pycache__/file.pyc";
+      return legacyEntry;
+    };
     const legacyJournal = {
       ...journal!,
-      baseEntries: journal!.baseEntries.map((entry) =>
-        entry.path === "file.txt" ? { ...entry, path: "__pycache__/file.pyc" } : entry,
-      ),
-      appliedEntries: journal!.appliedEntries.map((entry) =>
-        entry.path === "file.txt" ? { ...entry, path: "__pycache__/file.pyc" } : entry,
-      ),
+      baseEntries: journal!.baseEntries.map(withLegacyDerivedPath),
+      appliedEntries: journal!.appliedEntries.map(withLegacyDerivedPath),
     } satisfies WorkerWorkspaceReconciliationJournal;
     await fs.mkdir(path.join(local, "__pycache__"));
     await fs.writeFile(path.join(local, "__pycache__/file.pyc"), "local cache");

--- a/src/gateway/worker-environments/workspace-reconcile.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.test.ts
@@ -254,6 +254,38 @@ describe("worker workspace reconciliation", () => {
     await expect(fs.readFile(path.join(local, "src"), "utf8")).resolves.toBe("replacement");
   });
 
+  it("allows a remote file to replace a base directory with a new cache-only subtree", async () => {
+    const local = await temporaryDirectory("workspace-new-derived-subtree-replacement");
+    const staged = await temporaryDirectory("workspace-new-derived-subtree-replacement-staged");
+    await gitInit(local);
+    await fs.mkdir(path.join(local, "src"));
+    await fs.writeFile(path.join(local, "src", "old.txt"), "base");
+    const base = await manifestFor(local);
+    await fs.mkdir(path.join(local, "src", "tmp", "__pycache__"), { recursive: true });
+    await fs.writeFile(path.join(local, "src", "tmp", "__pycache__", "old.pyc"), "local cache");
+    await fs.writeFile(path.join(staged, "src"), "replacement");
+    const current = await manifestFor(staged);
+
+    await applyWorkspace({ root: local, stagingRoot: staged, base, current });
+
+    await expect(fs.readFile(path.join(local, "src"), "utf8")).resolves.toBe("replacement");
+  });
+
+  it("allows a remote file to replace a new cache-only directory", async () => {
+    const local = await temporaryDirectory("workspace-new-derived-directory-replacement");
+    const staged = await temporaryDirectory("workspace-new-derived-directory-replacement-staged");
+    await gitInit(local);
+    const base = await manifestFor(local);
+    await fs.mkdir(path.join(local, "src", "tmp", "__pycache__"), { recursive: true });
+    await fs.writeFile(path.join(local, "src", "tmp", "__pycache__", "old.pyc"), "local cache");
+    await fs.writeFile(path.join(staged, "src"), "replacement");
+    const current = await manifestFor(staged);
+
+    await applyWorkspace({ root: local, stagingRoot: staged, base, current });
+
+    await expect(fs.readFile(path.join(local, "src"), "utf8")).resolves.toBe("replacement");
+  });
+
   it("rolls back a remote file that replaced a base directory", async () => {
     const local = await temporaryDirectory("workspace-directory-rollback");
     const staged = await temporaryDirectory("workspace-directory-rollback-staged");

--- a/src/gateway/worker-environments/workspace-reconcile.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.test.ts
@@ -229,9 +229,23 @@ describe("worker workspace reconciliation", () => {
     const local = await temporaryDirectory("workspace-derived-directory-replacement");
     const staged = await temporaryDirectory("workspace-derived-directory-replacement-staged");
     await gitInit(local);
-    await fs.mkdir(path.join(local, "src", "__pycache__"), { recursive: true });
-    await fs.writeFile(path.join(local, "src", "__pycache__", "old.pyc"), "local cache");
-    const base = await manifestFor(local);
+    await fs.mkdir(path.join(local, "src", "pkg", "__pycache__"), { recursive: true });
+    await fs.mkdir(path.join(local, "src", "empty"));
+    await fs.writeFile(path.join(local, "src", "pkg", "__pycache__", "old.pyc"), "local cache");
+    const rawBase = await manifestFor(local);
+    const encodedBase = encodeManifest({
+      version: rawBase.version,
+      baseCommit: rawBase.baseCommit,
+      entries: [
+        ...(rawBase.directories ?? []).map((entryPath) => ({
+          path: entryPath,
+          type: "directory",
+          mode: 0o700,
+        })),
+        ...rawBase.entries,
+      ].toSorted((left, right) => left.path.localeCompare(right.path)),
+    });
+    const base = parseWorkerWorkspaceManifest(encodedBase.raw, encodedBase.ref);
     await fs.writeFile(path.join(staged, "src"), "replacement");
     const current = await manifestFor(staged);
 
@@ -283,8 +297,8 @@ describe("worker workspace reconciliation", () => {
         journal = value;
       },
     });
-    await fs.mkdir(path.join(local, "src", "__pycache__"), { recursive: true });
-    await fs.writeFile(path.join(local, "src", "__pycache__", "remote.pyc"), "local cache");
+    await fs.mkdir(path.join(local, "src", "pkg", "__pycache__"), { recursive: true });
+    await fs.writeFile(path.join(local, "src", "pkg", "__pycache__", "remote.pyc"), "local cache");
 
     await recoverWorkerWorkspaceReconciliation({ root: local, journal: journal! });
 

--- a/src/gateway/worker-environments/workspace-reconcile.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.ts
@@ -3,6 +3,7 @@ import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { FsSafeError, root as openFsSafeRoot, type Root } from "../../infra/fs-safe.js";
 import { runCommandBuffered } from "../../process/exec.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import {
@@ -15,6 +16,7 @@ import {
   type WorkerWorkspaceReconciliationJournal,
   type WorkerWorkspaceReconciliationJournalAdapter,
 } from "./workspace-manifest.js";
+import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
 export {
   MAX_RECONCILIATION_ENTRIES,
   MAX_RECONCILIATION_FILE_BYTES,
@@ -29,6 +31,16 @@ export {
 const PATCH_TIMEOUT_MS = 10 * 60_000;
 
 class ConcurrentWorkspacePathError extends Error {}
+
+function reconciliationEntries(
+  entries: readonly WorkerWorkspaceManifestEntry[],
+): WorkerWorkspaceManifestEntry[] {
+  return entries.filter((entry) => !isDerivedWorkspacePath(entry.path));
+}
+
+function reconciliationDirectories(directories: readonly string[] | undefined): string[] {
+  return (directories ?? []).filter((directory) => !isDerivedWorkspacePath(directory));
+}
 
 function localPath(root: string, relative: string): string {
   return path.join(root, ...relative.split("/"));
@@ -66,13 +78,99 @@ async function entryMatches(root: string, entry: WorkerWorkspaceManifestEntry): 
   return await absoluteEntryMatches(localPath(root, entry.path), entry);
 }
 
+async function removeDerivedWorkspaceDescendants(
+  root: Root,
+  relativeDirectory: string,
+): Promise<void> {
+  for (const entry of await root.list(relativeDirectory, { withFileTypes: true })) {
+    const child = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name;
+    if (isDerivedWorkspacePath(child)) {
+      await removeDerivedWorkspaceEntry(root, child, entry.isDirectory);
+      continue;
+    }
+    if (entry.isDirectory) {
+      await removeDerivedWorkspaceDescendants(root, child);
+    }
+  }
+}
+
+async function removeDerivedWorkspaceEntry(
+  root: Root,
+  relativePath: string,
+  isDirectory: boolean,
+): Promise<void> {
+  if (isDirectory) {
+    let entries;
+    try {
+      entries = await root.list(relativePath, { withFileTypes: true });
+    } catch (error) {
+      if (!(error instanceof FsSafeError) || !["not-found", "path-alias"].includes(error.code)) {
+        throw error;
+      }
+      entries = undefined;
+    }
+    for (const entry of entries ?? []) {
+      await removeDerivedWorkspaceEntry(root, `${relativePath}/${entry.name}`, entry.isDirectory);
+    }
+  }
+  await root.remove(relativePath).catch((error: unknown) => {
+    if (!(error instanceof FsSafeError) || error.code !== "not-found") {
+      throw error;
+    }
+  });
+}
+
+async function hasWorkspaceSymlinkAncestor(root: string, relativePath: string): Promise<boolean> {
+  const segments = relativePath.split("/");
+  for (let index = 1; index < segments.length; index += 1) {
+    const stats = await fs
+      .lstat(localPath(root, segments.slice(0, index).join("/")))
+      .catch(() => undefined);
+    if (stats?.isSymbolicLink()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function prepareNonDirectoryTargets(
+  root: string,
+  entries: readonly WorkerWorkspaceManifestEntry[],
+): Promise<void> {
+  const workspaceRoot = await openFsSafeRoot(root);
+  for (const entry of reconciliationEntries(entries)) {
+    if (await hasWorkspaceSymlinkAncestor(root, entry.path)) {
+      continue;
+    }
+    let stats;
+    try {
+      stats = await workspaceRoot.stat(entry.path);
+    } catch (error) {
+      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
+        continue;
+      }
+      throw error;
+    }
+    if (stats.isDirectory) {
+      // Excluded descendants cannot fence a namespace replacement, but Git
+      // cannot replace their still-nonempty parent until they are removed.
+      // fs-safe binds traversal/removal to root-relative directory handles, so
+      // a symlink swap cannot redirect cleanup outside this workspace.
+      await removeDerivedWorkspaceDescendants(workspaceRoot, entry.path);
+      if ((await workspaceRoot.list(entry.path)).length === 0) {
+        await workspaceRoot.remove(entry.path);
+      }
+    }
+  }
+}
+
 export async function assertWorkspaceMatchesManifest(params: {
   root: string;
   manifest: WorkerWorkspaceManifest;
   entries?: readonly WorkerWorkspaceManifestEntry[];
 }): Promise<void> {
   const root = await fs.realpath(params.root);
-  for (const entry of params.entries ?? params.manifest.entries) {
+  for (const entry of reconciliationEntries(params.entries ?? params.manifest.entries)) {
     if (!(await entryMatches(root, entry))) {
       throw new ConcurrentWorkspacePathError(
         `Gateway workspace changed after cloud dispatch: ${entry.path}`,
@@ -92,8 +190,12 @@ function changedPaths(
   base: WorkerWorkspaceManifest,
   current: WorkerWorkspaceManifest,
 ): Set<string> {
-  const baseByPath = new Map(base.entries.map((entry) => [entry.path, entry]));
-  const currentByPath = new Map(current.entries.map((entry) => [entry.path, entry]));
+  const baseByPath = new Map(
+    reconciliationEntries(base.entries).map((entry) => [entry.path, entry]),
+  );
+  const currentByPath = new Map(
+    reconciliationEntries(current.entries).map((entry) => [entry.path, entry]),
+  );
   return new Set(
     [...new Set([...baseByPath.keys(), ...currentByPath.keys()])].filter(
       (entryPath) => !sameEntry(baseByPath.get(entryPath), currentByPath.get(entryPath)),
@@ -122,7 +224,7 @@ export function workerWorkspaceTransferPaths(
   base: WorkerWorkspaceManifest,
 ): string[] {
   const changed = changedPaths(base, current);
-  const paths = current.entries
+  const paths = reconciliationEntries(current.entries)
     .filter((entry) => changed.has(entry.path))
     .map((entry) => {
       if (entry.type === "file" && entry.size > MAX_RECONCILIATION_FILE_BYTES) {
@@ -144,9 +246,11 @@ async function preflightWorkspaceApply(params: {
   current: WorkerWorkspaceManifest;
 }): Promise<void> {
   await assertWorkspaceMatchesManifest({ root: params.root, manifest: params.base });
-  const baseByPath = new Map(params.base.entries.map((entry) => [entry.path, entry]));
-  const currentByPath = new Map(params.current.entries.map((entry) => [entry.path, entry]));
-  const baseDirectories = new Set(params.base.directories ?? []);
+  const baseEntries = reconciliationEntries(params.base.entries);
+  const currentEntries = reconciliationEntries(params.current.entries);
+  const baseByPath = new Map(baseEntries.map((entry) => [entry.path, entry]));
+  const currentByPath = new Map(currentEntries.map((entry) => [entry.path, entry]));
+  const baseDirectories = new Set(reconciliationDirectories(params.base.directories));
   const baseNonemptyDirectories = new Set<string>();
   for (const entry of params.base.entries) {
     const segments = entry.path.split("/");
@@ -160,6 +264,9 @@ async function preflightWorkspaceApply(params: {
       const directory = pending.pop()!;
       for (const name of await fs.readdir(localPath(params.root, directory))) {
         const childPath = `${directory}/${name}`;
+        if (isDerivedWorkspacePath(childPath)) {
+          continue;
+        }
         const stats = await fs.lstat(localPath(params.root, childPath));
         if (stats.isDirectory() && !stats.isSymbolicLink()) {
           if (!baseDirectories.has(childPath)) {
@@ -176,7 +283,7 @@ async function preflightWorkspaceApply(params: {
     }
     return true;
   };
-  for (const entry of params.current.entries) {
+  for (const entry of currentEntries) {
     if (baseByPath.has(entry.path)) {
       continue;
     }
@@ -225,9 +332,11 @@ export async function assertWorkspaceResultStable(params: {
   current: WorkerWorkspaceManifest;
 }): Promise<void> {
   await assertWorkspaceMatchesManifest({ root: params.root, manifest: params.current });
-  const currentPaths = new Set(params.current.entries.map((entry) => entry.path));
-  const currentDirectories = new Set(params.current.directories ?? []);
-  for (const entry of params.base.entries) {
+  const currentPaths = new Set(
+    reconciliationEntries(params.current.entries).map((entry) => entry.path),
+  );
+  const currentDirectories = new Set(reconciliationDirectories(params.current.directories));
+  for (const entry of reconciliationEntries(params.base.entries)) {
     if (currentPaths.has(entry.path) || currentDirectories.has(entry.path)) {
       continue;
     }
@@ -292,7 +401,7 @@ async function writeRawWorkspaceTree(params: {
   const blobs: Array<{ entry: WorkerWorkspaceManifestEntry; mark: number; content: Uint8Array }> =
     [];
   let mark = 1;
-  for (const entry of params.entries.toSorted((left, right) =>
+  for (const entry of reconciliationEntries(params.entries).toSorted((left, right) =>
     left.path.localeCompare(right.path),
   )) {
     const content =
@@ -335,6 +444,57 @@ async function writeRawWorkspaceTree(params: {
     throw new Error(imported.stderr.toString("utf8").trim() || "git fast-import failed");
   }
   return await requireGit(params.repositoryRoot, ["rev-parse", `${ref}^{tree}`]);
+}
+
+async function readWorkspaceTreeFile(params: {
+  repositoryRoot: string;
+  tree: string;
+  entry: Extract<WorkerWorkspaceManifestEntry, { type: "file" }>;
+}): Promise<Uint8Array> {
+  const listed = await runCommandBuffered(
+    [
+      "git",
+      "--literal-pathspecs",
+      "-C",
+      params.repositoryRoot,
+      "ls-tree",
+      "-z",
+      "--full-tree",
+      params.tree,
+      "--",
+      params.entry.path,
+    ],
+    {
+      timeoutMs: PATCH_TIMEOUT_MS,
+      maxOutputBytes: 1024 * 1024,
+    },
+  );
+  if (listed.termination !== "exit" || listed.code !== 0) {
+    throw new Error(listed.stderr.toString("utf8").trim() || "git ls-tree failed");
+  }
+  const record = listed.stdout;
+  const terminator = record.indexOf(0);
+  const separator = record.indexOf(9);
+  if (terminator !== record.byteLength - 1 || separator < 0 || separator > terminator) {
+    throw new Error(`Cloud workspace recovery snapshot is missing: ${params.entry.path}`);
+  }
+  const metadata = record.subarray(0, separator).toString("utf8");
+  const match = /^100(?:644|755) blob ([a-f0-9]{40})$/u.exec(metadata);
+  const listedPath = record.subarray(separator + 1, terminator);
+  if (!match || !listedPath.equals(Buffer.from(params.entry.path))) {
+    throw new Error(`Cloud workspace recovery snapshot is invalid: ${params.entry.path}`);
+  }
+  const blob = await runCommandBuffered(
+    ["git", "-C", params.repositoryRoot, "cat-file", "blob", match[1]!],
+    {
+      timeoutMs: PATCH_TIMEOUT_MS,
+      maxOutputBytes: MAX_RECONCILIATION_FILE_BYTES + 1,
+    },
+  );
+  if (blob.termination !== "exit" || blob.code !== 0) {
+    throw new Error(blob.stderr.toString("utf8").trim() || "git cat-file failed");
+  }
+  return blob.stdout;
 }
 
 async function createWorkspacePatch(params: {
@@ -480,6 +640,9 @@ async function directoryContainsOnlyJournalPaths(
 ): Promise<boolean> {
   for (const name of await fs.readdir(localPath(root, directory))) {
     const child = `${directory}/${name}`;
+    if (isDerivedWorkspacePath(child)) {
+      continue;
+    }
     const stats = await fs.lstat(localPath(root, child));
     if (stats.isDirectory() && !stats.isSymbolicLink()) {
       if (!directories.has(child)) {
@@ -495,6 +658,22 @@ async function directoryContainsOnlyJournalPaths(
   return true;
 }
 
+async function directoryContainsOnlyDerivedWorkspaceEntries(
+  root: string,
+  directory: string,
+): Promise<boolean> {
+  const names = await fs.readdir(localPath(root, directory));
+  return names.length > 0 && names.every((name) => isDerivedWorkspacePath(`${directory}/${name}`));
+}
+
+async function clearTemporaryWorkspace(repositoryRoot: string): Promise<void> {
+  for (const name of await fs.readdir(repositoryRoot)) {
+    if (name !== ".git") {
+      await fs.rm(path.join(repositoryRoot, name), { recursive: true, force: true });
+    }
+  }
+}
+
 async function createWorkspaceRecoveryPatch(params: {
   root: string;
   journal: WorkerWorkspaceReconciliationJournal;
@@ -504,10 +683,10 @@ async function createWorkspaceRecoveryPatch(params: {
     await requireGit(temporary, ["init", "--quiet", "--object-format=sha1"]);
     await requireGit(temporary, ["index-pack", "--stdin"], params.journal.basePack);
     await requireGit(temporary, ["cat-file", "-e", `${params.journal.baseTree}^{tree}`]);
-    const baseByPath = new Map(params.journal.baseEntries.map((entry) => [entry.path, entry]));
-    const appliedByPath = new Map(
-      params.journal.appliedEntries.map((entry) => [entry.path, entry]),
-    );
+    const baseEntries = reconciliationEntries(params.journal.baseEntries);
+    const appliedEntries = reconciliationEntries(params.journal.appliedEntries);
+    const baseByPath = new Map(baseEntries.map((entry) => [entry.path, entry]));
+    const appliedByPath = new Map(appliedEntries.map((entry) => [entry.path, entry]));
     const paths = new Set([...baseByPath.keys(), ...appliedByPath.keys()]);
     const directories = new Set<string>();
     for (const entryPath of paths) {
@@ -545,8 +724,9 @@ async function createWorkspaceRecoveryPatch(params: {
       const isJournalDirectory =
         stats.isDirectory() &&
         !stats.isSymbolicLink() &&
-        directories.has(entryPath) &&
-        (await directoryContainsOnlyJournalPaths(params.root, entryPath, paths, directories));
+        ((directories.has(entryPath) &&
+          (await directoryContainsOnlyJournalPaths(params.root, entryPath, paths, directories))) ||
+          (await directoryContainsOnlyDerivedWorkspaceEntries(params.root, entryPath)));
       if (!isJournalDirectory) {
         throw new ConcurrentWorkspacePathError(
           `Gateway workspace changed while cloud recovery was pending: ${entryPath}`,
@@ -564,6 +744,26 @@ async function createWorkspaceRecoveryPatch(params: {
       repositoryRoot: temporary,
       entries: actualEntries,
     });
+    let recoveryBaseTree = params.journal.baseTree;
+    if (baseEntries.length !== params.journal.baseEntries.length) {
+      await clearTemporaryWorkspace(temporary);
+      for (const entry of baseEntries) {
+        const content =
+          entry.type === "file"
+            ? await readWorkspaceTreeFile({
+                repositoryRoot: temporary,
+                tree: params.journal.baseTree,
+                entry,
+              })
+            : undefined;
+        await materializeSnapshotEntry({ root: temporary, entry, content });
+      }
+      recoveryBaseTree = await writeRawWorkspaceTree({
+        repositoryRoot: temporary,
+        entries: baseEntries,
+      });
+      await clearTemporaryWorkspace(temporary);
+    }
     const diff = await runCommandBuffered(
       [
         "git",
@@ -574,7 +774,7 @@ async function createWorkspaceRecoveryPatch(params: {
         "--full-index",
         "--no-renames",
         actualTree,
-        params.journal.baseTree,
+        recoveryBaseTree,
         "--",
       ],
       {
@@ -605,7 +805,9 @@ async function assertWorkspaceRecoveryBase(params: {
     root: params.root,
     manifest: { version: 1, baseCommit: null, entries: params.journal.baseEntries },
   });
-  const basePaths = new Set(params.journal.baseEntries.map((entry) => entry.path));
+  const baseEntries = reconciliationEntries(params.journal.baseEntries);
+  const appliedEntries = reconciliationEntries(params.journal.appliedEntries);
+  const basePaths = new Set(baseEntries.map((entry) => entry.path));
   const baseDirectories = new Set<string>();
   for (const entryPath of basePaths) {
     const segments = entryPath.split("/");
@@ -613,7 +815,7 @@ async function assertWorkspaceRecoveryBase(params: {
       baseDirectories.add(segments.slice(0, index).join("/"));
     }
   }
-  for (const entry of params.journal.appliedEntries) {
+  for (const entry of appliedEntries) {
     if (basePaths.has(entry.path)) {
       continue;
     }
@@ -651,6 +853,7 @@ export async function recoverWorkerWorkspaceReconciliation(params: {
     // The journal may be persisted before, during, or after the multi-file apply.
   }
   const recoveryPatch = await createWorkspaceRecoveryPatch({ root, journal: params.journal });
+  await prepareNonDirectoryTargets(root, params.journal.baseEntries);
   await applyWorkspacePatch({ root, patch: recoveryPatch });
   await assertWorkspaceRecoveryBase({ root, journal: params.journal });
 }
@@ -671,11 +874,17 @@ export async function applyStagedWorkerWorkspace(params: {
     params.journal.commit(params.currentManifestRef);
     return;
   }
-  const baseByPath = new Map(params.base.entries.map((entry) => [entry.path, entry]));
-  const currentByPath = new Map(params.current.entries.map((entry) => [entry.path, entry]));
-  const baseEntries = params.base.entries.filter((entry) => changed.has(entry.path));
+  const baseByPath = new Map(
+    reconciliationEntries(params.base.entries).map((entry) => [entry.path, entry]),
+  );
+  const currentByPath = new Map(
+    reconciliationEntries(params.current.entries).map((entry) => [entry.path, entry]),
+  );
+  const baseEntries = reconciliationEntries(params.base.entries).filter((entry) =>
+    changed.has(entry.path),
+  );
   const appliedEntries: WorkerWorkspaceManifestEntry[] = [];
-  for (const entry of params.current.entries) {
+  for (const entry of reconciliationEntries(params.current.entries)) {
     if (!changed.has(entry.path)) {
       continue;
     }
@@ -712,6 +921,7 @@ export async function applyStagedWorkerWorkspace(params: {
   };
   params.journal.begin(journal);
   try {
+    await prepareNonDirectoryTargets(root, appliedEntries);
     await applyWorkspacePatch({ root, patch: snapshot.patch });
     await assertWorkspaceResultStable({ root, base: params.base, current: params.current });
     params.journal.commit(params.currentManifestRef);

--- a/src/gateway/worker-environments/workspace-reconcile.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.ts
@@ -1,13 +1,10 @@
 import { createHash, randomBytes } from "node:crypto";
-import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { FsSafeError, root as openFsSafeRoot, type Root } from "../../infra/fs-safe.js";
 import { runCommandBuffered } from "../../process/exec.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import {
-  gitFileMode,
   MAX_RECONCILIATION_ENTRIES,
   MAX_RECONCILIATION_FILE_BYTES,
   MAX_RECONCILIATION_TOTAL_BYTES,
@@ -17,6 +14,20 @@ import {
   type WorkerWorkspaceReconciliationJournalAdapter,
 } from "./workspace-manifest.js";
 import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
+import {
+  prepareNonDirectoryTargets,
+  reconciliationDirectories,
+  reconciliationEntries,
+} from "./workspace-reconcile-derived-paths.js";
+import {
+  absoluteEntryMatches,
+  clearTemporaryWorkspace,
+  directoryContainsOnlyDerivedWorkspaceEntries,
+  directoryContainsOnlyJournalPaths,
+  entryMatches,
+  localPath,
+  readWorkspaceTreeFile,
+} from "./workspace-reconcile-fs.js";
 export {
   MAX_RECONCILIATION_ENTRIES,
   MAX_RECONCILIATION_FILE_BYTES,
@@ -31,138 +42,6 @@ export {
 const PATCH_TIMEOUT_MS = 10 * 60_000;
 
 class ConcurrentWorkspacePathError extends Error {}
-
-function reconciliationEntries(
-  entries: readonly WorkerWorkspaceManifestEntry[],
-): WorkerWorkspaceManifestEntry[] {
-  return entries.filter((entry) => !isDerivedWorkspacePath(entry.path));
-}
-
-function reconciliationDirectories(directories: readonly string[] | undefined): string[] {
-  return (directories ?? []).filter((directory) => !isDerivedWorkspacePath(directory));
-}
-
-function localPath(root: string, relative: string): string {
-  return path.join(root, ...relative.split("/"));
-}
-
-async function sha256File(filePath: string): Promise<string> {
-  const hash = createHash("sha256");
-  for await (const chunk of createReadStream(filePath)) {
-    hash.update(chunk);
-  }
-  return hash.digest("hex");
-}
-
-async function absoluteEntryMatches(
-  absolute: string,
-  entry: WorkerWorkspaceManifestEntry,
-): Promise<boolean> {
-  const stats = await fs.lstat(absolute).catch(() => undefined);
-  if (!stats) {
-    return false;
-  }
-  if (entry.type === "symlink") {
-    return stats.isSymbolicLink() && (await fs.readlink(absolute)) === entry.target;
-  }
-  return (
-    stats.isFile() &&
-    !stats.isSymbolicLink() &&
-    gitFileMode(stats.mode & 0o777) === entry.mode &&
-    stats.size === entry.size &&
-    (await sha256File(absolute)) === entry.sha256
-  );
-}
-
-async function entryMatches(root: string, entry: WorkerWorkspaceManifestEntry): Promise<boolean> {
-  return await absoluteEntryMatches(localPath(root, entry.path), entry);
-}
-
-async function removeDerivedWorkspaceDescendants(
-  root: Root,
-  relativeDirectory: string,
-): Promise<void> {
-  for (const entry of await root.list(relativeDirectory, { withFileTypes: true })) {
-    const child = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name;
-    if (isDerivedWorkspacePath(child)) {
-      await removeDerivedWorkspaceEntry(root, child, entry.isDirectory);
-      continue;
-    }
-    if (entry.isDirectory) {
-      await removeDerivedWorkspaceDescendants(root, child);
-    }
-  }
-}
-
-async function removeDerivedWorkspaceEntry(
-  root: Root,
-  relativePath: string,
-  isDirectory: boolean,
-): Promise<void> {
-  if (isDirectory) {
-    let entries;
-    try {
-      entries = await root.list(relativePath, { withFileTypes: true });
-    } catch (error) {
-      if (!(error instanceof FsSafeError) || !["not-found", "path-alias"].includes(error.code)) {
-        throw error;
-      }
-      entries = undefined;
-    }
-    for (const entry of entries ?? []) {
-      await removeDerivedWorkspaceEntry(root, `${relativePath}/${entry.name}`, entry.isDirectory);
-    }
-  }
-  await root.remove(relativePath).catch((error: unknown) => {
-    if (!(error instanceof FsSafeError) || error.code !== "not-found") {
-      throw error;
-    }
-  });
-}
-
-async function hasWorkspaceSymlinkAncestor(root: string, relativePath: string): Promise<boolean> {
-  const segments = relativePath.split("/");
-  for (let index = 1; index < segments.length; index += 1) {
-    const stats = await fs
-      .lstat(localPath(root, segments.slice(0, index).join("/")))
-      .catch(() => undefined);
-    if (stats?.isSymbolicLink()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function prepareNonDirectoryTargets(
-  root: string,
-  entries: readonly WorkerWorkspaceManifestEntry[],
-): Promise<void> {
-  const workspaceRoot = await openFsSafeRoot(root);
-  for (const entry of reconciliationEntries(entries)) {
-    if (await hasWorkspaceSymlinkAncestor(root, entry.path)) {
-      continue;
-    }
-    let stats;
-    try {
-      stats = await workspaceRoot.stat(entry.path);
-    } catch (error) {
-      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
-        continue;
-      }
-      throw error;
-    }
-    if (stats.isDirectory) {
-      // Excluded descendants cannot fence a namespace replacement, but Git
-      // cannot replace their still-nonempty parent until they are removed.
-      // fs-safe binds traversal/removal to root-relative directory handles, so
-      // a symlink swap cannot redirect cleanup outside this workspace.
-      await removeDerivedWorkspaceDescendants(workspaceRoot, entry.path);
-      if ((await workspaceRoot.list(entry.path)).length === 0) {
-        await workspaceRoot.remove(entry.path);
-      }
-    }
-  }
-}
 
 export async function assertWorkspaceMatchesManifest(params: {
   root: string;
@@ -446,57 +325,6 @@ async function writeRawWorkspaceTree(params: {
   return await requireGit(params.repositoryRoot, ["rev-parse", `${ref}^{tree}`]);
 }
 
-async function readWorkspaceTreeFile(params: {
-  repositoryRoot: string;
-  tree: string;
-  entry: Extract<WorkerWorkspaceManifestEntry, { type: "file" }>;
-}): Promise<Uint8Array> {
-  const listed = await runCommandBuffered(
-    [
-      "git",
-      "--literal-pathspecs",
-      "-C",
-      params.repositoryRoot,
-      "ls-tree",
-      "-z",
-      "--full-tree",
-      params.tree,
-      "--",
-      params.entry.path,
-    ],
-    {
-      timeoutMs: PATCH_TIMEOUT_MS,
-      maxOutputBytes: 1024 * 1024,
-    },
-  );
-  if (listed.termination !== "exit" || listed.code !== 0) {
-    throw new Error(listed.stderr.toString("utf8").trim() || "git ls-tree failed");
-  }
-  const record = listed.stdout;
-  const terminator = record.indexOf(0);
-  const separator = record.indexOf(9);
-  if (terminator !== record.byteLength - 1 || separator < 0 || separator > terminator) {
-    throw new Error(`Cloud workspace recovery snapshot is missing: ${params.entry.path}`);
-  }
-  const metadata = record.subarray(0, separator).toString("utf8");
-  const match = /^100(?:644|755) blob ([a-f0-9]{40})$/u.exec(metadata);
-  const listedPath = record.subarray(separator + 1, terminator);
-  if (!match || !listedPath.equals(Buffer.from(params.entry.path))) {
-    throw new Error(`Cloud workspace recovery snapshot is invalid: ${params.entry.path}`);
-  }
-  const blob = await runCommandBuffered(
-    ["git", "-C", params.repositoryRoot, "cat-file", "blob", match[1]!],
-    {
-      timeoutMs: PATCH_TIMEOUT_MS,
-      maxOutputBytes: MAX_RECONCILIATION_FILE_BYTES + 1,
-    },
-  );
-  if (blob.termination !== "exit" || blob.code !== 0) {
-    throw new Error(blob.stderr.toString("utf8").trim() || "git cat-file failed");
-  }
-  return blob.stdout;
-}
-
 async function createWorkspacePatch(params: {
   root: string;
   stagingRoot: string;
@@ -629,48 +457,6 @@ function validateJournalSnapshot(journal: WorkerWorkspaceReconciliationJournal):
     createHash("sha256").update(journal.basePack).digest("hex") !== journal.basePackSha256
   ) {
     throw new Error("Cloud workspace reconciliation recovery snapshot is invalid");
-  }
-}
-
-async function directoryContainsOnlyJournalPaths(
-  root: string,
-  directory: string,
-  paths: ReadonlySet<string>,
-  directories: ReadonlySet<string>,
-): Promise<boolean> {
-  for (const name of await fs.readdir(localPath(root, directory))) {
-    const child = `${directory}/${name}`;
-    if (isDerivedWorkspacePath(child)) {
-      continue;
-    }
-    const stats = await fs.lstat(localPath(root, child));
-    if (stats.isDirectory() && !stats.isSymbolicLink()) {
-      if (!directories.has(child)) {
-        return false;
-      }
-      if (!(await directoryContainsOnlyJournalPaths(root, child, paths, directories))) {
-        return false;
-      }
-    } else if (!paths.has(child)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-async function directoryContainsOnlyDerivedWorkspaceEntries(
-  root: string,
-  directory: string,
-): Promise<boolean> {
-  const names = await fs.readdir(localPath(root, directory));
-  return names.length > 0 && names.every((name) => isDerivedWorkspacePath(`${directory}/${name}`));
-}
-
-async function clearTemporaryWorkspace(repositoryRoot: string): Promise<void> {
-  for (const name of await fs.readdir(repositoryRoot)) {
-    if (name !== ".git") {
-      await fs.rm(path.join(repositoryRoot, name), { recursive: true, force: true });
-    }
   }
 }
 

--- a/src/gateway/worker-environments/workspace-reconcile.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.ts
@@ -130,13 +130,6 @@ async function preflightWorkspaceApply(params: {
   const baseByPath = new Map(baseEntries.map((entry) => [entry.path, entry]));
   const currentByPath = new Map(currentEntries.map((entry) => [entry.path, entry]));
   const baseDirectories = new Set(reconciliationDirectories(params.base.directories));
-  const baseNonemptyDirectories = new Set<string>();
-  for (const entry of params.base.entries) {
-    const segments = entry.path.split("/");
-    for (let index = 1; index < segments.length; index += 1) {
-      baseNonemptyDirectories.add(segments.slice(0, index).join("/"));
-    }
-  }
   const directoryContainsOnlyBase = async (entryPath: string): Promise<boolean> => {
     const pending = [entryPath];
     while (pending.length > 0) {
@@ -194,7 +187,6 @@ async function preflightWorkspaceApply(params: {
       existing?.isDirectory() &&
       !existing.isSymbolicLink() &&
       baseDirectories.has(entry.path) &&
-      baseNonemptyDirectories.has(entry.path) &&
       (await directoryContainsOnlyBase(entry.path))
     ) {
       continue;

--- a/src/gateway/worker-environments/workspace-reconcile.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.ts
@@ -142,6 +142,9 @@ async function preflightWorkspaceApply(params: {
         const stats = await fs.lstat(localPath(params.root, childPath));
         if (stats.isDirectory() && !stats.isSymbolicLink()) {
           if (!baseDirectories.has(childPath)) {
+            if (await directoryContainsOnlyDerivedWorkspaceEntries(params.root, childPath)) {
+              continue;
+            }
             return false;
           }
           pending.push(childPath);
@@ -186,8 +189,8 @@ async function preflightWorkspaceApply(params: {
     if (
       existing?.isDirectory() &&
       !existing.isSymbolicLink() &&
-      baseDirectories.has(entry.path) &&
-      (await directoryContainsOnlyBase(entry.path))
+      ((baseDirectories.has(entry.path) && (await directoryContainsOnlyBase(entry.path))) ||
+        (await directoryContainsOnlyDerivedWorkspaceEntries(params.root, entry.path)))
     ) {
       continue;
     }

--- a/src/gateway/worker-environments/workspace-sync-local.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-local.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { runLocalCommandToFile } from "./workspace-sync-local.js";
+import { runLocalCommandToFile, writeEligibleGitFiles } from "./workspace-sync-local.js";
 
 async function waitForFile(filePath: string): Promise<void> {
   const deadline = Date.now() + 5_000;
@@ -51,6 +51,54 @@ describe("runLocalCommandToFile", () => {
     } finally {
       controller.abort();
       await operation.catch(() => undefined);
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("omits derived artifacts from outbound Git file lists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-files-"));
+    const files = [
+      "src/keep.ts",
+      "__pycache__/fizzbuzz.cpython-314.pyc",
+      "generated.pyc",
+      "generated.pyo",
+      "cache.pyc/inside",
+      "nested/.DS_Store/inside",
+      ".pytest_cache/state",
+      ".mypy_cache/state",
+      ".ruff_cache/state",
+      "node_modules/pkg/index.js",
+      ".DS_Store",
+    ];
+    const eligiblePath = path.join(root, "eligible");
+    const ignoredPath = path.join(root, "ignored");
+    const selectedPath = path.join(root, "selected");
+    const outputPath = path.join(root, "output");
+    try {
+      await Promise.all(
+        files.map(async (file) => {
+          await fs.mkdir(path.dirname(path.join(root, file)), { recursive: true });
+          await fs.writeFile(path.join(root, file), file);
+        }),
+      );
+      await Promise.all([
+        fs.writeFile(eligiblePath, `${files.join("\0")}\0`),
+        fs.writeFile(ignoredPath, ""),
+        fs.writeFile(selectedPath, ""),
+      ]);
+
+      await writeEligibleGitFiles({
+        gitRoot: root,
+        eligiblePath,
+        ignoredPath,
+        selectedPath,
+        outputPath,
+      });
+
+      expect((await fs.readFile(outputPath, "utf8")).split("\0").filter(Boolean)).toEqual([
+        "src/keep.ts",
+      ]);
+    } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/src/gateway/worker-environments/workspace-sync-local.ts
+++ b/src/gateway/worker-environments/workspace-sync-local.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { killProcessTree } from "../../process/kill-tree.js";
 import { workerSshCommandOptions } from "./ssh.js";
+import { isDerivedWorkspacePath } from "./workspace-path-exclusions.js";
 
 const STDERR_LIMIT = 4_096;
 const COMMAND_KILL_GRACE_MS = 300;
@@ -180,6 +181,9 @@ export async function writeEligibleGitFiles(params: {
     bufferedBytes = 0;
   };
   const appendIfTransferable = async (file: string) => {
+    if (isDerivedWorkspacePath(file)) {
+      return;
+    }
     const absolute = path.join(canonicalRoot, file);
     const stats = await fs.lstat(absolute).catch((error: unknown) => {
       if (hasErrorCode(error, "ENOENT")) {

--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -185,6 +185,48 @@ describe("remote workspace quiescence scripts", () => {
 });
 
 describe("remote workspace manifest script", () => {
+  it("drops derived artifacts from the worker manifest", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-manifest-derived-test-"));
+    roots.push(root);
+    const home = path.join(root, "home");
+    const workspace = path.join(root, "workspace");
+    const files = [
+      "keep.ts",
+      "__pycache__/fizzbuzz.cpython-314.pyc",
+      "generated.pyc",
+      "generated.pyo",
+      "cache.pyc/inside",
+      "nested/.DS_Store/inside",
+      ".pytest_cache/state",
+      ".mypy_cache/state",
+      ".ruff_cache/state",
+      "node_modules/pkg/index.js",
+      ".DS_Store",
+    ];
+    await Promise.all([fs.mkdir(home), fs.mkdir(workspace)]);
+    await Promise.all(
+      files.map(async (file) => {
+        await fs.mkdir(path.dirname(path.join(workspace, file)), { recursive: true });
+        await fs.writeFile(path.join(workspace, file), file);
+      }),
+    );
+
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", REMOTE_WORKSPACE_MANIFEST_JS, workspace],
+      { timeoutMs: 10_000, baseEnv: { ...process.env, HOME: home } },
+    );
+    expect(result.code).toBe(0);
+    const digest = result.stdout.trim().slice("sha256:".length);
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(home, ".openclaw-worker", "manifests", `${digest}.json`), "utf8"),
+    ) as { entries: Array<{ path: string }> };
+    const manifestPaths = manifest.entries.map((entry) => entry.path);
+    expect(manifestPaths).toContain("keep.ts");
+    for (const excluded of files.slice(1)) {
+      expect(manifestPaths).not.toContain(excluded);
+    }
+  });
+
   it("keeps base tombstones in the final ignored-path verification", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-manifest-tombstone-test-"));
     roots.push(root);

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -4,38 +4,7 @@ import {
   DERIVED_WORKSPACE_FILE_SUFFIXES,
   isDerivedWorkspacePath,
 } from "./workspace-path-exclusions.js";
-
-export const REMOTE_WORKSPACE_SETUP_SCRIPT = String.raw`set -eu
-relative=$1
-root=$HOME/.openclaw-worker
-
-ensure_private_directory() {
-  directory=$1
-  if [ -e "$directory" ] || [ -L "$directory" ]; then
-    if [ ! -d "$directory" ] || [ -L "$directory" ]; then
-      printf '%s\n' 'unsafe worker workspace directory' >&2
-      exit 2
-    fi
-  else
-    mkdir "$directory"
-  fi
-  chmod 700 "$directory"
-}
-
-ensure_private_directory "$root"
-current=$root
-old_ifs=$IFS
-IFS=/
-set -- $relative
-IFS=$old_ifs
-for segment in "$@"; do
-  current=$current/$segment
-  ensure_private_directory "$current"
-done
-cd "$current"
-find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-pwd -P
-`;
+export { REMOTE_WORKSPACE_SETUP_SCRIPT } from "./workspace-sync-setup-script.js";
 
 export const REMOTE_WORKSPACE_QUIESCE_JS = String.raw`const childProcess = require("node:child_process");
 const crypto = require("node:crypto");

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -1,3 +1,10 @@
+import {
+  DERIVED_WORKSPACE_DIRECTORY_NAMES,
+  DERIVED_WORKSPACE_FILE_NAMES,
+  DERIVED_WORKSPACE_FILE_SUFFIXES,
+  isDerivedWorkspacePath,
+} from "./workspace-path-exclusions.js";
+
 export const REMOTE_WORKSPACE_SETUP_SCRIPT = String.raw`set -eu
 relative=$1
 root=$HOME/.openclaw-worker
@@ -494,6 +501,10 @@ export const REMOTE_WORKSPACE_MANIFEST_JS = String.raw`const crypto = require("n
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
+const DERIVED_WORKSPACE_DIRECTORY_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_DIRECTORY_NAMES)};
+const DERIVED_WORKSPACE_FILE_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_NAMES)};
+const DERIVED_WORKSPACE_FILE_SUFFIXES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_SUFFIXES)};
+const isDerivedWorkspacePath = ${isDerivedWorkspacePath.toString()};
 const root = fs.realpathSync(process.argv[1]);
 const requestedBaseCommit = process.argv[2] || null;
 const eligibleOnly = process.argv[3] === "eligible";
@@ -512,6 +523,7 @@ function addEntry(relative) {
   ) {
     fail("unsafe worker workspace path: " + relative);
   }
+  if (isDerivedWorkspacePath(relative)) return;
   if (entriesByPath.has(relative)) return;
   const absolute = path.join(root, relative);
   let stats;
@@ -541,6 +553,7 @@ function addEntry(relative) {
   }
 }
 function addWithParents(relative) {
+  if (isDerivedWorkspacePath(relative)) return;
   const segments = relative.split("/");
   for (let index = 1; index < segments.length; index += 1) {
     addEntry(segments.slice(0, index).join("/"));
@@ -554,6 +567,7 @@ function walk(relativeDirectory) {
       continue;
     }
     const relative = relativeDirectory ? relativeDirectory + "/" + name : name;
+    if (isDerivedWorkspacePath(relative)) continue;
     const absolute = path.join(root, relative);
     const stats = fs.lstatSync(absolute);
     const mode = stats.mode & 0o777;
@@ -620,10 +634,12 @@ function eligiblePaths() {
     }
     for (const entry of prior.entries) {
       if (!entry || typeof entry.path !== "string") fail("invalid prior workspace manifest entry");
-      if (entry.path !== ".openclaw-base.pack") selected.add(entry.path);
+      if (entry.path !== ".openclaw-base.pack" && !isDerivedWorkspacePath(entry.path)) {
+        selected.add(entry.path);
+      }
     }
   }
-  return [...selected].sort();
+  return [...selected].filter((relative) => !isDerivedWorkspacePath(relative)).sort();
 }
 async function hashFiles() {
   const entries = [...entriesByPath.values()].sort((a, b) =>

--- a/src/gateway/worker-environments/workspace-sync-setup-script.ts
+++ b/src/gateway/worker-environments/workspace-sync-setup-script.ts
@@ -1,0 +1,31 @@
+export const REMOTE_WORKSPACE_SETUP_SCRIPT = String.raw`set -eu
+relative=$1
+root=$HOME/.openclaw-worker
+
+ensure_private_directory() {
+  directory=$1
+  if [ -e "$directory" ] || [ -L "$directory" ]; then
+    if [ ! -d "$directory" ] || [ -L "$directory" ]; then
+      printf '%s\n' 'unsafe worker workspace directory' >&2
+      exit 2
+    fi
+  else
+    mkdir "$directory"
+  fi
+  chmod 700 "$directory"
+}
+
+ensure_private_directory "$root"
+current=$root
+old_ifs=$IFS
+IFS=/
+set -- $relative
+IFS=$old_ifs
+for segment in "$@"; do
+  current=$current/$segment
+  ensure_private_directory "$current"
+done
+cd "$current"
+find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+pwd -P
+`;

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -16,6 +16,7 @@ import type {
   WorkerWorkspaceSyncRequest,
   WorkerWorkspaceSyncResult,
 } from "./tunnel-contract.js";
+import { DERIVED_WORKSPACE_RSYNC_EXCLUDES } from "./workspace-path-exclusions.js";
 import {
   applyStagedWorkerWorkspace,
   assertWorkspaceMatchesManifest,
@@ -447,6 +448,7 @@ export function createWorkerWorkspaceActions(
           "--archive",
           "--checksum",
           "--exclude=.git",
+          ...DERIVED_WORKSPACE_RSYNC_EXCLUDES.map((pattern) => `--exclude=${pattern}`),
           ...(fileListPath ? ["--recursive", "--from0", `--files-from=${fileListPath}`] : []),
           "-e",
           rsyncSsh,


### PR DESCRIPTION
Related: #110224

## What Problem This Solves

Fixes an issue where a cloud-worker session whose task produces derived cache artifacts (for example running Python tests creates `__pycache__/*.pyc`) becomes unusable after any local touch of those files. The worker synced caches back into the Gateway worktree; the moment they changed locally (user runs the tests in the worktree, or deletes the cache), every later inbound reconciliation fail-stopped with "Gateway workspace changed after cloud dispatch: __pycache__/…", the turn's workspace result was refused, and `sessions.reclaim` (Stop cloud worker) was blocked by the same divergence with no user-level recovery. Observed live on a dev gateway with the bundled crabbox AWS provider; full incident log in #110224.

## Why This Change Was Made

Derived caches must never fence workspace reconciliation. A single predicate module (`workspace-path-exclusions.ts`: `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `node_modules/`, `.DS_Store`, `*.pyc`, `*.pyo`) is applied on every path that transfers, hashes, compares, applies, or recovers workspace entries: outbound rsync excludes and eligible-git-file transfer, inbound manifest projection (so stale worker manifests that still contain cache paths are also ignored), divergence checks, patch apply, journal handling, and restart recovery. Cache-only directories that a remote file replaces are cleaned up (including removing the emptied directory) so namespace changes still apply. No new config surface — the set is a fixed product invariant.

This removes the common trigger for the unrecoverable-reconcile cluster in #110224; the remaining design gaps there (turn-claim release timing, restart recovery destroying an unreconciled result) stay tracked in that issue.

## User Impact

Cloud sessions keep working after you run the synced task locally: derived caches no longer sync back, no longer count as divergence, and no longer block follow-up turns or Stop cloud worker. Existing wedged worktrees recover on the next turn because pre-existing diverged cache files are ignored on every comparison path.

## Evidence

- Live repro before the fix: turn 2 after a local `python3 test_fizzbuzz.py` failed with "Gateway workspace changed after cloud dispatch: __pycache__/fizzbuzz.cpython-314.pyc"; `sessions.reclaim` failed with the same error on a second session (`__pycache__/shapes.cpython-314.pyc`); deleting the local cache did not unblock (deletion is divergence too).
- Focused tests: `node scripts/run-vitest.mjs src/gateway/worker-environments/` — 84 files, 1023 tests passed. New coverage: manifest projection drops excluded paths; inbound reconcile succeeds when only excluded paths differ locally; real divergence still fails; outbound sync (rsync + git file transfer) skips excluded paths; apply and recovery over cache-only directories.
- Structured autoreview (codex, gpt-5.6-sol): one P2 accepted (emptied cache-only directory blocking a dir→file replacement patch) — fixed with regression tests; final review clean.
