### PR TITLE
fix(ui): browser checks time out on cold starts

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -621,7 +621,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             },
           ],
         });
-        await page.goto(`${realChatServer.baseUrl}chat`);
+        await page.goto(`${realChatServer.baseUrl}chat`, {
+          waitUntil: "domcontentloaded",
+          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
+        });
         await page
           .getByText("Context hover regression fixture.")
           .waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
@@ -700,7 +703,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           },
         ],
       });
-      await page.goto(`${realChatServer.baseUrl}chat`);
+      await page.goto(`${realChatServer.baseUrl}chat`, {
+        waitUntil: "domcontentloaded",
+        timeout: APP_FIRST_RENDER_TIMEOUT_MS,
+      });
 
       const image = page.locator("img.chat-message-image");
       const video = page.locator("video");
@@ -1895,7 +1901,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           },
         ],
       });
-      await page.goto(`${realChatServer.baseUrl}chat`);
+      await page.goto(`${realChatServer.baseUrl}chat`, {
+        waitUntil: "domcontentloaded",
+        timeout: APP_FIRST_RENDER_TIMEOUT_MS,
+      });
       await page
         .getByText("Short landscape slash command keyboard regression fixture.")
         .waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
@@ -50,7 +50,7 @@ async function mountFile(content: FileSidebarContent): Promise<DetailPanel> {
   document.body.append(panel);
   mounted.push(panel);
   await panel.updateComplete;
-  await expect.poll(() => panel.querySelector(".cm-editor")).not.toBeNull();
+  await expect.poll(() => panel.querySelector(".cm-editor"), { timeout: 5_000 }).not.toBeNull();
   return panel;
 }
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes Control UI browser checks that could time out while initializing the file editor or loading the real chat page on a cold test server.

## Why This Change Was Made

The file-editor check now allows its asynchronous CodeMirror initialization to complete, and the real-page tests wait for DOM readiness before asserting the rendered UI. Existing editor, chat-content, media, and responsive-layout assertions remain unchanged.

## User Impact

No product behavior changes. Contributors receive stable Control UI CI results for valid file-editor and chat interactions.

## Evidence

Fresh after-fix run of the exact affected browser files:

```text
$ pnpm --dir ui exec vitest run --config vitest.config.ts \
    src/pages/chat/chat-responsive.browser.test.ts \
    src/pages/chat/components/chat-sidebar-file-view.browser.test.ts

RUN  v4.1.10
[vite] (client) [optimizer] bundling dependencies...

Test Files  2 passed (2)
Tests       71 passed (71)
Duration    27.91s
```

This fresh run starts the repository's Control UI browser harness, exercises the real-chat page navigation against its local test server, waits for asynchronous CodeMirror creation, and retains all existing content assertions.

- Full Control UI suite previously passed locally: 305 test files and 4395 tests.
- Hosted [`checks-ui`](https://github.com/openclaw/openclaw/actions/runs/29630418669/job/88042815335) passed on this PR head.
