### PR TITLE
fix(gateway): isolate wizard exits from shared process

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9513,17 +9513,20 @@ public struct SystemAgentSetupAuthStartResult: Codable, Sendable {
 public struct WizardStartParams: Codable, Sendable {
     public let mode: AnyCodable?
     public let workspace: String?
+    public let installdaemon: Bool?
     public let flow: AnyCodable?
     public let channel: String?
 
     public init(
         mode: AnyCodable? = nil,
         workspace: String? = nil,
+        installdaemon: Bool? = nil,
         flow: AnyCodable? = nil,
         channel: String? = nil)
     {
         self.mode = mode
         self.workspace = workspace
+        self.installdaemon = installdaemon
         self.flow = flow
         self.channel = channel
     }
@@ -9531,6 +9534,7 @@ public struct WizardStartParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case mode
         case workspace
+        case installdaemon = "installDaemon"
         case flow
         case channel
     }

--- a/packages/gateway-protocol/src/schema/wizard.ts
+++ b/packages/gateway-protocol/src/schema/wizard.ts
@@ -16,6 +16,7 @@ const WizardRunStatusSchema = Type.Union([
 export const WizardStartParamsSchema = closedObject({
   mode: Type.Optional(Type.Union([Type.Literal("local"), Type.Literal("remote")])),
   workspace: Type.Optional(Type.String()),
+  installDaemon: Type.Optional(Type.Boolean()),
   // "setup" (default) runs full onboarding; "channels" runs the guided
   // channel-setup flow (openclaw channels add) over the same step protocol.
   flow: Type.Optional(Type.Union([Type.Literal("setup"), Type.Literal("channels")])),

--- a/src/gateway/gateway-wizard-cancel.e2e.test.ts
+++ b/src/gateway/gateway-wizard-cancel.e2e.test.ts
@@ -34,7 +34,7 @@ const ENV_KEYS = [
   "OPENCLAW_BUNDLED_PLUGINS_DIR",
   "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
   "OPENCLAW_TEST_MINIMAL_GATEWAY",
-] as const;
+];
 
 function resetGatewayTestState(): void {
   resetConfigOverrides();

--- a/src/gateway/gateway-wizard-cancel.e2e.test.ts
+++ b/src/gateway/gateway-wizard-cancel.e2e.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { WizardStartResult } from "../../packages/gateway-protocol/src/index.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { resetConfigOverrides } from "../config/runtime-overrides.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
+import { resetAgentEventsForTest } from "../infra/agent-events.js";
+import { clearGatewaySubagentRuntime } from "../plugins/runtime/gateway-bindings.test-fixtures.js";
+import { createDeferred } from "../test-utils/deferred.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { startGatewayServer } from "./server.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+  getFreeGatewayPort,
+} from "./test-helpers.e2e.js";
+
+const GATEWAY_E2E_TIMEOUT_MS = 90_000;
+const ENV_KEYS = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_TEST_GATEWAY_OVERRIDE_TOKEN",
+  "OPENCLAW_TEST_RUNTIME_OVERRIDE_TOKEN",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_TEST_MINIMAL_GATEWAY",
+] as const;
+
+function resetGatewayTestState(): void {
+  resetConfigOverrides();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  clearSessionStoreCacheForTest();
+  resetAgentEventsForTest();
+  clearGatewaySubagentRuntime();
+}
+
+afterEach(() => {
+  resetGatewayTestState();
+});
+
+describe("gateway wizard cancellation lifecycle", () => {
+  it(
+    "keeps a cancelled wizard owner until settlement before allowing a replacement",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const envSnapshot = captureEnv(ENV_KEYS);
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wizard-cancel-home-"));
+      const stateDir = path.join(tempHome, ".openclaw");
+      const bundledPluginsDir = path.join(tempHome, "empty-bundled-plugins");
+      await fs.mkdir(bundledPluginsDir, { recursive: true });
+
+      setTestEnvValue("HOME", tempHome);
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
+      setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+      setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+      setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+      setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+      setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+      setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+      setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPluginsDir);
+      setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+      setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "1");
+
+      const token = `wizard-cancel-${process.pid}-${process.env.VITEST_POOL_ID ?? "0"}`;
+      const runnerSettled = [createDeferred(), createDeferred()] as const;
+      let runnerIndex = 0;
+      const port = await getFreeGatewayPort();
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token },
+        controlUiEnabled: false,
+        wizardRunner: async (_opts, _runtime, prompter) => {
+          const settlement = runnerSettled[runnerIndex++];
+          if (!settlement) {
+            throw new Error("wizard runner started more than twice");
+          }
+          prompter.progress("working");
+          await settlement.promise;
+        },
+      });
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        clientDisplayName: "vitest-wizard-cancel",
+      });
+
+      try {
+        const start = await client.request<WizardStartResult>("wizard.start", { mode: "local" });
+        expect(start).toMatchObject({ done: false, status: "running" });
+
+        await expect(
+          client.request("wizard.cancel", { sessionId: start.sessionId }),
+        ).resolves.toMatchObject({ status: "cancelled" });
+        await expect(client.request("wizard.start", { mode: "local" })).rejects.toMatchObject({
+          code: "UNAVAILABLE",
+        });
+
+        runnerSettled[0].resolve();
+        let replacement: WizardStartResult | undefined;
+        await expect
+          .poll(
+            async () => {
+              try {
+                replacement = await client.request<WizardStartResult>("wizard.start", {
+                  mode: "local",
+                });
+                return replacement.status;
+              } catch {
+                return "blocked";
+              }
+            },
+            { timeout: 5_000 },
+          )
+          .toBe("running");
+        if (!replacement) {
+          throw new Error("replacement wizard did not start");
+        }
+        expect(replacement).toMatchObject({ done: false, status: "running" });
+        await expect(client.request("health", {})).resolves.toBeDefined();
+
+        await expect(
+          client.request("wizard.cancel", { sessionId: replacement.sessionId }),
+        ).resolves.toMatchObject({ status: "cancelled" });
+        runnerSettled[1].resolve();
+      } finally {
+        runnerSettled[0].resolve();
+        runnerSettled[1].resolve();
+        await disconnectGatewayClient(client);
+        await server.close({ reason: "wizard cancellation lifecycle complete" });
+        await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+        envSnapshot.restore();
+      }
+    },
+  );
+});

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { WizardStartResult } from "../../packages/gateway-protocol/src/index.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -20,6 +21,7 @@ import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getPairedDevice } from "../infra/device-pairing.js";
 import { clearGatewaySubagentRuntime } from "../plugins/runtime/gateway-bindings.test-fixtures.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { callGateway } from "./call.js";
 import { startGatewayServer } from "./server.js";
@@ -878,6 +880,85 @@ module.exports = {
       } finally {
         await disconnectGatewayClient(client);
         await server.close({ reason: "wizard nonzero exit test complete" });
+        await removeGatewayTempHome(tempHome);
+        envSnapshot.restore();
+      }
+    },
+  );
+
+  it(
+    "keeps a cancelled wizard owner until settlement before allowing a replacement",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const { envSnapshot, tempHome } = await setupGatewayTempHome({
+        prefix: "openclaw-wizard-cancel-home-",
+        minimalGateway: true,
+      });
+      const wizardToken = nextGatewayId("wiz-cancel");
+      const runnerSettled = [createDeferred(), createDeferred()] as const;
+      let runnerIndex = 0;
+      const port = await getFreeGatewayPort();
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token: wizardToken },
+        controlUiEnabled: false,
+        wizardRunner: async (_opts, _runtime, prompter) => {
+          const settlement = runnerSettled[runnerIndex++];
+          if (!settlement) {
+            throw new Error("wizard runner started more than twice");
+          }
+          prompter.progress("working");
+          await settlement.promise;
+        },
+      });
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: wizardToken,
+        clientDisplayName: "vitest-wizard-cancel",
+      });
+      try {
+        const start = await client.request<WizardStartResult>("wizard.start", { mode: "local" });
+        expect(start).toMatchObject({ done: false, status: "running" });
+
+        await expect(
+          client.request("wizard.cancel", { sessionId: start.sessionId }),
+        ).resolves.toMatchObject({ status: "cancelled" });
+        await expect(client.request("wizard.start", { mode: "local" })).rejects.toMatchObject({
+          code: "UNAVAILABLE",
+        });
+
+        runnerSettled[0].resolve();
+        let replacement: WizardStartResult | undefined;
+        await expect
+          .poll(
+            async () => {
+              try {
+                replacement = await client.request<WizardStartResult>("wizard.start", {
+                  mode: "local",
+                });
+                return replacement.status;
+              } catch {
+                return "blocked";
+              }
+            },
+            { timeout: 5_000 },
+          )
+          .toBe("running");
+        if (!replacement) {
+          throw new Error("replacement wizard did not start");
+        }
+        expect(replacement).toMatchObject({ done: false, status: "running" });
+        await expect(client.request("health", {})).resolves.toBeDefined();
+
+        await expect(
+          client.request("wizard.cancel", { sessionId: replacement.sessionId }),
+        ).resolves.toMatchObject({ status: "cancelled" });
+        runnerSettled[1].resolve();
+      } finally {
+        runnerSettled[0].resolve();
+        runnerSettled[1].resolve();
+        await disconnectGatewayClient(client);
+        await server.close({ reason: "wizard cancellation lifecycle complete" });
         await removeGatewayTempHome(tempHome);
         envSnapshot.restore();
       }

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -720,7 +720,7 @@ module.exports = {
   );
 
   it(
-    "runs wizard over ws and writes auth token config",
+    "runs wizard over ws, contains zero exits, and writes auth token config",
     { timeout: GATEWAY_E2E_TIMEOUT_MS },
     async () => {
       const { envSnapshot, tempHome } = await setupGatewayTempHome({
@@ -740,7 +740,7 @@ module.exports = {
         bind: "loopback",
         auth: { mode: "token", token: wizardToken },
         controlUiEnabled: false,
-        wizardRunner: async (_opts, _runtime, prompter) => {
+        wizardRunner: async (_opts, runtime, prompter) => {
           await prompter.intro("Wizard E2E");
           await prompter.note("write token");
           const token = await prompter.text({ message: "token" });
@@ -748,6 +748,7 @@ module.exports = {
             gateway: { auth: { mode: "token", token } },
           });
           await prompter.outro("ok");
+          runtime.exit(0);
         },
       });
 
@@ -798,6 +799,7 @@ module.exports = {
           true,
         );
         expect(next.status).toBe("done");
+        await expect(client.request("health", {})).resolves.toBeDefined();
 
         await expect
           .poll(
@@ -835,6 +837,47 @@ module.exports = {
         expect(resToken.ok).toBe(true);
       } finally {
         await server2.close({ reason: "wizard auth verify" });
+        await removeGatewayTempHome(tempHome);
+        envSnapshot.restore();
+      }
+    },
+  );
+
+  it(
+    "reports nonzero wizard exits without terminating the gateway",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const { envSnapshot, tempHome } = await setupGatewayTempHome({
+        prefix: "openclaw-wizard-exit-home-",
+        minimalGateway: true,
+      });
+      const wizardToken = nextGatewayId("wiz-exit");
+      const port = await getFreeGatewayPort();
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token: wizardToken },
+        controlUiEnabled: false,
+        wizardRunner: async (_opts, runtime) => runtime.exit(23),
+      });
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: wizardToken,
+        clientDisplayName: "vitest-wizard-exit",
+      });
+
+      try {
+        const result = await client.request<{
+          done: boolean;
+          status: "running" | "done" | "cancelled" | "error";
+          error?: string;
+        }>("wizard.start", { mode: "local" });
+        expect(result.done).toBe(true);
+        expect(result.status).toBe("error");
+        expect(result.error).toContain("23");
+        await expect(client.request("health", {})).resolves.toBeDefined();
+      } finally {
+        await disconnectGatewayClient(client);
+        await server.close({ reason: "wizard nonzero exit test complete" });
         await removeGatewayTempHome(tempHome);
         envSnapshot.restore();
       }

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -4,7 +4,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import type { WizardStartResult } from "../../packages/gateway-protocol/src/index.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -21,7 +20,6 @@ import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getPairedDevice } from "../infra/device-pairing.js";
 import { clearGatewaySubagentRuntime } from "../plugins/runtime/gateway-bindings.test-fixtures.js";
-import { createDeferred } from "../test-utils/deferred.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { callGateway } from "./call.js";
 import { startGatewayServer } from "./server.js";
@@ -880,85 +878,6 @@ module.exports = {
       } finally {
         await disconnectGatewayClient(client);
         await server.close({ reason: "wizard nonzero exit test complete" });
-        await removeGatewayTempHome(tempHome);
-        envSnapshot.restore();
-      }
-    },
-  );
-
-  it(
-    "keeps a cancelled wizard owner until settlement before allowing a replacement",
-    { timeout: GATEWAY_E2E_TIMEOUT_MS },
-    async () => {
-      const { envSnapshot, tempHome } = await setupGatewayTempHome({
-        prefix: "openclaw-wizard-cancel-home-",
-        minimalGateway: true,
-      });
-      const wizardToken = nextGatewayId("wiz-cancel");
-      const runnerSettled = [createDeferred(), createDeferred()] as const;
-      let runnerIndex = 0;
-      const port = await getFreeGatewayPort();
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token: wizardToken },
-        controlUiEnabled: false,
-        wizardRunner: async (_opts, _runtime, prompter) => {
-          const settlement = runnerSettled[runnerIndex++];
-          if (!settlement) {
-            throw new Error("wizard runner started more than twice");
-          }
-          prompter.progress("working");
-          await settlement.promise;
-        },
-      });
-      const client = await connectGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token: wizardToken,
-        clientDisplayName: "vitest-wizard-cancel",
-      });
-      try {
-        const start = await client.request<WizardStartResult>("wizard.start", { mode: "local" });
-        expect(start).toMatchObject({ done: false, status: "running" });
-
-        await expect(
-          client.request("wizard.cancel", { sessionId: start.sessionId }),
-        ).resolves.toMatchObject({ status: "cancelled" });
-        await expect(client.request("wizard.start", { mode: "local" })).rejects.toMatchObject({
-          code: "UNAVAILABLE",
-        });
-
-        runnerSettled[0].resolve();
-        let replacement: WizardStartResult | undefined;
-        await expect
-          .poll(
-            async () => {
-              try {
-                replacement = await client.request<WizardStartResult>("wizard.start", {
-                  mode: "local",
-                });
-                return replacement.status;
-              } catch {
-                return "blocked";
-              }
-            },
-            { timeout: 5_000 },
-          )
-          .toBe("running");
-        if (!replacement) {
-          throw new Error("replacement wizard did not start");
-        }
-        expect(replacement).toMatchObject({ done: false, status: "running" });
-        await expect(client.request("health", {})).resolves.toBeDefined();
-
-        await expect(
-          client.request("wizard.cancel", { sessionId: replacement.sessionId }),
-        ).resolves.toMatchObject({ status: "cancelled" });
-        runnerSettled[1].resolve();
-      } finally {
-        runnerSettled[0].resolve();
-        runnerSettled[1].resolve();
-        await disconnectGatewayClient(client);
-        await server.close({ reason: "wizard cancellation lifecycle complete" });
         await removeGatewayTempHome(tempHome);
         envSnapshot.restore();
       }

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,8 +1,13 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import type {
+  WizardNextResult,
+  WizardStartResult,
+} from "../../../packages/gateway-protocol/src/index.js";
 import type { OnboardOptions } from "../../commands/onboard-types.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { createDeferred } from "../../shared/deferred.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { createWizardSessionTracker } from "../server-wizard-sessions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
@@ -15,23 +20,15 @@ type ProjectedOptions = Pick<
   "installDaemon" | "skipUi" | "suppressGatewayTokenOutput"
 >;
 
-type WizardResult = {
-  sessionId: string;
-  done: boolean;
-  status: "running" | "done" | "cancelled" | "error";
-  step?: { id: string };
-  error?: string;
-};
-
-function responsePayload(respond: ReturnType<typeof vi.fn>): WizardResult {
+function responsePayload(respond: ReturnType<typeof vi.fn>): unknown {
   expect(respond).toHaveBeenCalledOnce();
   const [ok, payload, error] = respond.mock.calls[0] ?? [];
   expect(ok).toBe(true);
   expect(error).toBeUndefined();
-  return payload as WizardResult;
+  return payload;
 }
 
-async function runWizardExit(flow: WizardFlow, exitCode: number): Promise<WizardResult> {
+async function runWizardExit(flow: WizardFlow, exitCode: number): Promise<WizardNextResult> {
   const tracker = createWizardSessionTracker();
   const runner = async (runtime: RuntimeEnv, prompter: WizardPrompter) => {
     await prompter.outro(exitCode === 0 ? "complete" : "invalid configuration");
@@ -53,7 +50,7 @@ async function runWizardExit(flow: WizardFlow, exitCode: number): Promise<Wizard
     respond: startRespond,
     context,
   } as never);
-  const start = responsePayload(startRespond);
+  const start = responsePayload(startRespond) as WizardStartResult;
   expect(start).toMatchObject({ done: false, status: "running" });
   expect(start.step?.id).toBeTruthy();
 
@@ -69,7 +66,7 @@ async function runWizardExit(flow: WizardFlow, exitCode: number): Promise<Wizard
     respond: nextRespond,
     context,
   } as never);
-  return responsePayload(nextRespond);
+  return responsePayload(nextRespond) as WizardNextResult;
 }
 
 describe("wizard session lookup", () => {
@@ -125,6 +122,71 @@ describe("wizard gateway runtime", () => {
 });
 
 describe("wizard setup ownership", () => {
+  it("blocks a replacement wizard until the cancelled runner settles", async () => {
+    const runnerSettled = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+
+    const startRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local" },
+      respond: startRespond,
+      context,
+    } as never);
+    const start = responsePayload(startRespond) as WizardStartResult;
+
+    const cancelRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.cancel"],
+      "wizard.cancel test invariant",
+    )({
+      params: { sessionId: start.sessionId },
+      respond: cancelRespond,
+      context,
+    } as never);
+    expect(responsePayload(cancelRespond)).toMatchObject({ status: "cancelled" });
+
+    const blockedRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local" },
+      respond: blockedRespond,
+      context,
+    } as never);
+    expect(blockedRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE" }),
+    );
+
+    runnerSettled.resolve();
+    await vi.waitFor(() => {
+      expect(tracker.wizardSessions.get(start.sessionId)?.isSettled()).toBe(true);
+    });
+
+    const replacementRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local" },
+      respond: replacementRespond,
+      context,
+    } as never);
+    expect(responsePayload(replacementRespond)).toMatchObject({ status: "running" });
+  });
+
   it.each([
     { label: "false", params: { installDaemon: false }, expected: false },
     { label: "true", params: { installDaemon: true }, expected: true },

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,8 +1,76 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import type { OnboardOptions } from "../../commands/onboard-types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { WizardPrompter } from "../../wizard/prompts.js";
+import { createWizardSessionTracker } from "../server-wizard-sessions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
-import { wizardHandlers } from "./wizard.js";
+import { type SetupWizardRunner, wizardHandlers } from "./wizard.js";
+
+type WizardFlow = "setup" | "channels";
+
+type ProjectedOptions = Pick<
+  OnboardOptions,
+  "installDaemon" | "skipUi" | "suppressGatewayTokenOutput"
+>;
+
+type WizardResult = {
+  sessionId: string;
+  done: boolean;
+  status: "running" | "done" | "cancelled" | "error";
+  step?: { id: string };
+  error?: string;
+};
+
+function responsePayload(respond: ReturnType<typeof vi.fn>): WizardResult {
+  expect(respond).toHaveBeenCalledOnce();
+  const [ok, payload, error] = respond.mock.calls[0] ?? [];
+  expect(ok).toBe(true);
+  expect(error).toBeUndefined();
+  return payload as WizardResult;
+}
+
+async function runWizardExit(flow: WizardFlow, exitCode: number): Promise<WizardResult> {
+  const tracker = createWizardSessionTracker();
+  const runner = async (runtime: RuntimeEnv, prompter: WizardPrompter) => {
+    await prompter.outro(exitCode === 0 ? "complete" : "invalid configuration");
+    runtime.exit(exitCode);
+  };
+  const context = {
+    ...tracker,
+    wizardRunner: async (_opts: unknown, runtime: RuntimeEnv, prompter: WizardPrompter) =>
+      runner(runtime, prompter),
+    channelWizardRunner: async (_opts: unknown, runtime: RuntimeEnv, prompter: WizardPrompter) =>
+      runner(runtime, prompter),
+  };
+  const startRespond = vi.fn();
+  await expectDefined(
+    wizardHandlers["wizard.start"],
+    "wizard.start test invariant",
+  )({
+    params: flow === "channels" ? { flow } : { mode: "local" },
+    respond: startRespond,
+    context,
+  } as never);
+  const start = responsePayload(startRespond);
+  expect(start).toMatchObject({ done: false, status: "running" });
+  expect(start.step?.id).toBeTruthy();
+
+  const nextRespond = vi.fn();
+  await expectDefined(
+    wizardHandlers["wizard.next"],
+    "wizard.next test invariant",
+  )({
+    params: {
+      sessionId: start.sessionId,
+      answer: { stepId: start.step?.id, value: null },
+    },
+    respond: nextRespond,
+    context,
+  } as never);
+  return responsePayload(nextRespond);
+}
 
 describe("wizard session lookup", () => {
   it.each([
@@ -31,5 +99,71 @@ describe("wizard session lookup", () => {
       message: "wizard not found",
       details: { code: "WIZARD_NOT_FOUND" },
     });
+  });
+});
+
+describe("wizard gateway runtime", () => {
+  it.each<WizardFlow>(["setup", "channels"])(
+    "keeps the gateway alive when the %s wizard exits successfully",
+    async (flow) => {
+      await expect(runWizardExit(flow, 0)).resolves.toMatchObject({
+        done: true,
+        status: "done",
+        error: undefined,
+      });
+    },
+  );
+
+  it.each<WizardFlow>(["setup", "channels"])(
+    "reports a non-zero %s wizard exit as a session error",
+    async (flow) => {
+      const result = await runWizardExit(flow, 1);
+      expect(result).toMatchObject({ done: true, status: "error" });
+      expect(result.error).toContain("exit 1");
+    },
+  );
+});
+
+describe("wizard setup ownership", () => {
+  it.each([
+    { label: "false", params: { installDaemon: false }, expected: false },
+    { label: "true", params: { installDaemon: true }, expected: true },
+    { label: "omitted", params: {}, expected: undefined },
+  ])("projects installDaemon when $label", async ({ params, expected }) => {
+    let receivedOptions: ProjectedOptions | undefined;
+    const tracker = createWizardSessionTracker();
+    const wizardRunner: SetupWizardRunner = async (opts, _runtime, prompter) => {
+      receivedOptions = {
+        installDaemon: opts.installDaemon,
+        skipUi: opts.skipUi,
+        suppressGatewayTokenOutput: opts.suppressGatewayTokenOutput,
+      };
+      await prompter.note("ready");
+    };
+    const context = {
+      ...tracker,
+      wizardRunner,
+    };
+    const respond = vi.fn();
+
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local", ...params },
+      respond,
+      context,
+    } as never);
+
+    expect(receivedOptions).toEqual({
+      installDaemon: expected,
+      skipUi: true,
+      suppressGatewayTokenOutput: true,
+    });
+    expect(responsePayload(respond)).toMatchObject({ done: false, status: "running" });
+
+    for (const session of tracker.wizardSessions.values()) {
+      session.cancel();
+    }
   });
 });

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -172,7 +172,7 @@ describe("wizard setup ownership", () => {
 
     runnerSettled.resolve();
     await vi.waitFor(() => {
-      expect(tracker.wizardSessions.get(start.sessionId)?.isSettled()).toBe(true);
+      expect(tracker.wizardSessions.has(start.sessionId)).toBe(false);
     });
 
     const replacementRespond = vi.fn();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -182,11 +182,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!session) {
       return;
     }
-    const cancelled = session.cancel();
+    session.cancel();
     const status = readWizardStatus(session);
-    if (cancelled || status.status !== "running") {
-      context.wizardSessions.delete(sessionId);
-    }
+    context.purgeWizardSession(sessionId);
     respond(true, status, undefined);
   },
   "wizard.status": ({ params, respond, context }) => {
@@ -199,9 +197,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const status = readWizardStatus(session);
-    if (status.status !== "running") {
-      context.wizardSessions.delete(sessionId);
-    }
+    context.purgeWizardSession(sessionId);
     respond(true, status, undefined);
   },
 };

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -12,7 +12,7 @@ import {
   validateWizardStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OnboardOptions } from "../../commands/onboard-types.js";
-import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { WizardSession } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
@@ -44,6 +44,19 @@ export const runDefaultChannelSetupWizard: ChannelSetupWizardRunner = async (...
   const { runChannelsSetupWizard } = await import("../../commands/channels/add-wizard.js");
   return runChannelsSetupWizard(...args);
 };
+
+async function runGatewayWizard(run: (runtime: RuntimeEnv) => Promise<void>): Promise<void> {
+  try {
+    await run(createNonExitingRuntime());
+  } catch (error) {
+    // Remote wizards share the Gateway process, so a successful CLI-style exit
+    // completes only this session. Non-zero exits remain explicit session errors.
+    if (error instanceof ExitError && error.code === 0) {
+      return;
+    }
+    throw error;
+  }
+}
 
 function readWizardStatus(session: WizardSession) {
   return {
@@ -88,26 +101,33 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const session =
       flow === "channels"
         ? new WizardSession((prompter, _signal, wizardSession) =>
-            context.channelWizardRunner(
-              {
-                channel: readStringValue(params.channel),
-                onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
-                // Durable effects (plugin installs, config commit) must finish
-                // even if the client cancels mid-write.
-                beforePersistentEffect: async () => wizardSession.lockCancellation(),
-              },
-              defaultRuntime,
-              prompter,
+            runGatewayWizard((runtime) =>
+              context.channelWizardRunner(
+                {
+                  channel: readStringValue(params.channel),
+                  onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
+                  // Durable effects (plugin installs, config commit) must finish
+                  // even if the client cancels mid-write.
+                  beforePersistentEffect: async () => wizardSession.lockCancellation(),
+                },
+                runtime,
+                prompter,
+              ),
             ),
           )
         : new WizardSession((prompter) =>
-            context.wizardRunner(
-              {
-                mode: params.mode,
-                workspace: readStringValue(params.workspace),
-              },
-              defaultRuntime,
-              prompter,
+            runGatewayWizard((runtime) =>
+              context.wizardRunner(
+                {
+                  mode: params.mode,
+                  workspace: readStringValue(params.workspace),
+                  installDaemon: params.installDaemon,
+                  skipUi: true,
+                  suppressGatewayTokenOutput: true,
+                },
+                runtime,
+                prompter,
+              ),
             ),
           );
     context.wizardSessions.set(sessionId, session);

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -182,9 +182,13 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!session) {
       return;
     }
-    session.cancel();
+    const cancelled = session.cancel();
     const status = readWizardStatus(session);
-    context.purgeWizardSession(sessionId);
+    if (cancelled) {
+      void session.whenSettled().then(() => context.purgeWizardSession(sessionId));
+    } else {
+      context.purgeWizardSession(sessionId);
+    }
     respond(true, status, undefined);
   },
   "wizard.status": ({ params, respond, context }) => {

--- a/src/gateway/server-wizard-sessions.test.ts
+++ b/src/gateway/server-wizard-sessions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../shared/deferred.js";
 import { WizardSession } from "../wizard/session.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 
@@ -32,5 +33,25 @@ describe("createWizardSessionTracker", () => {
     expect(tracker.findRunningWizard()).toBe("running");
     expect(tracker.wizardSessions.get("running")).toBe(running);
     running.cancel();
+  });
+
+  it("keeps a cancelled session active until its runner settles", async () => {
+    const tracker = createWizardSessionTracker();
+    const releaseRunner = createDeferred();
+    const cancelled = new WizardSession(async () => {
+      await releaseRunner.promise;
+    });
+    tracker.wizardSessions.set("cancelled", cancelled);
+
+    expect(cancelled.cancel()).toBe(true);
+    tracker.purgeWizardSession("cancelled");
+    expect(tracker.findRunningWizard()).toBe("cancelled");
+    expect(tracker.wizardSessions.has("cancelled")).toBe(true);
+
+    releaseRunner.resolve();
+    await expect.poll(() => cancelled.isSettled()).toBe(true);
+    expect(tracker.findRunningWizard()).toBeNull();
+    tracker.purgeWizardSession("cancelled");
+    expect(tracker.wizardSessions.has("cancelled")).toBe(false);
   });
 });

--- a/src/gateway/server-wizard-sessions.ts
+++ b/src/gateway/server-wizard-sessions.ts
@@ -12,7 +12,7 @@ export function createWizardSessionTracker(options?: { now?: () => number }) {
 
   const findRunningWizard = (): string | null => {
     for (const [id, session] of wizardSessions) {
-      if (session.getStatus() === "running") {
+      if (!session.isSettled()) {
         terminalSince.delete(id);
         return id;
       }
@@ -34,7 +34,7 @@ export function createWizardSessionTracker(options?: { now?: () => number }) {
     if (!session) {
       return;
     }
-    if (session.getStatus() === "running") {
+    if (!session.isSettled()) {
       return;
     }
     wizardSessions.delete(id);

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -237,6 +237,7 @@ export class WizardSession {
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private pendingTerminalResolution = false;
   private cancellationLocked = false;
+  private settled = false;
   private pendingExternalUrl: string | undefined;
   private answerDeferred = new Map<
     string,
@@ -432,6 +433,7 @@ export class WizardSession {
         this.error = String(err);
       }
     } finally {
+      this.settled = true;
       if (this.expiryTimer) {
         clearTimeout(this.expiryTimer);
       }
@@ -468,6 +470,11 @@ export class WizardSession {
 
   getStatus(): WizardSessionStatus {
     return this.status;
+  }
+
+  /** Whether the runner has stopped and can no longer mutate setup state. */
+  isSettled(): boolean {
+    return this.settled;
   }
 
   getError(): string | undefined {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -231,6 +231,7 @@ class WizardSessionPrompter implements WizardPrompter {
 export class WizardSession {
   private readonly abortController = new AbortController();
   private readonly expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly runnerPromise: Promise<void>;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
   private deliveredProgressStepIds = new Set<string>();
@@ -264,7 +265,7 @@ export class WizardSession {
       this.expiryTimer = setTimeout(() => this.cancel(), options.timeoutMs);
       this.expiryTimer.unref?.();
     }
-    void this.run(prompter);
+    this.runnerPromise = this.run(prompter);
   }
 
   async next(): Promise<WizardNextResult> {
@@ -475,6 +476,11 @@ export class WizardSession {
   /** Whether the runner has stopped and can no longer mutate setup state. */
   isSettled(): boolean {
     return this.settled;
+  }
+
+  /** Resolves after the runner can no longer mutate setup state. */
+  whenSettled(): Promise<void> {
+    return this.runnerPromise;
   }
 
   getError(): string | undefined {

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -1,5 +1,6 @@
 // Setup finalize tests cover writing final onboarding config and artifacts.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
@@ -734,7 +735,7 @@ describe("finalizeSetupWizard", () => {
       routeVariants: catalog,
     });
     expect(resolveDefaultModelAuthStatus).toHaveBeenCalledWith(nextConfig, {
-      agentDir: "/tmp/custom-agent",
+      agentDir: path.resolve("/tmp/custom-agent"),
       observedRoutes,
     });
   });
@@ -783,7 +784,7 @@ describe("finalizeSetupWizard", () => {
           list: [{ id: "main", agentDir: "/tmp/custom-agent" }],
         },
       }),
-      { agentDir: "/tmp/custom-agent" },
+      { agentDir: path.resolve("/tmp/custom-agent") },
     );
     expectNoteContains(
       prompter,

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -739,6 +739,20 @@ describe("finalizeSetupWizard", () => {
     });
   });
 
+  it("does not load the model catalog for a headless gateway wizard", async () => {
+    const nextConfig = {
+      agents: {
+        defaults: { model: "openai/gpt-5.6" },
+      },
+    } satisfies OpenClawConfig;
+
+    await finalizeSetupWizard(createAdvancedFinalizeArgs({ nextConfig }));
+
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(resolveDefaultModelCatalogFacts).not.toHaveBeenCalled();
+    expect(resolveDefaultModelAuthStatus).not.toHaveBeenCalled();
+  });
+
   it("skips the doomed hatch seed message and warns when model auth is missing", async () => {
     vi.spyOn(fs, "access").mockResolvedValueOnce(undefined);
     resolveDefaultModelAuthStatus.mockReturnValueOnce({

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -604,35 +604,44 @@ export async function finalizeSetupWizard(
       resolveUserPath(options.workspaceDir),
       DEFAULT_BOOTSTRAP_FILENAME,
     );
-    const hasBootstrap = await fs
-      .access(bootstrapPath)
-      .then(() => true)
-      .catch(() => false);
+    const shouldLaunchTui = !opts.skipUi;
+    const hasBootstrap =
+      shouldLaunchTui &&
+      (await fs
+        .access(bootstrapPath)
+        .then(() => true)
+        .catch(() => false));
     const agentDir = resolveDefaultAgentDir(nextConfig);
-    // Seed only when the selected route is proven ready. Unknown or incompatible
-    // route facts must not turn the onboarding greeting into a guaranteed failure.
-    const [
-      { resolveDefaultModelAuthStatus, resolveDefaultModelCatalogFacts },
-      { loadPreparedModelCatalogSnapshot },
-    ] = await Promise.all([
-      import("../commands/auth-choice.js"),
-      import("../agents/prepared-model-catalog.js"),
-    ]);
-    const modelCatalog = await loadPreparedModelCatalogSnapshot({
-      config: nextConfig,
-      readOnly: true,
-    });
-    const modelCatalogFacts = resolveDefaultModelCatalogFacts(nextConfig, modelCatalog.entries, {
-      routeVariants: modelCatalog.routeVariants,
-    });
-    const modelAuthStatus = resolveDefaultModelAuthStatus(nextConfig, {
-      agentDir,
-      ...(modelCatalogFacts.observedRoutes
-        ? { observedRoutes: modelCatalogFacts.observedRoutes }
-        : {}),
-    });
-    const shouldSeedBootstrapHatch =
-      hasBootstrap && options.hadExistingConfig !== true && modelAuthStatus.status === "ready";
+    let shouldSeedBootstrapHatch = false;
+    let missingModelAuthProvider: string | undefined;
+    if (shouldLaunchTui) {
+      // Seed only when the selected route is proven ready. Headless Gateway wizards do not hatch
+      // an agent, so they must not read a catalog for config that is still being committed.
+      const [
+        { resolveDefaultModelAuthStatus, resolveDefaultModelCatalogFacts },
+        { loadPreparedModelCatalogSnapshot },
+      ] = await Promise.all([
+        import("../commands/auth-choice.js"),
+        import("../agents/prepared-model-catalog.js"),
+      ]);
+      const modelCatalog = await loadPreparedModelCatalogSnapshot({
+        config: nextConfig,
+        readOnly: true,
+      });
+      const modelCatalogFacts = resolveDefaultModelCatalogFacts(nextConfig, modelCatalog.entries, {
+        routeVariants: modelCatalog.routeVariants,
+      });
+      const modelAuthStatus = resolveDefaultModelAuthStatus(nextConfig, {
+        agentDir,
+        ...(modelCatalogFacts.observedRoutes
+          ? { observedRoutes: modelCatalogFacts.observedRoutes }
+          : {}),
+      });
+      shouldSeedBootstrapHatch =
+        hasBootstrap && options.hadExistingConfig !== true && modelAuthStatus.status === "ready";
+      missingModelAuthProvider =
+        modelAuthStatus.status === "missing" ? modelAuthStatus.provider : undefined;
+    }
 
     await prompter.note(
       [
@@ -653,7 +662,6 @@ export async function finalizeSetupWizard(
     let controlUiOpened = false;
     const seededInBackground = false;
     let launchedTui = false;
-    const shouldLaunchTui = !opts.skipUi;
 
     if (shouldLaunchTui) {
       if (hasBootstrap) {
@@ -666,10 +674,10 @@ export async function finalizeSetupWizard(
           t("wizard.finalize.hatchYourAgent"),
         );
       }
-      if (modelAuthStatus.status === "missing") {
+      if (missingModelAuthProvider) {
         await prompter.note(
           [
-            t("wizard.finalize.noModelAuth", { provider: modelAuthStatus.provider }),
+            t("wizard.finalize.noModelAuth", { provider: missingModelAuthProvider }),
             t("wizard.finalize.noModelAuthNext", {
               command: formatCliCommand("openclaw configure --section model"),
             }),


### PR DESCRIPTION
Closes #110545

## What Problem This Solves

Gateway RPC wizard sessions inherited CLI-owned behavior that does not belong inside a shared host process:

- setup and channel runners could terminate the Gateway through `runtime.exit()`;
- remote callers could not state whether setup should install the daemon;
- cancellation could release or retain ownership while the underlying runner could still mutate setup state;
- headless Gateway setup loaded the interactive model catalog even though it cannot use that UI path.

In the Windows Companion path, this appeared as a lost Gateway connection during `run-wizard`. The cancellation race could also allow overlapping setup work or retain a settled cancelled session indefinitely.

This PR:

- runs setup and channel RPC wizards with `createNonExitingRuntime()`;
- treats only `ExitError(0)` as normal completion and preserves nonzero exits as session errors;
- adds optional `installDaemon` to `WizardStartParamsSchema` and forwards `true`, `false`, or omission unchanged;
- retains cancelled wizard ownership until the runner settles;
- rejects replacement while cancellation cleanup is still running;
- removes the cancelled session automatically after settlement so a later start can succeed;
- skips interactive model-catalog loading for headless Gateway setup;
- keeps `skipUi: true` and `suppressGatewayTokenOutput: true` explicit at the RPC boundary.

User impact: remote wizard flows remain inside the shared Gateway process. Cancellation preserves single-wizard ownership until in-flight work settles, then releases it so a later wizard can start.

Non-goals:

- no dependency or lockfile changes;
- no provider, credential, permission, model, or workflow changes;
- no change to CLI-owned wizard exits outside the Gateway RPC wrapper;
- no new Gateway method;
- no protocol-train change.

This consolidates and replaces #109412.

## Change Type

- [x] Bug fix
- [x] Tests / validation
- [x] Security hardening
- [ ] Feature
- [ ] Dependency change

## Scope

- [x] Gateway wizard RPC lifecycle
- [x] Setup and channel runner ownership
- [x] Generated Gateway protocol projection
- [x] Cancellation and settlement cleanup
- [ ] Providers, credentials, permissions, or channels

## Linked Issue / PR

- Core issue: #110545
- Downstream consumer: openclaw/openclaw-windows-node#999
- Superseded PR: #109412

## Contract Decision

`wizard.start.installDaemon` is an optional generated Gateway request field. Omission preserves the existing onboarding default. An explicit boolean lets a trusted remote setup client choose whether that wizard invocation installs the daemon.

This is intentional API ownership, not an accidental implementation detail. Maintainer acceptance of that public request field remains the only open design decision.

## Evidence

Exact published head: `71ff15af52e76b129ff295334c7bfa8d9bc2713d`

- GitHub CI: **90 passed, 0 failed, 0 pending**, with 31 normal skipped/neutral jobs.
- Wizard ownership suite: **11/11 passed**.
- Dedicated authenticated Gateway E2E: **1/1 passed**.
- Exact core-test TypeScript project: passed with no diagnostics.
- Full `node scripts/build-all.mjs`: passed in 5m27s.
- Build included package and unified bundles, CLI bootstrap guard, runtime postbuild, 143 plugin SDK export checks, Control UI build, sidecar verification, and performance budgets.
- Scoped Auto-review for the final code correction: no accepted or actionable findings (`patch is correct`, confidence `0.97`).
- ClawSweeper patch quality on the preceding production-equivalent head: **Platinum 4/6**, with no actionable code or security findings.

The one-line change from the reviewed predecessor head to this head is test-only TypeScript mutability cleanup. Production behavior is unchanged.

## Real Behavior Proof

Proof level: `runtime_proven` for the cancellation, settlement, replacement, and same-Gateway lifecycle on exact head `71ff15af52e`.

Environment and boundary:

- disposable Ubuntu 24.04 WSL2 lab;
- exact Git archive of the published head;
- exact frozen lockfile, candidate-local dependencies, and full official build;
- real Gateway in a separate child process;
- token-authenticated calls through the built public `dist/index.js gateway call` entrypoint;
- deterministic proof-only runner settlement controlled outside the Gateway process;
- isolated temporary home, state, config, workspace, port, and synthetic token;
- no operator runtime, private data, credentials, channels, providers, or persistent config.

Observed sequence:

1. The child Gateway started and reached ready.
2. `wizard.start` returned a running session.
3. `wizard.cancel` returned `cancelled`.
4. An immediate replacement was rejected with `UNAVAILABLE: wizard already running` while the cancelled runner remained unsettled.
5. After settlement, the cancelled owner was purged.
6. A later `wizard.start` succeeded.
7. Authenticated `health` succeeded after replacement.
8. The replacement was cancelled and settled.
9. Authenticated `health` succeeded again with the same child PID.
10. The child Gateway shut down cleanly.

Redacted terminal summary:

```json
{
  "proof": "gateway-separate-process-wizard-cancel-survival",
  "head": "71ff15af52e76b129ff295334c7bfa8d9bc2713d",
  "separateProcess": true,
  "authenticatedRpc": true,
  "replacementBlockedWhileUnsettled": true,
  "cancelledRunnerPurged": true,
  "replacementWizardStarted": true,
  "replacementAttempts": 1,
  "sameGatewayPid": true,
  "rpcHealthyAfterCancel": true
}
```

Redacted Gateway transcript:

```text
[gateway] starting HTTP server...
[gateway] http server listening (0 plugins)
[gateway] ready
[ws] response error: wizard.start UNAVAILABLE "wizard already running"
[shutdown] completed cleanly in 89ms
```

Evidence integrity:

- proof controller SHA-256: `7FCB763241AA976C3C05CFB67A566C5B32029557D605747F10016456C43757F6`
- summary SHA-256: `E0889B73579DC2790B6C49AD30B853F63196452EA3ABD140402EE7EFE53C89F5`
- redacted stdout log SHA-256: `1205BF73CDFECB6FC32B8AF14805CE2FA8184AF6FCE9FFA779F0FA0FB628CCFE`
- stderr log SHA-256: `29DFA7B84F233D3663B8403E0A02784D056834FC0EDAFB998541FA329C133BE9`
- teardown readback: no proof controller or proof Gateway process remained.

This proves the requested process boundary. It does not claim official-package, Companion-update, or operator-runtime end-to-end proof.

## Failed-First Evidence

- The first source-CLI harness proved child-process startup but did not preserve a deterministic unsettled interval and its teardown was not bounded.
- The replacement proof therefore moved to a separate child Gateway with an externally controlled settlement point.
- Fresh source dependencies required the repository's official build before public CLI RPC could be used.
- No product code was changed to mask proof-environment failures.

## Security Impact

The patch narrows lifecycle authority. An RPC wizard cannot terminate its shared Gateway, and cancellation cannot release single-flight ownership while the runner can still mutate setup state.

No secrets, credentials, permissions, dependencies, or network boundaries change. The optional `installDaemon` field is limited to the existing trusted Gateway RPC boundary and preserves existing behavior when omitted.

## Compatibility / Migration

- Omitted `installDaemon`: preserves the current default.
- Explicit `installDaemon`: forwards the caller's boolean unchanged.
- Existing clients: no migration required.
- Generated Swift and TypeScript projections are covered by current protocol checks.

## Review Conversations

- [x] Fixed the cancellation cleanup defect found by Auto-review.
- [x] Preserved replacement blocking until the runner settles.
- [x] Added automatic post-settlement cleanup.
- [x] Added focused unit and authenticated E2E coverage.
- [x] Completed exact-head CI.
- [x] Added exact-head separate-process lifecycle proof.
- [x] Kept `installDaemon` explicit as an intentional optional public request field.
- [ ] Maintainer acceptance of the request contract remains pending.

## Agent Transcript

<details>
<summary>Redacted operator and agent timeline</summary>

- The operator kept the fix in OpenClaw Core because the Gateway owns embedded wizard lifecycle; the Windows Companion remains the downstream consumer.
- Failed-first evidence showed that cancellation could purge an unsettled session once and never retry, retaining ownership indefinitely.
- The implementation added settlement-backed cleanup while preserving single-wizard ownership until the runner could no longer mutate setup state.
- Review identified two separate gates: current-head process proof and maintainer acceptance of the optional `installDaemon` request contract.
- A broad source-CLI proof path was rejected after it failed to provide deterministic ownership timing and bounded teardown.
- The final proof used a separately hosted real Gateway, authenticated public CLI RPC, an external settlement controller, and exact-head build provenance.
- The proof observed rejection while unsettled, cleanup after settlement, later start, same-PID health, and clean shutdown.
- No operator runtime, private data, credentials, channels, providers, or persistent configuration were used.

</details>
