### PR TITLE
fix(imessage): prevent missed messages after gateway crashes

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -731,7 +731,7 @@ describe("iMessage monitor last-route updates", () => {
     { label: "unset", imessagePatch: {}, expectedDisable: undefined },
   ] as const)(
     "passes iMessage block streaming config ($label) through to reply dispatch",
-    async ({ imessagePatch, expectedDisable }) => {
+    async ({ label, imessagePatch, expectedDisable }) => {
       dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.disableBlockStreaming).toBe(expectedDisable);
         return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
@@ -811,7 +811,7 @@ describe("iMessage monitor last-route updates", () => {
     },
   ] as const)(
     "preserves account-level block streaming opt-outs when inheriting channel streaming ($label)",
-    async ({ channelBlockEnabled, accountBlockEnabled, expectedDisable }) => {
+    async ({ label, channelBlockEnabled, accountBlockEnabled, expectedDisable }) => {
       dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.disableBlockStreaming).toBe(expectedDisable);
         return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
@@ -893,7 +893,7 @@ describe("iMessage monitor last-route updates", () => {
     },
   ] as const)(
     "preserves channel-level nested block streaming when an account overrides $label",
-    async ({ accountStreaming }) => {
+    async ({ label, accountStreaming }) => {
       dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(async (params) => {
         expect(params.replyOptions?.disableBlockStreaming).toBe(false);
         return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
@@ -1267,7 +1267,7 @@ describe("iMessage monitor last-route updates", () => {
       { timeoutMs: 30_000 },
     );
     await vi.waitFor(() => {
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -235,6 +235,7 @@ describe("iMessage monitor last-route updates", () => {
           params: {
             message: {
               id: 7,
+              guid: "typing-keepalive-guid-7",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,
@@ -320,6 +321,7 @@ describe("iMessage monitor last-route updates", () => {
           params: {
             message: {
               id: 13,
+              guid: "typing-unsupported-guid-13",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,
@@ -401,6 +403,7 @@ describe("iMessage monitor last-route updates", () => {
           params: {
             message: {
               id: 12,
+              guid: "typing-early-guid-12",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,
@@ -501,6 +504,7 @@ describe("iMessage monitor last-route updates", () => {
             params: {
               message: {
                 id: 8,
+                guid: `typing-mode-${typingMode}-guid-8`,
                 chat_id: 123,
                 sender: "+15550001111",
                 is_from_me: false,
@@ -582,6 +586,7 @@ describe("iMessage monitor last-route updates", () => {
           params: {
             message: {
               id: 9,
+              guid: "send-policy-guid-9",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,
@@ -661,6 +666,7 @@ describe("iMessage monitor last-route updates", () => {
           params: {
             message: {
               id: 11,
+              guid: "read-receipt-guid-11",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,
@@ -745,6 +751,7 @@ describe("iMessage monitor last-route updates", () => {
             params: {
               message: {
                 id: 10,
+                guid: `block-streaming-${label}-guid-10`,
                 chat_id: 123,
                 sender: "+15550001111",
                 is_from_me: false,
@@ -824,6 +831,7 @@ describe("iMessage monitor last-route updates", () => {
             params: {
               message: {
                 id: 11,
+                guid: `account-block-streaming-${label}-guid-11`,
                 chat_id: 123,
                 sender: "+15550001111",
                 is_from_me: false,
@@ -905,6 +913,7 @@ describe("iMessage monitor last-route updates", () => {
             params: {
               message: {
                 id: 11,
+                guid: `account-streaming-${label}-guid-11`,
                 chat_id: 123,
                 sender: "+15550001111",
                 is_from_me: false,
@@ -971,6 +980,7 @@ describe("iMessage monitor last-route updates", () => {
           params: {
             message: {
               id: 1,
+              guid: "last-route-guid-1",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,
@@ -1177,7 +1187,7 @@ describe("iMessage monitor last-route updates", () => {
     );
   });
 
-  it("preserves enabled legacy catchup as the startup replay path", async () => {
+  it("routes legacy catchup through durable ingress and rejects a live GUID overlap", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-catchup-window-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
@@ -1189,20 +1199,46 @@ describe("iMessage monitor last-route updates", () => {
     } finally {
       database.close();
     }
+    const createdAt = new Date().toISOString();
+    const historyMessage = {
+      id: 4995,
+      guid: "CATCHUP-LIVE-OVERLAP-GUID",
+      chat_id: 123,
+      sender: "+15550001111",
+      is_from_me: false,
+      text: "caught up exactly once",
+      is_group: false,
+      created_at: createdAt,
+    };
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
     const client = {
       request: vi.fn(async (method: string) => {
         if (method === "watch.subscribe") {
           return { subscription: 1 };
         }
         if (method === "chats.list") {
-          return { chats: [] };
+          return { chats: [{ id: 123, last_message_at: createdAt }] };
+        }
+        if (method === "messages.history") {
+          return { messages: [historyMessage] };
         }
         throw new Error(`unexpected request ${method}`);
       }),
-      waitForClose: vi.fn(async () => {}),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: { message: { ...historyMessage, id: 5001 } },
+        });
+      }),
       stop: vi.fn(async () => {}),
     };
-    createIMessageRpcClientMock.mockImplementation(async () => client as never);
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
 
     await monitorIMessageProvider({
       config: {
@@ -1230,6 +1266,9 @@ describe("iMessage monitor last-route updates", () => {
       { limit: 200 },
       { timeoutMs: 30_000 },
     );
+    await vi.waitFor(() => {
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("recovers downtime messages: replays from the cursor and delivers replay rows older than the live fence", async () => {
@@ -1468,7 +1507,7 @@ describe("iMessage monitor last-route updates", () => {
     expect(dispatchReplyWithBufferedBlockDispatcherMock).not.toHaveBeenCalled();
   });
 
-  it("does not advance the recovery cursor past a failed replay row", async () => {
+  it("advances the recovery cursor after durable enqueue before dispatch", async () => {
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-failed-"));
     tempDirs.push(stateDir);
@@ -1487,9 +1526,6 @@ describe("iMessage monitor last-route updates", () => {
       database.close();
     }
     const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
-    dispatchReplyWithBufferedBlockDispatcherMock
-      .mockRejectedValueOnce(new Error("dispatch failed"))
-      .mockResolvedValue({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
 
     let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
     const client = {
@@ -1540,16 +1576,12 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(debouncerControl.entries).toHaveLength(2);
     });
-    await debouncerControl.flushEach?.();
-    await vi.waitFor(() => {
-      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
-    });
     expect(
       loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
-    ).toBe(4994);
+    ).toBe(4996);
   });
 
-  it("advances the recovery cursor after lower pending replay rows complete", async () => {
+  it("keeps the durable recovery cursor independent of later dispatch order", async () => {
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-ordered-"));
     tempDirs.push(stateDir);
@@ -1612,11 +1644,6 @@ describe("iMessage monitor last-route updates", () => {
 
     await vi.waitFor(() => {
       expect(debouncerControl.entries).toHaveLength(2);
-    });
-    debouncerControl.entries.reverse();
-    await debouncerControl.flushEach?.();
-    await vi.waitFor(() => {
-      expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(2);
     });
     expect(
       loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),

--- a/extensions/imessage/src/monitor.media-policy.test.ts
+++ b/extensions/imessage/src/monitor.media-policy.test.ts
@@ -150,6 +150,7 @@ describe("iMessage monitor attachment policy", () => {
           params: {
             message: {
               id: 1,
+              guid: "dropped-media-policy-guid-1",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,

--- a/extensions/imessage/src/monitor.plugin-payload.test.ts
+++ b/extensions/imessage/src/monitor.plugin-payload.test.ts
@@ -3,6 +3,7 @@ import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
+import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 
 const waitForTransportReadyMock = vi.hoisted(() =>
   vi.fn<typeof waitForTransportReady>(async () => {}),
@@ -41,6 +42,7 @@ vi.mock("./monitor/abort-handler.js", () => ({
 
 describe("iMessage plugin payload attachments", () => {
   beforeEach(() => {
+    installIMessageStateRuntimeForTest();
     waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
     createIMessageRpcClientMock.mockReset();
     shouldDebounceTextInboundMock.mockReset().mockReturnValue(false);
@@ -56,6 +58,7 @@ describe("iMessage plugin payload attachments", () => {
           params: {
             message: {
               id: 1,
+              guid: "plugin-payload-guid-1",
               chat_id: 123,
               sender: "+15550001111",
               is_from_me: false,

--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -102,7 +102,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
       runtime: runtime as never,
     });
 
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(1_000);
     await monitorPromise;
 
     expect(createIMessageRpcClientMock).toHaveBeenCalledTimes(2);
@@ -147,7 +147,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
       runtime: runtime as never,
     }).catch((error: unknown) => error);
 
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(2_000);
     const monitorError = await monitorErrorPromise;
 
     expect(monitorError).toBeInstanceOf(Error);

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -48,13 +48,11 @@ type RunIMessageCatchupParams = {
   config: ResolvedCatchupConfig;
   includeAttachments: boolean;
   /**
-   * The same per-message handler the live `imsg watch` notification path
-   * runs (i.e. the post-debounce `handleMessageNow` in `monitor-provider`).
-   * Catchup feeds rows in oldest-first by rowid. Throws are recorded as
-   * dispatch failures; non-throw returns count as successful dispatch
-   * (including non-error drops, which mirrors the live pipeline).
+   * The durable admission handler shared with live `imsg watch` notifications.
+   * Catchup feeds rows oldest-first by rowid. Throws are recorded as admission
+   * failures; non-throw returns mean the row is durably queued.
    */
-  dispatchPayload: (message: IMessagePayload) => Promise<void>;
+  dispatchPayload: (message: IMessagePayload, rawEnvelope: unknown) => Promise<void>;
   /**
    * Called for `is_from_me=true` rows that catchup intentionally does not
    * dispatch. The live inbound path still needs to observe those rows so
@@ -74,14 +72,12 @@ type RunIMessageCatchupParams = {
  *   1. listing recently-active chats via `chats.list`,
  *   2. fetching per-chat history since the cursor via `messages.history`,
  *   3. sorting cross-chat by `rowid`, capping at `perRunLimit`,
- *   4. replaying each row through the same `dispatchPayload` handler used
- *      by the live notification loop, so existing dedupe / coalesce / echo
- *      / read-receipt behavior covers replayed rows for free.
+ *   4. admitting each row through the same durable GUID queue used by live
+ *      notifications, so replay, coalescing, echo, and receipt behavior match.
  *
  * Runs at most once per `monitorIMessageProvider` invocation, between
  * `watch.subscribe` and the live dispatch loop. Anything that arrives during
- * catchup itself flows through live dispatch; the existing inbound-dedupe
- * cache absorbs any overlap.
+ * catchup itself flows through live admission; queue tombstones reject overlap.
  */
 export async function runIMessageCatchup(
   params: RunIMessageCatchupParams,
@@ -93,7 +89,10 @@ export async function runIMessageCatchup(
   // Map keyed by guid so the dispatch adapter can recover the full payload
   // the fetcher pulled from `messages.history`. Local to this catchup pass —
   // discarded when the function returns.
-  const payloadByGuid = new Map<string, IMessagePayload>();
+  const payloadByGuid = new Map<
+    string,
+    { message: IMessagePayload; rawEnvelope: { message: unknown } }
+  >();
 
   const fetchFn: CatchupFetchFn = async ({ sinceMs, sinceRowid, limit }) => {
     const sinceISO = timestampMsToIsoString(sinceMs);
@@ -203,7 +202,7 @@ export async function runIMessageCatchup(
           date: dateMs,
           isFromMe: payload.is_from_me === true,
         });
-        payloadByGuid.set(guid, payload);
+        payloadByGuid.set(guid, { message: payload, rawEnvelope: { message: raw } });
       }
     }
 
@@ -260,8 +259,8 @@ export async function runIMessageCatchup(
   };
 
   const dispatchFn: CatchupDispatchFn = async (row) => {
-    const payload = payloadByGuid.get(row.guid);
-    if (!payload) {
+    const entry = payloadByGuid.get(row.guid);
+    if (!entry) {
       // Should not happen: the fetcher only emits rows it has stashed. But
       // if a future caller wires a different fetcher and forgets to populate
       // the map, we would otherwise silently no-op. Treat as a transient
@@ -270,7 +269,7 @@ export async function runIMessageCatchup(
       return { ok: false };
     }
     try {
-      await dispatchPayload(payload);
+      await dispatchPayload(entry.message, entry.rawEnvelope);
       return { ok: true };
     } catch (err) {
       warnLog(`imessage catchup: dispatch threw for guid=${row.guid}: ${String(err)}`);
@@ -284,12 +283,12 @@ export async function runIMessageCatchup(
     fetch: fetchFn,
     dispatch: dispatchFn,
     observeSkippedFromMe: async (row) => {
-      const payload = payloadByGuid.get(row.guid);
-      if (!payload) {
+      const entry = payloadByGuid.get(row.guid);
+      if (!entry) {
         warnLog(`imessage catchup: missing skipped from-me payload for guid=${row.guid}`);
         return;
       }
-      await params.observeSkippedFromMePayload?.(payload);
+      await params.observeSkippedFromMePayload?.(entry.message);
     },
     log,
     warn: warnLog,

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -426,7 +426,7 @@ export async function performIMessageCatchup(
   // failure is held, the persisted cursor must NOT leapfrog it — otherwise
   // the next pass would filter the failed row out via `row.rowid <= sinceRowid`
   // and never retry. Already-successful rows above the held failure get
-  // re-replayed on the next pass and absorbed by the inbound-dedupe cache.
+  // re-replayed on the next pass and rejected by durable ingress tombstones.
   const cursorBeforeMs = cursor?.lastSeenMs ?? windowStartMs;
   const cursorBeforeRowid = cursor?.lastSeenRowid ?? 0;
   let highWatermarkMs = cursorBeforeMs;
@@ -526,8 +526,8 @@ export async function performIMessageCatchup(
   let lastSeenRowid: number;
   if (earliestHeldFailureRow !== null) {
     // Hold cursor strictly below the failed row. Already-successful rows
-    // above it get re-replayed next pass; the inbound-dedupe cache absorbs
-    // the duplicate dispatch.
+    // above it get re-replayed next pass; durable ingress tombstones reject
+    // the duplicate GUID before dispatch.
     lastSeenMs = Math.max(cursorBeforeMs, earliestHeldFailureRow.date - 1);
     lastSeenRowid = Math.max(cursorBeforeRowid, earliestHeldFailureRow.rowid - 1);
   } else {

--- a/extensions/imessage/src/monitor/inbound-dedupe.test-support.ts
+++ b/extensions/imessage/src/monitor/inbound-dedupe.test-support.ts
@@ -1,10 +1,6 @@
-// Imessage test support covers inbound dedupe + stale-backlog age fence behavior.
+// Imessage test support covers stale-backlog age fence behavior.
 import { describe, expect, it } from "vitest";
-import {
-  buildIMessageInboundReplayKey,
-  IMESSAGE_STALE_INBOUND_THRESHOLD_MS,
-  isStaleIMessageBacklog,
-} from "./inbound-dedupe.js";
+import { IMESSAGE_STALE_INBOUND_THRESHOLD_MS, isStaleIMessageBacklog } from "./inbound-dedupe.js";
 import type { IMessagePayload } from "./types.js";
 
 function payload(overrides: Partial<IMessagePayload> = {}): IMessagePayload {
@@ -18,60 +14,6 @@ function payload(overrides: Partial<IMessagePayload> = {}): IMessagePayload {
     ...overrides,
   } as IMessagePayload;
 }
-
-describe("buildIMessageInboundReplayKey", () => {
-  it("prefers the GUID", () => {
-    expect(buildIMessageInboundReplayKey({ accountId: "default", message: payload() })).toBe(
-      "default:guid:GUID-1",
-    );
-  });
-
-  it("falls back to a bounded composite key when the GUID is absent", () => {
-    const key = buildIMessageInboundReplayKey({
-      accountId: "default",
-      message: payload({ guid: undefined }),
-    });
-    // Hashed composite: account-scoped prefix + 32-hex digest, length-bounded
-    // regardless of message text length.
-    expect(key).toMatch(/^default:c:[0-9a-f]{32}$/);
-  });
-
-  it("keeps the composite key bounded for very long text", () => {
-    const key = buildIMessageInboundReplayKey({
-      accountId: "default",
-      message: payload({ guid: undefined, text: "x".repeat(20_000) }),
-    });
-    expect(key).toMatch(/^default:c:[0-9a-f]{32}$/);
-    expect((key ?? "").length).toBeLessThan(60);
-  });
-
-  it("derives distinct composite keys for distinct GUID-less rows", () => {
-    const a = buildIMessageInboundReplayKey({
-      accountId: "default",
-      message: payload({ guid: undefined, text: "hello" }),
-    });
-    const b = buildIMessageInboundReplayKey({
-      accountId: "default",
-      message: payload({ guid: undefined, text: "world" }),
-    });
-    expect(a).not.toBe(b);
-  });
-
-  it("returns null (fail open) when the message cannot be identified", () => {
-    expect(
-      buildIMessageInboundReplayKey({
-        accountId: "default",
-        message: payload({ guid: undefined, sender: undefined }),
-      }),
-    ).toBeNull();
-  });
-
-  it("scopes keys by account so two accounts never collide on the same GUID", () => {
-    const a = buildIMessageInboundReplayKey({ accountId: "work", message: payload() });
-    const b = buildIMessageInboundReplayKey({ accountId: "home", message: payload() });
-    expect(a).not.toBe(b);
-  });
-});
 
 describe("isStaleIMessageBacklog", () => {
   const now = Date.parse("2026-05-30T05:23:18.000Z");

--- a/extensions/imessage/src/monitor/inbound-dedupe.ts
+++ b/extensions/imessage/src/monitor/inbound-dedupe.ts
@@ -1,28 +1,7 @@
-// iMessage inbound replay protection: GUID dedupe on a stable identity, plus
-// an age fence that suppresses stale backlog Apple delivers in a burst after a
-// bridge/Push recovery.
-//
-// Why both, and what survives ingress-drain adoption:
-// - The GUID dedupe stops a message that was already dispatched from being
-//   dispatched again when imsg re-emits a recent row on reconnect. It is the
-//   transitional layer: if this channel adopts the durable ingress drain with
-//   event_id = GUID, the queue tombstone owns this job and the dedupe goes.
-// - The age fence is NOT a dedupe and stays regardless. It catches messages
-//   the gateway *never saw* (sent while down): Apple writes that backlog into
-//   chat.db with a fresh ROWID/GUID but the original old send date, so no
-//   dedupe or tombstone can recognize it — only the send-date fence does.
-import { createHash } from "node:crypto";
-import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
+// iMessage age fence. This is not replay dedupe: Apple can write never-seen
+// backlog with a fresh ROWID/GUID but the original old send date, so only the
+// send-date fence can distinguish that backlog from live traffic.
 import type { IMessagePayload } from "./types.js";
-
-const IMESSAGE_INBOUND_DEDUPE_PLUGIN_ID = "imessage";
-const IMESSAGE_INBOUND_DEDUPE_NAMESPACE_PREFIX = "imessage.inbound-dedupe";
-// 4h recency window: long enough to absorb a reconnect/restart burst that
-// re-emits recently dispatched rows, short enough that a genuinely-new message
-// reusing a stale composite key after hours is not wrongly suppressed.
-const IMESSAGE_INBOUND_DEDUPE_TTL_MS = 4 * 60 * 60 * 1000;
-const IMESSAGE_INBOUND_DEDUPE_MEMORY_MAX = 5_000;
-const IMESSAGE_INBOUND_DEDUPE_STATE_MAX_ENTRIES = 10_000;
 
 // Drop a LIVE inbound row whose send date is older than this relative to
 // arrival. Stale backlog Apple flushes after a Push recovery carries old send
@@ -39,71 +18,6 @@ export const IMESSAGE_RECOVERY_MAX_AGE_MS = 2 * 60 * 60 * 1000;
 // Cap the replay span so a months-down gateway does not stream its whole
 // history: never set since_rowid more than this many rows below the current max.
 export const IMESSAGE_RECOVERY_MAX_ROWS = 500;
-
-/**
- * Persistent inbound replay guard. Claimable (not a bare check/record) so the
- * claim is atomic: a duplicate emitted twice in a reconnect burst while the
- * first copy is still in flight is reported as a duplicate/inflight instead of
- * racing through. Persistent so a claim committed before a crash still blocks a
- * post-restart re-emit; release on dispatch failure lets a transient failure
- * retry instead of being permanently suppressed.
- */
-type IMessageInboundReplayEvent =
-  | { accountId: string; message: IMessagePayload }
-  | { accountId: string; keys: readonly string[] };
-
-export function createIMessageInboundReplayGuard() {
-  return createChannelReplayGuard<IMessageInboundReplayEvent>({
-    dedupe: {
-      pluginId: IMESSAGE_INBOUND_DEDUPE_PLUGIN_ID,
-      namespacePrefix: IMESSAGE_INBOUND_DEDUPE_NAMESPACE_PREFIX,
-      ttlMs: IMESSAGE_INBOUND_DEDUPE_TTL_MS,
-      memoryMaxSize: IMESSAGE_INBOUND_DEDUPE_MEMORY_MAX,
-      stateMaxEntries: IMESSAGE_INBOUND_DEDUPE_STATE_MAX_ENTRIES,
-    },
-    buildReplayKey: (event) =>
-      "message" in event
-        ? buildIMessageInboundReplayKey({ accountId: event.accountId, message: event.message })
-        : event.keys,
-    namespace: (event) => event.accountId,
-  });
-}
-
-/**
- * Stable replay key for an inbound message. Prefers the Apple GUID (globally
- * unique, survives chat.db rowid churn). Falls back to a composite of the
- * fields that identify a distinct send when no GUID is present, and returns
- * null when the message cannot be identified at all (fail open: never suppress
- * an unidentifiable message).
- */
-export function buildIMessageInboundReplayKey(params: {
-  accountId: string;
-  message: IMessagePayload;
-}): string | null {
-  const { accountId, message } = params;
-  const guid = message.guid?.trim();
-  if (guid) {
-    return `${accountId}:guid:${guid}`;
-  }
-  const sender = message.sender?.trim();
-  const conversation =
-    message.chat_id != null
-      ? `chat:${message.chat_id}`
-      : (message.chat_guid?.trim() ?? message.chat_identifier?.trim());
-  const createdAt = message.created_at?.trim();
-  if (!sender || !conversation || !createdAt) {
-    return null;
-  }
-  const text = (message.text ?? "").trim();
-  // Hash the variable parts so the key is bounded regardless of text length
-  // (the persisted dedupe store caps key size); createdAt + sender + text make
-  // the identity unique enough for a GUID-less row.
-  const digest = createHash("sha256")
-    .update(`${conversation}\0${sender}\0${createdAt}\0${text}`)
-    .digest("hex")
-    .slice(0, 32);
-  return `${accountId}:c:${digest}`;
-}
 
 /**
  * Age fence: true when the message's own send date is materially older than

--- a/extensions/imessage/src/monitor/ingress.test.ts
+++ b/extensions/imessage/src/monitor/ingress.test.ts
@@ -222,9 +222,9 @@ describe("iMessage durable ingress", () => {
       const ingress = createIMessageDurableIngress({
         accountId: "default",
         queue,
-        dispatch: vi.fn(async (_message, lifecycle, _receivedAt, provenance) => {
+        dispatch: vi.fn(async (_message, claimLifecycle, _receivedAt, provenance) => {
           provenances.push(provenance);
-          await lifecycle.onAdopted();
+          await claimLifecycle.onAdopted();
         }),
         runtime: runtime(),
       });

--- a/extensions/imessage/src/monitor/ingress.test.ts
+++ b/extensions/imessage/src/monitor/ingress.test.ts
@@ -216,6 +216,34 @@ describe("iMessage durable ingress", () => {
     });
   });
 
+  it("carries catchup provenance through the journal to dispatch", async () => {
+    await withQueue(async (queue) => {
+      const provenances: Array<{ catchup?: boolean } | undefined> = [];
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(async (_message, lifecycle, _receivedAt, provenance) => {
+          provenances.push(provenance);
+          await lifecycle.onAdopted();
+        }),
+        runtime: runtime(),
+      });
+      try {
+        ingress.start();
+        // Catchup rows must reach dispatch flagged: the monitor skips the live
+        // Push-flush age fence for them, or operator-requested history older
+        // than the live threshold would be suppressed AND tombstoned.
+        await ingress.receive(rawRow({ guid: "GUID-CATCHUP", id: 900 }), { catchup: true });
+        await ingress.receive(rawRow({ guid: "GUID-LIVE", id: 901 }));
+        await vi.waitFor(() => expect(provenances).toHaveLength(2));
+        expect(provenances[0]).toEqual({ catchup: true });
+        expect(provenances[1]).toEqual({});
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
   it("dead-letters malformed persisted payloads without retry", async () => {
     await withQueue(async (queue) => {
       await queue.enqueue(

--- a/extensions/imessage/src/monitor/ingress.test.ts
+++ b/extensions/imessage/src/monitor/ingress.test.ts
@@ -1,0 +1,290 @@
+// iMessage durable ingress tests cover append, recovery, adoption, and GUID tombstones.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildIMessageFlushIngressLifecycle,
+  createIMessageDurableIngress,
+  type IMessageIngressLifecycle,
+} from "./ingress.js";
+
+type IMessageIngressQueue = NonNullable<
+  Parameters<typeof createIMessageDurableIngress>[0]["queue"]
+>;
+type IMessageIngressPayload = Parameters<IMessageIngressQueue["enqueue"]>[1];
+
+function rawRow(overrides: Record<string, unknown> = {}) {
+  return {
+    message: {
+      id: 101,
+      guid: "GUID-101",
+      chat_id: 42,
+      sender: "+15550001111",
+      text: "hello",
+      created_at: "2026-07-17T10:00:00.000Z",
+      is_from_me: false,
+      ...overrides,
+    },
+  };
+}
+
+function createQueue(stateDir: string): IMessageIngressQueue {
+  return createChannelIngressQueueForTests<IMessageIngressPayload>({
+    channelId: "imessage",
+    accountId: "default",
+    stateDir,
+  });
+}
+
+async function withQueue<T>(
+  run: (queue: IMessageIngressQueue, stateDir: string) => Promise<T>,
+): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-ingress-"));
+  const stateDir = await fs.realpath(created);
+  try {
+    return await run(createQueue(stateDir), stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function runtime() {
+  return { error: vi.fn(), log: vi.fn() };
+}
+
+function lifecycle() {
+  return {
+    abortSignal: new AbortController().signal,
+    onAdopted: vi.fn(async () => {}),
+    onDeferred: vi.fn(),
+    onAdoptionFinalizing: vi.fn(),
+    onAbandoned: vi.fn(async () => {}),
+  } satisfies IMessageIngressLifecycle;
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("iMessage durable ingress", () => {
+  it("does not advance the read cursor or dispatch when durable append fails", async () => {
+    await withQueue(async (queue) => {
+      const appendError = new Error("sqlite unavailable");
+      const failingQueue = {
+        ...queue,
+        enqueue: vi.fn().mockRejectedValue(appendError),
+      } satisfies IMessageIngressQueue;
+      const dispatch = vi.fn();
+      const onDurableEnqueue = vi.fn();
+      const onDurableEnqueueFailure = vi.fn();
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue: failingQueue,
+        dispatch,
+        runtime: runtime(),
+        onDurableEnqueue,
+        onDurableEnqueueFailure,
+      });
+
+      try {
+        await expect(ingress.receive(rawRow())).rejects.toBe(appendError);
+        expect(onDurableEnqueue).not.toHaveBeenCalled();
+        expect(onDurableEnqueueFailure).toHaveBeenCalledWith(101, appendError);
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("recovers a durable row with a fresh drain and dispatches exactly once", async () => {
+    await withQueue(async (queue, stateDir) => {
+      const event = rawRow();
+      const interrupted = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(),
+        runtime: runtime(),
+      });
+      await interrupted.receive(event);
+      await interrupted.stop();
+
+      closeOpenClawStateDatabaseForTest();
+      const recoveredDispatch = vi.fn(async (_message, claimLifecycle) => {
+        await claimLifecycle.onAdopted();
+        return { kind: "deferred" } as const;
+      });
+      const recovered = createIMessageDurableIngress({
+        accountId: "default",
+        queue: createQueue(stateDir),
+        dispatch: recoveredDispatch,
+        runtime: runtime(),
+      });
+      recovered.start();
+      try {
+        await recovered.waitForIdle();
+        expect(recoveredDispatch).toHaveBeenCalledTimes(1);
+        expect(recoveredDispatch.mock.calls[0]?.[0]).toMatchObject({
+          id: 101,
+          guid: "GUID-101",
+          chat_id: 42,
+        });
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("keeps a completion tombstone so a duplicate cannot dispatch twice", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_message, claimLifecycle) => {
+        await claimLifecycle.onAdopted();
+        return { kind: "deferred" } as const;
+      });
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch,
+        runtime: runtime(),
+      });
+      ingress.start();
+      try {
+        await ingress.receive(rawRow());
+        await ingress.waitForIdle();
+        await ingress.receive(rawRow());
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("preserves the retired guard's GUID parity across ROWID churn", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_message, claimLifecycle) => {
+        await claimLifecycle.onAdopted();
+        return { kind: "deferred" } as const;
+      });
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch,
+        runtime: runtime(),
+      });
+      ingress.start();
+      try {
+        await ingress.receive(rawRow());
+        await ingress.waitForIdle();
+        await ingress.receive(rawRow({ id: 999 }));
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("stores the raw row under its GUID in the per-chat lane", async () => {
+    await withQueue(async (queue) => {
+      const event = rawRow({ text: "\u0005hello" });
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(),
+        runtime: runtime(),
+      });
+      try {
+        await ingress.receive(event);
+        expect(await queue.listPending({ limit: "all" })).toEqual([
+          expect.objectContaining({
+            id: "GUID-101",
+            laneKey: "chat:42",
+            payload: expect.objectContaining({ raw: event }),
+          }),
+        ]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters malformed persisted payloads without retry", async () => {
+    await withQueue(async (queue) => {
+      await queue.enqueue(
+        "GUID-bad",
+        {
+          version: 1,
+          receivedAt: Date.now(),
+          raw: rawRow({ guid: "GUID-bad", text: 123 }),
+        },
+        { laneKey: "chat:42" },
+      );
+      const dispatch = vi.fn();
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch,
+        runtime: runtime(),
+      });
+      ingress.start();
+      try {
+        await ingress.waitForIdle();
+        expect((await queue.enqueue("GUID-bad", {} as IMessageIngressPayload)).kind).toBe("failed");
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters permanent Full Disk Access failures", async () => {
+    await withQueue(async (queue) => {
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(async () => {
+          throw new Error("Full Disk Access denied for Messages chat.db");
+        }),
+        runtime: runtime(),
+      });
+      ingress.start();
+      try {
+        await ingress.receive(rawRow());
+        await ingress.waitForIdle();
+        expect((await queue.enqueue("GUID-101", {} as IMessageIngressPayload)).kind).toBe("failed");
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("fans merged adoption to every constituent claim", async () => {
+    const first = lifecycle();
+    const second = lifecycle();
+    const merged = buildIMessageFlushIngressLifecycle([first, second]);
+
+    await merged.lifecycle?.onAdopted();
+
+    expect(first.onAdopted).toHaveBeenCalledTimes(1);
+    expect(second.onAdopted).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes every constituent claim when a flush has no dispatch", async () => {
+    const first = lifecycle();
+    const second = lifecycle();
+    const merged = buildIMessageFlushIngressLifecycle([first, second]);
+
+    await merged.settle();
+
+    expect(first.onAdopted).toHaveBeenCalledTimes(1);
+    expect(second.onAdopted).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/imessage/src/monitor/ingress.ts
+++ b/extensions/imessage/src/monitor/ingress.ts
@@ -259,9 +259,12 @@ export function createIMessageDurableIngress(options: {
           if (lifecycle.abortSignal.aborted) {
             throw lifecycle.abortSignal.reason;
           }
-          return await options.dispatch(message, lifecycle, record.payload.receivedAt, {
-            ...(record.payload.catchup ? { catchup: true } : {}),
-          });
+          return await options.dispatch(
+            message,
+            lifecycle,
+            record.payload.receivedAt,
+            record.payload.catchup ? { catchup: true } : {},
+          );
         }),
     });
     return drain;

--- a/extensions/imessage/src/monitor/ingress.ts
+++ b/extensions/imessage/src/monitor/ingress.ts
@@ -26,6 +26,8 @@ type IMessageIngressPayload = {
   version: number;
   receivedAt: number;
   raw: unknown;
+  /** Operator-requested legacy catchup rows skip the live Push-flush age fence. */
+  catchup?: boolean;
 };
 
 export type IMessageIngressLifecycle = {
@@ -52,6 +54,7 @@ type IMessageIngressDispatch = (
   message: IMessagePayload,
   lifecycle: IMessageIngressLifecycle,
   receivedAt: number,
+  provenance?: { catchup?: boolean },
 ) => Promise<IMessageIngressDispatchResult | void> | IMessageIngressDispatchResult | void;
 
 class IMessageIngressPayloadError extends Error {
@@ -149,7 +152,7 @@ function resolveIMessageIngressNonRetryableFailure(error: unknown) {
 }
 
 type IMessageDurableIngress = {
-  receive: (raw: unknown) => Promise<void>;
+  receive: (raw: unknown, opts?: { catchup?: boolean }) => Promise<void>;
   start: () => void;
   stop: () => Promise<void>;
   waitForIdle: () => Promise<void>;
@@ -256,7 +259,9 @@ export function createIMessageDurableIngress(options: {
           if (lifecycle.abortSignal.aborted) {
             throw lifecycle.abortSignal.reason;
           }
-          return await options.dispatch(message, lifecycle, record.payload.receivedAt);
+          return await options.dispatch(message, lifecycle, record.payload.receivedAt, {
+            ...(record.payload.catchup ? { catchup: true } : {}),
+          });
         }),
     });
     return drain;
@@ -313,7 +318,7 @@ export function createIMessageDurableIngress(options: {
     pumping = runPump();
   };
 
-  const receive = async (raw: unknown) => {
+  const receive = async (raw: unknown, receiveOpts?: { catchup?: boolean }) => {
     const admission = admissionTail.then(async () => {
       const rowid = rawRowid(raw);
       try {
@@ -322,7 +327,12 @@ export function createIMessageDurableIngress(options: {
         const receivedAt = now();
         await queue.enqueue(
           facts.eventId,
-          { version: IMESSAGE_INGRESS_PAYLOAD_VERSION, receivedAt, raw },
+          {
+            version: IMESSAGE_INGRESS_PAYLOAD_VERSION,
+            receivedAt,
+            raw,
+            ...(receiveOpts?.catchup ? { catchup: true } : {}),
+          },
           { receivedAt, laneKey: facts.laneKey },
         );
         await options.onDurableEnqueue?.(facts);

--- a/extensions/imessage/src/monitor/ingress.ts
+++ b/extensions/imessage/src/monitor/ingress.ts
@@ -1,0 +1,372 @@
+// iMessage plugin module owns raw-row durable admission and replay.
+import {
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { getIMessageRuntime } from "../runtime.js";
+import { parseIMessageNotification } from "./parse-notification.js";
+import type { IMessagePayload } from "./types.js";
+
+const IMESSAGE_INGRESS_PAYLOAD_VERSION = 1;
+const IMESSAGE_INGRESS_DRAIN_INTERVAL_MS = 1_000;
+const IMESSAGE_INGRESS_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
+// Match or exceed the retired GUID guard's 4h / 10k persistent window.
+const IMESSAGE_INGRESS_COMPLETED_TTL_MS = 4 * 60 * 60 * 1_000;
+const IMESSAGE_INGRESS_COMPLETED_MAX_ENTRIES = 10_000;
+const IMESSAGE_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const IMESSAGE_INGRESS_FAILED_MAX_ENTRIES = 1_000;
+
+type IMessageIngressPayload = {
+  version: number;
+  receivedAt: number;
+  raw: unknown;
+};
+
+export type IMessageIngressLifecycle = {
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onAdoptionFinalizing: () => void;
+  onAbandoned: () => void | Promise<void>;
+};
+
+type IMessageIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type IMessageIngressFacts = {
+  eventId: string;
+  laneKey: string;
+  rowid: number;
+  createdAt?: string;
+};
+
+type IMessageIngressDispatch = (
+  message: IMessagePayload,
+  lifecycle: IMessageIngressLifecycle,
+  receivedAt: number,
+) => Promise<IMessageIngressDispatchResult | void> | IMessageIngressDispatchResult | void;
+
+class IMessageIngressPayloadError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "IMessageIngressPayloadError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rawMessageRecord(raw: unknown): Record<string, unknown> | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  return isRecord(raw.message) ? raw.message : null;
+}
+
+function rawRowid(raw: unknown): number | null {
+  const rowid = rawMessageRecord(raw)?.id;
+  return typeof rowid === "number" && Number.isSafeInteger(rowid) && rowid >= 0 ? rowid : null;
+}
+
+/** Read only stable transport metadata; payload normalization waits for dispatch. */
+function inspectIMessageIngress(raw: unknown): IMessageIngressFacts {
+  const message = rawMessageRecord(raw);
+  const guid = typeof message?.guid === "string" ? message.guid.trim() : "";
+  if (!guid) {
+    throw new IMessageIngressPayloadError("iMessage ingress row is missing its stable GUID.");
+  }
+  const rowid = rawRowid(raw);
+  if (rowid === null) {
+    throw new IMessageIngressPayloadError("iMessage ingress row is missing its ROWID.");
+  }
+  const chatId = message?.chat_id;
+  if (typeof chatId !== "number" || !Number.isSafeInteger(chatId)) {
+    throw new IMessageIngressPayloadError("iMessage ingress row is missing its chat id.");
+  }
+  const createdAt = message?.created_at;
+  return {
+    eventId: guid,
+    laneKey: `chat:${chatId}`,
+    rowid,
+    ...(typeof createdAt === "string" ? { createdAt } : {}),
+  };
+}
+
+function parseClaimedIMessageIngress(payload: IMessageIngressPayload, eventId: string) {
+  if (
+    payload.version !== IMESSAGE_INGRESS_PAYLOAD_VERSION ||
+    typeof payload.receivedAt !== "number" ||
+    !Number.isFinite(payload.receivedAt)
+  ) {
+    throw new IMessageIngressPayloadError(`iMessage ingress payload ${eventId} is invalid.`);
+  }
+  let facts: IMessageIngressFacts;
+  try {
+    facts = inspectIMessageIngress(payload.raw);
+  } catch (error) {
+    throw new IMessageIngressPayloadError(`iMessage ingress payload ${eventId} is invalid.`, {
+      cause: error,
+    });
+  }
+  const message = parseIMessageNotification(payload.raw);
+  if (!message || facts.eventId !== eventId) {
+    throw new IMessageIngressPayloadError(`iMessage ingress payload ${eventId} is invalid.`);
+  }
+  return message;
+}
+
+function isIMessageAuthenticationFailure(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (current) => [
+    current.cause,
+    current.error,
+    current.original,
+  ]).some((candidate) => {
+    const message = formatErrorMessage(candidate).toLowerCase();
+    return (
+      (message.includes("full disk access") && message.includes("chat.db")) ||
+      (message.includes("authorization denied") && message.includes("messages"))
+    );
+  });
+}
+
+function resolveIMessageIngressNonRetryableFailure(error: unknown) {
+  if (error instanceof IMessageIngressPayloadError) {
+    return { reason: "invalid-event", message: error.message };
+  }
+  if (isIMessageAuthenticationFailure(error)) {
+    return { reason: "authentication-failed", message: formatErrorMessage(error) };
+  }
+  return null;
+}
+
+type IMessageDurableIngress = {
+  receive: (raw: unknown) => Promise<void>;
+  start: () => void;
+  stop: () => Promise<void>;
+  waitForIdle: () => Promise<void>;
+};
+
+export function buildIMessageFlushIngressLifecycle(
+  lifecycles: readonly IMessageIngressLifecycle[],
+): {
+  lifecycle: IMessageIngressLifecycle | undefined;
+  settle: () => Promise<void>;
+  abandon: () => Promise<void>;
+} {
+  const first = lifecycles[0];
+  if (!first) {
+    return { lifecycle: undefined, settle: async () => {}, abandon: async () => {} };
+  }
+  let handedOff = false;
+  const adoptAll = async () => {
+    for (const lifecycle of lifecycles) {
+      await lifecycle.onAdopted();
+    }
+  };
+  const abandonAll = async () => {
+    for (const lifecycle of lifecycles) {
+      await lifecycle.onAbandoned();
+    }
+  };
+  return {
+    lifecycle: {
+      abortSignal:
+        lifecycles.length === 1
+          ? first.abortSignal
+          : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+      onAdopted: async () => {
+        handedOff = true;
+        await adoptAll();
+      },
+      onDeferred: () => {
+        handedOff = true;
+        for (const lifecycle of lifecycles) {
+          lifecycle.onDeferred();
+        }
+      },
+      onAdoptionFinalizing: () => {
+        for (const lifecycle of lifecycles) {
+          lifecycle.onAdoptionFinalizing();
+        }
+      },
+      onAbandoned: async () => {
+        handedOff = true;
+        await abandonAll();
+      },
+    },
+    // Gated/no-dispatch turns still consumed every raw row in the flush.
+    settle: async () => {
+      if (!handedOff) {
+        handedOff = true;
+        await adoptAll();
+      }
+    },
+    abandon: async () => {
+      if (!handedOff) {
+        handedOff = true;
+        await abandonAll();
+      }
+    },
+  };
+}
+
+export function createIMessageDurableIngress(options: {
+  accountId: string;
+  queue?: ChannelIngressQueue<IMessageIngressPayload>;
+  dispatch: IMessageIngressDispatch;
+  runtime: Pick<RuntimeEnv, "error" | "log">;
+  onDurableEnqueue?: (facts: IMessageIngressFacts) => void | Promise<void>;
+  onDurableEnqueueFailure?: (rowid: number | null, error: unknown) => void | Promise<void>;
+  now?: () => number;
+}): IMessageDurableIngress {
+  const queue =
+    options.queue ??
+    getIMessageRuntime().state.openChannelIngressQueue<IMessageIngressPayload>({
+      accountId: options.accountId,
+    });
+  const now = options.now ?? Date.now;
+  const dispatchAdmissionQueue = new KeyedAsyncQueue();
+  let drain: ChannelIngressDrain | undefined;
+  const getDrain = () => {
+    drain ??= createChannelIngressDrain<IMessageIngressPayload>({
+      queue,
+      retryPolicy: {
+        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      },
+      // Rows retain their per-chat lane in durable state. Claims use a unique
+      // core lane so a deferred debounce entry cannot block the later rows it
+      // must merge with; this short queue preserves chat order until debounce
+      // takes ownership of each claim.
+      deriveLaneKey: (record) => `${record.laneKey ?? "event"}:${record.id}`,
+      resolveNonRetryableFailure: resolveIMessageIngressNonRetryableFailure,
+      onLog: (message) => options.runtime.log?.(`imessage ${message}`),
+      dispatchClaimedEvent: async (record, lifecycle) =>
+        await dispatchAdmissionQueue.enqueue(record.laneKey ?? record.id, async () => {
+          const message = parseClaimedIMessageIngress(record.payload, record.id);
+          if (lifecycle.abortSignal.aborted) {
+            throw lifecycle.abortSignal.reason;
+          }
+          return await options.dispatch(message, lifecycle, record.payload.receivedAt);
+        }),
+    });
+    return drain;
+  };
+  let running = false;
+  let requested = false;
+  let pumping: Promise<void> | undefined;
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let lastPrunedAt = Number.NEGATIVE_INFINITY;
+  let admissionTail = Promise.resolve();
+
+  const pruneIfDue = async () => {
+    const currentTime = now();
+    if (currentTime - lastPrunedAt < IMESSAGE_INGRESS_PRUNE_INTERVAL_MS) {
+      return;
+    }
+    await queue.prune({
+      completedTtlMs: IMESSAGE_INGRESS_COMPLETED_TTL_MS,
+      completedMaxEntries: IMESSAGE_INGRESS_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: IMESSAGE_INGRESS_FAILED_TTL_MS,
+      failedMaxEntries: IMESSAGE_INGRESS_FAILED_MAX_ENTRIES,
+      now: currentTime,
+    });
+    lastPrunedAt = currentTime;
+  };
+
+  const runPump = async () => {
+    try {
+      for (;;) {
+        requested = false;
+        await pruneIfDue();
+        const activeDrain = getDrain();
+        const { started } = await activeDrain.drainOnce();
+        await activeDrain.waitForIdle();
+        if (!running || (!requested && started === 0)) {
+          break;
+        }
+      }
+    } catch (error) {
+      options.runtime.error?.(`imessage: ingress drain failed: ${formatErrorMessage(error)}`);
+    } finally {
+      pumping = undefined;
+      if (running && requested) {
+        requestDrain();
+      }
+    }
+  };
+
+  const requestDrain = () => {
+    requested = true;
+    if (!running || pumping) {
+      return;
+    }
+    pumping = runPump();
+  };
+
+  const receive = async (raw: unknown) => {
+    const admission = admissionTail.then(async () => {
+      const rowid = rawRowid(raw);
+      try {
+        const facts = inspectIMessageIngress(raw);
+        await pruneIfDue();
+        const receivedAt = now();
+        await queue.enqueue(
+          facts.eventId,
+          { version: IMESSAGE_INGRESS_PAYLOAD_VERSION, receivedAt, raw },
+          { receivedAt, laneKey: facts.laneKey },
+        );
+        await options.onDurableEnqueue?.(facts);
+        requestDrain();
+      } catch (error) {
+        await options.onDurableEnqueueFailure?.(rowid, error);
+        throw error;
+      }
+    });
+    admissionTail = admission.catch(() => undefined);
+    return await admission;
+  };
+
+  return {
+    receive,
+    start: () => {
+      if (running) {
+        return;
+      }
+      running = true;
+      requestDrain();
+      pollTimer = setInterval(requestDrain, IMESSAGE_INGRESS_DRAIN_INTERVAL_MS);
+      pollTimer.unref?.();
+    },
+    stop: async () => {
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = undefined;
+      }
+      await admissionTail;
+      // Source shutdown happens first. Drain every durably accepted row into
+      // its deferred owner before disposing claim lifecycles; later restart is
+      // then only for genuinely unadopted work.
+      requestDrain();
+      await pumping;
+      running = false;
+      await drain?.waitForIdle();
+      drain?.dispose();
+      drain = undefined;
+    },
+    waitForIdle: async () => {
+      await admissionTail;
+      await pumping;
+      await drain?.waitForIdle();
+    },
+  };
+}

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1459,6 +1459,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         );
         // Returning completes the durable GUID claim. A later restart cannot
         // reinterpret this live-fence suppression under the wider replay fence.
+        // Accepted overlap: a legacy-catchup redelivery of this GUID stays
+        // tombstone-blocked, so Push-flush backlog suppressed here is not
+        // recoverable via catchup either. The window is narrow (downtime
+        // backlog + catchup enabled) and preferring it over releasable
+        // suppressions keeps restart replay deterministic.
         return;
       }
       const repairedMessage = await repairMessageConversationAnchor(message);

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1424,7 +1424,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const ingress = createIMessageDurableIngress({
     accountId: accountInfo.accountId,
     runtime,
-    dispatch: async (message, ingressLifecycle, receivedAt) => {
+    dispatch: async (message, ingressLifecycle, receivedAt, provenance) => {
       if (!imsgEmitsBalloonMetadata && hasIMessageBalloonMetadata(message)) {
         imsgEmitsBalloonMetadata = true;
       }
@@ -1444,7 +1444,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       const staleThresholdMs = isRecoveryReplay
         ? IMESSAGE_RECOVERY_MAX_AGE_MS
         : IMESSAGE_STALE_INBOUND_THRESHOLD_MS;
-      if (isStaleIMessageBacklog(message, receivedAt, staleThresholdMs)) {
+      // Catchup rows are operator-requested history: the catchup query's own
+      // maxAge window is their age gate. Running them through the live fence
+      // would suppress AND tombstone rows older than 15 minutes — losing
+      // messages the operator explicitly asked to replay.
+      if (!provenance?.catchup && isStaleIMessageBacklog(message, receivedAt, staleThresholdMs)) {
         staleBacklogSuppressed += 1;
         runtime.log?.(
           warn(
@@ -1694,7 +1698,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         // A watch/catchup overlap is therefore rejected before either copy can
         // dispatch, replacing the retired standalone GUID guard.
         dispatchPayload: async (_message, rawEnvelope) => {
-          await ingress.receive(rawEnvelope);
+          await ingress.receive(rawEnvelope, { catchup: true });
         },
         observeSkippedFromMePayload: (message) => {
           const { bodyText } = resolveIMessageInboundBodyText(message);

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -14,6 +14,7 @@ import {
   type ChannelInboundTurnPlan,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
+  bindIngressLifecycleToReplyOptions,
   createChannelMessageReplyPipeline,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -26,7 +27,6 @@ import {
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { normalizeScpRemoteHost } from "openclaw/plugin-sdk/host-runtime";
 import { isInboundPathAllowed, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
-import type { ChannelReplayClaimHandle } from "openclaw/plugin-sdk/persistent-dedupe";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveTextChunkLimit, type GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
@@ -83,8 +83,6 @@ import {
   warnGroupAllowlistMisconfigOnce,
 } from "./group-allowlist-warnings.js";
 import {
-  buildIMessageInboundReplayKey,
-  createIMessageInboundReplayGuard,
   IMESSAGE_RECOVERY_MAX_AGE_MS,
   IMESSAGE_RECOVERY_MAX_ROWS,
   IMESSAGE_STALE_INBOUND_THRESHOLD_MS,
@@ -98,9 +96,13 @@ import {
   resolveIMessageReactionContext,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
+import {
+  buildIMessageFlushIngressLifecycle,
+  createIMessageDurableIngress,
+  type IMessageIngressLifecycle,
+} from "./ingress.js";
 import { createLoopRateLimiter } from "./loop-rate-limiter.js";
 import { stageIMessageAttachments } from "./media-staging.js";
-import { parseIMessageNotification } from "./parse-notification.js";
 import { createPollCommentFolder } from "./poll-comment.js";
 import { renderIMessagePollBody } from "./poll-render.js";
 import { enqueueIMessageReactionSystemEvent } from "./reaction-system-event.js";
@@ -515,19 +517,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       logVerbose(`imessage: detected remoteHost=${remoteHost} from cliPath`);
     }
   }
-  // Inbound replay guard: dedupes already-seen messages (imsg re-emitting a
-  // recent row on reconnect, or the downtime-recovery replay overlapping rows we
-  // already handled) so nothing is dispatched twice. This is what lets recovery
-  // replay aggressively without the old catchup cursor/retry bookkeeping.
-  const inboundReplayGuard = createIMessageInboundReplayGuard();
   let staleBacklogSuppressed = 0;
   const loggedThrottledDropDiagnostics = createIMessageThrottledDropDiagnosticCache();
 
-  // Downtime recovery. We pass the persisted recovery cursor (the last
-  // dispatched rowid) to watch.subscribe as since_rowid so imsg replays the rows
+  // Downtime recovery. We pass the persisted recovery cursor (the last durably
+  // admitted rowid) to watch.subscribe as since_rowid so imsg replays the rows
   // that landed while the gateway was down — over the same RPC client, so this
-  // works for remote SSH `cliPath` setups too — then tails live. The GUID dedupe
-  // drops anything already handled.
+  // works for remote SSH `cliPath` setups too — then tails live. GUID tombstones
+  // reject anything already completed.
   //
   // `recoveryBoundaryRowid` (M) is the local MAX(ROWID) at startup, read before
   // the transport probe. It is only available when the gateway can read chat.db
@@ -568,61 +565,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   // build carries balloon metadata. The coalesce flush gate needs a build-level
   // signal because imsg omits `balloon_bundle_id` for plain rows.
   let imsgEmitsBalloonMetadata = false;
-  let recoveryCursorHoldBeforeRowid: number | null = null;
   let latestAdvancedRecoveryCursorRowid = recoveryCursorRowid ?? -1;
-  const pendingRecoveryReplayRowids = new Set<number>();
-  const handledRecoveryCursorRowids = new Set<number>();
-
-  function collectFiniteRowids(
-    entries: readonly { message: Pick<IMessagePayload, "id"> }[],
-  ): number[] {
-    const rowids: number[] = [];
-    for (const entry of entries) {
-      if (typeof entry.message.id === "number" && Number.isFinite(entry.message.id)) {
-        rowids.push(entry.message.id);
-      }
-    }
-    return rowids;
-  }
-
-  function holdRecoveryCursorBeforeFailedRows(
-    entries: readonly { message: Pick<IMessagePayload, "id"> }[],
-  ): void {
-    if (catchupCfg.enabled || recoveryCursorRowid === null) {
-      return;
-    }
-    if (recoveryBoundaryRowid === null) {
-      return;
-    }
-    const failedReplayRowids = collectFiniteRowids(entries).filter(
-      (rowid) => rowid <= recoveryBoundaryRowid,
-    );
-    if (failedReplayRowids.length === 0) {
-      return;
-    }
-
-    const firstFailedRowid = Math.min(...failedReplayRowids);
-    for (const rowid of failedReplayRowids) {
-      pendingRecoveryReplayRowids.delete(rowid);
-    }
-    recoveryCursorHoldBeforeRowid =
-      recoveryCursorHoldBeforeRowid === null
-        ? firstFailedRowid
-        : Math.min(recoveryCursorHoldBeforeRowid, firstFailedRowid);
-  }
-
-  function trackPendingRecoveryReplayRow(message: Pick<IMessagePayload, "id">): void {
-    if (catchupCfg.enabled || recoveryCursorRowid === null || recoveryBoundaryRowid === null) {
-      return;
-    }
-    if (
-      typeof message.id === "number" &&
-      Number.isFinite(message.id) &&
-      message.id <= recoveryBoundaryRowid
-    ) {
-      pendingRecoveryReplayRowids.add(message.id);
-    }
-  }
+  const durableRecoveryCursorRowids = new Set<number>();
+  const failedRecoveryCursorRowids = new Set<number>();
 
   function minSetValue(values: ReadonlySet<number>): number | null {
     let min: number | null = null;
@@ -632,36 +577,16 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     return min;
   }
 
-  function resolveRecoveryCursorHoldFloor(): number | null {
-    const pendingFloor = minSetValue(pendingRecoveryReplayRowids);
-    if (pendingFloor === null) {
-      return recoveryCursorHoldBeforeRowid;
-    }
-    if (recoveryCursorHoldBeforeRowid === null) {
-      return pendingFloor;
-    }
-    return Math.min(pendingFloor, recoveryCursorHoldBeforeRowid);
-  }
-
-  function advanceRecoveryCursorAfterHandled(
-    entries: readonly { message: Pick<IMessagePayload, "id"> }[],
-  ): void {
+  function advanceRecoveryCursorAfterDurableEnqueue(rowid: number): void {
     if (catchupCfg.enabled) {
       return;
     }
-    const rowids = collectFiniteRowids(entries);
-    if (rowids.length === 0) {
-      return;
-    }
-    for (const rowid of rowids) {
-      pendingRecoveryReplayRowids.delete(rowid);
-      handledRecoveryCursorRowids.add(rowid);
-    }
-
-    const maxHandledRowid = Math.max(...handledRecoveryCursorRowids);
-    const holdFloor = resolveRecoveryCursorHoldFloor();
+    failedRecoveryCursorRowids.delete(rowid);
+    durableRecoveryCursorRowids.add(rowid);
+    const maxDurableRowid = Math.max(...durableRecoveryCursorRowids);
+    const holdFloor = minSetValue(failedRecoveryCursorRowids);
     const nextCursorRowid =
-      holdFloor !== null && maxHandledRowid >= holdFloor ? holdFloor - 1 : maxHandledRowid;
+      holdFloor !== null && maxDurableRowid >= holdFloor ? holdFloor - 1 : maxDurableRowid;
 
     if (nextCursorRowid >= 0 && nextCursorRowid > latestAdvancedRecoveryCursorRowid) {
       advanceIMessageRecoveryCursor(
@@ -670,19 +595,24 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         nextCursorRowid,
       );
       latestAdvancedRecoveryCursorRowid = nextCursorRowid;
-      for (const rowid of handledRecoveryCursorRowids) {
-        if (rowid <= nextCursorRowid) {
-          handledRecoveryCursorRowids.delete(rowid);
+      for (const durableRowid of durableRecoveryCursorRowids) {
+        if (durableRowid <= nextCursorRowid) {
+          durableRecoveryCursorRowids.delete(durableRowid);
         }
       }
     }
   }
 
+  function holdRecoveryCursorBeforeFailedEnqueue(rowid: number | null): void {
+    if (catchupCfg.enabled || rowid === null || rowid <= latestAdvancedRecoveryCursorRowid) {
+      return;
+    }
+    failedRecoveryCursorRowids.add(rowid);
+  }
+
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<{
     message: IMessagePayload;
-    // The ingestion claim owns the exact GUID/composite key even when debounce
-    // later rewrites the payload identity. Missing handles fail open.
-    replayClaim?: ChannelReplayClaimHandle;
+    ingressLifecycle?: IMessageIngressLifecycle;
   }>({
     cfg,
     channel: "imessage",
@@ -734,26 +664,24 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (entries.length === 0) {
         return;
       }
-      // Dispatch one unit (a single row or a merged bucket), then commit the
-      // exact replay keys that were claimed at ingestion, or release them if
-      // dispatch throws so a transient failure can retry on a later re-emit. Per
-      // unit so a failure in one bucket entry cannot strand another's claim.
+      // Dispatch one unit (a single row or merged bucket). Every raw queue
+      // claim in that unit follows the merged turn's adoption lifecycle.
       const dispatchUnit = async (
-        unitEntries: { message: IMessagePayload; replayClaim?: ChannelReplayClaimHandle }[],
+        unitEntries: { message: IMessagePayload; ingressLifecycle?: IMessageIngressLifecycle }[],
         message: IMessagePayload,
       ) => {
-        const replayClaims = unitEntries
-          .map((entry) => entry.replayClaim)
-          .filter((claim): claim is ChannelReplayClaimHandle => claim !== undefined);
+        const { lifecycle, settle, abandon } = buildIMessageFlushIngressLifecycle(
+          unitEntries.flatMap((entry) => (entry.ingressLifecycle ? [entry.ingressLifecycle] : [])),
+        );
         try {
-          await handleMessageNow(message);
-          await Promise.all(replayClaims.map((claim) => claim.commit()));
-          advanceRecoveryCursorAfterHandled(unitEntries);
-        } catch (err) {
-          holdRecoveryCursorBeforeFailedRows(unitEntries);
-          for (const claim of replayClaims) {
-            claim.release({ error: err });
+          if (lifecycle?.abortSignal.aborted) {
+            await abandon();
+            return;
           }
+          await handleMessageNow(message, lifecycle);
+          await settle();
+        } catch (err) {
+          await abandon();
           runtime.error?.(`imessage: inbound dispatch failed: ${String(err)}`);
         }
       };
@@ -779,7 +707,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (messages.some(hasIMessageUrlBalloonBundleID)) {
         let pending: {
           message: IMessagePayload;
-          replayClaim?: ChannelReplayClaimHandle;
+          ingressLifecycle?: IMessageIngressLifecycle;
         } | null = null;
         for (const entry of entries) {
           if (isStandaloneIMessageUrlPreviewPayload(entry.message) && pending) {
@@ -907,12 +835,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
 
   async function handleMessageNow(
     message: IMessagePayload,
-    options: { advanceCatchupCursor?: boolean } = {},
+    ingressLifecycle?: IMessageIngressLifecycle,
   ) {
-    await handleMessageNowInner(message);
-    if (options.advanceCatchupCursor !== false) {
-      await maybeAdvanceLiveCatchupCursor(message);
-    }
+    await handleMessageNowInner(message, ingressLifecycle);
   }
 
   // iMessage delivers a poll's comment as a separate inline reply to the poll
@@ -940,7 +865,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     };
   }
 
-  async function handleMessageNowInner(rawMessage: IMessagePayload) {
+  async function handleMessageNowInner(
+    rawMessage: IMessagePayload,
+    ingressLifecycle?: IMessageIngressLifecycle,
+  ) {
     const message = await repairMessageConversationAnchor(rawMessage);
     if (!message) {
       return;
@@ -1481,6 +1409,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             onSettled: () => stopEarlyDirectTyping?.(),
           },
           replyOptions: {
+            ...(ingressLifecycle ? bindIngressLifecycleToReplyOptions(ingressLifecycle) : {}),
             disableBlockStreaming:
               typeof configuredBlockStreaming === "boolean" ? !configuredBlockStreaming : undefined,
             onModelSelected,
@@ -1492,93 +1421,61 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     });
   }
 
-  const handleMessage = async (raw: unknown) => {
-    const message = parseIMessageNotification(raw);
-    if (!message) {
-      // A malformed RPC notification means imsg shipped a payload shape
-      // we do not understand — almost always a real bridge bug. Surface
-      // the keys so an operator can correlate without leaking content.
-      const shape =
-        raw && typeof raw === "object" && !Array.isArray(raw)
-          ? Object.keys(raw as Record<string, unknown>)
-              .toSorted()
-              .join(",")
-          : typeof raw;
-      runtime.error?.(`imessage: dropping malformed RPC message payload (keys=${shape})`);
-      return;
-    }
-    if (!imsgEmitsBalloonMetadata && hasIMessageBalloonMetadata(message)) {
-      imsgEmitsBalloonMetadata = true;
-    }
-    // Age fence with two windows, split on the recovery boundary:
-    //  - rows at/below recoveryBoundaryRowid are the downtime-recovery replay
-    //    imsg emits from since_rowid — deliver them up to the wider recovery
-    //    age, suppressing only ancient history.
-    //  - rows above it are genuinely live — suppress at the tighter live
-    //    threshold, which is where #89237's Push-flush backlog (old send date,
-    //    fresh rowid) appears.
-    // Logged at default level so suppressed traffic is never silent (#89237).
-    const isRecoveryReplay =
-      recoveryCursorRowid !== null &&
-      recoveryBoundaryRowid !== null &&
-      typeof message.id === "number" &&
-      message.id <= recoveryBoundaryRowid;
-    const staleThresholdMs = isRecoveryReplay
-      ? IMESSAGE_RECOVERY_MAX_AGE_MS
-      : IMESSAGE_STALE_INBOUND_THRESHOLD_MS;
-    if (isStaleIMessageBacklog(message, Date.now(), staleThresholdMs)) {
-      staleBacklogSuppressed += 1;
-      runtime.log?.(
-        warn(
-          `imessage: suppressed stale inbound backlog account=${accountInfo.accountId} ` +
-            `sent=${message.created_at ?? "unknown"} recovery=${isRecoveryReplay} ` +
-            `(${staleBacklogSuppressed} suppressed since start)`,
-        ),
-      );
-      // Record the suppression so it is durable: without this, a live row
-      // suppressed under the tight live fence would fall under the wider
-      // recovery window after a restart (its rowid is now below the new
-      // boundary) and be delivered. Committing the key makes the recovery
-      // replay treat it as already handled.
-      const suppressedKey = buildIMessageInboundReplayKey({
-        accountId: accountInfo.accountId,
-        message,
-      });
-      if (suppressedKey) {
-        await inboundReplayGuard.shouldProcess({
-          accountId: accountInfo.accountId,
-          keys: [suppressedKey],
-        });
+  const ingress = createIMessageDurableIngress({
+    accountId: accountInfo.accountId,
+    runtime,
+    dispatch: async (message, ingressLifecycle, receivedAt) => {
+      if (!imsgEmitsBalloonMetadata && hasIMessageBalloonMetadata(message)) {
+        imsgEmitsBalloonMetadata = true;
       }
-      return;
-    }
-    const repairedMessage = await repairMessageConversationAnchor(message);
-    if (!repairedMessage) {
-      return;
-    }
-    // Replay dedupe: a recovered bridge can re-emit a row already dispatched.
-    // GUID-keyed (survives chat.db rowid churn) and persistent (holds across a
-    // restart). Claim atomically here so two copies in a reconnect burst cannot
-    // both pass; the claim is committed after handling and released on a
-    // transient dispatch failure (see handleMessageNow) so a failed message can
-    // still retry on a later re-emit. Claimed only once we will actually enqueue
-    // so a dropped row never leaks an uncommitted claim.
-    const replay = await inboundReplayGuard.claim({
-      accountId: accountInfo.accountId,
-      message: repairedMessage,
-    });
-    if (replay.kind === "duplicate" || replay.kind === "inflight") {
-      logVerbose(
-        `imessage: dropping duplicate inbound notification account=${accountInfo.accountId}`,
-      );
-      return;
-    }
-    trackPendingRecoveryReplayRow(repairedMessage);
-    await inboundDebouncer.enqueue({
-      message: repairedMessage,
-      ...(replay.kind === "claimed" ? { replayClaim: replay.handle } : {}),
-    });
-  };
+      // Age fence with two windows, split on the recovery boundary:
+      //  - rows at/below recoveryBoundaryRowid are the downtime-recovery replay
+      //    imsg emits from since_rowid — deliver them up to the wider recovery
+      //    age, suppressing only ancient history.
+      //  - rows above it are genuinely live — suppress at the tighter live
+      //    threshold, which is where #89237's Push-flush backlog (old send date,
+      //    fresh rowid) appears.
+      // Logged at default level so suppressed traffic is never silent (#89237).
+      const isRecoveryReplay =
+        recoveryCursorRowid !== null &&
+        recoveryBoundaryRowid !== null &&
+        typeof message.id === "number" &&
+        message.id <= recoveryBoundaryRowid;
+      const staleThresholdMs = isRecoveryReplay
+        ? IMESSAGE_RECOVERY_MAX_AGE_MS
+        : IMESSAGE_STALE_INBOUND_THRESHOLD_MS;
+      if (isStaleIMessageBacklog(message, receivedAt, staleThresholdMs)) {
+        staleBacklogSuppressed += 1;
+        runtime.log?.(
+          warn(
+            `imessage: suppressed stale inbound backlog account=${accountInfo.accountId} ` +
+              `sent=${message.created_at ?? "unknown"} recovery=${isRecoveryReplay} ` +
+              `(${staleBacklogSuppressed} suppressed since start)`,
+          ),
+        );
+        // Returning completes the durable GUID claim. A later restart cannot
+        // reinterpret this live-fence suppression under the wider replay fence.
+        return;
+      }
+      const repairedMessage = await repairMessageConversationAnchor(message);
+      if (!repairedMessage) {
+        return;
+      }
+      await inboundDebouncer.enqueue({
+        message: repairedMessage,
+        ingressLifecycle,
+      });
+      // Debounce owns the claim until its eventual flush adopts or abandons.
+      return { kind: "deferred" };
+    },
+    onDurableEnqueue: async (facts) => {
+      advanceRecoveryCursorAfterDurableEnqueue(facts.rowid);
+      await maybeAdvanceLiveCatchupCursor({ id: facts.rowid, created_at: facts.createdAt });
+    },
+    onDurableEnqueueFailure: (rowid) => {
+      holdRecoveryCursorBeforeFailedEnqueue(rowid);
+    },
+  });
 
   await waitForTransportReady({
     label: "imsg rpc",
@@ -1611,8 +1508,8 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       runtime,
       onNotification: (msg) => {
         if (msg.method === "message") {
-          void handleMessage(msg.params).catch((err: unknown) => {
-            runtime.error?.(`imessage: handler failed: ${String(err)}`);
+          void ingress.receive(msg.params).catch((err: unknown) => {
+            runtime.error?.(`imessage: durable admission failed: ${String(err)}`);
           });
         } else if (msg.method === "error") {
           runtime.error?.(
@@ -1646,7 +1543,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         client: attemptClient,
         getSubscriptionId: () => attemptSubscriptionId,
       });
-      // since_rowid = the recovery cursor (last dispatched rowid, capped),
+      // since_rowid = the recovery cursor (last durably admitted rowid, capped),
       // captured before the transport-ready probe, so imsg replays messages that
       // landed while the gateway was down and during the startup window instead
       // of self-fencing them at subscribe-time MAX(ROWID). When unavailable
@@ -1736,6 +1633,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   if (!activeClient) {
     return;
   }
+  ingress.start();
 
   // Register the iMessage approval native runtime context with the gateway so
   // proactive exec/plugin approval prompts can be delivered through the
@@ -1792,7 +1690,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         accountId: accountInfo.accountId,
         config: catchupCfg,
         includeAttachments,
-        dispatchPayload: (message) => handleMessageNow(message, { advanceCatchupCursor: false }),
+        // Legacy history rows enter the same durable GUID queue as watch rows.
+        // A watch/catchup overlap is therefore rejected before either copy can
+        // dispatch, replacing the retired standalone GUID guard.
+        dispatchPayload: async (_message, rawEnvelope) => {
+          await ingress.receive(rawEnvelope);
+        },
         observeSkippedFromMePayload: (message) => {
           const { bodyText } = resolveIMessageInboundBodyText(message);
           rememberIMessageSkippedFromMeForSelfChatDedupe({
@@ -1833,6 +1736,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     approvalContextLease?.dispose();
     detachAbortHandler();
     await activeClient.stop();
+    await ingress.stop();
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1464,11 +1464,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         // recoverable via catchup either. The window is narrow (downtime
         // backlog + catchup enabled) and preferring it over releasable
         // suppressions keeps restart replay deterministic.
-        return;
+        return { kind: "completed" };
       }
       const repairedMessage = await repairMessageConversationAnchor(message);
       if (!repairedMessage) {
-        return;
+        return { kind: "completed" };
       }
       await inboundDebouncer.enqueue({
         message: repairedMessage,

--- a/extensions/imessage/src/monitor/recovery-cursor.ts
+++ b/extensions/imessage/src/monitor/recovery-cursor.ts
@@ -187,6 +187,6 @@ export function advanceIMessageRecoveryCursor(
     store.register(key, { lastRowid: rowid });
   } catch {
     // Best effort: a failed cursor write just means we replay a little more
-    // next startup, which the dedupe absorbs.
+    // next startup, which durable ingress tombstones reject by GUID.
   }
 }

--- a/extensions/imessage/src/test-support/runtime.ts
+++ b/extensions/imessage/src/test-support/runtime.ts
@@ -6,6 +6,8 @@ import type {
   PluginStateSyncKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
   createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
@@ -15,9 +17,9 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { vi } from "vitest";
 import { setIMessageRuntime } from "../runtime.js";
 
-function createIMessageTestEnv(): NodeJS.ProcessEnv {
-  const stateDir = fs.mkdtempSync(
-    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-imessage-state-"),
+function createIMessageTestEnv(): NodeJS.ProcessEnv & { OPENCLAW_STATE_DIR: string } {
+  const stateDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-imessage-state-")),
   );
   return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 }
@@ -34,10 +36,20 @@ export function createIMessagePluginStateSyncStoreForTest<T>(
 }
 
 export function installIMessageStateRuntimeForTest(): void {
+  closeOpenClawStateDatabaseForTest();
   imessageTestEnv = createIMessageTestEnv();
   resetPluginStateStoreForTests();
   setIMessageRuntime({
     state: {
+      resolveStateDir: () => imessageTestEnv.OPENCLAW_STATE_DIR,
+      openChannelIngressQueue: (
+        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+      ) =>
+        createChannelIngressQueueForTests({
+          ...options,
+          channelId: "imessage",
+          stateDir: options?.stateDir ?? imessageTestEnv.OPENCLAW_STATE_DIR,
+        }),
       openKeyedStore: ((options) =>
         createPluginStateKeyedStoreForTests("imessage", {
           ...options,
@@ -64,6 +76,7 @@ export async function loadFreshIMessageReplyCacheForTest(options?: {
   preservePersistentState?: boolean;
 }): Promise<typeof import("../monitor-reply-cache.js")> {
   if (!options?.preservePersistentState) {
+    closeOpenClawStateDatabaseForTest();
     imessageTestEnv = createIMessageTestEnv();
   }
   resetPluginStateStoreForTests();
@@ -71,6 +84,15 @@ export async function loadFreshIMessageReplyCacheForTest(options?: {
   const { setIMessageRuntime: setFreshIMessageRuntime } = await import("../runtime.js");
   setFreshIMessageRuntime({
     state: {
+      resolveStateDir: () => imessageTestEnv.OPENCLAW_STATE_DIR,
+      openChannelIngressQueue: (
+        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+      ) =>
+        createChannelIngressQueueForTests({
+          ...options,
+          channelId: "imessage",
+          stateDir: options?.stateDir ?? imessageTestEnv.OPENCLAW_STATE_DIR,
+        }),
       openKeyedStore: ((storeOptions) =>
         createPluginStateKeyedStoreForTests("imessage", {
           ...storeOptions,
@@ -95,8 +117,19 @@ export async function loadFreshIMessageReplyCacheForTest(options?: {
 }
 
 export function installIMessageFailingStateRuntimeForTest(): void {
+  closeOpenClawStateDatabaseForTest();
+  imessageTestEnv = createIMessageTestEnv();
   setIMessageRuntime({
     state: {
+      resolveStateDir: () => imessageTestEnv.OPENCLAW_STATE_DIR,
+      openChannelIngressQueue: (
+        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+      ) =>
+        createChannelIngressQueueForTests({
+          ...options,
+          channelId: "imessage",
+          stateDir: options?.stateDir ?? imessageTestEnv.OPENCLAW_STATE_DIR,
+        }),
       openKeyedStore: (() => {
         throw new Error("test plugin-state failure");
       }) as PluginRuntime["state"]["openKeyedStore"],

--- a/extensions/imessage/src/test-support/runtime.ts
+++ b/extensions/imessage/src/test-support/runtime.ts
@@ -86,12 +86,12 @@ export async function loadFreshIMessageReplyCacheForTest(options?: {
     state: {
       resolveStateDir: () => imessageTestEnv.OPENCLAW_STATE_DIR,
       openChannelIngressQueue: (
-        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+        queueOptions?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
       ) =>
         createChannelIngressQueueForTests({
-          ...options,
+          ...queueOptions,
           channelId: "imessage",
-          stateDir: options?.stateDir ?? imessageTestEnv.OPENCLAW_STATE_DIR,
+          stateDir: queueOptions?.stateDir ?? imessageTestEnv.OPENCLAW_STATE_DIR,
         }),
       openKeyedStore: ((storeOptions) =>
         createPluginStateKeyedStoreForTests("imessage", {


### PR DESCRIPTION
Refs #109657

## What Problem This Solves

Fixes an issue where iMessage users could permanently miss inbound messages when the gateway crashed after `imsg watch` advanced its chat.db ROWID cursor but before OpenClaw finished dispatching the row. On restart, the advanced cursor caused that never-dispatched message to be skipped.

## Why This Change Was Made

The iMessage monitor now journals each raw row before advancing the recovery cursor, mirroring Telegram's offset-after-spool contract. The durable queue uses the message GUID as its event ID and a per-chat lane, then carries claims through deferred debounce, merged fan-out adoption, gated settlement, restart recovery, and the legacy catchup path.

Completed queue tombstones replace the retired persistent GUID guard with the same 4-hour / 10,000-entry parity. There is intentionally no migration for the retired guard namespace: it was a transient dedupe cache, its existing entries expire on their own, and the layering policy requires cache state to be dropped/rebuilt rather than preserved through a compatibility path. The existing age fence and the 2-hour / 500-row recovery caps are unchanged.

Legacy catchup rows carry provenance through the durable journal so their configured catchup age window remains authoritative instead of the tighter live Push-flush fence. The documented live-fence/catchup overlap is accepted: tombstoning live-fence suppressions keeps restart replay deterministic, while the overlap requires the narrow combination of downtime Push-flush backlog and legacy catchup being enabled.

Twin verdict: tapbacks remain distinct events. Upstream `imsg` exposes every message row's own ROWID and GUID in [`Sources/imsg/OutputModels.swift`](https://github.com/openclaw/imsg/blob/b5b7464bc748af482bfc3059b28d5dab0395da9e/Sources/imsg/OutputModels.swift#L81-L126), while [`Sources/IMsgCore/MessageWatcher.swift`](https://github.com/openclaw/imsg/blob/b5b7464bc748af482bfc3059b28d5dab0395da9e/Sources/IMsgCore/MessageWatcher.swift#L236-L260) yields and advances by each row's ROWID, including reaction rows. GUID event IDs therefore do not collapse tapbacks into their parent messages.

AI-assisted implementation; maintainer-reviewed behavior and contracts.

## User Impact

iMessage ingress now survives a crash between receipt and dispatch without silently losing the message. Replayed live and catchup rows share one durable admission path, duplicates are suppressed by durable GUID tombstones, and existing backlog age limits remain in force.

## Evidence

- Rebased onto current `origin/main` (`4e0cc187a21c`).
- `node scripts/run-vitest.mjs extensions/imessage` — 46 test files and 798 tests passed after the lint-fix rebase.
- Targeted `oxlint` and `oxfmt --check` — passed on all four CI-fallout files.
- `node scripts/check-deadcode-exports.mjs` — production, full-tree, and script scans passed with 0 entries.
- `node scripts/check-deadcode-unused-files.mjs` — production and full-tree scans passed with 0 entries.
- `git diff --check origin/main...HEAD` — passed.
- Fresh uncommitted autoreview of the lint-fix — clean, with no accepted/actionable findings; full branch review also verified the upstream `imsg` row contract and catchup cursor failure gate.
