### PR TITLE
fix(openai): avoid whole-body read for bodyless image responses

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1163,6 +1163,30 @@ describe("openai image generation provider", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("does not whole-body read bodyless Codex OAuth image responses", async () => {
+    mockCodexAuthOnly();
+    const release = vi.fn(async () => {});
+    const text = vi.fn(async () => "data: " + "x".repeat(64 * 1024 * 1024 + 1));
+    postJsonRequestMock.mockResolvedValue({
+      response: { body: null, text },
+      release,
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw a bodyless Codex lighthouse",
+        cfg: {},
+        authStore: createCodexOAuthAuthStore(),
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation response malformed");
+
+    expect(text).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("does not treat Codex API key profiles as configured Codex OAuth image auth", async () => {
     mockGeneratedPngResponse();
     resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -513,11 +513,7 @@ function inferImageUploadFileName(params: {
 
 async function readResponseBodyText(response: Response): Promise<string> {
   if (!response.body) {
-    const text = await response.text();
-    if (Buffer.byteLength(text, "utf8") > MAX_CODEX_IMAGE_SSE_BYTES) {
-      throw new Error("OpenAI Codex image generation response exceeded size limit");
-    }
-    return text;
+    throw new Error("OpenAI Codex image generation response malformed");
   }
   const reader = response.body.getReader();
   const decoder = new TextDecoder();


### PR DESCRIPTION
## What Problem This Solves

Codex OAuth image generation reads streaming Responses output through `readResponseBodyText()`. The stream path enforces `MAX_CODEX_IMAGE_SSE_BYTES` while reading and cancels on overflow, but the bodyless fallback called `response.text()` before checking size. A non-standard Response adapter with `body === null` could therefore force a whole-body read before the size guard ran.

## Why This Change Was Made

This keeps the bounded streaming path unchanged and makes the bodyless path fail closed as a malformed response. A successful Codex image-generation response without a readable SSE body cannot provide image output, so the provider now errors without invoking a non-cancellable whole-body reader.

## User Impact

Oversized or hostile bodyless Codex image responses can no longer bypass the streaming byte cap via `response.text()`. Valid streaming Codex image responses continue to parse normally; bodyless responses now surface through the existing malformed-response error path.

## Evidence

### Regression Test

Added `does not whole-body read bodyless Codex OAuth image responses` in `extensions/openai/image-generation-provider.test.ts`. The test injects a bodyless Response-like object whose `text()` would return an oversized payload and verifies generation fails through the malformed-response path without calling `text()`.

### Runtime Evidence (Live Transcript)

**Command:**
```text
$ node --import tsx /tmp/pr110408-runtime-proof.mts 2>&1
```

**Output:**
```text
PROOF_PR=110408
HEAD=578cab30bb74e67bf4aa885c1bdeb47d14f290d4
HIT_CODEX_RESPONSES_ROUTE=true
OBSERVED_ERROR=OpenAI Codex image generation response malformed
TEXT_CALLS=0
RESULT=PASS
```

**What this proves:**
- Real Node.js runtime with native `fetch` and `Response`
- HTTP 204 response returns `body: null`
- Provider correctly throws `"OpenAI Codex image generation response malformed"` error
- **`Response.text()` was never called** - the fix works as intended

### Focused Regression Test

```text
$ node scripts/run-vitest.mjs extensions/openai/image-generation-provider.test.ts --reporter=verbose -t "does not whole-body read bodyless Codex OAuth image responses"

 RUN  v4.1.10 /home/0668001344/Desktop/openclaw

 ✓ openai image generation provider > does not whole-body read bodyless Codex OAuth image responses 165ms

 Test Files  1 passed (1)
      Tests  1 passed | 69 skipped (70)
   Start at  13:36:37
   Duration  14.67s (transform 11.34s, setup 925ms, import 13.31s, tests 170ms, environment 0ms)
```

### Local checks

```text
$ pnpm dlx oxfmt@0.58.0 --check extensions/openai/image-generation-provider.ts extensions/openai/image-generation-provider.test.ts

All matched files use the correct format.
```

```text
$ git diff --check -- extensions/openai/image-generation-provider.ts extensions/openai/image-generation-provider.test.ts

passed
```

## Change Type / Scope / Security Impact

- Type: audit-fix / bounded response read
- Scope: OpenAI Codex image generation Responses fallback only
- Security: reduces memory exposure from non-standard bodyless Response adapters; no dependency, credential, config, or protocol surface changes
