### PR TITLE
fix(ios): refresh stale localization catalog

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main CI rejected the generated iOS localization catalog as stale after a new native string landed.

## Why This Change Was Made

Regenerates the canonical iOS string catalog and contradiction report with the repository-owned generator. No runtime logic changes.

## User Impact

No user-visible behavior change. Restores deterministic native localization checks on main.

## Evidence

- Exact failing main run: https://github.com/openclaw/openclaw/actions/runs/29629284704
- `node --import tsx scripts/apple-app-i18n.ts sync-ios --write`
- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` — 13 passed
- Autoreview: clean, no accepted/actionable findings
