### PR TITLE
fix(channels): prevent observe-only delivery and orphaned turn adoption

### DIFF
--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -1019,6 +1019,40 @@ describe("channel turn kernel", () => {
     expect(hasFinalChannelTurnDispatch(result.dispatchResult)).toBe(false);
   });
 
+  it("uses noop delivery for direct assembled observe-only dispatch", async () => {
+    const events: string[] = [];
+    const deliver = vi.fn(async () => {
+      events.push("deliver");
+      return { visibleReplySent: true };
+    });
+
+    const result = await dispatchAssembledChannelTurn({
+      cfg,
+      channel: "test",
+      agentId: "observer",
+      routeSessionKey: "agent:observer:test:peer",
+      storePath: "/tmp/sessions.json",
+      ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
+      recordInboundSession: createRecordInboundSession(events),
+      dispatchReplyWithBufferedBlockDispatcher: createDispatch(events),
+      delivery: { deliver },
+      admission: { kind: "observeOnly", reason: "broadcast-observer" },
+    });
+
+    expect(events).toEqual(["record", "dispatch"]);
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result.admission).toEqual({ kind: "observeOnly", reason: "broadcast-observer" });
+    expect(result.dispatched).toBe(true);
+    if (!result.dispatched) {
+      throw new Error("expected dispatch");
+    }
+    expect(resolveChannelTurnDispatchCounts(result.dispatchResult)).toEqual({
+      tool: 0,
+      block: 0,
+      final: 0,
+    });
+  });
+
   it("clears pending group history after a successful prepared turn", async () => {
     const historyMap = new Map([["room-1", [{ sender: "User", body: "queued before reply" }]]]);
 
@@ -1451,6 +1485,40 @@ describe("channel turn kernel", () => {
       throw new Error("expected dispatch");
     }
     expect(result.dispatchResult.queuedFinal).toBe(true);
+  });
+
+  it("rejects top-level adoption lifecycles for prepared turns", async () => {
+    const recordInboundSession = createRecordInboundSession();
+    const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
+    const onFinalize = vi.fn();
+
+    await expect(
+      runChannelInboundEvent({
+        channel: "test",
+        raw: { id: "msg-1", text: "hello" },
+        turnAdoptionLifecycle: { onAdopted: vi.fn(async () => undefined) },
+        adapter: {
+          ingest: () => ({ id: "msg-1", rawText: "hello" }),
+          resolveTurn: () => ({
+            channel: "test",
+            routeSessionKey: "agent:main:test:peer",
+            storePath: "/tmp/sessions.json",
+            ctxPayload: createCtx(),
+            recordInboundSession,
+            runDispatch,
+          }),
+          onFinalize,
+        },
+      }),
+    ).rejects.toThrow(
+      "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn",
+    );
+
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(runDispatch).not.toHaveBeenCalled();
+    expect(onFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({ admission: { kind: "dispatch" }, dispatched: false }),
+    );
   });
 
   it("suppresses prepared dispatch for observe-only full turns", async () => {

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -23,7 +23,6 @@ import type {
   AssembledChannelTurn,
   ChannelEventClass,
   ChannelTurnAdmission,
-  ChannelEventDeliveryAdapter,
   ChannelTurnLogEvent,
   ChannelTurnPlan,
   ChannelTurnResult,
@@ -121,15 +120,6 @@ function emit(params: {
     accountId: params.accountId,
     ...params.event,
   });
-}
-
-function createNoopChannelEventDeliveryAdapter(): ChannelEventDeliveryAdapter {
-  // Observe-only channels still need an adapter shape for shared turn plumbing.
-  return {
-    deliver: async () => ({
-      visibleReplySent: false,
-    }),
-  };
 }
 
 function resolveDroppedHistorySender(input: NormalizedTurnInput, preflight: PreflightFacts) {
@@ -288,6 +278,13 @@ async function runChannelTurn<
   const admission = resolved.admission ?? preflightAdmission ?? ({ kind: "dispatch" } as const);
   let result: ChannelTurnResult<TDispatchResult>;
   try {
+    if ("runDispatch" in resolved && params.turnAdoptionLifecycle) {
+      // Prepared dispatchers already own their reply options. Accepting a top-level lifecycle
+      // here would silently orphan durable-ingress adoption.
+      throw new Error(
+        "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn; attach the lifecycle when creating runDispatch",
+      );
+    }
     const dispatchResult = (
       "runDispatch" in resolved
         ? await runPreparedInboundReply({
@@ -298,9 +295,6 @@ async function runChannelTurn<
           })
         : await dispatchAssembledChannelTurn({
             ...resolved,
-            ...(admission.kind === "observeOnly"
-              ? { delivery: createNoopChannelEventDeliveryAdapter() }
-              : {}),
             admission,
             log: params.log,
             messageId: input.id,

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -122,6 +122,14 @@ async function runChannelDeliveryObserver(params: {
   }
 }
 
+function createObserveOnlyDeliveryAdapter(): ChannelEventDeliveryAdapter {
+  // Observe-only turns still run the agent, but transport delivery must remain impossible for
+  // every assembled-turn entry point, including direct SDK dispatch.
+  return {
+    deliver: async () => ({ visibleReplySent: false }),
+  };
+}
+
 type AssembledChannelTurnWithBotLoopProtection = AssembledChannelTurn & {
   botLoopProtection: NonNullable<AssembledChannelTurn["botLoopProtection"]>;
 };
@@ -146,6 +154,8 @@ export async function dispatchAssembledChannelTurn(
   params: AssembledChannelTurn,
 ): Promise<ChannelTurnResult> {
   const replyPipeline = resolveAssembledReplyPipeline(params);
+  const delivery =
+    params.admission?.kind === "observeOnly" ? createObserveOnlyDeliveryAdapter() : params.delivery;
   return await runPreparedChannelTurnCore(
     {
       channel: params.channel,
@@ -170,13 +180,13 @@ export async function dispatchAssembledChannelTurn(
               dispatcherOptions: {
                 ...replyPipeline.dispatcherOptions,
                 deliver: async (payload: ReplyPayload, info) => {
-                  const preparedPayload = params.delivery.preparePayload
-                    ? await params.delivery.preparePayload(payload, info)
+                  const preparedPayload = delivery.preparePayload
+                    ? await delivery.preparePayload(payload, info)
                     : payload;
                   const durableOptions =
-                    typeof params.delivery.durable === "function"
-                      ? await params.delivery.durable(preparedPayload, info)
-                      : params.delivery.durable;
+                    typeof delivery.durable === "function"
+                      ? await delivery.durable(preparedPayload, info)
+                      : delivery.durable;
                   if (durableOptions) {
                     const durable = await deliverInboundReplyWithMessageSendContext({
                       cfg: params.cfg,
@@ -191,7 +201,7 @@ export async function dispatchAssembledChannelTurn(
                     throwIfDurableInboundReplyDeliveryFailed(durable);
                     if (isDurableInboundReplyDeliveryHandled(durable)) {
                       await runChannelDeliveryObserver({
-                        onDelivered: params.delivery.onDelivered,
+                        onDelivered: delivery.onDelivered,
                         payload: preparedPayload,
                         info,
                         result: durable.delivery,
@@ -199,16 +209,16 @@ export async function dispatchAssembledChannelTurn(
                       return durable.delivery;
                     }
                   }
-                  const result = await params.delivery.deliver(preparedPayload, info);
+                  const result = await delivery.deliver(preparedPayload, info);
                   await runChannelDeliveryObserver({
-                    onDelivered: params.delivery.onDelivered,
+                    onDelivered: delivery.onDelivered,
                     payload: preparedPayload,
                     info,
                     result,
                   });
                   return result;
                 },
-                onError: params.delivery.onError,
+                onError: delivery.onError,
               },
               toolsAllow: params.toolsAllow,
               replyOptions: replyPipeline.replyOptions,

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -198,52 +198,90 @@ describe("createPluginRuntimeMock", () => {
     );
   });
 
-  it("assembles routed prepared turns before dispatch", async () => {
-    const resolveStorePath = vi.fn(() => "/tmp/routed-sessions.json");
+  it("rejects top-level adoption lifecycles for prepared turns", async () => {
     const recordInboundSession = vi.fn(async () => undefined);
     const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
     const runtime = createPluginRuntimeMock({
       channel: {
-        session: { resolveStorePath, recordInboundSession },
+        session: { recordInboundSession },
       },
     });
+
+    await expect(
+      runtime.channel.inbound.run({
+        channel: "test",
+        raw: { id: "m1" },
+        turnAdoptionLifecycle: { onAdopted: vi.fn(async () => undefined) },
+        adapter: {
+          ingest: vi.fn(() => ({ id: "m1", rawText: "hello" })),
+          resolveTurn: vi.fn(() => ({
+            channel: "test",
+            routeSessionKey: "agent:main:test:direct:u1",
+            storePath: "/tmp/routed-sessions.json",
+            ctxPayload: {
+              Body: "hello",
+              CommandAuthorized: false,
+              SessionKey: "agent:main:test:direct:u1",
+            },
+            recordInboundSession,
+            runDispatch,
+          })),
+        },
+      }),
+    ).rejects.toThrow(
+      "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn",
+    );
+
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(runDispatch).not.toHaveBeenCalled();
+  });
+
+  it("threads top-level lifecycles and masks observe-only delivery", async () => {
+    const runtime = createPluginRuntimeMock();
+    const onAdopted = vi.fn(async () => undefined);
+    const deliver = vi.fn(async () => ({ visibleReplySent: true }));
+    vi.mocked(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).mockImplementation(
+      async (params) => {
+        await params.replyOptions?.turnAdoptionLifecycle?.onAdopted();
+        await params.dispatcherOptions.deliver({ text: "hidden" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+        };
+      },
+    );
 
     const result = await runtime.channel.inbound.run({
       channel: "test",
       raw: { id: "m1" },
+      turnAdoptionLifecycle: { onAdopted },
       adapter: {
         ingest: vi.fn(() => ({ id: "m1", rawText: "hello" })),
+        preflight: vi.fn(() => ({ kind: "observeOnly" as const, reason: "broadcast-observer" })),
         resolveTurn: vi.fn(() => ({
           cfg: {},
-          route: {
-            agentId: "main",
-            sessionKey: "agent:main:test:direct:u1",
-          },
+          route: { agentId: "main", sessionKey: "agent:main:test:direct:u1" },
           channel: "test",
           ctxPayload: {
             Body: "hello",
             CommandAuthorized: false,
             SessionKey: "agent:main:test:direct:u1",
           },
-          runDispatch,
+          delivery: { deliver },
         })),
       },
     });
 
-    expect(resolveStorePath).toHaveBeenCalledWith(undefined, { agentId: "main" });
-    expect(recordInboundSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        storePath: "/tmp/routed-sessions.json",
-        sessionKey: "agent:main:test:direct:u1",
-      }),
-    );
-    expect(runDispatch).toHaveBeenCalledOnce();
-    expect(result).toEqual(
-      expect.objectContaining({
-        admission: { kind: "dispatch" },
-        dispatched: true,
-      }),
-    );
+    expect(onAdopted).toHaveBeenCalledOnce();
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      admission: { kind: "observeOnly", reason: "broadcast-observer" },
+      dispatched: true,
+      dispatchResult: {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      },
+    });
   });
 
   it("assembles routed prepared turns before dispatch", async () => {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -158,6 +158,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     ) as unknown as PluginRuntime["tasks"]["managedFlows"]["fromToolContext"],
   };
   const dispatchAssembledChannelTurnMock = vi.fn(async (params: Record<string, unknown>) => {
+    const admission = (params.admission ?? { kind: "dispatch" }) as { kind: string };
     const ctxPayload = params.ctxPayload as Record<string, unknown>;
     const record = params.record as
       | Parameters<PluginRuntime["channel"]["inbound"]["runPreparedReply"]>[0]["record"]
@@ -167,11 +168,15 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     >[0]["recordInboundSession"];
     const routeSessionKey = params.routeSessionKey as string;
     const storePath = params.storePath as string;
-    const delivery = params.delivery as {
+    const sourceDelivery = params.delivery as {
       deliver: (payload: unknown, info: unknown) => Promise<unknown>;
       onDelivered?: (payload: unknown, info: unknown, result: unknown) => Promise<void> | void;
       onError?: (err: unknown, info: unknown) => void;
     };
+    const delivery =
+      admission.kind === "observeOnly"
+        ? { deliver: async () => ({ visibleReplySent: false }) }
+        : sourceDelivery;
     const ctxSessionKey = ctxPayload.SessionKey;
     const sessionKey = typeof ctxSessionKey === "string" ? ctxSessionKey : routeSessionKey;
     const dispatchReplyWithBufferedBlockDispatcher =
@@ -209,7 +214,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       trackSessionMetaTask: record?.trackSessionMetaTask,
     });
     await (params.afterRecord as (() => void | Promise<void>) | undefined)?.();
-    const dispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
+    const rawDispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg: params.cfg,
       dispatcherOptions: {
@@ -225,11 +230,18 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       replyOptions: {
         ...(onModelSelected ? { onModelSelected } : {}),
         ...(params.replyOptions as Record<string, unknown> | undefined),
+        ...(params.turnAdoptionLifecycle
+          ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+          : {}),
       },
       replyResolver: params.replyResolver,
     });
+    const dispatchResult =
+      admission.kind === "observeOnly"
+        ? { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }
+        : rawDispatchResult;
     return {
-      admission: params.admission ?? { kind: "dispatch" },
+      admission,
       dispatched: true,
       ctxPayload,
       routeSessionKey,
@@ -332,6 +344,11 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         resolved.admission ?? preflight.admission ?? ({ kind: "dispatch" } as const);
       let dispatchResult;
       if ("runDispatch" in resolved) {
+        if (params.turnAdoptionLifecycle) {
+          throw new Error(
+            "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn; attach the lifecycle when creating runDispatch",
+          );
+        }
         const prepared =
           "route" in resolved
             ? (() => {
@@ -353,24 +370,22 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           ...prepared,
           admission,
         } as unknown as Parameters<PluginRuntime["channel"]["inbound"]["runPreparedReply"]>[0]);
+      } else if ("route" in resolved) {
+        dispatchResult = await dispatchChannelTurnPlanMock({
+          ...resolved,
+          admission,
+          ...(params.turnAdoptionLifecycle
+            ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+            : {}),
+        });
       } else {
-        const delivery =
-          admission.kind === "observeOnly"
-            ? { deliver: async () => ({ visibleReplySent: false }) }
-            : resolved.delivery;
-        if ("route" in resolved) {
-          dispatchResult = await dispatchChannelTurnPlanMock({
-            ...resolved,
-            admission,
-            delivery,
-          });
-        } else {
-          dispatchResult = await dispatchAssembledChannelTurnMock({
-            ...resolved,
-            admission,
-            delivery,
-          });
-        }
+        dispatchResult = await dispatchAssembledChannelTurnMock({
+          ...resolved,
+          admission,
+          ...(params.turnAdoptionLifecycle
+            ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+            : {}),
+        });
       }
       const result = {
         ...dispatchResult,


### PR DESCRIPTION
Related: #110095

## What Problem This Solves

Fixes two latent turn-kernel failures for durable channel ingress. A prepared turn could accept a top-level adoption lifecycle without ever completing it, allowing the ingress watchdog to time out and redeliver. A direct SDK call to assembled-turn dispatch could also execute a real transport delivery despite observe-only admission while reporting that nothing was dispatched.

This is a hardening follow-up to merged PR #110095 (`601ffa253037`), which moved inbound turn execution into core. No live affected adapters are known today.

## Why This Change Was Made

Prepared dispatchers already own their reply options, so the kernel now rejects the invalid top-level lifecycle combination instead of silently dropping it. Observe-only delivery suppression now lives in the assembled-turn lifecycle owner, beside result masking, so both kernel-routed and direct SDK entry points share the same behavior. The plugin runtime mock mirrors both contracts.

The patch stays additive and bounded: no public type shape changes, no ingress policy changes, and no transport-specific behavior.

## User Impact

Durable-ingress adapters get fail-fast protection against orphaned turn adoption, and direct SDK assembled-turn dispatch cannot leak observe-only replies to a real channel. Existing valid turn plans keep their current behavior. No changelog entry: latent internal hardening with no known live victims.

## Evidence

- Focused kernel and plugin-runtime-mock tests: 46 passed.
- `pnpm check:changed` on Blacksmith Testbox `tbx_01kxsp6ca5j5xkx3bp9b3s42yk`: succeeded across formatting, SDK surface, plugin boundaries, core/extension typechecks, core/extension lint, and repository guards. Linked run: https://github.com/openclaw/openclaw/actions/runs/29629856912
- `git diff --check`: clean.
- Fresh `autoreview --mode uncommitted`: clean, no accepted/actionable findings.

AI-assisted with Codex. I reviewed the changed kernel, lifecycle, SDK mock, callers, sibling paths, and tests, and understand the resulting contracts.
