### PR TITLE
fix(messaging): document group recall and await Signal cleanup

### DIFF
--- a/docs/concepts/memory-qmd.md
+++ b/docs/concepts/memory-qmd.md
@@ -197,9 +197,13 @@ QMD.
 
 Session hits are still filtered by
 [`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The
-default `tree` visibility does not expose unrelated same-agent sessions. If a
-gateway-dispatched session should be recallable from a separate DM session,
-set `tools.sessions.visibility: "agent"` intentionally.
+default `tree` visibility includes the current session, its spawned sessions,
+and same-agent group sessions watched through ambient group awareness. With
+`session.dmScope: "main"`, users in a multi-user DM setup share the main
+session and can recall content from its watched groups. Use a per-peer
+`dmScope` for DM isolation, or set visibility to `"self"` to opt out of ambient
+watched-session reads. Other unrelated same-agent sessions still require
+`"agent"` visibility.
 
 ## Search scope
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -166,10 +166,13 @@ Optionally index session transcripts so `memory_search` can recall earlier
 conversations. This is opt-in: set `experimental.sessionMemory: true` and add
 `"sessions"` to `sources` (default `sources` is `["memory"]`).
 
-Session hits obey `tools.sessions.visibility`: the default `"tree"` only
-exposes the current session and sessions it spawned. To recall an unrelated
-same-agent session from a different session (for example a gateway-dispatched
-session from a DM), widen visibility to `"agent"`.
+Session hits obey `tools.sessions.visibility`: the default `"tree"` exposes the
+current session, sessions it spawned, and same-agent group sessions watched
+through ambient group awareness. With `session.dmScope: "main"`, a multi-user
+DM setup shares that main session, so users routed there can recall content
+from its watched groups. Use a per-peer `dmScope` for DM isolation, or set
+visibility to `"self"` to opt out of ambient watched-session reads. Other
+unrelated same-agent sessions still require `"agent"` visibility.
 
 When using the QMD backend, also set `memory.qmd.sessions.enabled: true` so
 transcripts get exported into the QMD collection; `experimental.sessionMemory`

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -396,7 +396,8 @@ Configures inbound media understanding (image/audio/video):
 
 Controls which sessions can be targeted by the session tools (`sessions_list`, `sessions_history`, `sessions_send`).
 
-Default: `tree` (current session + sessions spawned by it, such as subagents).
+Default: `tree` (current session + sessions spawned by it, such as subagents, plus ambient
+watched group sessions for the same agent).
 
 ```json5
 {
@@ -412,7 +413,7 @@ Default: `tree` (current session + sessions spawned by it, such as subagents).
 <AccordionGroup>
   <Accordion title="Visibility scopes">
     - `self`: only the current session key.
-    - `tree`: current session + sessions spawned by the current session (subagents).
+    - `tree`: current session + sessions spawned by the current session (subagents). For read operations, it also includes same-agent group sessions that the current session watches through ambient group awareness.
     - `agent`: any session belonging to the current agent id (can include other users if you run per-sender sessions under the same agent id).
     - `all`: any session. Cross-agent targeting still requires `tools.agentToAgent`.
     - Sandbox clamp: when the current session is sandboxed and `agents.defaults.sandbox.sessionToolsVisibility="spawned"` (the default), visibility is forced to `tree` even if `tools.sessions.visibility="all"`.
@@ -422,6 +423,12 @@ Default: `tree` (current session + sessions spawned by it, such as subagents).
 
   </Accordion>
 </AccordionGroup>
+
+With the default `session.dmScope: "main"`, human activity in a group makes that same-agent group
+session ambiently visible to the agent's main session. In a multi-user setup, `"main"` also shares
+one DM session across users, so each user routed there can read from ambiently watched groups,
+including through session-memory `memory_search`. Use a per-peer `dmScope` for DM isolation, or set
+`tools.sessions.visibility: "self"` to opt out of ambient watched-session reads.
 
 ### `tools.sessions_spawn`
 

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -142,6 +142,7 @@ function appendDiscordButtonBlocks(
   blocks: NonNullable<DiscordComponentMessageSpec["blocks"]>,
   buttons: readonly MessagePresentationButton[],
 ): void {
+  // Index is position in the question's options; core emits one buttons block in option order.
   const components = buttons
     .map((button, optionIndex) => buildDiscordButtonComponent(button, optionIndex))
     .filter((button): button is DiscordComponentButtonSpec => Boolean(button));

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -325,6 +325,9 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       // Keep the claim owner live until every real delivery and core handler exits;
       // disposing earlier lets a replacement drain recover work still producing replies.
       await Promise.allSettled(activeDeliveries);
+      // Accepted shutdown tradeoff: deferred claims may wait for the full agent run.
+      // A deadline would allow duplicate side effects after replacement recovery;
+      // remove this wait only when core can cancel or abandon the run before release.
       await Promise.allSettled(deferredClaims.values());
       await drain.waitForIdle();
       drain.dispose();

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -687,11 +687,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             lifecycle.onAdoptionFinalizing();
           }
         },
-        onAbandoned: () => {
+        onAbandoned: async () => {
           handedOff = true;
-          for (const lifecycle of lifecycles) {
-            lifecycle.onAbandoned();
-          }
+          await Promise.all(
+            lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
+          );
         },
       },
       // Terminal no-dispatch (gated, whitespace-only, deliberate skip) must
@@ -800,14 +800,16 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       }
       // Keep the current keyed debounce task reserved through backoff so a
       // newer same-conversation flush cannot overtake this failed batch.
-      const retryTask = retrySignalInboundFlush(entries, err).catch((terminalError: unknown) => {
-        // Exhausted retries: release the drain claims so queue retry policy
-        // owns redelivery instead of the stall watchdog dead-lettering them.
-        for (const entry of entries) {
-          entry.turnAdoptionLifecycle?.onAbandoned();
-        }
-        throw terminalError;
-      });
+      const retryTask = retrySignalInboundFlush(entries, err).catch(
+        async (terminalError: unknown) => {
+          // Exhausted retries: release the drain claims so queue retry policy
+          // owns redelivery instead of the stall watchdog dead-lettering them.
+          await Promise.all(
+            entries.map((entry) => Promise.resolve(entry.turnAdoptionLifecycle?.onAbandoned())),
+          );
+          throw terminalError;
+        },
+      );
       deps.runTrackedTask?.(() => retryTask.catch(() => undefined));
       await retryTask;
     }

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -42,7 +42,7 @@ export type SignalIngressLifecycle = {
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
   onAdoptionFinalizing: () => void;
-  onAbandoned: () => void;
+  onAbandoned: () => void | Promise<void>;
 };
 
 type SignalIngressDispatchResult =

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -268,6 +268,7 @@ export function buildSlackInteractiveBlocks(
       return state;
     }
     if (block.type === "buttons") {
+      // Index is position in the question's options; core emits one buttons block in option order.
       const elements = block.buttons
         .flatMap((button, choiceIndex) => {
           const target = resolveSlackButtonTarget(button, choiceIndex);

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -100,6 +100,7 @@ function chunkInteractiveButtons(
   buttons: readonly MessagePresentationButton[],
   rows: TelegramInlineButton[][],
 ) {
+  // Index is position in the question's options; core emits one buttons block in option order.
   for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
     const row = buttons
       .slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE)

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -275,7 +275,8 @@ export function completeFollowupRunLifecycle(run: FollowupLifecycleRun): void {
       return;
     }
     completedTurnAdoptionLifecycleCallbacks.add(lifecycle);
-    // onSettled must run even when onAbandoned throws (gateway/plugin cleanup).
+    // Async onAbandoned work must contain its own rejections; core guarantees a
+    // non-rejecting promise. onSettled must still run after a synchronous throw.
     try {
       if (!admittedTurnAdoptionLifecycles.has(lifecycle)) {
         lifecycle.onAbandoned?.();


### PR DESCRIPTION
Related: #110332
Related: #110104

## What Problem This Solves

Fixes an issue where the session-memory docs described default tree visibility as current-session descendants only, even though ambiently watched same-agent group sessions are now readable. It also closes small lifecycle and encoder-contract gaps found in the messaging review sweep.

## Why This Change Was Made

The docs now describe ambient group awareness, the multi-user `session.dmScope: "main"` read-widening tradeoff, and the `tools.sessions.visibility: "self"` opt-out. Signal preserves and awaits asynchronous abandonment cleanup, LINE documents why deferred shutdown must remain unbounded until core can cancel safely, and the ask-user channel encoders record their shared positional-index invariant.

The initially considered LINE timeout was rejected during review because releasing ownership while the original run remained active could duplicate side effects. This PR intentionally keeps the existing wait and documents its removal condition.

## User Impact

Operators can now understand which watched group transcripts are recallable under default session visibility and how to opt out. Signal teardown waits for core abandonment cleanup before retry ownership proceeds. No configuration or migration is required.

Release-note context: documentation and bounded messaging lifecycle follow-ups to #110332 and #110104; no root changelog edit because the release changelog is maintained separately.

## Evidence

- `git diff --check`
- Fresh branch autoreview on rebased head `07fc2f1fede42b59f1b8831216eca49a5f9678cd`: clean, no accepted/actionable findings
- Hosted changed-surface run 29630401797: format, API/boundary guards, all core/extension typechecks, and core lint passed; its two Signal extension-lint findings were fixed before this head
- Exact-head CI run 29631435722: all required jobs passed after rerunning one unrelated `qa-runtime.test.ts` timing flake on the identical SHA
- The earlier Apple i18n baseline failure was repaired upstream in #110271; `test/scripts/apple-app-i18n.test.ts` passes 13/13 on the refreshed base

AI-assisted: yes (Codex implementation and review; maintainer-directed scope).
