### PR TITLE
fix(ui): release failed browser screenshot bodies

### DIFF
--- a/ui/src/components/browser/browser-client.test.ts
+++ b/ui/src/components/browser/browser-client.test.ts
@@ -43,6 +43,26 @@ describe("fetchBrowserScreenshotDataUrl", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("cancels an unsuccessful screenshot response body", async () => {
+    vi.useFakeTimers();
+    const response = new Response("not found", { status: 404 });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => response),
+    );
+
+    await expect(
+      fetchBrowserScreenshotDataUrl({
+        basePath: "/openclaw",
+        authToken: null,
+        path: "/tmp/missing.png",
+      }),
+    ).rejects.toThrow("screenshot fetch failed (404)");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("aborts a stalled screenshot fetch after the request deadline", async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {

--- a/ui/src/components/browser/browser-client.test.ts
+++ b/ui/src/components/browser/browser-client.test.ts
@@ -63,6 +63,28 @@ describe("fetchBrowserScreenshotDataUrl", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("rejects an unsuccessful screenshot without waiting for stream cancellation", async () => {
+    vi.useFakeTimers();
+    const response = new Response("not found", { status: 404 });
+    const cancel = vi
+      .spyOn(response.body!, "cancel")
+      .mockImplementation(() => new Promise<void>(() => {}));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => response),
+    );
+
+    await expect(
+      fetchBrowserScreenshotDataUrl({
+        basePath: "/openclaw",
+        authToken: null,
+        path: "/tmp/missing.png",
+      }),
+    ).rejects.toThrow("screenshot fetch failed (404)");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("aborts a stalled screenshot fetch after the request deadline", async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -335,6 +335,8 @@ export async function fetchBrowserScreenshotDataUrl(params: {
       signal: controller.signal,
     });
     if (!res.ok) {
+      // Release an unread error stream before surfacing the stable status error.
+      await res.body?.cancel().catch(() => undefined);
       throw new Error(`screenshot fetch failed (${res.status})`);
     }
     blob = await res.blob();

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -335,8 +335,9 @@ export async function fetchBrowserScreenshotDataUrl(params: {
       signal: controller.signal,
     });
     if (!res.ok) {
-      // Release an unread error stream before surfacing the stable status error.
-      await res.body?.cancel().catch(() => undefined);
+      // A response stream can take indefinitely to cancel; release it without
+      // delaying the stable HTTP error or defeating the request deadline.
+      void res.body?.cancel().catch(() => undefined);
       throw new Error(`screenshot fetch failed (${res.status})`);
     }
     blob = await res.blob();

--- a/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
+++ b/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
@@ -64,8 +64,8 @@ describeControlUiE2e("Control UI browser screenshot failed-body E2E", () => {
           fetchCount: number;
           statuses: number[];
         };
-        const proofWindow = window as Window & { __openclawScreenshotProof?: ScreenshotProof };
-        const proof = (proofWindow.__openclawScreenshotProof ??= {
+        const proofWindow = window as Window & { openclawScreenshotProof?: ScreenshotProof };
+        const proof = (proofWindow.openclawScreenshotProof ??= {
           cancelCount: 0,
           cancelResolvedCount: 0,
           fetchCount: 0,
@@ -130,7 +130,7 @@ describeControlUiE2e("Control UI browser screenshot failed-body E2E", () => {
     try {
       const response = await page.goto(`${server.baseUrl}chat`);
       expect(response?.status()).toBe(200);
-      const showFiles = page.getByRole("button", { name: "Show session files", exact: true });
+      const showFiles = page.getByRole("button", { name: "Show thread files", exact: true });
       await showFiles.waitFor();
       await showFiles.click();
       const toggle = page.getByRole("button", { name: "Toggle browser panel", exact: true });
@@ -148,14 +148,14 @@ describeControlUiE2e("Control UI browser screenshot failed-body E2E", () => {
             () =>
               (
                 window as Window & {
-                  __openclawScreenshotProof?: {
+                  openclawScreenshotProof?: {
                     cancelCount?: number;
                     cancelResolvedCount?: number;
                     fetchCount?: number;
                     statuses?: number[];
                   };
                 }
-              ).__openclawScreenshotProof,
+              ).openclawScreenshotProof,
           ),
         )
         .toEqual({
@@ -186,8 +186,7 @@ describeControlUiE2e("Control UI browser screenshot failed-body E2E", () => {
           path: path.join(proofDir, "failed-screenshot.png"),
         });
         const stream = await page.evaluate(
-          () =>
-            (window as Window & { __openclawScreenshotProof?: unknown }).__openclawScreenshotProof,
+          () => (window as Window & { openclawScreenshotProof?: unknown }).openclawScreenshotProof,
         );
         await writeFile(
           path.join(proofDir, "proof.json"),

--- a/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
+++ b/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
@@ -1,0 +1,218 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.resolve(
+  process.cwd(),
+  ".artifacts/control-ui-e2e/browser-screenshot-body-cancel",
+);
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI browser screenshot failed-body E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps the status error visible and cancels the unread media body", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      localStorage.removeItem("openclaw.browser.panel.v1");
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const response = await originalFetch(input, init);
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (!url.includes("/__openclaw__/assistant-media")) {
+          return response;
+        }
+        const source = response.body;
+        if (!source) {
+          return response;
+        }
+        type ScreenshotProof = {
+          cancelCount: number;
+          cancelResolvedCount: number;
+          fetchCount: number;
+          statuses: number[];
+        };
+        const proofWindow = window as Window & { __openclawScreenshotProof?: ScreenshotProof };
+        const proof = (proofWindow.__openclawScreenshotProof ??= {
+          cancelCount: 0,
+          cancelResolvedCount: 0,
+          fetchCount: 0,
+          statuses: [],
+        });
+        proof.fetchCount += 1;
+        proof.statuses.push(response.status);
+        const originalCancel = source.cancel.bind(source);
+        source.cancel = async (reason) => {
+          proof.cancelCount += 1;
+          await originalCancel(reason);
+          proof.cancelResolvedCount += 1;
+        };
+        return response;
+      };
+    });
+    let mediaRequest: { authorization: string; source: string | null } | null = null;
+    await page.route("**/__openclaw__/assistant-media**", (route) => {
+      const request = route.request();
+      mediaRequest = {
+        authorization: request.headers().authorization ?? "",
+        source: new URL(request.url()).searchParams.get("source"),
+      };
+      return route.fulfill({
+        body: "screenshot unavailable",
+        contentType: "text/plain; charset=utf-8",
+        status: 404,
+      });
+    });
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "browser.request"],
+      methodResponses: {
+        "browser.request": {
+          cases: [
+            {
+              match: { method: "GET", path: "/tabs" },
+              response: {
+                running: true,
+                tabs: [
+                  {
+                    targetId: "target-1",
+                    tabId: "t1",
+                    title: "Example",
+                    url: "https://example.test/",
+                  },
+                ],
+              },
+            },
+            {
+              match: { method: "POST", path: "/screenshot" },
+              response: {
+                path: "/proof/missing.png",
+                targetId: "target-1",
+                url: "https://example.test/",
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      const showFiles = page.getByRole("button", { name: "Show session files", exact: true });
+      await showFiles.waitFor();
+      await showFiles.click();
+      const toggle = page.getByRole("button", { name: "Toggle browser panel", exact: true });
+      await toggle.waitFor();
+      await toggle.click();
+
+      const panel = page.locator("section.bp");
+      await panel.waitFor();
+      const alert = panel.getByRole("alert");
+      await alert.waitFor();
+      expect(await alert.textContent()).toContain("screenshot fetch failed (404)");
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  __openclawScreenshotProof?: {
+                    cancelCount?: number;
+                    cancelResolvedCount?: number;
+                    fetchCount?: number;
+                    statuses?: number[];
+                  };
+                }
+              ).__openclawScreenshotProof,
+          ),
+        )
+        .toEqual({
+          cancelCount: 1,
+          cancelResolvedCount: 1,
+          fetchCount: 1,
+          statuses: [404],
+        });
+
+      const requests = await gateway.getRequests("browser.request");
+      expect(requests.map((request) => request.params)).toEqual([
+        { method: "GET", path: "/tabs" },
+        {
+          body: { targetId: "t1", type: "png" },
+          method: "POST",
+          path: "/screenshot",
+        },
+      ]);
+      expect(mediaRequest).toEqual({
+        authorization: "Bearer e2e-device-token",
+        source: "/proof/missing.png",
+      });
+
+      if (captureUiProofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(proofDir, "failed-screenshot.png"),
+        });
+        const stream = await page.evaluate(
+          () =>
+            (window as Window & { __openclawScreenshotProof?: unknown }).__openclawScreenshotProof,
+        );
+        await writeFile(
+          path.join(proofDir, "proof.json"),
+          `${JSON.stringify(
+            {
+              error: (await alert.textContent())?.trim() ?? "",
+              mediaRequest,
+              requests,
+              stream,
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        console.log(
+          `CONTROL_UI_BROWSER_SCREENSHOT_PROOF=${JSON.stringify({
+            error: (await alert.textContent())?.trim() ?? "",
+            mediaRequest,
+            requests: requests.map((request) => request.params),
+            stream,
+          })}`,
+        );
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI browser screenshot refresh left a failed HTTP response body unread when the Gateway returned a non-success status. Repeated screenshot failures could keep the response stream and its connection open until transport cleanup.

## Why This Change Was Made

Cancel the unread response body before raising the existing status error. Cancellation is best-effort so cleanup failure never changes the established error message or successful screenshot path.

## User Impact

Failed browser screenshot requests release their response stream promptly while preserving the same UI error. Successful screenshots and timeout behavior are unchanged.

## Evidence

- Focused unit test: `node scripts/run-vitest.mjs ui/src/components/browser/browser-client.test.ts` (5 passed).
- Permanent Control UI E2E: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts` (1 passed).
- `oxfmt`, targeted oxlint, `git diff --check`, and isolated Claude autoreview passed with 0 findings.
- Submitted at head `7f0de582ae246b6b019fed14c8ba09371124a814`, after the code was rebased onto main `6aee64179c5b348b5a3f8fa1e9518a1edd244bfc`.

## Real Gateway / browser proof

The following was run against the PR head with a freshly built Gateway, loopback-only token auth, the real bundled browser plugin, and a real system Chromium process. No provider credentials, mocked WebSocket, request interception, or `route.fulfill` were used. The screenshot source was deleted only inside the isolated state directory immediately before the real assistant-media fetch.

```json
{
  "gateway": {"healthz": 200, "readyz": 200, "loopback": true, "browserStartExitCode": 0},
  "media": {"status": 404, "deleted": true},
  "alert": "screenshot fetch failed (404)",
  "stream": {"cancelCount": 1, "cancelResolvedCount": 1, "fetchCount": 1, "statuses": [404]}
}
```

The real request included the expected authenticated media header; the captured artifact redacts the token and all state paths. The visual artifact is retained on the data disk at `.artifacts/control-ui-e2e/browser-screenshot-body-cancel-real/failed-screenshot.png`; the full redacted result is `.artifacts/control-ui-e2e/browser-screenshot-body-cancel-real/proof.json`.
