### PR TITLE
fix(agents): expose filesystem tool results in Code Mode

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -525,18 +525,21 @@ export default defineToolPlugin({
 For `api.registerTool(...)` or a factory tool, put the same `outputSchema`
 property on the returned `AnyAgentTool` object.
 
-Current built-in contracts include `agents_list`, `conversations_list`,
-`conversations_send`, `conversations_turn`, `openclaw`, `screen`,
-`sessions_search`, `spawn_task`, `terminal`, `web_fetch`, and `web_search`.
+Current built-in contracts include `agents_list`, `apply_patch`,
+`conversations_list`, `conversations_send`, `conversations_turn`, `edit`,
+`openclaw`, `read`, `screen`, `sessions_search`, `spawn_task`, `terminal`,
+`web_fetch`, and `web_search`.
 Exact passthroughs can reuse their owning protocol schema instead of
 duplicating a model-only contract. For example, the conversation tools expose
 the same Gateway result schemas used by `conversations.list`,
 `conversations.send`, and `conversations.turn`; `web_fetch` owns a tool-local
 schema whose hint exposes stable metadata, text, cache state, and nested spill
 metadata; `web_search` declares its exact normalized results/answer/error/raw
-union as a complete quick-index hint. When the quick index declares the
-fields, one cell can compose discovery and delivery without a separate
-inspection turn:
+union as a complete quick-index hint. Filesystem contracts return structured
+read text, image, truncation, and optional-not-found outcomes; explicit edit
+change state plus diff/patch data; and apply-patch path summaries. When the
+quick index declares the fields, one cell can compose discovery and delivery
+without a separate inspection turn:
 
 ```javascript
 const listed = await tools.conversations_list({ query: "build bot" });

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -38,7 +38,13 @@ import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
-import { createEditTool, createReadTool, createWriteTool } from "./sessions/index.js";
+import {
+  createEditTool,
+  createReadTool,
+  createWriteTool,
+  type ReadToolDetails,
+  type ReadToolTruncationDetails,
+} from "./sessions/index.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
@@ -435,6 +441,56 @@ async function normalizeReadImageResult(
   });
 
   return { ...result, content: nextContent };
+}
+
+function normalizeReadResultDetails(
+  result: AgentToolResult<unknown>,
+): AgentToolResult<ReadToolDetails> {
+  const currentDetails =
+    result.details && typeof result.details === "object"
+      ? (result.details as Record<string, unknown>)
+      : undefined;
+  if (
+    currentDetails?.status === "not_found" &&
+    typeof currentDetails.path === "string" &&
+    currentDetails.optional === true
+  ) {
+    return {
+      ...result,
+      details: {
+        kind: "not_found",
+        status: "not_found",
+        path: currentDetails.path,
+        optional: true,
+      },
+    };
+  }
+
+  const content = Array.isArray(result.content) ? result.content : [];
+  const text = getToolResultText(result) ?? "";
+  const image = content.find(
+    (block): block is ImageContentBlock =>
+      Boolean(block) &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "image" &&
+      typeof (block as { mimeType?: unknown }).mimeType === "string",
+  );
+  if (image) {
+    return { ...result, details: { kind: "image", content: text, mimeType: image.mimeType } };
+  }
+
+  const truncation = currentDetails?.truncation;
+  if (truncation && typeof truncation === "object") {
+    return {
+      ...result,
+      details: {
+        kind: "truncated",
+        content: text,
+        truncation: truncation as ReadToolTruncationDetails,
+      },
+    };
+  }
+  return { ...result, details: { kind: "text", content: text } };
 }
 
 /** Wrap a file tool so path params stay inside the workspace root. */
@@ -895,11 +951,12 @@ export function createOpenClawReadTool(
         typeof normalizedRecord?.path === "string" ? normalizedRecord.path : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
-      return sanitizeToolResultImages(
+      const sanitizedResult = await sanitizeToolResultImages(
         normalizedResult,
         `read:${filePath}`,
         options?.imageSanitization,
       );
+      return normalizeReadResultDetails(sanitizedResult);
     },
   };
 }

--- a/src/agents/agent-tools.workspace-only-false.test.ts
+++ b/src/agents/agent-tools.workspace-only-false.test.ts
@@ -176,6 +176,7 @@ describe("FS tools with workspaceOnly=false", () => {
         },
       ],
       details: {
+        kind: "not_found",
         status: "not_found",
         path: "memory/2026-05-15.md",
         optional: true,

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -97,6 +97,20 @@ const applyPatchSchema = Type.Object({
   }),
 });
 
+const ApplyPatchToolOutputSchema = Type.Object(
+  {
+    summary: Type.Object(
+      {
+        added: Type.Array(Type.String()),
+        modified: Type.Array(Type.String()),
+        deleted: Type.Array(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
 /** Create the agent tool wrapper for applying patch-envelope input. */
 export function createApplyPatchTool(
   options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
@@ -110,6 +124,7 @@ export function createApplyPatchTool(
     label: "apply_patch",
     description: "Patch one/many files. Input requires *** Begin Patch and *** End Patch.",
     parameters: applyPatchSchema,
+    outputSchema: ApplyPatchToolOutputSchema,
     execute: async (_toolCallId, args, signal) => {
       const params = args as { input?: string };
       const input = typeof params.input === "string" ? params.input : "";

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
+import { createOpenClawReadTool } from "./agent-tools.read.js";
 import {
   clearCodeModeNamespacesForPlugin,
   createCodeModeNamespaceTool,
@@ -23,6 +24,7 @@ import {
   resolveCodeModeConfig,
 } from "./code-mode.js";
 import { testing } from "./code-mode.test-support.js";
+import { createReadTool } from "./sessions/index.js";
 import { createToolSearchCatalogRef, type ToolSearchCatalogRef } from "./tool-search.js";
 import {
   TOOL_CALL_RAW_TOOL_NAME,
@@ -1002,6 +1004,36 @@ describe("Code Mode", () => {
     expect(details.output).toEqual([{ type: "text", text: "created" }]);
     expect(details.telemetry).toMatchObject({ searchCount: 1, describeCount: 0, callCount: 1 });
     expect(ticket.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns ordinary read content through tools.callValue", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const read = createOpenClawReadTool(
+      createReadTool("/workspace", {
+        operations: {
+          access: async () => {},
+          detectImageMimeType: async () => null,
+          readFile: async () => Buffer.from("ordinary file content"),
+        },
+      }) as unknown as Parameters<typeof createOpenClawReadTool>[0],
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, read],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = await runUntilCompleted({
+      execTool: expectDefined(codeModeTools[0], "codeModeTools[0] test invariant"),
+      waitTool: expectDefined(codeModeTools[1], "codeModeTools[1] test invariant"),
+      code: `return await tools.callValue("openclaw:core:read", { path: "notes.txt" });`,
+    });
+
+    expect(details.status).toBe("completed");
+    expect(details.value).toEqual({ kind: "text", content: "ordinary file content" });
   });
 
   it("resolves sequential bridge tool calls inline within one exec instead of a wait per call", async () => {

--- a/src/agents/filesystem-tools-output-contract.test.ts
+++ b/src/agents/filesystem-tools-output-contract.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Value } from "typebox/value";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createOpenClawReadTool } from "./agent-tools.read.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+import { createApplyPatchTool } from "./apply-patch.js";
+import { createEditTool, createReadTool } from "./sessions/index.js";
+import { DEFAULT_MAX_BYTES } from "./sessions/tools/truncate.js";
+import { compactToolOutputHint } from "./tool-schema-hints.js";
+
+const ONE_PIXEL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function expectContract(tool: AnyAgentTool, details: unknown): void {
+  expect(tool.outputSchema).toBeDefined();
+  expect(Value.Check(tool.outputSchema!, details)).toBe(true);
+}
+
+describe("filesystem tool output contracts", () => {
+  let tmpDir = "";
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-filesystem-contract-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("validates read text, image, truncation, and optional-not-found results", async () => {
+    await fs.writeFile(path.join(tmpDir, "notes.txt"), "ordinary text\n", "utf8");
+    await fs.writeFile(path.join(tmpDir, "pixel.png"), Buffer.from(ONE_PIXEL_PNG_BASE64, "base64"));
+    await fs.writeFile(path.join(tmpDir, "long.txt"), "x".repeat(DEFAULT_MAX_BYTES + 1), "utf8");
+
+    const tool = createOpenClawReadTool(
+      createReadTool(tmpDir, { autoResizeImages: false }) as unknown as AnyAgentTool,
+    );
+    const text = await tool.execute("read-text", { path: "notes.txt", limit: 10 });
+    const image = await tool.execute("read-image", { path: "pixel.png", limit: 10 });
+    const truncated = await tool.execute("read-truncated", { path: "long.txt", limit: 10 });
+    const notFound = await tool.execute("read-not-found", { path: "memory/2026-07-17.md" });
+
+    for (const result of [text, image, truncated, notFound]) {
+      expectContract(tool, result.details);
+    }
+    expect(text.details).toEqual({ kind: "text", content: "ordinary text\n" });
+    expect(image.details).toMatchObject({ kind: "image", mimeType: "image/png" });
+    expect(truncated.details).toMatchObject({ kind: "truncated" });
+    expect(notFound.details).toEqual({
+      kind: "not_found",
+      status: "not_found",
+      path: "memory/2026-07-17.md",
+      optional: true,
+    });
+    expect(compactToolOutputHint(tool.outputSchema)).toBe(
+      '{ content: string; kind: "text" } | { content: string; kind: "image"; mimeType: string } | { content: string; kind: "truncated"; truncation: { firstLineExceedsLimit: boolean; lastLinePartial: boolean; maxBytes: number; maxLines: number; outputBytes: number; outputLines: number; totalBytes: number; totalLines: number; truncated: true; truncatedBy: "lines" | "bytes" } } | { kind: "not_found"; optional: true; path: string; status: "not_found" }',
+    );
+  });
+
+  it("validates edit changed and no-op results", async () => {
+    const filePath = path.join(tmpDir, "edit.txt");
+    await fs.writeFile(filePath, "before\n", "utf8");
+    const tool = createEditTool(tmpDir) as unknown as AnyAgentTool;
+    const changed = await tool.execute("edit-changed", {
+      path: filePath,
+      edits: [{ oldText: "before", newText: "after" }],
+    });
+    const noOp = await tool.execute("edit-no-op", {
+      path: filePath,
+      edits: [{ oldText: "after", newText: "after" }],
+    });
+
+    expectContract(tool, changed.details);
+    expectContract(tool, noOp.details);
+    expect(changed.details).toMatchObject({ changed: true });
+    expect(noOp.details).toEqual({ changed: false });
+    expect(compactToolOutputHint(tool.outputSchema)).toBe(
+      "{ changed: false } | { changed: true; diff: string; patch: string; firstChangedLine?: number }",
+    );
+  });
+
+  it("validates apply_patch path summaries", async () => {
+    const tool = createApplyPatchTool({ cwd: tmpDir }) as unknown as AnyAgentTool;
+    const result = await tool.execute("patch-add", {
+      input: "*** Begin Patch\n*** Add File: added.txt\n+added\n*** End Patch",
+    });
+
+    expectContract(tool, result.details);
+    expect(result.details).toEqual({
+      summary: { added: ["added.txt"], modified: [], deleted: [] },
+    });
+    expect(compactToolOutputHint(tool.outputSchema)).toBe(
+      "{ summary: { added: Array<string>; deleted: Array<string>; modified: Array<string> } }",
+    );
+  });
+});

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -503,6 +503,8 @@ export interface ToolDefinition<
   promptGuidelines?: string[];
   /** Parameter schema (TypeBox) */
   parameters: TParams;
+  /** Exact schema for the structured value returned in AgentToolResult.details. */
+  outputSchema?: TSchema;
   /** Controls whether ToolExecutionComponent renders the standard colored shell or the tool renders its own framing. */
   renderShell?: "default" | "self";
 

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -199,6 +199,10 @@ describe("edit tool", () => {
     ].join("\n");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(expected);
     const details = result.details as EditToolDetails;
+    expect(details.changed).toBe(true);
+    if (!details.changed) {
+      throw new Error("expected changed edit details");
+    }
     expect(applyPatch(original, details.patch)).toBe(expected);
   });
 
@@ -219,6 +223,10 @@ describe("edit tool", () => {
     const expected = "after\nafter   \n";
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(expected);
     const details = result.details as EditToolDetails;
+    expect(details.changed).toBe(true);
+    if (!details.changed) {
+      throw new Error("expected changed edit details");
+    }
     expect(applyPatch(original, details.patch)).toBe(expected);
   });
 

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -68,6 +68,19 @@ const editSchema = Type.Object(
   },
   {},
 );
+
+const EditToolOutputSchema = Type.Union([
+  Type.Object({ changed: Type.Literal(false) }, { additionalProperties: false }),
+  Type.Object(
+    {
+      changed: Type.Literal(true),
+      diff: Type.String(),
+      patch: Type.String(),
+      firstChangedLine: Type.Optional(Type.Integer({ minimum: 1 })),
+    },
+    { additionalProperties: false },
+  ),
+]);
 type LegacyEditToolInput = Record<string, unknown> & {
   edits?: unknown;
   oldText?: unknown;
@@ -309,7 +322,7 @@ function formatEditResult(
     return theme.fg("error", errorText);
   }
 
-  const resultDiff = result.details?.diff;
+  const resultDiff = result.details?.changed === true ? result.details.diff : undefined;
   if (resultDiff && resultDiff !== previewDiff) {
     return renderDiff(resultDiff);
   }
@@ -379,7 +392,7 @@ function setEditPreview(
 export function createEditToolDefinition(
   cwd: string,
   options?: EditToolOptions,
-): ToolDefinition<typeof editSchema, EditToolDetails | undefined, EditRenderState> {
+): ToolDefinition<typeof editSchema, EditToolDetails, EditRenderState> {
   const ops = options?.operations ?? defaultEditOperations;
   return {
     name: "edit",
@@ -394,6 +407,7 @@ export function createEditToolDefinition(
       "oldText minimal but unique; no padding",
     ],
     parameters: editSchema,
+    outputSchema: EditToolOutputSchema,
     renderShell: "self",
     prepareArguments: prepareEditArguments,
     async execute(toolCallId, input: EditToolInput, signal?: AbortSignal, onUpdate?, ctx?) {
@@ -440,7 +454,7 @@ export function createEditToolDefinition(
             return {
               ...textResult(
                 `No changes made to ${path}. The replacement text is identical to the original.`,
-                undefined,
+                { changed: false } satisfies EditToolDetails,
               ),
               terminate: true,
             };
@@ -466,9 +480,12 @@ export function createEditToolDefinition(
               },
             ],
             details: {
+              changed: true,
               diff: diffResult.diff,
               patch,
-              firstChangedLine: diffResult.firstChangedLine,
+              ...(diffResult.firstChangedLine === undefined
+                ? {}
+                : { firstChangedLine: diffResult.firstChangedLine }),
             },
           };
         } catch (error: unknown) {
@@ -491,7 +508,7 @@ export function createEditToolDefinition(
                   text: `Successfully replaced ${realEdits.length} block(s) in ${path}.`,
                 },
               ],
-              details: { diff: "", patch: "" },
+              details: { changed: true, diff: "", patch: "" },
             };
           }
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
@@ -502,7 +519,7 @@ export function createEditToolDefinition(
             return {
               ...textResult(
                 `No changes made to ${path}. The replacement produced identical content.`,
-                undefined,
+                { changed: false } satisfies EditToolDetails,
               ),
               terminate: true,
             };
@@ -550,7 +567,10 @@ export function createEditToolDefinition(
         ? JSON.stringify({ path: previewInput.path, edits: previewInput.edits })
         : undefined;
       const typedResult = result as EditToolResultLike;
-      const resultDiff = !context.isError ? typedResult.details?.diff : undefined;
+      const resultDiff =
+        !context.isError && typedResult.details?.changed === true
+          ? typedResult.details.diff
+          : undefined;
       let changed = false;
       if (callComponent) {
         if (typeof resultDiff === "string") {
@@ -559,7 +579,10 @@ export function createEditToolDefinition(
               callComponent,
               {
                 diff: resultDiff,
-                firstChangedLine: typedResult.details?.firstChangedLine,
+                firstChangedLine:
+                  typedResult.details?.changed === true
+                    ? typedResult.details.firstChangedLine
+                    : undefined,
               },
               argsKey,
             ) || changed;

--- a/src/agents/sessions/tools/index.ts
+++ b/src/agents/sessions/tools/index.ts
@@ -25,6 +25,7 @@ export type {
   LsToolInput,
   ReadToolDetails,
   ReadToolInput,
+  ReadToolTruncationDetails,
   WriteToolInput,
 } from "./tool-contracts.js";
 export {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -32,15 +32,93 @@ import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/type
 import { normalizePositiveLimit } from "./limits.js";
 import { resolveReadPath } from "./path-utils.js";
 import { getTextOutput, invalidArgText, replaceTabs, shortenPath, str } from "./render-utils.js";
-import type { ReadToolDetails } from "./tool-contracts.js";
+import type { ReadToolDetails, ReadToolTruncationDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "./truncate.js";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+  type TruncationResult,
+} from "./truncate.js";
 
 const readSchema = Type.Object({
   path: Type.String({ description: "File path; relative/absolute." }),
   offset: Type.Optional(Type.Integer({ minimum: 1, description: "Start line; 1-based." })),
   limit: Type.Optional(Type.Number({ description: "Max lines." })),
 });
+
+const ReadTruncationOutputSchema = Type.Object(
+  {
+    truncated: Type.Literal(true),
+    truncatedBy: Type.Union([Type.Literal("lines"), Type.Literal("bytes")]),
+    totalLines: Type.Integer({ minimum: 0 }),
+    totalBytes: Type.Integer({ minimum: 0 }),
+    outputLines: Type.Integer({ minimum: 0 }),
+    outputBytes: Type.Integer({ minimum: 0 }),
+    lastLinePartial: Type.Boolean(),
+    firstLineExceedsLimit: Type.Boolean(),
+    maxLines: Type.Integer({ minimum: 1 }),
+    maxBytes: Type.Integer({ minimum: 1 }),
+  },
+  { additionalProperties: false },
+);
+
+const ReadToolOutputSchema = Type.Union([
+  Type.Object(
+    { kind: Type.Literal("text"), content: Type.String() },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      kind: Type.Literal("image"),
+      content: Type.String(),
+      mimeType: Type.String(),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      kind: Type.Literal("truncated"),
+      content: Type.String(),
+      truncation: ReadTruncationOutputSchema,
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      kind: Type.Literal("not_found"),
+      status: Type.Literal("not_found"),
+      path: Type.String(),
+      optional: Type.Literal(true),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+function withoutTruncationContent(truncation: TruncationResult): ReadToolTruncationDetails {
+  const { content: _content, ...details } = truncation;
+  return details;
+}
+
+function createReadDetails(
+  content: (TextContent | ImageContent)[],
+  truncation?: TruncationResult,
+): ReadToolDetails {
+  const text = content.find((part): part is TextContent => part.type === "text")?.text ?? "";
+  const image = content.find((part): part is ImageContent => part.type === "image");
+  if (image) {
+    return { kind: "image", content: text, mimeType: image.mimeType };
+  }
+  if (truncation) {
+    return {
+      kind: "truncated",
+      content: text,
+      truncation: withoutTruncationContent(truncation),
+    };
+  }
+  return { kind: "text", content: text };
+}
 interface CompactReadClassification {
   kind: "docs" | "resource" | "skill";
   label: string;
@@ -235,7 +313,7 @@ function formatReadResult(
     text += `${theme.fg("muted", `\n... (${remaining} more lines,`)} ${keyHint("app.tools.expand", "to expand")})`;
   }
 
-  const truncation = result.details?.truncation;
+  const truncation = result.details?.kind === "truncated" ? result.details.truncation : undefined;
   if (truncation?.truncated) {
     if (truncation.firstLineExceedsLimit) {
       text += `\n${theme.fg("warning", `[First line exceeds ${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit]`)}`;
@@ -251,7 +329,7 @@ function formatReadResult(
 export function createReadToolDefinition(
   cwd: string,
   options?: ReadToolOptions,
-): ToolDefinition<typeof readSchema, ReadToolDetails | undefined> {
+): ToolDefinition<typeof readSchema, ReadToolDetails> {
   const autoResizeImages = options?.autoResizeImages ?? true;
   const ops = options?.operations ?? defaultReadOperations;
   return {
@@ -261,6 +339,7 @@ export function createReadToolDefinition(
     promptSnippet: "Read file contents",
     promptGuidelines: ["Use read to examine files instead of cat or sed."],
     parameters: readSchema,
+    outputSchema: ReadToolOutputSchema,
     async execute(
       toolCallId,
       { path, offset, limit }: { path: string; offset?: number; limit?: number },
@@ -275,7 +354,7 @@ export function createReadToolDefinition(
       }
       return new Promise<{
         content: (TextContent | ImageContent)[];
-        details: ReadToolDetails | undefined;
+        details: ReadToolDetails;
       }>((resolve, reject) => {
         if (signal?.aborted) {
           reject(new Error("Operation aborted"));
@@ -300,7 +379,7 @@ export function createReadToolDefinition(
               ? await ops.detectImageMimeType(absolutePath)
               : undefined;
             let content: (TextContent | ImageContent)[];
-            let details: ReadToolDetails | undefined;
+            let truncationDetails: TruncationResult | undefined;
             const nonVisionImageNote = getNonVisionImageNote(ctx?.model);
             if (mimeType) {
               // Read image as binary.
@@ -364,7 +443,7 @@ export function createReadToolDefinition(
                 }
                 const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
                 outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
-                details = { truncation };
+                truncationDetails = truncation;
               } else if (truncation.truncated) {
                 // Truncation occurred. Build an actionable continuation notice.
                 const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
@@ -375,7 +454,7 @@ export function createReadToolDefinition(
                 } else {
                   outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
                 }
-                details = { truncation };
+                truncationDetails = truncation;
               } else if (
                 userLimitedLines !== undefined &&
                 startLine + userLimitedLines < allLines.length
@@ -395,7 +474,7 @@ export function createReadToolDefinition(
               return;
             }
             signal?.removeEventListener("abort", onAbort);
-            resolve({ content, details });
+            resolve({ content, details: createReadDetails(content, truncationDetails) });
           } catch (error: unknown) {
             signal?.removeEventListener("abort", onAbort);
             if (!aborted) {

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -25,14 +25,19 @@ export interface EditToolInput {
   edits: Edit[];
 }
 
-export interface EditToolDetails {
-  /** Display-oriented diff of the changes made */
-  diff: string;
-  /** Standard unified patch of the changes made */
-  patch: string;
-  /** Line number of the first change in the new file (for editor navigation) */
-  firstChangedLine?: number;
-}
+export type EditToolDetails =
+  | {
+      changed: false;
+    }
+  | {
+      changed: true;
+      /** Display-oriented diff of the changes made */
+      diff: string;
+      /** Standard unified patch of the changes made */
+      patch: string;
+      /** Line number of the first change in the new file (for editor navigation) */
+      firstChangedLine?: number;
+    };
 
 export interface FindToolInput {
   pattern: string;
@@ -77,9 +82,22 @@ export interface ReadToolInput {
   limit?: number;
 }
 
-export interface ReadToolDetails {
-  truncation?: TruncationResult;
-}
+export type ReadToolTruncationDetails = Omit<TruncationResult, "content">;
+
+export type ReadToolDetails =
+  | { kind: "text"; content: string }
+  | { kind: "image"; content: string; mimeType: string }
+  | {
+      kind: "truncated";
+      content: string;
+      truncation: ReadToolTruncationDetails;
+    }
+  | {
+      kind: "not_found";
+      status: "not_found";
+      path: string;
+      optional: true;
+    };
 
 export interface WriteToolInput {
   path: string;

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -22,6 +22,7 @@ export function wrapToolDefinition<
     ...(definition.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
     description: definition.description,
     parameters: definition.parameters,
+    ...(definition.outputSchema ? { outputSchema: definition.outputSchema } : {}),
     prepareArguments: definition.prepareArguments,
     executionMode: definition.executionMode,
     execute: (toolCallId, params, signal, onUpdate) =>
@@ -50,6 +51,7 @@ export function createToolDefinitionFromAgentTool(tool: AgentTool): ToolDefiniti
     ...(tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
     description: tool.description,
     parameters: tool.parameters,
+    ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
     prepareArguments: tool.prepareArguments,
     executionMode: tool.executionMode,
     execute: async (toolCallId, params, signal, onUpdate) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Code Mode callers reading ordinary files through `tools.callValue("openclaw:core:read", ...)` received `undefined`, so file content could not be composed into later calls. The same high-volume workflow also lacked declared result contracts for edits and patch application.

## Why This Change Was Made

Read now returns a closed, discriminated details union for text, image, truncation, and optional-not-found outcomes after adaptive paging and image normalization. Edit declares explicit changed/no-op variants, while apply_patch declares its added/modified/deleted path summary. Session tool adapters preserve these tool-local TypeBox contracts.

The read return value is an intentional compatibility change for Code Mode. Existing optional-not-found fields remain available, with an additive `kind` discriminator. Rendered content blocks remain unchanged.

AI-assisted. I reviewed the whole result path, callers, renderers, sibling contract pattern, tests, TypeBox behavior, and the Code Mode bridge.

## User Impact

Code Mode can now read ordinary file text as a structured value and compose it without dropping to the raw result envelope. It can also branch reliably on edit no-ops versus real changes and inspect apply_patch summaries from the quick index.

Release note: Code Mode filesystem tools now expose structured read, edit, and apply_patch results for composition.

## Evidence

- Exact head: `5c9a9fb3327bc3241dc83e6efd4452a37b24a88d`
- Blacksmith Testbox: 7 focused files, 166 tests passed, including a real QuickJS-WASI `tools.callValue("openclaw:core:read", ...)` round trip and executed-result `Value.Check` coverage for every read/edit variant plus apply_patch: https://github.com/openclaw/openclaw/actions/runs/29629586159
- `pnpm check:changed` passed core/core-test typechecks, formatting, exhaustive core lint, plugin boundaries, import-cycle checks, and repository guards on the same patch before the conflict-free rebase.
- Exact compact output-hint snapshots cover all three contracts.
- Fresh exact-head autoreview: clean, no accepted/actionable findings.
