### PR TITLE
fix(ui): re-render composer after input-history navigation

### DIFF
--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -316,7 +316,9 @@ describe("ChatStateController render lifecycle", () => {
     } as unknown as ChatPageHost;
 
     state.handleChatInputHistoryKey = vi.fn((input: { key: string }) => {
-      if (input.key !== "ArrowUp") return { handled: false };
+      if (input.key !== "ArrowUp") {
+        return { handled: false };
+      }
       state.chatMessage = "previous draft";
       return { handled: true };
     }) as ChatPageHost["handleChatInputHistoryKey"];

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -278,6 +278,83 @@ describe("ChatStateController render lifecycle", () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(2);
     expect(painted).not.toHaveBeenCalled();
   });
+
+  it("re-renders when input-history navigation mutates chatMessage (#109031)", () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    const requestUpdate = vi.fn();
+    const host = {
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    } satisfies ReactiveControllerHost;
+    const controller = new ChatStateController<ChatPageHost>(host);
+    controller.hostConnected();
+    const renderLifecycle = controller.createRenderLifecycle();
+
+    const state = {
+      settings: { gatewayUrl: "ws://gateway.test/control" },
+      sessionKey: "main",
+      assistantAgentId: "main",
+      agentsList: { defaultId: "main", mainKey: "main" },
+      chatMessage: "",
+      chatQueue: [],
+      chatQueueByScope: {},
+      chatMessages: [],
+      chatMessagesBySession: new Map(),
+      chatAttachments: [],
+      chatToolMessages: [],
+      chatStreamSegments: [],
+      toolStreamById: new Map(),
+      toolStreamOrder: [],
+      realtimeTalkConversation: [],
+      renderLifecycle,
+      handleSendChat: vi.fn(async () => undefined),
+      handleChatDraftChange: vi.fn(),
+      handleChatInputHistoryKey: vi.fn(),
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+
+    state.handleChatInputHistoryKey = vi.fn((input: { key: string }) => {
+      if (input.key !== "ArrowUp") return { handled: false };
+      state.chatMessage = "previous draft";
+      return { handled: true };
+    }) as ChatPageHost["handleChatInputHistoryKey"];
+
+    controller.attach(state);
+    requestUpdate.mockClear();
+
+    const blocked = state.handleChatInputHistoryKey({
+      key: "ArrowDown",
+      selectionStart: 0,
+      selectionEnd: 0,
+      valueLength: 0,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 40,
+    });
+    expect(blocked.handled).toBe(false);
+    expect(requestUpdate).not.toHaveBeenCalled();
+
+    const recalled = state.handleChatInputHistoryKey({
+      key: "ArrowUp",
+      selectionStart: 0,
+      selectionEnd: 0,
+      valueLength: 0,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 38,
+    });
+    expect(recalled.handled).toBe(true);
+    expect(state.chatMessage).toBe("previous draft");
+    expect(requestUpdate).toHaveBeenCalledOnce();
+  });
 });
 
 describe("route composer fallback", () => {

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1717,6 +1717,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     state.handleChatInputHistoryKey = (input) => {
       const result = navigateInputHistory(input);
       if (result.handled) {
+        renderLifecycle.invalidate();
         this.composerPersistence.schedule();
       }
       return result;


### PR DESCRIPTION
Closes #109031

## What Problem This Solves

Fixes an issue where the Control UI chat composer textarea does not update after pressing ↑/↓ to recall previous input. The internal state (`chatMessage`) is correctly updated, but the DOM never reflects the change because a re-render is not triggered.

## Why This Change Was Made

The `handleChatInputHistoryKey` wrapper in `ChatStateController.attach()` updates `state.chatMessage` when a history navigation key is handled, but unlike every sibling handler in the same method, it does not call `renderLifecycle.invalidate()`. This adds the missing call, matching the pattern used by `handleSendChat` and other handlers that mutate state and require a re-render.

## User Impact

Control UI users can now see recalled input history in the composer textarea when pressing ↑/↓, matching the expected behavior.

## Evidence

**Head:** `2f3fceb` (rebased onto upstream/main `4e0cc18`)

**Focused unit test — verifies re-render is triggered when history navigation is handled (#109031):**
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts \
  ui/src/pages/chat/chat-state.test.ts -t "input-history"

 Test Files  1 passed (1)
      Tests  1 passed | 34 skipped (35)
```

The new test (`re-renders when input-history navigation mutates chatMessage`) confirms:
- ArrowDown (unhandled) does NOT call `requestUpdate`
- ArrowUp (handled) calls `requestUpdate` exactly once
- State mutation correctly sets `chatMessage` to the recalled value

**Existing view-level test continues to pass:**
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts \
  ui/src/pages/chat/chat-view.test.ts -t "invalidates after handled input history navigation"

 Test Files  1 passed (1)
      Tests  1 passed | 171 skipped (172)
```

**Code evidence:** The fix follows the exact same pattern as `handleSendChat` in the same `attach()` method, which calls `renderLifecycle.invalidate()` after mutating state. The `renderLifecycle` binding is established at line 1698 of `chat-state.ts` and used by every sibling handler — the history handler was the only one missing it.

**Diff:** `+1` line in `ui/src/pages/chat/chat-state.ts`, `+77` lines of focused test in `ui/src/pages/chat/chat-state.test.ts`.