### PR TITLE
fix(outbound): keep newline-mode paragraphs as separate outbound units

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -231,6 +231,39 @@ describe("chunkText", () => {
   ]);
 });
 
+describe("chunkByParagraph packAdjacent option", () => {
+  it("keeps each paragraph its own chunk when packAdjacent is false", () => {
+    const text = "First short paragraph.\n\nSecond short paragraph.";
+
+    expect(chunkByParagraph(text, 4096)).toEqual([text]);
+    expect(chunkByParagraph(text, 4096, { packAdjacent: false })).toEqual([
+      "First short paragraph.",
+      "Second short paragraph.",
+    ]);
+  });
+
+  it("still length-splits an oversized paragraph when packAdjacent is false", () => {
+    const text = `${"a".repeat(30)}\n\n${"b".repeat(30)}`;
+
+    expect(chunkByParagraph(text, 20, { packAdjacent: false })).toEqual([
+      "a".repeat(20),
+      "a".repeat(10),
+      "b".repeat(20),
+      "b".repeat(10),
+    ]);
+  });
+
+  it("does not pack across fence-preserved paragraph boundaries when packAdjacent is false", () => {
+    const text = "intro paragraph\n\n```\ncode line one\n\ncode line two\n```\n\noutro paragraph";
+
+    expect(chunkByParagraph(text, 4096, { packAdjacent: false })).toEqual([
+      "intro paragraph",
+      "```\ncode line one\n\ncode line two\n```",
+      "outro paragraph",
+    ]);
+  });
+});
+
 describe("chunkByParagraph Unicode line/paragraph separators", () => {
   it.each([
     {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -191,13 +191,14 @@ export function chunkByNewline(
  *
  * - Only breaks at paragraph separators ("\n\n" or more, allowing whitespace on blank lines)
  * - Packs multiple paragraphs into a single chunk up to `limit`
+ *   (unless `packAdjacent` is disabled, in which case each paragraph stays its own chunk)
  * - Falls back to length-based splitting when a single paragraph exceeds `limit`
  *   (unless `splitLongParagraphs` is disabled)
  */
 export function chunkByParagraph(
   text: string,
   limit: number,
-  opts?: { splitLongParagraphs?: boolean },
+  opts?: { splitLongParagraphs?: boolean; packAdjacent?: boolean },
 ): string[] {
   if (!text) {
     return [];
@@ -206,6 +207,7 @@ export function chunkByParagraph(
     return [text];
   }
   const splitLongParagraphs = opts?.splitLongParagraphs !== false;
+  const packAdjacent = opts?.packAdjacent !== false;
 
   // U+2029 PARAGRAPH SEPARATOR maps to a blank-line boundary; U+2028 LINE
   // SEPARATOR and CR/CRLF map to a single newline.
@@ -264,7 +266,7 @@ export function chunkByParagraph(
     }
 
     const candidate = `${currentChunk}${separatorBefore ?? "\n\n"}${paragraph}`;
-    if (candidate.length <= limit) {
+    if (packAdjacent && candidate.length <= limit) {
       currentChunk = candidate;
       return;
     }
@@ -299,11 +301,19 @@ export function chunkTextWithMode(text: string, limit: number, mode: ChunkMode):
   return chunkText(text, limit);
 }
 
-export function chunkMarkdownTextWithMode(text: string, limit: number, mode: ChunkMode): string[] {
+export function chunkMarkdownTextWithMode(
+  text: string,
+  limit: number,
+  mode: ChunkMode,
+  opts?: { packAdjacent?: boolean },
+): string[] {
   if (mode === "newline") {
     // Paragraph chunking is fence-safe because we never split at arbitrary indices.
     // If a paragraph must be split by length, defer to the markdown-aware chunker.
-    const paragraphChunks = chunkByParagraph(text, limit, { splitLongParagraphs: false });
+    const paragraphChunks = chunkByParagraph(text, limit, {
+      splitLongParagraphs: false,
+      ...(opts?.packAdjacent === undefined ? {} : { packAdjacent: opts.packAdjacent }),
+    });
     const out: string[] = [];
     for (const chunk of paragraphChunks.flatMap((paragraphChunk) =>
       paragraphChunk.length > limit

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4116,8 +4116,14 @@ describe("deliverOutboundPayloads", () => {
     expect(results.map((r) => r.messageId)).toEqual(["m1", "m2"]);
   });
 
-  it("respects newline chunk mode for plugin text without splitting short messages", async () => {
-    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+  it("keeps blank-line paragraphs as separate sends in newline mode", async () => {
+    // openclaw/openclaw#109032: paragraph boundaries are visible-reply
+    // boundaries; newline mode must not pack logical blocks back into one
+    // bubble just because they fit under the transport limit.
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
     const cfg: OpenClawConfig = {
       channels: {
         matrix: { textChunkLimit: 4000, chunkMode: "newline" },
@@ -4132,18 +4138,22 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
-    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(sendMatrix).toHaveBeenCalledTimes(2);
     const firstChunkCall = requireMatrixSendCall(sendMatrix);
     expect(firstChunkCall?.[0]).toBe("!room:example");
-    expect(firstChunkCall?.[1]).toBe("Line one\n\nLine two");
+    expect(firstChunkCall?.[1]).toBe("Line one");
     expect((firstChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
+    expect(sendMatrix.mock.calls[1]?.[1]).toBe("Line two");
   });
 
-  it("splits long plugin text on packed paragraph boundaries in newline mode", async () => {
+  it("splits plugin text on every paragraph boundary in newline mode", async () => {
+    // openclaw/openclaw#109032: previously "Alpha\n\nBeta" were packed into
+    // one bubble under the limit; each paragraph is now its own send.
     const sendMatrix = vi
       .fn()
       .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
-      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m3", roomId: "!room:example" });
     const cfg: OpenClawConfig = {
       channels: {
         matrix: { textChunkLimit: 14, chunkMode: "newline" },
@@ -4158,15 +4168,11 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
-    expect(sendMatrix).toHaveBeenCalledTimes(2);
+    expect(sendMatrix).toHaveBeenCalledTimes(3);
+    expect(sendMatrix.mock.calls.map((call) => call[1])).toEqual(["Alpha", "Beta", "Gamma"]);
     const firstChunkCall = requireMatrixSendCall(sendMatrix);
     expect(firstChunkCall?.[0]).toBe("!room:example");
-    expect(firstChunkCall?.[1]).toBe("Alpha\n\nBeta");
     expect((firstChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
-    const secondChunkCall = sendMatrix.mock.calls[1];
-    expect(secondChunkCall?.[0]).toBe("!room:example");
-    expect(secondChunkCall?.[1]).toBe("Gamma");
-    expect((secondChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
   });
 
   it("lets explicit formatting options override configured chunking", async () => {

--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -32,6 +32,40 @@ describe("outbound message planning", () => {
     ]);
   });
 
+  it("plans blank-line-separated paragraphs as separate units in newline mode", () => {
+    // openclaw/openclaw#109032: the Codex runtime hands the planner the full
+    // reply text at once; paragraph boundaries must survive as unit boundaries
+    // instead of being packed back under the transport limit.
+    const units = planOutboundTextMessageUnits({
+      text: "First short paragraph.\n\nSecond short paragraph.",
+      textLimit: 4096,
+      chunker: (text) => [text],
+      chunkMode: "newline",
+      overrides: {},
+    });
+
+    expect(units.map((unit) => (unit.kind === "text" ? unit.text : unit.kind))).toEqual([
+      "First short paragraph.",
+      "Second short paragraph.",
+    ]);
+  });
+
+  it("plans markdown newline mode without re-packing paragraphs", () => {
+    const units = planOutboundTextMessageUnits({
+      text: "First short paragraph.\n\nSecond short paragraph.",
+      textLimit: 4096,
+      chunker: (text) => [text],
+      chunkMode: "newline",
+      chunkerMode: "markdown",
+      overrides: {},
+    });
+
+    expect(units.map((unit) => (unit.kind === "text" ? unit.text : unit.kind))).toEqual([
+      "First short paragraph.",
+      "Second short paragraph.",
+    ]);
+  });
+
   it("keeps explicit text replies from consuming the implicit slot", () => {
     const policy = createReplyToDeliveryPolicy({
       replyToId: "implicit-reply",

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -136,10 +136,17 @@ export function planOutboundTextMessageUnits(params: {
   }
 
   if (params.chunkMode === "newline") {
+    // Keep each paragraph its own outbound unit: newline mode encodes the
+    // author's visible-reply boundaries, so adjacent blocks must not be packed
+    // back together just because they fit under the transport limit
+    // (openclaw/openclaw#109032 — Codex runtime delivers the full reply text in
+    // one plan call, unlike streamed block delivery which plans per block).
     const blockChunks =
       (params.chunkerMode ?? "text") === "markdown"
-        ? chunkMarkdownTextWithMode(params.text, params.textLimit, "newline")
-        : chunkByParagraph(params.text, params.textLimit);
+        ? chunkMarkdownTextWithMode(params.text, params.textLimit, "newline", {
+            packAdjacent: false,
+          })
+        : chunkByParagraph(params.text, params.textLimit, { packAdjacent: false });
 
     if (!blockChunks.length && params.text) {
       blockChunks.push(params.text);


### PR DESCRIPTION
Fixes #109032

## User-facing bug

With `chunkMode: "newline"` configured, automatic visible replies from the Codex agent runtime can collapse multiple intended paragraphs into a single WhatsApp bubble, while the OpenClaw runtime delivers the same response shape as separate bubbles under identical channel configuration.

## Root cause

`chunkByParagraph` (src/auto-reply/chunk.ts) splits on blank-line boundaries but then **packs adjacent paragraphs back into one chunk whenever they fit under the transport limit**. The OpenClaw runtime path streams block-by-block — the planner sees one block per call, so packing never has two blocks to join. The Codex runtime hands `planOutboundTextMessageUnits` (src/infra/outbound/message-plan.ts) the full reply text in one call, so its blank-line-separated paragraphs get packed into one outbound unit → one bubble.

The transport-size limit was doing double duty as a packing target. Newline mode's paragraph boundaries encode the author's visible-reply boundaries; a limit should only *split* oversized payloads, never *join* logical blocks (exactly as the issue states).

## Fix

- `chunkByParagraph` gains a `packAdjacent` option (default `true` — every existing caller keeps current behavior).
- `chunkMarkdownTextWithMode` forwards the option for the markdown path.
- The outbound planner's `newline` branch — the one place where logical block boundaries must survive — passes `packAdjacent: false` for both text and markdown chunker paths.

Length-splitting of oversized single paragraphs is unchanged, fence handling is unchanged, and all other chunker consumers (Slack/Telegram/Matrix/Feishu/Mattermost/plugin-sdk streaming paths) are unaffected by default.

Two existing `deliver.test.ts` expectations pinned the old packing behavior ("Line one\n\nLine two" → 1 send; "Alpha\n\nBeta" packed); they are updated to the issue-expected behavior with comments referencing #109032.

## Targeted tests

- `chunk.test.ts`: `packAdjacent: false` keeps paragraphs separate; still length-splits an oversized paragraph; does not join across fence-preserved boundaries.
- `message-plan.test.ts`: two blank-line paragraphs → two units, for both text and markdown chunker modes.
- `deliver.test.ts`: end-to-end `deliverOutboundPayloads` produces one send per paragraph in newline mode.

## Real behavior proof

Real environment: branch checkout at `8e3700901e` (based on current main `c08ce42cef`), Node v22.23.1.

Driving the actual production planner (`planOutboundTextMessageUnits`) via tsx with the issue's config shape (`chunkMode: "newline"`, WhatsApp-scale `textLimit: 4096`):

```ts
import { planOutboundTextMessageUnits } from "../src/infra/outbound/message-plan.ts";
import { chunkText } from "../src/auto-reply/chunk.ts";

const text = "First short paragraph.\n\nSecond short paragraph.";
const units = planOutboundTextMessageUnits({
  text, textLimit: 4096,
  chunker: (t, limit) => chunkText(t, limit),
  chunkMode: "newline", overrides: {},
});
console.log("units:", units.length);
for (const [i, u] of units.entries()) console.log(`  [${i}]`, JSON.stringify(u.text));
```

Before fix (HEAD `c08ce42cef`) — the collapsed single bubble from the issue:

```text
units: 1
  [0] "First short paragraph.\n\nSecond short paragraph."
```

After fix (`8e3700901e`) — separate bubbles matching the OpenClaw-runtime behavior:

```text
units: 2
  [0] "First short paragraph."
  [1] "Second short paragraph."
```

Verification against the committed head (`git status` clean): `tsgo` core / core-test / extensions all exit 0; `deliver.test.ts` 159/159, `message-plan.test.ts` 6/6, `chunk.test.ts` 74/74; `oxlint` clean on all touched files.

## Not tested / known gaps

- Not exercised over a live WhatsApp connection (no channel credentials); the issue is labeled `clawsweeper:source-repro` and the proof above drives the exact production planner code path that feeds WhatsApp delivery.

## AI-assisted disclosure

This patch was prepared with AI assistance, with source-level reproduction, targeted regression tests, and real planner-invocation proof as shown above.
