### PR TITLE
fix(whatsapp): evaluate mention patterns when other members are @-mentioned

### DIFF
--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -68,26 +68,25 @@ function isBotMentionedFromTargets(
     : isSelfChatMode(targets.self.e164, mentionCfg.allowFrom) && !isGroupConversation;
 
   const hasMentions = targets.normalizedMentions.length > 0;
-  if (hasMentions && !isSelfChat) {
+  const hasNativeMentionsOutsideSelfChat = hasMentions && !isSelfChat;
+  if (hasNativeMentionsOutsideSelfChat) {
     for (const mention of targets.normalizedMentions) {
       if (identitiesOverlap(targets.self, mention)) {
         return true;
       }
     }
-    // The message natively @-mentions only other members. That must not veto
-    // the operator's configured text mentionPatterns — `marlow, look at
-    // @SomeoneElse's message` still explicitly addresses the bot (#109488).
-    // Only the loose self-number digit fallback stays suppressed here: an
-    // @-tag of another member injects that member's number into the body, so
-    // substring digit matching is unreliable in this shape.
-    const bodyWithMentions = clean(msg.payload.body);
-    return mentionCfg.mentionRegexes.some((re) => re.test(bodyWithMentions));
   } else if (hasMentions && isSelfChat) {
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in self-chat triggers the bot.
   }
   const bodyClean = clean(msg.payload.body);
   if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) {
     return true;
+  }
+
+  // Native mentions for other participants inject their identities into the
+  // body, so they must not activate the loose self-number fallback below.
+  if (hasNativeMentionsOutsideSelfChat) {
+    return false;
   }
 
   // Fallback: detect body containing our own number (with or without +, spacing)

--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -74,8 +74,14 @@ function isBotMentionedFromTargets(
         return true;
       }
     }
-    // If the message explicitly mentions someone else, do not fall back to regex matches.
-    return false;
+    // The message natively @-mentions only other members. That must not veto
+    // the operator's configured text mentionPatterns — `marlow, look at
+    // @SomeoneElse's message` still explicitly addresses the bot (#109488).
+    // Only the loose self-number digit fallback stays suppressed here: an
+    // @-tag of another member injects that member's number into the body, so
+    // substring digit matching is unreliable in this shape.
+    const bodyWithMentions = clean(msg.payload.body);
+    return mentionCfg.mentionRegexes.some((re) => re.test(bodyWithMentions));
   } else if (hasMentions && isSelfChat) {
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in self-chat triggers the bot.
   }

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -575,11 +575,13 @@ describe("applyGroupGating", () => {
       messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
     });
 
+    // Third-party @-mention and no configured-pattern match: still dropped
+    // (the self-chat suppression path must not swallow the identity check).
     const { result, groupHistories } = await runGroupGating({
       cfg,
       msg: createGroupMessage({
         id: "g-other-mention",
-        body: "@openclaw please check this",
+        body: "please check this out",
         mentionedJids: ["15550000000@s.whatsapp.net"],
         selfE164: "+15551234567",
         selfJid: "15551234567@s.whatsapp.net",
@@ -588,6 +590,33 @@ describe("applyGroupGating", () => {
 
     expect(result.shouldProcess).toBe(false);
     expect(groupHistories.get("whatsapp:default:group:123@g.us")?.length).toBe(1);
+  });
+
+  it("processes a pattern-matching message that also @-mentions another member (#109488)", async () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          groups: { "*": { requireMention: true } },
+        },
+      },
+      messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+    });
+
+    // Previously the native third-party @-mention short-circuited gating to
+    // false before mentionPatterns were evaluated and the message was
+    // silently dropped.
+    const { result } = await runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "g-other-mention-pattern",
+        body: "@openclaw please check this",
+        mentionedJids: ["15550000000@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(true);
   });
 
   it.each([

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -136,9 +136,35 @@ describe("isBotMentionedFromTargets", () => {
     expect(debugMention(msg, cfg).wasMentioned).toBe(expected);
   }
 
-  it("ignores regex matches when other mentions are present", () => {
+  it("honors configured mention patterns when only other members are @-mentioned (#109488)", () => {
+    // Previously a native @-mention of a non-bot member short-circuited the
+    // gate to false before mentionPatterns were evaluated, silently dropping
+    // messages like "marlow, look at @SomeoneElse's message".
     const msg = makeMsg({
       body: "@OpenClaw please help",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
+    expectMentioned(msg, mentionCfg, true);
+  });
+
+  it("still rejects third-party mentions when no configured pattern matches", () => {
+    const msg = makeMsg({
+      body: "look at @SomeoneElse's message",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
+    expectMentioned(msg, mentionCfg, false);
+  });
+
+  it("keeps the self-number digit fallback suppressed when other members are @-mentioned", () => {
+    // An @-tag of another member injects that member's number into the body,
+    // so loose digit matching stays disabled in this shape — only explicit
+    // mentionPatterns can rescue the message (#109488).
+    const msg = makeMsg({
+      body: "call me at +15551234567 and ask @SomeoneElse",
       mentionedJids: ["19998887777@s.whatsapp.net"],
       selfE164: "+15551234567",
       selfJid: "15551234567@s.whatsapp.net",


### PR DESCRIPTION
Fixes #109488

## User-facing bug

In a `requireMention: true` group, a message that matches the configured text `mentionPatterns` **and** natively @-tags another (non-bot) member — e.g. `marlow, look at @SomeoneElse's message` — is silently dropped. The identical text without the @-tag triggers the agent normally.

## Root cause

`isBotMentionedFromTargets()` (`extensions/whatsapp/src/auto-reply/mentions.ts`) returns `false` as soon as the message carries native mentions and none of them matches the bot's identity. The `mentionPatterns` regex check further down the function is unreachable in that shape, so an explicit textual address of the bot is vetoed by an unrelated @-tag.

## Fix

When the native @-mention JIDs do not include the bot, fall through to the configured text `mentionPatterns` check instead of returning `false`. Two behaviors are deliberately preserved:

- **No pattern match → still dropped.** A message that only @-tags someone else does not trigger the bot.
- **The loose self-number digit fallback stays suppressed in this shape.** An @-tag of another member injects that member's number into the body, so substring digit matching is unreliable there; only explicit `mentionPatterns` can rescue the message.

One existing expectation ("ignores regex matches when other mentions are present") pinned the buggy short-circuit and is flipped with a comment referencing this issue; the adjacent self-chat-fallback test keeps its original intent via a non-matching body, with a new companion test covering the pattern-match path end-to-end through `applyGroupGating`.

## Targeted tests

- `web-auto-reply-utils.test.ts`: pattern + third-party @-tag → mentioned (#109488); third-party @-tag without pattern → not mentioned; digit-fallback stays suppressed under third-party @-tags.
- `web-auto-reply-monitor.test.ts`: full `applyGroupGating` — pattern-matching message with a third-party @-tag is processed; non-matching message with a third-party @-tag is still stored-only.

## Real behavior proof

Real environment: branch checkout at `c8520616e0` (based on current main `c08ce42cef`), Node v22.23.1. Driving the **actual production gate** (`debugMention` → `isBotMentionedFromTargets`) via tsx with the issue's exact configuration (`mentionRegexes: [/^marlow[,:]?/i]`) and message shape (group message, native third-party mention JID):

Before fix (main `c08ce42cef`):

```text
wasMentioned: false          # ← the silent drop from the issue
mentionedJids: [ '19998887777@s.whatsapp.net' ]
```

After fix (`c8520616e0`):

```text
wasMentioned: true           # pattern-matching text + third-party @-tag
mentionedJids: [ '19998887777@s.whatsapp.net' ]
control (no @-tag) wasMentioned: true          # unchanged behavior
control (no pattern match) wasMentioned: false # third-party tag alone still gated
```

Verification against the committed head (`git status` clean): `tsgo` core / extensions / extensions-test all exit 0; `web-auto-reply-utils.test.ts` 33/33 and `web-auto-reply-monitor.test.ts` 22/22 (55 total); `oxlint` clean on touched files.

## Not tested / known gaps

- Not exercised over a live WhatsApp connection (no channel credentials). The proof above drives the exact production gating function with the message shape the WhatsApp inbound path produces; the issue reporter's deterministic Docker repro plus these controls cover the behavioral contract.

## AI-assisted disclosure

This patch was prepared with AI assistance, with source-level reproduction, targeted regression tests, and real gate-invocation proof as shown above.
