### PR TITLE
chore(i18n): sync stale iOS catalog (unbreak main)

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",


### PR DESCRIPTION
## What Problem This Solves

Main's `apple-app-i18n` catalog guard fails repo-wide (main run 29629024764 and every PR merging current main): a landed change touched iOS-visible strings without running `apple-app-i18n.ts sync-ios --write`, leaving `apps/ios/Resources/Localizable.xcstrings` stale.

## Why This Change Was Made

Regenerated exactly what the guard demands: `node --import tsx scripts/apple-app-i18n.ts sync-ios --write` on main tip (synced the iOS catalog and 84 InfoPlist files). Generated files only — no hand edits.

## User Impact

Unbreaks CI for every PR; ships the missing iOS localization entries that the originating change should have carried.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` — 13 passed on this branch (fails on main tip).
- Diff is exclusively the two generated artifacts (`Localizable.xcstrings`, `apple-translation-contradictions.json`).

Note: this was attempted as a direct-to-main repair (the 11th merge-skew unbreak today) but main now enforces required status checks on pushes, so it lands via PR.
