### PR TITLE
fix(i18n): sync stale iOS localization catalog

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -7704,38 +7704,6 @@
     },
     {
       "locale": "de",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Denkprozess und Tool-Aktivität anzeigen",
-        "Gedankengang und Werkzeugaktivität anzeigen"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "แสดงกระบวนการให้เหตุผลและการทำงานของเครื่องมือ",
-        "แสดงการให้เหตุผลและกิจกรรมของเครื่องมือ"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Akıl yürütme ve araç etkinliğini göster",
-        "Akıl yürütmeyi ve araç etkinliğini göster"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Show reasoning & tool activity",
-      "translations": [
-        "Показувати міркування та активність інструментів",
-        "Показувати міркування та дії інструментів"
-      ]
-    },
-    {
-      "locale": "de",
       "source": "Skill Workshop",
       "translations": [
         "Skill Workshop",


### PR DESCRIPTION
## What Problem This Solves

`main` CI is red: `test/scripts/apple-app-i18n.test.ts` fails in `checks-node-compact-small-5` with "Apple catalog apps/ios/Resources/Localizable.xcstrings is stale; run apple-app-i18n.ts sync-ios --write" — failing identically on latest main (e.g. run 29629284704) and therefore blocking every open PR via `openclaw/ci-gate`.

## Why This Change Was Made

Recent iOS/macOS feature merges (e.g. #110254, #110276) added user-facing strings without re-running the Apple catalog sync. This PR is exactly the output of the documented regen command: `node --import tsx scripts/apple-app-i18n.ts sync-ios --write` (no hand edits) — +136 catalog entries and the script-owned contradictions bookkeeping update.

## User Impact

Unblocks CI for all PRs; iOS catalog carries the new strings for localization.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` — passes on this branch (was the exact failing test).
- Diff is generator output only: `apps/ios/Resources/Localizable.xcstrings` (+136), `apps/.i18n/apple-translation-contradictions.json` (−32), produced by one `sync-ios --write` run ("synced iOS catalog and 84 InfoPlist files").
- Main failure reference: https://github.com/openclaw/openclaw/actions/runs/29629284704/job/88039949946
