### PR TITLE
fix(sessions): preserve active turns during session compaction

### DIFF
--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -7,11 +7,13 @@ import {
   estimateContextTokens,
   prepareCompaction,
   shouldCompact,
+  type CompactionPreparation,
   type CompactionResult,
 } from "../runtime/index.js";
 import { AgentSessionInspection } from "./agent-session-inspection.js";
 import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
+import { preflightManualSessionCompaction } from "./manual-compaction-preflight.js";
 import { getLatestCompactionEntry, type CompactionEntry } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 
@@ -141,23 +143,17 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     }
 
     const pathEntries = this.sessionManager.getBranch();
-    let preparation = unwrapCoreResult(prepareCompaction(pathEntries, options.settings));
-    if (!preparation && isManual) {
-      // An explicit request should compact the smallest valid history instead of
-      // relying on the old empty-summary behavior when the whole session fits the keep budget.
-      preparation = unwrapCoreResult(
-        prepareCompaction(pathEntries, { ...options.settings, keepRecentTokens: 0 }),
-      );
+    let preparation: CompactionPreparation | undefined;
+    if (isManual) {
+      const manualPreflight = preflightManualSessionCompaction(pathEntries, options.settings);
+      if (!manualPreflight.compactable) {
+        throw new Error(manualPreflight.reason);
+      }
+      preparation = manualPreflight.preparation;
+    } else {
+      preparation = unwrapCoreResult(prepareCompaction(pathEntries, options.settings));
     }
     if (!preparation) {
-      if (isManual) {
-        const lastEntry = pathEntries[pathEntries.length - 1];
-        throw new Error(
-          lastEntry?.type === "compaction"
-            ? "Already compacted"
-            : "Nothing to compact (session too small)",
-        );
-      }
       return { status: "skipped" };
     }
 

--- a/src/agents/sessions/manual-compaction-preflight.ts
+++ b/src/agents/sessions/manual-compaction-preflight.ts
@@ -1,0 +1,41 @@
+import {
+  prepareCompaction,
+  type CompactionPreparation,
+  type CompactionSettings,
+} from "../../../packages/agent-core/src/harness/compaction/compaction.js";
+import type { SessionEntry } from "./session-manager.js";
+
+type ManualCompactionPreflight =
+  | { compactable: true; preparation: CompactionPreparation }
+  | { compactable: false; reason: "Already compacted" | "Nothing to compact (session too small)" };
+
+/** Plans manual compaction without aborting or otherwise mutating the active session. */
+export function preflightManualSessionCompaction(
+  pathEntries: SessionEntry[],
+  settings: CompactionSettings,
+): ManualCompactionPreflight {
+  const initial = prepareCompaction(pathEntries, settings);
+  if (!initial.ok) {
+    throw initial.error;
+  }
+  let preparation = initial.value;
+  if (!preparation) {
+    // Explicit manual compaction uses the smallest valid history rather than
+    // treating a session that fits the configured keep budget as a no-op.
+    const smallest = prepareCompaction(pathEntries, { ...settings, keepRecentTokens: 0 });
+    if (!smallest.ok) {
+      throw smallest.error;
+    }
+    preparation = smallest.value;
+  }
+  if (preparation) {
+    return { compactable: true, preparation };
+  }
+  return {
+    compactable: false,
+    reason:
+      pathEntries.at(-1)?.type === "compaction"
+        ? "Already compacted"
+        : "Nothing to compact (session too small)",
+  };
+}

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -5,6 +5,7 @@ import {
   errorShape,
   validateSessionsCompactParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import {
   resolveSessionWorkStartError,
@@ -18,16 +19,19 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
-  interruptSessionWorkAdmissions,
+  isCompetingSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
-  SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
 } from "../../sessions/session-lifecycle-admission.js";
 import { recordSessionCompacted } from "../../sessions/session-state-events.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import { migrateAndPruneGatewaySessionStoreKey } from "../session-utils.js";
+import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
+import { hasVisibleActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
-import { runGatewaySessionCompaction } from "./sessions-compaction-runner.js";
-import { interruptSessionRunIfActive } from "./sessions-messaging.js";
+import {
+  preflightGatewaySessionCompaction,
+  runGatewaySessionCompaction,
+} from "./sessions-compaction-runner.js";
 import {
   emitSessionOperation,
   loadAccessorSessionEntryForGatewayTarget,
@@ -39,7 +43,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionCompactHandlers: GatewayRequestHandlers = {
-  "sessions.compact": async ({ req, params, respond, context, client, isWebchatConnect }) => {
+  "sessions.compact": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsCompactParams, "sessions.compact", respond)) {
       return;
     }
@@ -168,7 +172,8 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
       lifecycleRevision,
     ];
     let sessionStillCurrent = true;
-    let admittedWorkReleased = true;
+    let compactionNoopReason: string | undefined;
+    let blockedByActiveRun = false;
     try {
       await runExclusiveSessionLifecycleMutation({
         scope: storePath,
@@ -180,23 +185,51 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
             cfg,
             agentId: requestedAgentId,
           }).entry;
-          sessionStillCurrent = Boolean(
-            latestEntry &&
-            latestEntry.sessionId === sessionId &&
-            latestEntry.lifecycleRevision === lifecycleRevision &&
-            !resolveSessionWorkStartError(target.canonicalKey, latestEntry),
-          );
-          if (!sessionStillCurrent) {
+          if (
+            !latestEntry ||
+            latestEntry.sessionId !== sessionId ||
+            latestEntry.lifecycleRevision !== lifecycleRevision ||
+            resolveSessionWorkStartError(target.canonicalKey, latestEntry)
+          ) {
+            sessionStillCurrent = false;
+            return;
+          }
+          if (maxLines === undefined) {
+            compactionNoopReason = (
+              await preflightGatewaySessionCompaction({
+                cfg,
+                entry: latestEntry,
+                agentId: target.agentId,
+                sessionId,
+                sessionKey: target.canonicalKey,
+                sessionStoreKey: compactTarget.primaryKey,
+                storePath,
+              })
+            )?.reason;
+            if (compactionNoopReason) {
+              return;
+            }
+          }
+          blockedByActiveRun =
+            isCompetingSessionWorkAdmissionActive(storePath, lifecycleIdentities) ||
+            (asWorkerInferenceControl(context.workerEnvironmentService)?.hasInferenceForSession(
+              sessionId,
+            ) ??
+              false) ||
+            hasVisibleActiveSessionRun({
+              context,
+              requestedKey: key,
+              canonicalKey: target.canonicalKey,
+              sessionId,
+              agentId: requestedAgentId,
+              defaultAgentId: resolveDefaultAgentId(cfg),
+            });
+          if (blockedByActiveRun) {
             return;
           }
           // Drop work queued against the pre-compaction transcript before its
-          // active admission drains and no longer exposes queue cleanup.
+          // lifecycle fence commits and no longer exposes queue cleanup.
           clearSessionQueues([key, target.canonicalKey, compactTarget.primaryKey, sessionId]);
-          admittedWorkReleased = await interruptSessionWorkAdmissions({
-            scope: storePath,
-            identities: lifecycleIdentities,
-            timeoutMs: SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
-          });
         },
         run: async () => {
           if (!sessionStillCurrent) {
@@ -211,11 +244,27 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
             );
             return;
           }
-          if (!admittedWorkReleased) {
+          if (compactionNoopReason) {
+            respond(
+              true,
+              {
+                ok: false,
+                key: target.canonicalKey,
+                compacted: false,
+                reason: compactionNoopReason,
+              },
+              undefined,
+            );
+            return;
+          }
+          if (blockedByActiveRun) {
             respond(
               false,
               undefined,
-              errorShape(ErrorCodes.UNAVAILABLE, `Session ${key} is still active; try again.`),
+              errorShape(
+                ErrorCodes.INVALID_REQUEST,
+                `Session ${key} has an active run; retry after it finishes.`,
+              ),
             );
             return;
           }
@@ -240,21 +289,6 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
                 { details: { reason: SESSION_LIFECYCLE_CHANGED_ERROR_REASON } },
               ),
             );
-            return;
-          }
-
-          const interruptResult = await interruptSessionRunIfActive({
-            req,
-            context,
-            client,
-            isWebchatConnect,
-            requestedKey: key,
-            canonicalKey: target.canonicalKey,
-            agentId: requestedAgentId,
-            sessionId,
-          });
-          if (interruptResult.error) {
-            respond(false, undefined, interruptResult.error);
             return;
           }
 

--- a/src/gateway/server-methods/sessions-compaction-runner.ts
+++ b/src/gateway/server-methods/sessions-compaction-runner.ts
@@ -3,14 +3,24 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
 import { resolvePersistedSessionRuntimeId } from "../../agents/session-runtime-compat.js";
+import { preflightManualSessionCompaction } from "../../agents/sessions/manual-compaction-preflight.js";
+import type { SessionEntry as AgentSessionEntry } from "../../agents/sessions/session-manager.js";
 import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { resolveSessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.js";
+import {
+  loadTranscriptEvents,
+  resolveSessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.js";
+import {
+  isCanonicalSessionTranscriptEntry,
+  scanSessionTranscriptTree,
+  selectSessionTranscriptTreePathNodes,
+} from "../../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveSessionModelRef } from "../session-utils.js";
 
-export async function runGatewaySessionCompaction(params: {
+type GatewaySessionCompactionParams = {
   agentId: string;
   cfg: OpenClawConfig;
   entry: SessionEntry;
@@ -18,13 +28,62 @@ export async function runGatewaySessionCompaction(params: {
   sessionKey: string;
   sessionStoreKey: string;
   storePath: string;
-}): Promise<Awaited<ReturnType<typeof compactEmbeddedAgentSession>>> {
-  const transcriptTarget = await resolveSessionTranscriptRuntimeTarget({
+};
+
+function usesLegacyOpenClawCompaction(params: GatewaySessionCompactionParams): boolean {
+  const persistedRuntime = params.entry.modelSelectionLocked
+    ? resolvePersistedSessionRuntimeId(params.entry)
+    : params.entry.agentHarnessId;
+  const contextEngine = params.cfg.plugins?.slots?.contextEngine?.trim();
+  return (
+    (!persistedRuntime || persistedRuntime === "openclaw") &&
+    (!contextEngine || contextEngine === "legacy")
+  );
+}
+
+async function resolveGatewayCompactionTranscriptTarget(params: GatewaySessionCompactionParams) {
+  return await resolveSessionTranscriptRuntimeTarget({
     agentId: params.agentId,
     sessionId: params.sessionId,
     sessionKey: params.sessionStoreKey,
     storePath: params.storePath,
   });
+}
+
+/** Returns only definitive legacy-runtime no-op verdicts; other runtimes decide for themselves. */
+export async function preflightGatewaySessionCompaction(
+  params: GatewaySessionCompactionParams,
+): Promise<{ reason: "Already compacted" | "Nothing to compact (session too small)" } | undefined> {
+  if (!usesLegacyOpenClawCompaction(params)) {
+    return undefined;
+  }
+  try {
+    const transcriptEvents = await loadTranscriptEvents({
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionStoreKey,
+      storePath: params.storePath,
+    });
+    const tree = scanSessionTranscriptTree(transcriptEvents);
+    const branch = selectSessionTranscriptTreePathNodes(tree, tree.leafId)
+      .map((node) => node.entry)
+      .filter(isCanonicalSessionTranscriptEntry) as unknown as AgentSessionEntry[];
+    const preflight = preflightManualSessionCompaction(branch, {
+      enabled: true,
+      reserveTokens: 0,
+      keepRecentTokens: 0,
+    });
+    return preflight.compactable ? undefined : { reason: preflight.reason };
+  } catch {
+    // Preserve the existing compaction error path for malformed or unavailable transcripts.
+    return undefined;
+  }
+}
+
+export async function runGatewaySessionCompaction(
+  params: GatewaySessionCompactionParams,
+): Promise<Awaited<ReturnType<typeof compactEmbeddedAgentSession>>> {
+  const transcriptTarget = await resolveGatewayCompactionTranscriptTarget(params);
   const resolvedModel = resolveSessionModelRef(params.cfg, params.entry, params.agentId);
   const workspaceDir =
     resolveIngressWorkspaceOverrideForSessionRun({

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import {
   beginSessionWorkAdmission,
+  isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
 } from "../sessions/session-lifecycle-admission.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -34,7 +35,7 @@ import {
   sessionStoreEntry,
   createCheckpointFixture,
   directSessionReq,
-  expectSessionQueueCleanup,
+  expectNoSessionQueueCleanup,
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
@@ -585,6 +586,10 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
     message: { role: "user", content: "hello", timestamp: 1 },
     now: Date.parse("2026-06-19T12:00:01.000Z"),
   });
+  await appendTranscriptMessage(sessionScope, {
+    message: { role: "user", content: "follow-up", timestamp: 2 },
+    now: Date.parse("2026-06-19T12:00:02.000Z"),
+  });
   embeddedRunMock.compactEmbeddedAgentSession.mockImplementationOnce(async (params) => {
     const call = params as {
       sessionTarget?: {
@@ -609,7 +614,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
       storePath: call.sessionTarget.storePath,
     };
     const rows = await loadTranscriptEvents(targetScope);
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3);
     await appendTranscriptEvent(targetScope, {
       type: "compaction",
       id: "compact-1",
@@ -753,7 +758,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
   expect(compactionCall.trigger).toBe("manual");
 
   const sqliteRows = await loadTranscriptEvents(sessionScope);
-  expect(sqliteRows).toHaveLength(3);
+  expect(sqliteRows).toHaveLength(4);
   expect(sqliteRows.at(-1)).toMatchObject({
     type: "compaction",
     summary: "summary",
@@ -956,7 +961,7 @@ test("sessions.compact emits a terminal operation event when persistence fails",
     sessionId,
     sessionKey: "agent:main:main",
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   const compaction = createDeferred<{
     ok: true;
@@ -1016,7 +1021,7 @@ test("sessions.compact rejects stale terminal persistence after the session chan
     sessionId: "sess-compact-old",
     sessionKey: "agent:main:main",
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   const compaction = createDeferred<{
     ok: true;
@@ -1075,7 +1080,7 @@ test("sessions.reset waits for terminal compaction before replacing the session"
     sessionId: "sess-compact-reset",
     sessionKey: "agent:main:main",
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   const compaction = createDeferred<{
     ok: true;
@@ -1150,7 +1155,7 @@ test("sessions.compaction.restore waits for terminal compaction before replacing
     sessionId: fixture.sessionId,
     sessionKey: "agent:main:main",
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   const compaction = createDeferred<{
     ok: true;
@@ -1282,7 +1287,7 @@ test("sessions.compact blocks new work admission through terminal persistence", 
     sessionId,
     sessionKey: "agent:main:main",
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   const compaction = createDeferred<{
     ok: true;
@@ -1336,7 +1341,56 @@ test("sessions.compact blocks new work admission through terminal persistence", 
   ws.close();
 });
 
-test("sessions.compact clears queued work before draining an active admission", async () => {
+test("sessions.compact returns a no-op without interrupting an active admission", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-compact-noop-active";
+  await seedSessionEntry({
+    entry: sessionStoreEntry(sessionId),
+    sessionKey: "agent:main:main",
+    storePath,
+  });
+  await seedTranscriptRows({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    totalLines: 2,
+  });
+
+  let interrupted = false;
+  const admission = await beginSessionWorkAdmission({
+    scope: storePath,
+    identities: ["main", "agent:main:main", sessionId],
+    assertAllowed: () => {},
+    onInterrupt: () => {
+      interrupted = true;
+    },
+  });
+
+  const { ws } = await openClient();
+  try {
+    const compacted = await rpcReq<{
+      ok: boolean;
+      compacted: boolean;
+      reason?: string;
+    }>(ws, "sessions.compact", { key: "main" });
+
+    expect(compacted.ok).toBe(true);
+    expect(compacted.payload).toMatchObject({
+      ok: false,
+      compacted: false,
+      reason: "Nothing to compact (session too small)",
+    });
+    expect(interrupted).toBe(false);
+    expect(isSessionWorkAdmissionActive(storePath, [sessionId])).toBe(true);
+    expect(embeddedRunMock.compactEmbeddedAgentSession).not.toHaveBeenCalled();
+    expectNoSessionQueueCleanup();
+  } finally {
+    admission.release();
+    ws.close();
+  }
+});
+
+test("sessions.compact refuses real compaction without interrupting an active admission", async () => {
   const { storePath } = await createSessionStoreDir();
   const sessionId = "sess-compact-queued-work";
   await seedSessionEntry({
@@ -1348,7 +1402,7 @@ test("sessions.compact clears queued work before draining an active admission", 
     sessionId,
     sessionKey: "agent:main:main",
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   embeddedRunMock.compactEmbeddedAgentSession.mockResolvedValueOnce({
     ok: true,
@@ -1361,25 +1415,76 @@ test("sessions.compact clears queued work before draining an active admission", 
     },
   });
 
-  let releaseAdmission = () => {};
+  let interrupted = false;
   const admission = await beginSessionWorkAdmission({
     scope: storePath,
     identities: ["main", "agent:main:main", sessionId],
     assertAllowed: () => {},
-    onInterrupt: () => releaseAdmission(),
+    onInterrupt: () => {
+      interrupted = true;
+    },
   });
-  releaseAdmission = admission.release;
 
   const { ws } = await openClient();
   try {
     const compacted = await rpcReq(ws, "sessions.compact", { key: "main" });
 
-    expect(compacted.ok).toBe(true);
-    expectSessionQueueCleanup(["main", "agent:main:main", sessionId]);
+    expect(compacted.ok).toBe(false);
+    expect(compacted.error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("has an active run"),
+    });
+    expect(interrupted).toBe(false);
+    expect(isSessionWorkAdmissionActive(storePath, [sessionId])).toBe(true);
+    expect(embeddedRunMock.compactEmbeddedAgentSession).not.toHaveBeenCalled();
+    expectNoSessionQueueCleanup();
   } finally {
     admission.release();
     ws.close();
   }
+});
+
+test("sessions.compact refuses real compaction while a worker inference owns the session", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-compact-worker-inference";
+  await seedSessionEntry({
+    entry: sessionStoreEntry(sessionId),
+    sessionKey: "agent:main:main",
+    storePath,
+  });
+  await seedTranscriptRows({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    totalLines: 3,
+  });
+  const hasInferenceForSession = vi.fn(
+    (candidateSessionId: string) => candidateSessionId === sessionId,
+  );
+  const runtimeConfig = {
+    agents: { list: [{ id: "main", default: true }] },
+    session: { store: storePath },
+  };
+
+  const compacted = await directSessionReq(
+    "sessions.compact",
+    { key: "main" },
+    {
+      context: {
+        getRuntimeConfig: () => runtimeConfig,
+        workerEnvironmentService: { hasInferenceForSession },
+      },
+    },
+  );
+
+  expect(compacted.ok, JSON.stringify(compacted)).toBe(false);
+  expect(compacted.error).toMatchObject({
+    code: "INVALID_REQUEST",
+    message: expect.stringContaining("has an active run"),
+  });
+  expect(hasInferenceForSession).toHaveBeenCalledWith(sessionId);
+  expect(embeddedRunMock.compactEmbeddedAgentSession).not.toHaveBeenCalled();
+  expectNoSessionQueueCleanup();
 });
 
 test("sessions.patch rejects archive while terminal compaction owns the session", async () => {
@@ -1394,7 +1499,7 @@ test("sessions.patch rejects archive while terminal compaction owns the session"
     sessionId: "sess-compact-archive",
     sessionKey,
     storePath,
-    totalLines: 2,
+    totalLines: 3,
   });
   const compaction = createDeferred<{
     ok: true;
@@ -1482,8 +1587,8 @@ test("sessions.compact maxLines trims SQLite transcript rows and returns an arch
   ws.close();
 });
 
-test("sessions.compact maxLines interrupts an active run before trimming rows", async () => {
-  const { storePath } = await createSessionStoreDir();
+test("sessions.compact maxLines refuses an active run without trimming rows", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
   await seedSessionEntry({
     entry: sessionStoreEntry("sess-main"),
     sessionKey: "agent:main:main",
@@ -1499,31 +1604,21 @@ test("sessions.compact maxLines interrupts an active run before trimming rows", 
   const { ws } = await openClient();
   // Simulate an embedded agent run actively appending to this session transcript.
   embeddedRunMock.activeIds.add("sess-main");
-  embeddedRunMock.waitResults.set("sess-main", true);
 
-  const compacted = await rpcReq<{
-    ok: true;
-    compacted: boolean;
-    kept?: number;
-  }>(ws, "sessions.compact", { key: "main", maxLines: 50 });
+  const compacted = await rpcReq(ws, "sessions.compact", { key: "main", maxLines: 50 });
 
-  // Regression for the ClawSweeper finding: the maxLines trim branch must run
-  // the same active-run interrupt guard as the LLM-summarize branch before it
-  // replaces transcript rows, so an active runner cannot keep appending stale rows.
-  expect(embeddedRunMock.abortCalls).toEqual(["sess-main"]);
-  expect(embeddedRunMock.waitCalls).toEqual(["sess-main"]);
-
-  // The guard ran first; row trimming still completed deterministically afterwards.
-  expect(compacted.ok).toBe(true);
-  expect(compacted.payload?.compacted).toBe(true);
-  expect(compacted.payload?.kept).toBe(50);
+  expect(compacted.ok).toBe(false);
+  expect(compacted.error?.message).toContain("has an active run");
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(embeddedRunMock.waitCalls).toEqual([]);
   await expect(
     loadTranscriptRows({
       sessionId: "sess-main",
       sessionKey: "agent:main:main",
       storePath,
     }),
-  ).resolves.toHaveLength(50);
+  ).resolves.toHaveLength(500);
+  expect((await fs.readdir(dir)).some((name) => name.includes(".bak"))).toBe(false);
 
   ws.close();
 });
@@ -1584,50 +1679,6 @@ test("sessions.compact maxLines does not interrupt an active run when no transcr
   expect(compacted.payload?.reason).toBe("no transcript");
   expect(embeddedRunMock.abortCalls).toEqual([]);
   expect(embeddedRunMock.waitCalls).toEqual([]);
-
-  ws.close();
-});
-
-test("sessions.compact maxLines aborts without trimming rows when an active run cannot be interrupted", async () => {
-  const { dir, storePath } = await createSessionStoreDir();
-  await seedSessionEntry({
-    entry: sessionStoreEntry("sess-main"),
-    sessionKey: "agent:main:main",
-    storePath,
-  });
-  await seedTranscriptRows({
-    sessionId: "sess-main",
-    sessionKey: "agent:main:main",
-    storePath,
-    totalLines: 500,
-  });
-
-  const { ws } = await openClient();
-  // Active embedded run that fails to end within the interrupt window.
-  embeddedRunMock.activeIds.add("sess-main");
-  embeddedRunMock.waitResults.set("sess-main", false);
-
-  const compacted = await rpcReq<{ ok: boolean }>(ws, "sessions.compact", {
-    key: "main",
-    maxLines: 50,
-  });
-
-  // Order proof: the guard ran first and failed, so the RPC errors out before
-  // replacing rows. If the guard ran after trimming, the transcript would
-  // already be 50 rows here. It is still 500 with no archive marker file.
-  expect(compacted.ok).toBe(false);
-  expect(embeddedRunMock.abortCalls).toEqual(["sess-main"]);
-  expect(embeddedRunMock.waitCalls).toEqual(["sess-main"]);
-
-  await expect(
-    loadTranscriptRows({
-      sessionId: "sess-main",
-      sessionKey: "agent:main:main",
-      storePath,
-    }),
-  ).resolves.toHaveLength(500);
-  const dirEntries = await fs.readdir(dir);
-  expect(dirEntries.some((name) => name.includes(".bak"))).toBe(false);
 
   ws.close();
 });

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -635,7 +635,7 @@ export function expectActiveRunCleanup(
   expect(embeddedRunMock.waitCalls).toEqual([sessionId]);
 }
 
-export function expectSessionQueueCleanup(expectedQueueKeys: string[]) {
+function expectSessionQueueCleanup(expectedQueueKeys: string[]) {
   expect(sessionCleanupMocks.clearSessionQueues).toHaveBeenCalledTimes(1);
   const clearedKeys = (
     sessionCleanupMocks.clearSessionQueues.mock.calls as unknown as Array<[string[]]>
@@ -643,6 +643,10 @@ export function expectSessionQueueCleanup(expectedQueueKeys: string[]) {
   for (const key of expectedQueueKeys) {
     expect(clearedKeys).toContain(key);
   }
+}
+
+export function expectNoSessionQueueCleanup() {
+  expect(sessionCleanupMocks.clearSessionQueues).not.toHaveBeenCalled();
 }
 
 export async function getMainPreviewEntry(ws: import("ws").WebSocket) {

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -326,6 +326,20 @@ export function isSessionWorkAdmissionActive(
   );
 }
 
+/** Whether another admitted turn currently owns any of these session identities. */
+export function isCompetingSessionWorkAdmissionActive(
+  scope: string,
+  identities: Iterable<string | undefined>,
+): boolean {
+  const currentAdmissions = CURRENT_SESSION_WORK_ADMISSIONS.getStore();
+  return normalizeSessionIdentities(scope, identities).some((identity) =>
+    Array.from(
+      ACTIVE_SESSION_WORK_ADMISSIONS.get(identity) ?? [],
+      (admission) => !currentAdmissions?.has(admission),
+    ).some(Boolean),
+  );
+}
+
 /** Active session identities for one store/lifecycle scope. */
 export function collectActiveSessionWorkAdmissionIdentities(scope: string): Set<string> {
   const normalizedScope = scope.trim();


### PR DESCRIPTION
## What Problem This Solves

`sessions compact` on a session with an in-flight agent turn killed the live turn (`status:"timeout", stopReason:"restart", timeoutPhase:"gateway_draining"`) — even when compaction then decided there was nothing to do (`ok:false, "Nothing to compact (session too small)"`). The user's live run was aborted for a compaction that never happened.

## Why This Change Was Made

Found by the R5 QA campaign (2× live repro): the lifecycle-mutation prepare step drained queues and interrupted session work admissions (`src/gateway/server-methods/sessions-compact.ts`) before the no-op verdict was computed much later in `src/agents/sessions/agent-session-compaction.ts`.

## User Impact

- Definitive no-op compacts (missing session, too-small, already-compacted) are now decided by a canonical preflight **before** any queue clearing or admission interruption — they can never disturb a live run.
- Real compaction against a session with active work now **refuses** with a clear `INVALID_REQUEST` error instead of silently killing the run — consistent with `sessions cleanup` preserving active sessions and archive refusing active mutation. No `--force` added.
- Idle-session compaction is unchanged; lifecycle fencing still blocks new work during an actual compaction.

## Evidence

- Preflight: `src/agents/sessions/manual-compaction-preflight.ts`, wired at `src/gateway/server-methods/sessions-compaction-runner.ts:54` and before queue clearing at `sessions-compact.ts:198`; active-work guard at `sessions-compact.ts:212,:261`; competing-admission detection at `src/sessions/session-lifecycle-admission.ts:330`.
- Tests: gateway compaction 20/20, agent compaction 13/13 — covering no-op-with-active-run (run survives), real-compact-refusal, idle-path unchanged, maxLines trimming.
- `node scripts/check-changed.mjs` green (types/lint/format/guards).
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.87), no actionable findings".
