### PR TITLE
Preserve UTF-8 characters while capturing capped HTTP/2 APNs response bodies across data chunk boundaries

### DIFF
--- a/src/infra/push-apns-http2.ts
+++ b/src/infra/push-apns-http2.ts
@@ -1,6 +1,7 @@
 // Opens APNs HTTP/2 sessions with optional managed proxy tunneling.
 import { once } from "node:events";
 import http2 from "node:http2";
+import { StringDecoder } from "node:string_decoder";
 import tls from "node:tls";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { openProxyConnectTunnel } from "@openclaw/proxyline";
@@ -26,7 +27,8 @@ const APNS_RESPONSE_BODY_MAX_BYTES = 8192;
 const APNS_HTTP2_MIN_TIMEOUT_MS = 1000;
 
 type ApnsResponseBodyCapture = {
-  text: string;
+  chunks: Buffer[];
+  capturedBytes: number;
   bytes: number;
   truncated: boolean;
 };
@@ -205,7 +207,7 @@ function resolveApnsHttp2TimeoutMs(timeoutMs: number): number {
 }
 
 export function createApnsResponseBodyCapture(): ApnsResponseBodyCapture {
-  return { text: "", bytes: 0, truncated: false };
+  return { chunks: [], capturedBytes: 0, bytes: 0, truncated: false };
 }
 
 export function appendApnsResponseBodyCapture(
@@ -213,18 +215,25 @@ export function appendApnsResponseBodyCapture(
   chunk: unknown,
   maxBytes = APNS_RESPONSE_BODY_MAX_BYTES,
 ): void {
-  const buffer = Buffer.from(String(chunk));
+  const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
   capture.bytes += buffer.byteLength;
-  const remaining = maxBytes - Buffer.byteLength(capture.text);
+  const remaining = maxBytes - capture.capturedBytes;
   if (remaining <= 0) {
     capture.truncated = capture.truncated || buffer.byteLength > 0;
     return;
   }
   const slice = buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer;
-  capture.text += slice.toString("utf8");
+  capture.chunks.push(slice);
+  capture.capturedBytes += slice.byteLength;
   if (slice.byteLength < buffer.byteLength) {
     capture.truncated = true;
   }
+}
+
+export function getApnsResponseBodyCaptureText(capture: ApnsResponseBodyCapture): string {
+  // Do not call end(): when byte capping splits a code point, its incomplete
+  // suffix must be omitted rather than emitted as U+FFFD.
+  return new StringDecoder("utf8").write(Buffer.concat(capture.chunks));
 }
 
 /** Sends an intentionally invalid APNs push through a proxy to prove HTTP/2 reachability. */
@@ -278,7 +287,6 @@ export async function probeApnsHttp2ReachabilityViaProxy(
       });
 
       session.once("error", fail);
-      request.setEncoding("utf8");
       request.on("response", (headers) => {
         const rawStatus = headers[":status"];
         status = typeof rawStatus === "number" ? rawStatus : Number(rawStatus);
@@ -302,7 +310,7 @@ export async function probeApnsHttp2ReachabilityViaProxy(
           reject(new Error("APNs reachability probe ended without an HTTP/2 status"));
           return;
         }
-        resolve({ status, body: body.text, responseHeaders });
+        resolve({ status, body: getApnsResponseBodyCaptureText(body), responseHeaders });
       });
       request.end(JSON.stringify({ aps: { alert: "OpenClaw APNs proxy validation" } }));
     });

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -6,7 +6,11 @@ import net from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startProxy, stopProxy, type ProxyHandle } from "./net/proxy/proxy-lifecycle.js";
-import { appendApnsResponseBodyCapture, createApnsResponseBodyCapture } from "./push-apns-http2.js";
+import {
+  appendApnsResponseBodyCapture,
+  createApnsResponseBodyCapture,
+  getApnsResponseBodyCaptureText,
+} from "./push-apns-http2.js";
 import {
   sendApnsAlert,
   sendApnsBackgroundWake,
@@ -292,11 +296,27 @@ describe("push APNs send semantics", () => {
     appendApnsResponseBodyCapture(capture, "abc", 5);
     appendApnsResponseBodyCapture(capture, "def", 5);
 
-    expect(capture).toEqual({
-      text: "abcde",
-      bytes: 6,
-      truncated: true,
-    });
+    expect(getApnsResponseBodyCaptureText(capture)).toBe("abcde");
+    expect(capture.bytes).toBe(6);
+    expect(capture.truncated).toBe(true);
+  });
+
+  it("preserves UTF-8 across HTTP/2 chunks and drops an incomplete capped suffix", () => {
+    const splitCapture = createApnsResponseBodyCapture();
+    const emoji = Buffer.from("🚀");
+
+    appendApnsResponseBodyCapture(splitCapture, Buffer.from("before "));
+    appendApnsResponseBodyCapture(splitCapture, emoji.subarray(0, 2));
+    appendApnsResponseBodyCapture(splitCapture, emoji.subarray(2));
+    appendApnsResponseBodyCapture(splitCapture, Buffer.from(" after"));
+
+    expect(getApnsResponseBodyCaptureText(splitCapture)).toBe("before 🚀 after");
+
+    const cappedCapture = createApnsResponseBodyCapture();
+    appendApnsResponseBodyCapture(cappedCapture, Buffer.from("abc🚀"), 5);
+
+    expect(getApnsResponseBodyCaptureText(cappedCapture)).toBe("abc");
+    expect(cappedCapture).toMatchObject({ bytes: 7, truncated: true });
   });
 
   it("sends alert pushes with alert headers and payload", async () => {

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -11,6 +11,7 @@ import {
   appendApnsResponseBodyCapture,
   connectApnsHttp2Session,
   createApnsResponseBodyCapture,
+  getApnsResponseBodyCaptureText,
 } from "./push-apns-http2.js";
 import {
   createApnsAlertPayload,
@@ -304,7 +305,6 @@ async function sendApnsRequest(params: {
     let apnsId: string | undefined;
     const responseBody = createApnsResponseBodyCapture();
 
-    req.setEncoding("utf8");
     req.setTimeout(params.timeoutMs, () => {
       req.close(APNS_HTTP2_CANCEL_CODE);
       fail(new Error(`APNs request timed out after ${params.timeoutMs}ms`));
@@ -318,12 +318,10 @@ async function sendApnsRequest(params: {
       }
     });
     req.on("data", (chunk) => {
-      if (typeof chunk === "string") {
-        appendApnsResponseBodyCapture(responseBody, chunk);
-      }
+      appendApnsResponseBodyCapture(responseBody, chunk);
     });
     req.on("end", () => {
-      finish({ status: statusCode, apnsId, body: responseBody.text });
+      finish({ status: statusCode, apnsId, body: getApnsResponseBodyCaptureText(responseBody) });
     });
     req.on("error", (err) => fail(err));
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users receiving an oversized APNs HTTP/2 response could see corrupted diagnostic text when the response-body limit cut through a UTF-8 character.

## Why This Change Was Made

Response capture now retains the original bytes until the request ends, then decodes them once. An incomplete UTF-8 suffix caused by the byte cap is omitted instead of becoming a replacement character. This leaves APNs request and response semantics unchanged.

## User Impact

APNs failures and proxy reachability diagnostics preserve valid non-ASCII response text, making error investigation reliable.

## Evidence

- `node scripts/test-projects.mjs src/infra/push-apns.test.ts src/infra/push-apns-http2.test.ts` — 31 passing tests.
- The direct APNs path is exercised against a local HTTP/2 APNs server through a CONNECT proxy.
- Added regressions for a four-byte character split across capture calls and a cap that ends inside that character.
