### PR TITLE
fix(codex): avoid false exhaustion when usage remains

### DIFF
--- a/extensions/codex/src/app-server/rate-limits.test.ts
+++ b/extensions/codex/src/app-server/rate-limits.test.ts
@@ -152,6 +152,45 @@ describe("formatCodexUsageLimitErrorMessage", () => {
     expect(message).not.toContain("Next reset");
     expect(message).not.toContain("1 hour");
   });
+
+  it("does not report exhaustion when an authoritative snapshot has no active limit", () => {
+    const message = formatCodexUsageLimitErrorMessage({
+      message: "You've reached your usage limit.",
+      codexErrorInfo: "usageLimitExceeded",
+      rateLimits: {
+        rateLimits: {
+          limitId: "codex",
+          primary: { usedPercent: 0, windowDurationMins: null, resetsAt: null },
+          secondary: null,
+          rateLimitReachedType: null,
+        },
+      },
+      rateLimitsAuthoritative: true,
+    });
+
+    expect(message).toContain("current account usage does not report an exhausted limit");
+    expect(message).not.toContain("subscription usage limit");
+    expect(message).not.toContain("could not determine a reset time");
+  });
+
+  it("does not treat an empty authoritative snapshot as exhaustion", () => {
+    const message = formatCodexUsageLimitErrorMessage({
+      message: "You've reached your usage limit.",
+      codexErrorInfo: "usageLimitExceeded",
+      rateLimits: {
+        rateLimits: {
+          limitId: "codex",
+          primary: null,
+          secondary: null,
+          rateLimitReachedType: null,
+        },
+      },
+      rateLimitsAuthoritative: true,
+    });
+
+    expect(message).toContain("current account usage does not report an exhausted limit");
+    expect(message).not.toContain("subscription usage limit");
+  });
 });
 
 describe("buildCodexAppServerUsageSnapshot", () => {

--- a/extensions/codex/src/app-server/rate-limits.ts
+++ b/extensions/codex/src/app-server/rate-limits.ts
@@ -26,6 +26,8 @@ const DAY_WINDOW_MINUTES = 24 * 60;
 const WEEKLY_WINDOW_MINUTES = 7 * DAY_WINDOW_MINUTES;
 const WEEKLY_RESET_GAP_MS = 3 * ONE_DAY_MS;
 const CODEX_USAGE_LIMIT_MESSAGE_PREFIX = "You've reached your Codex subscription usage limit.";
+const CODEX_USAGE_LIMIT_STATE_MISMATCH_MESSAGE =
+  "Codex rejected the request with a usage-limit error, but its current account usage does not report an exhausted limit.";
 
 type LimitWindowKey = (typeof LIMIT_WINDOW_KEYS)[number];
 
@@ -56,6 +58,7 @@ export function formatCodexUsageLimitErrorMessage(params: {
   message?: string | null;
   codexErrorInfo?: JsonValue | null;
   rateLimits?: JsonValue;
+  rateLimitsAuthoritative?: boolean;
   nowMs?: number;
 }): string | undefined {
   const message = normalizeText(params.message);
@@ -64,6 +67,16 @@ export function formatCodexUsageLimitErrorMessage(params: {
   }
   const nowMs = params.nowMs ?? Date.now();
   const usageSummary = summarizeCodexAccountUsage(params.rateLimits, nowMs);
+  if (
+    params.rateLimitsAuthoritative &&
+    hasCodexRateLimitSnapshots(params.rateLimits) &&
+    !usageSummary?.blocked
+  ) {
+    return [
+      CODEX_USAGE_LIMIT_STATE_MISMATCH_MESSAGE,
+      "Retry the request, use another Codex account if available, or switch to another configured model/provider.",
+    ].join(" ");
+  }
   const blockingReset = selectBlockingRateLimitReset(params.rateLimits, nowMs);
   const nextReset =
     blockingReset ??

--- a/extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
@@ -204,6 +204,41 @@ describe("runCodexAppServerAttempt usage limits", () => {
     expect(promptError.message).not.toContain("Codex did not return a reset time");
   });
 
+  it("does not report exhaustion when refreshed account limits show full availability", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "turn/start") {
+        throw Object.assign(new Error("You've reached your usage limit."), {
+          data: { codexErrorInfo: "usageLimitExceeded" },
+        });
+      }
+      if (method === "account/rateLimits/read") {
+        return {
+          rateLimits: {
+            limitId: "codex",
+            primary: { usedPercent: 0, windowDurationMins: null, resetsAt: null },
+            secondary: null,
+            rateLimitReachedType: null,
+          },
+        };
+      }
+      return undefined;
+    });
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("account/rateLimits/read");
+
+    const result = await run;
+    expect(result.promptErrorSource).toBe("prompt");
+    const promptError = expectUsageLimitPromptError(result.promptError);
+    expect(promptError.message).toContain(
+      "current account usage does not report an exhausted limit",
+    );
+    expect(promptError.message).not.toContain("subscription usage limit");
+    expect(promptError.message).not.toContain("could not determine a reset time");
+  });
+
   it("refreshes Codex account rate limits when a failed turn omits reset details", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/usage-limit-error.ts
+++ b/extensions/codex/src/app-server/usage-limit-error.ts
@@ -161,6 +161,7 @@ async function refreshCodexUsageLimitError(params: {
     message: params.source.message,
     codexErrorInfo: params.source.codexErrorInfo,
     rateLimits,
+    rateLimitsAuthoritative: true,
   });
   const message = refreshedMessage ?? initialMessage;
   return message ? { message, rateLimitsForProfile: rateLimits } : undefined;


### PR DESCRIPTION
Closes #96815

## What Problem This Solves

Fixes an issue where Codex users could receive a definitive “subscription usage limit reached” message when Codex returned a structured usage-limit error but a fresh account-rate-limit read showed no exhausted window and no reset time.

Community-reported by lastguru. Mason had started investigating; no overlapping branch or PR was found.

## Why This Change Was Made

OpenClaw now treats the fresh `account/rateLimits/read` response as authoritative for the explanatory copy. If that snapshot contains a real block, existing reset-aware messaging and structural 429 failover remain unchanged. If it contains a recognizable but non-blocked or empty snapshot, OpenClaw reports the upstream state mismatch instead of inventing subscription exhaustion.

This keeps provider rejection/failover semantics intact. It does not suppress a real Codex 429 or guess a reset timestamp.

Dependency contract checked at `@openai/codex` 0.144.5 (`87db9bc18ba5`): `UsageLimitExceeded` combines usage-limit, quota, and usage-not-included variants (`codex-rs/protocol/src/error.rs:223-230`), while reset fields are optional (`codex-rs/protocol/src/protocol.rs:2141-2150`). Therefore missing reset alone cannot safely erase the structural 429; the fresh account snapshot is the needed discriminator.

## User Impact

Users with available or unreported Codex limits no longer see a false exhausted-subscription diagnosis. Real exhausted limits still show their reset/recovery guidance, and fallback routing still receives status 429.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/rate-limits.test.ts extensions/codex/src/app-server/run-attempt.usage-limits.test.ts` — 2 files, 28 tests passed.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/rate-limits.ts extensions/codex/src/app-server/usage-limit-error.ts extensions/codex/src/app-server/rate-limits.test.ts extensions/codex/src/app-server/run-attempt.usage-limits.test.ts` — passed on Blacksmith Testbox `tbx_01kxsmdqm8hrwzf13myh128xzv`: https://github.com/openclaw/openclaw/actions/runs/29628949635
- Live Codex app-server probe returned a recognizable empty account-rate-limit snapshot (no windows, reset, or reached type); `codex exec --skip-git-repo-check --sandbox read-only 'Reply with exactly OK.'` then succeeded with `OK` on the same account.
- Autoreview: clean, no accepted/actionable findings (`gpt-5.6-sol`, xhigh).
- AI-assisted. No agent transcript attached; private Discord context was not uploaded.
