### PR TITLE
fix(ios): keep localization catalog synchronized

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the generated iOS localization catalog was stale after the native chat reasoning and tool-activity label changed, causing the core CI shard to fail on every unrelated pull request merged with current `main`.

## Why This Change Was Made

Regenerates the canonical iOS string catalog and removes contradiction records resolved by the selected catalog translations. No runtime source or translation policy changes.

## User Impact

No user-visible behavior change. Pull requests can pass the Apple localization consistency gate again, and the iOS catalog includes the existing reasoning and tool-activity label.

## Evidence

- `node scripts/apple-app-i18n.ts sync-ios --write` — generated the checked-in catalog and contradiction baseline.
- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` — 13 tests passed.
- `git diff --check` — passed.
- Fresh autoreview: clean, no accepted/actionable findings.

