### PR TITLE
fix(qa): unblock Matrix maturity scorecard runs

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { readQaBootstrapScenarioCatalog } from "../../scenario-catalog.js";
+import {
+  readQaBootstrapScenarioCatalog,
+  readQaScenarioById,
+  readQaScenarioExecutionConfig,
+} from "../../scenario-catalog.js";
 
 function readModuleBinding(
   scenario: ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number],
@@ -78,11 +82,18 @@ describe("Matrix QA Lab scenario flows", () => {
     expect(bindings.size).toBe(82);
   });
 
-  it("prepares the shared reaction canary only for reaction scenarios", () => {
+  it("prepares the shared canary only for canary-dependent scenarios", () => {
+    const canaryScenarioIds = new Set([
+      "matrix-reaction-not-a-reply",
+      "matrix-reaction-notification",
+      "matrix-reaction-redaction-observed",
+      "matrix-reaction-threaded",
+      "matrix-voice-preflight-mention",
+    ]);
     for (const scenario of scenarios) {
       const config = scenario.execution.config ?? {};
       expect(config.matrixRequireCanary === true, scenario.id).toBe(
-        scenario.id.startsWith("matrix-reaction-"),
+        canaryScenarioIds.has(scenario.id),
       );
       expect(readModuleBinding(scenario).callAction.args).toEqual([{ expr: "scenarioContext" }]);
     }
@@ -100,6 +111,44 @@ describe("Matrix QA Lab scenario flows", () => {
       call: "scenarioModule.runMatrixQaAllowlistHotReloadScenario",
       args: [{ expr: "scenarioContext" }],
       saveAs: "result",
+    });
+  });
+
+  it("loads the voice preflight provider and media overrides", () => {
+    expect(readQaScenarioById("matrix-voice-preflight-mention").execution).toMatchObject({
+      kind: "flow",
+      providerMode: "mock-openai",
+      retryCount: 0,
+      timeoutMs: 90_000,
+    });
+    expect(readQaScenarioById("matrix-voice-preflight-mention").gatewayConfigPatch).toMatchObject({
+      tools: {
+        media: {
+          audio: {
+            echoTranscript: true,
+            enabled: true,
+            models: [{ model: "gpt-4o-transcribe", provider: "openai" }],
+            prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
+          },
+        },
+      },
+      messages: {
+        groupChat: {
+          mentionPatterns: ["matrix\\W+qa\\W+voice\\W+pre[ -]?flight\\W+ok(?:ay)?"],
+        },
+      },
+    });
+    expect(readQaScenarioExecutionConfig("matrix-voice-preflight-mention")).toMatchObject({
+      matrixRequireCanary: true,
+      matrixConfigOverrides: {
+        audio: {
+          echoTranscript: true,
+          enabled: true,
+          models: [{ model: "gpt-4o-transcribe", provider: "openai" }],
+          prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
+        },
+        groupMentionPatterns: ["matrix\\W+qa\\W+voice\\W+pre[ -]?flight\\W+ok(?:ay)?"],
+      },
     });
   });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -1,5 +1,5 @@
 // QA Lab Matrix tests cover scenario environment readiness boundaries.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const buildMatrixQaConfig = vi.hoisted(() =>
   vi.fn(() => ({ channels: { matrix: { execApprovals: { enabled: true } } } })),
@@ -10,8 +10,13 @@ vi.mock("./scenario-runtime-room.js", () => ({ runMatrixQaCanary: vi.fn() }));
 
 import { createMatrixQaScenarioEnvironment } from "./scenario-environment.js";
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("matrix scenario environment", () => {
   it("waits for config restart settle before accepting Matrix readiness", async () => {
+    vi.useFakeTimers();
     const callOrder: string[] = [];
     let configReadCount = 0;
     let statusReadCount = 0;
@@ -24,10 +29,24 @@ describe("matrix scenario environment", () => {
         callOrder.push(method);
         if (method === "config.get") {
           configReadCount += 1;
-          return configReadCount === 1 ? { config: {} } : { hash: "config-hash" };
+          if (configReadCount === 1) {
+            return { config: {} };
+          }
+          if (configReadCount === 2) {
+            return { hash: "config-hash" };
+          }
+          return {
+            appliedConfigHash: configReadCount === 3 ? "old-revision" : "new-revision",
+            configRevisionHash: "new-revision",
+            hash: "patched-config-hash",
+          };
         }
         if (method === "config.patch") {
-          return { ok: true };
+          return {
+            hash: "patched-config-hash",
+            ok: true,
+            sentinel: { payload: { stats: { requiresRestart: true } } },
+          };
         }
         if (method === "channels.status") {
           statusReadCount += 1;
@@ -38,7 +57,7 @@ describe("matrix scenario environment", () => {
                   accountId: "sut",
                   connected: true,
                   healthState: "healthy",
-                  lastStartAt: 100,
+                  lastStartAt: statusReadCount < 3 ? 100 : 200,
                   restartPending: false,
                   running: true,
                 },
@@ -68,13 +87,15 @@ describe("matrix scenario environment", () => {
       callOrder.push("config.settle");
     });
 
-    const prepared = await environment.prepareFlow({
+    const preparing = environment.prepareFlow({
       config: {},
       gateway,
       outputDir: "/tmp/matrix-qa/output",
       timeoutMs: 1_000,
       waitForConfigRestartSettle,
     });
+    await vi.runAllTimersAsync();
+    const prepared = await preparing;
     const scenarioContext = prepared.scenarioContext;
     await scenarioContext.gatewayCall?.(
       "exec.approval.request",
@@ -82,12 +103,16 @@ describe("matrix scenario environment", () => {
       { expectFinal: false, timeoutMs: 1_000 },
     );
 
-    expect(statusReadCount).toBe(1);
+    expect(statusReadCount).toBe(3);
     expect(callOrder).toEqual([
       "config.get",
+      "channels.status",
       "config.get",
       "config.patch",
       "config.settle",
+      "config.get",
+      "config.get",
+      "channels.status",
       "channels.status",
       "exec.approval.request",
     ]);
@@ -100,5 +125,93 @@ describe("matrix scenario environment", () => {
       { id: "approval-1" },
       { expectFinal: false, timeoutMs: 1_000 },
     );
+  });
+
+  it("waits for a pending config revision after a no-op patch", async () => {
+    vi.useFakeTimers();
+    const callOrder: string[] = [];
+    let configReadCount = 0;
+    const gateway = {
+      baseUrl: "http://127.0.0.1:12345",
+      runtimeEnv: {},
+      tempRoot: "/tmp/matrix-qa",
+      workspaceDir: "/tmp/matrix-qa/workspace",
+      call: vi.fn(async (method: string) => {
+        callOrder.push(method);
+        if (method === "config.get") {
+          configReadCount += 1;
+          if (configReadCount === 1) {
+            return { config: {} };
+          }
+          if (configReadCount === 2) {
+            return { hash: "config-hash" };
+          }
+          return {
+            appliedConfigHash: configReadCount === 3 ? "old-revision" : "new-revision",
+            configRevisionHash: "new-revision",
+            hash: "config-hash",
+          };
+        }
+        if (method === "config.patch") {
+          return {
+            noop: true,
+            ok: true,
+          };
+        }
+        if (method === "channels.status") {
+          return {
+            channelAccounts: {
+              matrix: [
+                {
+                  accountId: "sut",
+                  connected: true,
+                  healthState: "healthy",
+                  lastStartAt: 100,
+                  restartPending: false,
+                  running: true,
+                },
+              ],
+            },
+          };
+        }
+        throw new Error(`unexpected gateway method ${method}`);
+      }),
+    };
+    const environment = createMatrixQaScenarioEnvironment({
+      accountId: "sut",
+      harness: { baseUrl: "http://127.0.0.1:8008", recording: {} } as never,
+      observedEvents: [],
+      provisioning: {
+        driver: { accessToken: "fixture", userId: "@driver:test" },
+        observer: { accessToken: "fixture", userId: "@observer:test" },
+        roomId: "!room:test",
+        sut: { accessToken: "fixture", userId: "@sut:test" },
+        topology: { rooms: [] },
+      } as never,
+    });
+    const waitForConfigRestartSettle = vi.fn(async () => {
+      callOrder.push("config.settle");
+    });
+
+    const preparing = environment.prepareFlow({
+      config: {},
+      gateway,
+      outputDir: "/tmp/matrix-qa/output",
+      timeoutMs: 1_000,
+      waitForConfigRestartSettle,
+    });
+    await vi.runAllTimersAsync();
+    await preparing;
+
+    expect(callOrder).toEqual([
+      "config.get",
+      "channels.status",
+      "config.get",
+      "config.patch",
+      "config.get",
+      "config.get",
+      "channels.status",
+    ]);
+    expect(waitForConfigRestartSettle).not.toHaveBeenCalled();
   });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -24,6 +24,24 @@ type MatrixQaScenarioEnvironmentParams = {
   provisioning: MatrixQaProvisionResult;
 };
 
+type MatrixQaConfigPatchResult = {
+  hash?: string;
+  noop?: boolean;
+  sentinel?: {
+    payload?: {
+      stats?: {
+        requiresRestart?: boolean;
+      };
+    };
+  };
+};
+
+type MatrixQaConfigApplyStatus = {
+  appliedConfigHash?: string | null;
+  configRevisionHash?: string;
+  hash?: string;
+};
+
 function readMatrixConfigOverrides(
   config: Record<string, unknown>,
 ): MatrixQaConfigOverrides | undefined {
@@ -51,7 +69,7 @@ async function patchGatewayConfig(params: {
       throw new Error("Matrix QA config patch requires config.get hash");
     }
     try {
-      return (await params.gateway.call(
+      const result = (await params.gateway.call(
         "config.patch",
         {
           raw: JSON.stringify(params.patch, null, 2),
@@ -60,7 +78,8 @@ async function patchGatewayConfig(params: {
           restartDelayMs: params.restartDelayMs ?? 0,
         },
         { timeoutMs: 60_000 },
-      )) as { noop?: boolean };
+      )) as MatrixQaConfigPatchResult;
+      return result.noop === true ? { ...result, hash: snapshot.hash } : result;
     } catch (error) {
       if (attempt === 0 && isStaleConfigPatchError(error)) {
         continue;
@@ -101,6 +120,38 @@ async function waitForMatrixAccountReady(params: {
   }
   throw new Error(
     `matrix account "${params.accountId}" did not become ready; last accounts: ${JSON.stringify(lastAccounts ?? [])}`,
+  );
+}
+
+async function waitForGatewayConfigApplied(params: {
+  expectedHash: string;
+  gateway: FlowPreparationInput["gateway"];
+  timeoutMs: number;
+}) {
+  const deadline = Date.now() + params.timeoutMs;
+  let lastStatus: MatrixQaConfigApplyStatus | undefined;
+  while (Date.now() < deadline) {
+    try {
+      const status = (await params.gateway.call(
+        "config.get",
+        {},
+        { timeoutMs: Math.max(1, Math.min(5_000, deadline - Date.now())) },
+      )) as MatrixQaConfigApplyStatus;
+      lastStatus = status;
+      if (
+        status.hash === params.expectedHash &&
+        typeof status.configRevisionHash === "string" &&
+        status.configRevisionHash === status.appliedConfigHash
+      ) {
+        return;
+      }
+    } catch {
+      // A restart may temporarily disconnect the control client; retry until the deadline.
+    }
+    await sleep(Math.min(250, Math.max(1, deadline - Date.now())));
+  }
+  throw new Error(
+    `Matrix QA config was not applied by the active Gateway; last status: ${JSON.stringify(lastStatus ?? {})}`,
   );
 }
 
@@ -148,6 +199,10 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       sutUserId: params.provisioning.sut.userId,
       topology: params.provisioning.topology,
     });
+    const patchStartedAt = Date.now();
+    const accountStartAtBeforePatch = (
+      await readMatrixAccountStatuses(input.gateway).catch(() => [])
+    ).find((account) => account.accountId === params.accountId)?.lastStartAt;
     const patchResult = await patchGatewayConfig({
       gateway: input.gateway,
       patch: gatewayConfig as Record<string, unknown>,
@@ -159,7 +214,23 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
         timeoutMs: input.timeoutMs,
       });
     }
+    if (!patchResult.hash) {
+      throw new Error("Matrix QA config patch returned no persisted hash");
+    }
+    // A changed or no-op write can observe persisted config before an earlier
+    // reload installs that revision. Do not run against the previous snapshot.
+    await waitForGatewayConfigApplied({
+      expectedHash: patchResult.hash,
+      gateway: input.gateway,
+      timeoutMs: input.timeoutMs,
+    });
     await waitForMatrixAccountReady({
+      // Restart-required writes acknowledge before SIGUSR1 completes. Require a
+      // fresh Matrix account start so the scenario cannot race the old gateway.
+      afterStartAt:
+        patchResult.sentinel?.payload?.stats?.requiresRestart === true
+          ? (accountStartAtBeforePatch ?? patchStartedAt - 1)
+          : undefined,
       accountId: params.accountId,
       gateway: input.gateway,
       timeoutMs: input.timeoutMs,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive-recovery.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive-recovery.ts
@@ -238,7 +238,8 @@ export function assertMatrixQaCliBackupRestoreFailed(
           error.includes(
             "backup decryption key is not loaded on this device (secret storage did not return a key)",
           ))
-      : ["bad mac", "backup key mismatch", "does not have the matching backup decryption key"].some(
+      : error.includes("bad mac") ||
+        ["bad mac", "backup key mismatch", "does not have the matching backup decryption key"].some(
           (expected) => keyLoadError.includes(expected),
         );
   if (!expectedDiagnostic) {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
@@ -141,6 +141,32 @@ describe("Matrix destructive E2EE backup failure assertions", () => {
     ).not.toThrow();
   });
 
+  it("accepts the SDK bad-MAC diagnostic from the restore error", () => {
+    expect(() =>
+      testing.assertMatrixQaCliBackupRestoreFailed(
+        {
+          payload: {
+            backup: {
+              decryptionKeyCached: false,
+              keyLoadError: "getSecretStorageKey callback returned falsey",
+              matchesDecryptionKey: false,
+            },
+            backupVersion: "1",
+            error:
+              "Matrix room key backup is not usable: backup decryption key could not be loaded from secret storage (Error decrypting secret m.megolm_backup.v1: bad MAC).",
+            success: false,
+          },
+          result: { exitCode: 1 },
+        },
+        {
+          expectedBackupVersion: "1",
+          failureKind: "rejected-recovery-key",
+          label: "restore",
+        },
+      ),
+    ).not.toThrow();
+  });
+
   it("rejects a wrapper-only key-mismatch diagnostic", () => {
     expect(() =>
       testing.assertMatrixQaCliBackupRestoreFailed(

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-media.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-media.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { testing } from "./scenario-runtime-media.js";
+
+describe("Matrix voice preflight reply matching", () => {
+  it("accepts punctuation differences in the transcribed marker", () => {
+    expect(
+      testing.hasMatrixQaVoicePreflightReply(
+        '📝 "C3PLQA reply with only these words Matrix QA voice pre-flight OK."',
+      ),
+    ).toBe(true);
+  });
+});

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-media.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-media.ts
@@ -68,14 +68,26 @@ function buildMatrixQaMediaTypeCoveragePrompt(params: {
 }
 
 function normalizeMatrixQaVoiceReply(value: string | undefined) {
-  return (value ?? "")
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, " ")
-    .trim();
+  return (value ?? "").toUpperCase().replace(/[^A-Z0-9]+/g, "");
 }
 
 function hasMatrixQaVoicePreflightReply(body: string | undefined) {
-  return normalizeMatrixQaVoiceReply(body).includes(MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER);
+  return normalizeMatrixQaVoiceReply(body).includes(
+    normalizeMatrixQaVoiceReply(MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER),
+  );
+}
+
+export const testing = { hasMatrixQaVoicePreflightReply };
+
+async function runMatrixQaVoicePhase<T>(phase: string, task: () => Promise<T>): Promise<T> {
+  try {
+    return await task();
+  } catch (error) {
+    throw new Error(
+      `Matrix voice-preflight scenario failed while ${phase}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
 }
 
 export async function runImageUnderstandingAttachmentScenario(context: MatrixQaScenarioContext) {
@@ -242,21 +254,23 @@ export async function runVoicePreflightMentionScenario(context: MatrixQaScenario
     kind: "audio",
     roomId,
   });
-  const attachmentEvent = await client.waitForRoomEvent({
-    observedEvents: context.observedEvents,
-    predicate: (event) =>
-      event.roomId === roomId &&
-      event.eventId === driverEventId &&
-      event.sender === context.driverUserId &&
-      event.msgtype === "m.audio" &&
-      event.attachment?.kind === "audio" &&
-      event.attachment.filename === MATRIX_QA_VOICE_PREFLIGHT_FILENAME &&
-      event.attachment.caption === undefined,
-    roomId,
-    since: startSince,
-    timeoutMs: context.timeoutMs,
-  });
-  const matched = await client.waitForRoomEvent({
+  const attachmentEvent = await runMatrixQaVoicePhase("waiting for the driver audio event", () =>
+    client.waitForRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === roomId &&
+        event.eventId === driverEventId &&
+        event.sender === context.driverUserId &&
+        event.msgtype === "m.audio" &&
+        event.attachment?.kind === "audio" &&
+        event.attachment.filename === MATRIX_QA_VOICE_PREFLIGHT_FILENAME &&
+        event.attachment.caption === undefined,
+      roomId,
+      since: startSince,
+      timeoutMs: context.timeoutMs,
+    }),
+  );
+  const matched = await client.waitForOptionalRoomEvent({
     observedEvents: context.observedEvents,
     predicate: (event) =>
       event.roomId === roomId &&
@@ -269,6 +283,22 @@ export async function runVoicePreflightMentionScenario(context: MatrixQaScenario
     since: attachmentEvent.since,
     timeoutMs: context.timeoutMs,
   });
+  if (!matched.matched) {
+    const recentRoomEvents = context.observedEvents
+      .filter((event) => event.roomId === roomId)
+      .slice(-8)
+      .map((event) => ({
+        body: truncateMatrixQaPreview(event.body),
+        eventId: event.eventId,
+        kind: event.kind,
+        msgtype: event.msgtype,
+        sender: event.sender,
+        type: event.type,
+      }));
+    throw new Error(
+      `Matrix voice-preflight scenario failed while waiting for the transcript echo; recent room events: ${JSON.stringify(recentRoomEvents)}`,
+    );
+  }
   advanceMatrixQaActorCursor({
     actorId: "driver",
     syncState: context.syncState,
@@ -285,6 +315,7 @@ export async function runVoicePreflightMentionScenario(context: MatrixQaScenario
       expectedMarker: MATRIX_QA_VOICE_PREFLIGHT_REPLY_MARKER,
     },
     details: [
+      "post-gate transcript echo proved captionless audio satisfied mention gating",
       `room id: ${roomId}`,
       `driver voice event: ${driverEventId}`,
       `voice filename: ${MATRIX_QA_VOICE_PREFLIGHT_FILENAME}`,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-room.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-room.ts
@@ -227,7 +227,7 @@ async function ensureMembershipLossRoomRestored(params: {
 
 export async function runMembershipLossScenario(context: MatrixQaScenarioContext) {
   const roomId = resolveMatrixQaScenarioRoomId(context, MATRIX_QA_MEMBERSHIP_ROOM_KEY);
-  const driverClient = createMatrixQaDriverScenarioClient(context);
+  const { client: driverClient } = await primeMatrixQaDriverScenarioClient(context);
   const sutClient = createMatrixQaScenarioClient({
     accessToken: context.sutAccessToken,
     baseUrl: context.baseUrl,

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -246,6 +246,9 @@ const QA_AUDIO_TRANSCRIPTION_TEXT =
 const QA_GROUP_AUDIO_TRANSCRIPTION_TEXT =
   "openclawqa reply with only this exact marker after group audio preflight: WHATSAPP_QA_GROUP_AUDIO_TRANSCRIPT_OK";
 const QA_GROUP_AUDIO_TRIGGER_SENTINEL = "OPENCLAW_QA_GROUP_AUDIO_TRIGGER";
+const QA_MATRIX_VOICE_TRANSCRIPTION_TRIGGER = "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER";
+const QA_MATRIX_VOICE_TRANSCRIPTION_TEXT =
+  "C3PLQA reply with only these words Matrix QA voice pre-flight OK.";
 export const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa check/i;
 
 export type MockScenarioState = {
@@ -307,6 +310,9 @@ export function writeOpenAiMalformedJsonError(res: ServerResponse, label: string
 }
 
 export function transcriptionTextForAudioRequest(rawBody: string) {
+  if (rawBody.includes(QA_MATRIX_VOICE_TRANSCRIPTION_TRIGGER)) {
+    return QA_MATRIX_VOICE_TRANSCRIPTION_TEXT;
+  }
   if (rawBody.includes(QA_GROUP_AUDIO_TRIGGER_SENTINEL)) {
     return QA_GROUP_AUDIO_TRANSCRIPTION_TEXT;
   }

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -5239,6 +5239,32 @@ describe("qa mock openai server", () => {
     });
   });
 
+  it("serves deterministic Matrix voice preflight transcription for the request prompt", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: {
+        "content-type": "multipart/form-data; boundary=qa",
+      },
+      body:
+        '--qa\r\ncontent-disposition: form-data; name="file"; filename="audio.wav"\r\n\r\n' +
+        'fixture audio\r\n--qa\r\ncontent-disposition: form-data; name="prompt"\r\n\r\n' +
+        "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER\r\n--qa--\r\n",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      text: "C3PLQA reply with only these words Matrix QA voice pre-flight OK.",
+    });
+  });
+
   it("dispatches an Anthropic /v1/messages read tool call for source discovery prompts", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -415,18 +415,12 @@ describe("qa scenario catalog", () => {
     expect(config?.unavailableNeedles).toContain("not in my available tool surface");
   });
 
-  it("loads Matrix flow provider overrides", () => {
+  it("loads the Matrix room block streaming provider override", () => {
     expect(readQaScenarioById("matrix-room-block-streaming").execution).toMatchObject({
       kind: "flow",
       providerMode: "mock-openai",
       retryCount: 0,
       timeoutMs: 75_000,
-    });
-    expect(readQaScenarioById("matrix-voice-preflight-mention").execution).toMatchObject({
-      kind: "flow",
-      providerMode: "live-frontier",
-      retryCount: 0,
-      timeoutMs: 180_000,
     });
   });
 

--- a/qa/scenarios/channels/matrix-voice-preflight-mention.yaml
+++ b/qa/scenarios/channels/matrix-voice-preflight-mention.yaml
@@ -5,19 +5,39 @@ scenario:
   coverage:
     primary:
       - channels.media-rich-content
+  gatewayConfigPatch:
+    tools:
+      media:
+        audio:
+          enabled: true
+          echoTranscript: true
+          models:
+            - provider: openai
+              model: gpt-4o-transcribe
+          prompt: MATRIX_QA_VOICE_PREFLIGHT_TRIGGER
+    messages:
+      groupChat:
+        mentionPatterns:
+          - 'matrix\W+qa\W+voice\W+pre[ -]?flight\W+ok(?:ay)?'
   execution:
     profiles: { "matrix:all": 54, "matrix:media": 3 }
     kind: flow
     channel: matrix
-    providerMode: live-frontier
-    timeoutMs: 180000
+    providerMode: mock-openai
+    timeoutMs: 90000
     retryCount: 0
     config:
+      matrixRequireCanary: true
       matrixConfigOverrides:
         audio:
           enabled: true
+          echoTranscript: true
+          models:
+            - provider: openai
+              model: gpt-4o-transcribe
+          prompt: MATRIX_QA_VOICE_PREFLIGHT_TRIGGER
         groupMentionPatterns:
-          - \S
+          - 'matrix\W+qa\W+voice\W+pre[ -]?flight\W+ok(?:ay)?'
       matrixTopology:
         defaultRoomKey: main
         rooms:


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the canonical Matrix maturity lane reported 10 intermittent or harness-caused failures, leaving Matrix at 72/82 despite the covered behavior working.

The failures came from config-application and restart races, a membership observer that started after the event it needed to see, recovery-key diagnostics that did not recognize the Matrix SDK's actual error placement, and a voice scenario that depended on a live model.

## Why This Change Was Made

The Matrix QA environment now waits for the persisted config revision to become active, including no-op patches, and requires a fresh account start for restart-required writes. Membership observation is primed before the kick, E2EE assertions accept the SDK's top-level bad-MAC diagnostic, and voice mention gating uses deterministic mock transcription configured before gateway startup.

This keeps the channel driver pluggable and enforces a scenario's `channel` only when present; it does not introduce a separate class of “live scenarios.”

## User Impact

No end-user product behavior changes. Maintainers get deterministic Matrix maturity evidence so the scorecard can be regenerated from a fully passing QA lane.

AI-assisted: Codex. I reviewed the implementation and validation evidence.

## Evidence

- Original canonical maturity run: https://github.com/openclaw/openclaw/actions/runs/29621890703 (Matrix 72/82; 10 failures)
- All 10 former failures together: https://github.com/openclaw/openclaw/actions/runs/29628728927 (10/10 pass across shared and startup-isolated groups)
- Final no-op config-readiness voice proof: https://github.com/openclaw/openclaw/actions/runs/29629604022 (1/1 pass)
- Final changed-file gate: https://github.com/openclaw/openclaw/actions/runs/29629703172 (typecheck, formatting, Oxlint, plugin boundaries, import cycles all pass)
- Current-head full PR CI: https://github.com/openclaw/openclaw/actions/runs/29637399288 (all jobs pass)
- Focused unit tests: 185/185 pass across Matrix readiness, E2EE, media, mock provider, and scenario catalog coverage
- Autoreview: accepted one no-op config-readiness race finding, fixed it, then reran clean; the final CI-fix review also found no actionable findings (0.98 confidence)

