### PR TITLE
fix(i18n): sync Apple catalog with the Linux CI runner

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",


### PR DESCRIPTION
## What Problem This Solves

Fixes a broken-main condition where `apple-app-i18n` fails on the Linux CI runner for every PR: "Apple catalog apps/ios/Resources/Localizable.xcstrings is stale; run apple-app-i18n.ts sync-ios --write." This reddens `ci-gate`, blocking all PRs from landing even though the failure is unrelated to their changes.

## Why This Change Was Made

The committed catalog was last regenerated on macOS. macOS's case-insensitive filesystem misses a source string that the Linux runner discovers ("Show reasoning & tool activity"), so `apple-app-i18n check` reports the catalog stale on Linux (iosKeys=1439 on Linux vs 1430 on macOS). CI truth is Linux Node 24, so the fix is to regenerate the catalog and the translation-contradictions report on Linux and commit the runner-matching output. Regenerated on a Blacksmith Testbox; `apple-app-i18n check` passes there after the write.

## User Impact

No user-visible behavior change — this is generated i18n metadata. Unblocks the shared CI gate so PRs can land again.

## Evidence

- Reproduced on a Linux Blacksmith Testbox: `sync-ios --write` then `check` passes (exit 0); only `apps/ios/Resources/Localizable.xcstrings` and `apps/.i18n/apple-translation-contradictions.json` change.
- The added catalog entry is a real, fully-translated source string ("Show reasoning & tool activity") that the Linux scan finds and the macOS scan missed.
- Diff scope: +136 / -32 across the two generated artifacts only.
