### PR TITLE
fix(pairing): normalize account key in legacy allowFrom filename parsing

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1437,6 +1437,32 @@ describe("doctor legacy state migrations", () => {
     expect(fs.existsSync(path.join(oauthDir, "telegram-allowFrom.json"))).toBe(false);
   });
 
+  it("migrates a case-preserved Telegram account filename through Doctor", async () => {
+    const root = await makeTempRoot();
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            HY_RIN_Bot: {},
+          },
+        },
+      },
+    };
+    const oauthDir = ensureCredentialsDir(root);
+    const sourcePath = path.join(oauthDir, "telegram-HY_RIN_Bot-allowFrom.json");
+    fs.writeFileSync(sourcePath, '["1008"]\n', "utf8");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+
+    const detected = await detectLegacyStateMigrations({ cfg, env });
+    const result = await runLegacyStateMigrations({ detected, config: cfg, env, now: () => 123 });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
+      hy_rin_bot: ["1008"],
+    });
+    expect(fs.existsSync(sourcePath)).toBe(false);
+  });
+
   it("no-ops when nothing detected", async () => {
     const root = await makeTempRoot();
     const cfg: OpenClawConfig = {};

--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -161,7 +161,7 @@ describe("legacy channel pairing state migration", () => {
 
   it("leaves ambiguous sanitized account filenames in place", async () => {
     const { env, sourceDir } = await createFixture();
-    const filePath = path.join(sourceDir, "telegram-ops_bot-allowFrom.json");
+    const filePath = path.join(sourceDir, "telegram-Ops_Bot-allowFrom.json");
     writeJson(filePath, { version: 1, allowFrom: ["1003"] });
 
     const detected = detectLegacyChannelPairingState({
@@ -174,6 +174,27 @@ describe("legacy channel pairing state migration", () => {
     expect(result.warnings).toEqual([
       expect.stringContaining(
         "Legacy channel allowFrom channel/account is ambiguous; left in place",
+      ),
+    ]);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+  });
+
+  it("does not re-encode filename punctuation into another account", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-ops..bot-allowFrom.json");
+    writeJson(filePath, { version: 1, allowFrom: ["1003"] });
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["ops_bot"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Legacy channel allowFrom channel/account is unresolved; left in place",
       ),
     ]);
     expect(fs.existsSync(filePath)).toBe(true);
@@ -220,89 +241,6 @@ describe("legacy channel pairing state migration", () => {
     ]);
     expect(fs.existsSync(filePath)).toBe(true);
     expect(readChannelPairingStateSnapshot("custom-channel", env).allowFrom).toEqual({});
-  });
-
-  it("imports allowFrom files with mixed-case account id segments", async () => {
-    const { env, sourceDir } = await createFixture();
-    const filePath = path.join(sourceDir, "telegram-HY_RIN_Bot-allowFrom.json");
-    writeJson(filePath, ["1005"]);
-
-    const detected = detectLegacyChannelPairingState({
-      sourceDir,
-      configuredAccountIds: { telegram: ["hy_rin_bot"] },
-    });
-    const result = migrateLegacyChannelPairingState({ detected, env });
-
-    expect(result.warnings).toEqual([]);
-    expect(result.changes).toEqual([
-      "Migrated 1 telegram/hy_rin_bot allowFrom entry → shared SQLite state",
-    ]);
-    expect(fs.existsSync(filePath)).toBe(false);
-    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
-      hy_rin_bot: ["1005"],
-    });
-  });
-
-  it("imports underscore-bearing allowFrom files with mixed-case account id segments", async () => {
-    const { env, sourceDir } = await createFixture();
-    const filePath = path.join(sourceDir, "telegram-My_Work_Bot-allowFrom.json");
-    writeJson(filePath, ["1006"]);
-
-    const detected = detectLegacyChannelPairingState({
-      sourceDir,
-      configuredAccountIds: { telegram: ["my_work_bot"] },
-    });
-    const result = migrateLegacyChannelPairingState({ detected, env });
-
-    expect(result.warnings).toEqual([]);
-    expect(result.changes).toEqual([
-      "Migrated 1 telegram/my_work_bot allowFrom entry → shared SQLite state",
-    ]);
-    expect(fs.existsSync(filePath)).toBe(false);
-    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
-      my_work_bot: ["1006"],
-    });
-  });
-
-  it("imports uppercase DEFAULT allowFrom files when a configured account matches", async () => {
-    const { env, sourceDir } = await createFixture();
-    const filePath = path.join(sourceDir, "telegram-DEFAULT-allowFrom.json");
-    writeJson(filePath, ["1008"]);
-
-    const detected = detectLegacyChannelPairingState({
-      sourceDir,
-      configuredAccountIds: { telegram: ["default"] },
-    });
-    const result = migrateLegacyChannelPairingState({ detected, env });
-
-    expect(result.warnings).toEqual([]);
-    expect(result.changes).toEqual([
-      "Migrated 1 telegram/default allowFrom entry → shared SQLite state",
-    ]);
-    expect(fs.existsSync(filePath)).toBe(false);
-    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
-      default: ["1008"],
-    });
-  });
-
-  it("leaves uppercase DEFAULT allowFrom files unresolved for bundled channels", async () => {
-    const { env, sourceDir } = await createFixture();
-    const filePath = path.join(sourceDir, "telegram-DEFAULT-allowFrom.json");
-    writeJson(filePath, ["1007"]);
-
-    const detected = detectLegacyChannelPairingState({
-      sourceDir,
-    });
-    const result = migrateLegacyChannelPairingState({ detected, env });
-
-    expect(result.changes).toEqual([]);
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Legacy channel allowFrom channel/account is unresolved; left in place",
-      ),
-    ]);
-    expect(fs.existsSync(filePath)).toBe(true);
-    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
   });
 
   it("leaves overlapping channel and account filename interpretations in place", async () => {

--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -65,7 +65,7 @@ describe("legacy channel pairing state migration", () => {
 
     const detected = detectLegacyChannelPairingState({
       sourceDir,
-      configuredAccountIds: { telegram: ["alerts", "ops/bot"] },
+      configuredAccountIds: { telegram: ["alerts", "ops_bot"] },
     });
     expect(detected.hasLegacy).toBe(true);
     const result = migrateLegacyChannelPairingState({ detected, env });
@@ -84,7 +84,7 @@ describe("legacy channel pairing state migration", () => {
           meta: { accountId: "alerts" },
         },
       ],
-      allowFrom: { default: ["1001"], alerts: ["1002"], "ops/bot": ["1003"] },
+      allowFrom: { default: ["1001"], alerts: ["1002"], ops_bot: ["1003"] },
     });
     expect(fs.existsSync(path.join(path.dirname(sourceDir), "state", "openclaw.sqlite"))).toBe(
       true,
@@ -167,7 +167,7 @@ describe("legacy channel pairing state migration", () => {
     });
   });
 
-  it("leaves ambiguous sanitized account filenames in place", async () => {
+  it("matches the raw account key instead of a punctuation-normalized sibling", async () => {
     const { env, sourceDir } = await createFixture();
     const filePath = path.join(sourceDir, "telegram-Ops_Bot-allowFrom.json");
     writeJson(filePath, { version: 1, allowFrom: ["1003"] });
@@ -178,14 +178,14 @@ describe("legacy channel pairing state migration", () => {
     });
     const result = migrateLegacyChannelPairingState({ detected, env });
 
-    expect(result.changes).toEqual([]);
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Legacy channel allowFrom channel/account is ambiguous; left in place",
-      ),
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 telegram/ops_bot allowFrom entry → shared SQLite state",
     ]);
-    expect(fs.existsSync(filePath)).toBe(true);
-    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
+      ops_bot: ["1003"],
+    });
   });
 
   it("leaves case-folded filename collision sets in place", async () => {
@@ -226,26 +226,32 @@ describe("legacy channel pairing state migration", () => {
     expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
   });
 
-  it("does not re-encode filename punctuation into another account", async () => {
-    const { env, sourceDir } = await createFixture();
-    const filePath = path.join(sourceDir, "telegram-ops..bot-allowFrom.json");
-    writeJson(filePath, { version: 1, allowFrom: ["1003"] });
+  it.each([
+    { filenameAccountKey: "ops..bot", configuredAccountId: "ops_bot" },
+    { filenameAccountKey: "ops_bot", configuredAccountId: "ops.bot" },
+  ])(
+    "does not re-encode $filenameAccountKey into $configuredAccountId",
+    async ({ filenameAccountKey, configuredAccountId }) => {
+      const { env, sourceDir } = await createFixture();
+      const filePath = path.join(sourceDir, `telegram-${filenameAccountKey}-allowFrom.json`);
+      writeJson(filePath, { version: 1, allowFrom: ["1003"] });
 
-    const detected = detectLegacyChannelPairingState({
-      sourceDir,
-      configuredAccountIds: { telegram: ["ops_bot"] },
-    });
-    const result = migrateLegacyChannelPairingState({ detected, env });
+      const detected = detectLegacyChannelPairingState({
+        sourceDir,
+        configuredAccountIds: { telegram: [configuredAccountId] },
+      });
+      const result = migrateLegacyChannelPairingState({ detected, env });
 
-    expect(result.changes).toEqual([]);
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Legacy channel allowFrom channel/account is unresolved; left in place",
-      ),
-    ]);
-    expect(fs.existsSync(filePath)).toBe(true);
-    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
-  });
+      expect(result.changes).toEqual([]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining(
+          "Legacy channel allowFrom channel/account is unresolved; left in place",
+        ),
+      ]);
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+    },
+  );
 
   it("ignores invalid account candidates while resolving scoped filenames", async () => {
     const { env, sourceDir } = await createFixture();

--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -32,6 +32,14 @@ function writeJson(filePath: string, value: unknown): void {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
+function isCaseSensitiveDirectory(directory: string): boolean {
+  const marker = path.join(directory, "case-check");
+  fs.writeFileSync(marker, "case", "utf8");
+  const caseSensitive = !fs.existsSync(path.join(directory, "CASE-CHECK"));
+  fs.rmSync(marker);
+  return caseSensitive;
+}
+
 describe("legacy channel pairing state migration", () => {
   it("imports pairing requests and scoped allowFrom entries into SQLite", async () => {
     const { env, sourceDir } = await createFixture();
@@ -177,6 +185,44 @@ describe("legacy channel pairing state migration", () => {
       ),
     ]);
     expect(fs.existsSync(filePath)).toBe(true);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+  });
+
+  it("leaves case-folded filename collision sets in place", async () => {
+    const { env, sourceDir } = await createFixture();
+    const caseSensitive = isCaseSensitiveDirectory(sourceDir);
+    if (!caseSensitive) {
+      expect(caseSensitive).toBe(false);
+      return;
+    }
+    const filenames = [
+      "telegram-AmbiguousAcct-allowFrom.json",
+      "telegram-AMBIGUOUSACCT-allowFrom.json",
+      "telegram-exactacct-allowFrom.json",
+      "telegram-ExactAcct-allowFrom.json",
+    ];
+    for (const [index, filename] of filenames.entries()) {
+      writeJson(path.join(sourceDir, filename), { version: 1, allowFrom: [`user-${index}`] });
+    }
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["ambiguousacct", "exactacct"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(filenames.length);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining(
+        filenames.map((filename) =>
+          expect.stringContaining(
+            `Legacy channel allowFrom channel/account is ambiguous; left in place at ${path.join(sourceDir, filename)}`,
+          ),
+        ),
+      ),
+    );
+    expect(filenames.every((filename) => fs.existsSync(path.join(sourceDir, filename)))).toBe(true);
     expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
   });
 

--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -222,6 +222,89 @@ describe("legacy channel pairing state migration", () => {
     expect(readChannelPairingStateSnapshot("custom-channel", env).allowFrom).toEqual({});
   });
 
+  it("imports allowFrom files with mixed-case account id segments", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-HY_RIN_Bot-allowFrom.json");
+    writeJson(filePath, ["1005"]);
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["hy_rin_bot"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 telegram/hy_rin_bot allowFrom entry → shared SQLite state",
+    ]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
+      hy_rin_bot: ["1005"],
+    });
+  });
+
+  it("imports underscore-bearing allowFrom files with mixed-case account id segments", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-My_Work_Bot-allowFrom.json");
+    writeJson(filePath, ["1006"]);
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["my_work_bot"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 telegram/my_work_bot allowFrom entry → shared SQLite state",
+    ]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
+      my_work_bot: ["1006"],
+    });
+  });
+
+  it("imports uppercase DEFAULT allowFrom files when a configured account matches", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-DEFAULT-allowFrom.json");
+    writeJson(filePath, ["1008"]);
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["default"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 telegram/default allowFrom entry → shared SQLite state",
+    ]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
+      default: ["1008"],
+    });
+  });
+
+  it("leaves uppercase DEFAULT allowFrom files unresolved for bundled channels", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-DEFAULT-allowFrom.json");
+    writeJson(filePath, ["1007"]);
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Legacy channel allowFrom channel/account is unresolved; left in place",
+      ),
+    ]);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+  });
+
   it("leaves overlapping channel and account filename interpretations in place", async () => {
     const { env, sourceDir } = await createFixture();
     const filePath = path.join(sourceDir, "telegram-business-allowFrom.json");

--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -274,6 +274,27 @@ describe("legacy channel pairing state migration", () => {
     });
   });
 
+  it("leaves nonliteral default filename suffixes unresolved", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-DEFAULT-allowFrom.json");
+    writeJson(filePath, { version: 1, allowFrom: ["1003"] });
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["default"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Legacy channel allowFrom channel/account is unresolved; left in place",
+      ),
+    ]);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+  });
+
   it("does not infer default accounts for external channels", async () => {
     const { env, sourceDir } = await createFixture();
     const filePath = path.join(sourceDir, "custom-channel-default-allowFrom.json");

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -78,6 +78,35 @@ function parsePairingFilename(filename: string): PairingChannel | null {
     : null;
 }
 
+function findCaseFoldedAllowFromCollisions(
+  filenames: readonly string[],
+  knownChannelIds: readonly string[],
+): Set<string> {
+  const firstFilenameByKey = new Map<string, string>();
+  const collisions = new Set<string>();
+  for (const filename of filenames) {
+    if (!filename.endsWith(ALLOW_FROM_SUFFIX)) {
+      continue;
+    }
+    const stem = filename.slice(0, -ALLOW_FROM_SUFFIX.length);
+    for (const channel of knownChannelIds) {
+      if (!stem.startsWith(`${channel}-`)) {
+        continue;
+      }
+      const accountKey = stem.slice(channel.length + 1).toLowerCase();
+      const collisionKey = `${channel}\0${accountKey}`;
+      const firstFilename = firstFilenameByKey.get(collisionKey);
+      if (firstFilename) {
+        collisions.add(firstFilename);
+        collisions.add(filename);
+      } else {
+        firstFilenameByKey.set(collisionKey, filename);
+      }
+    }
+  }
+  return collisions;
+}
+
 function parseAllowFromFilename(
   filename: string,
   knownChannelIds: readonly string[],
@@ -242,6 +271,10 @@ export function migrateLegacyChannelPairingState(params: {
 }): { changes: string[]; warnings: string[] } {
   const changes: string[] = [];
   const warnings: string[] = [];
+  const caseFoldedCollisions = findCaseFoldedAllowFromCollisions(
+    params.detected.files,
+    params.detected.knownChannelIds,
+  );
   for (const filename of params.detected.files) {
     const filePath = path.join(params.detected.sourceDir, filename);
     const pairingChannel = parsePairingFilename(filename);
@@ -270,8 +303,10 @@ export function migrateLegacyChannelPairingState(params: {
     if (!allowTarget) {
       continue;
     }
-    if (!allowTarget.target) {
-      const reason = allowTarget.reason === "ambiguous" ? "ambiguous" : "unresolved";
+    const hasCaseFoldedCollision = caseFoldedCollisions.has(filename);
+    if (hasCaseFoldedCollision || !allowTarget.target) {
+      const reason =
+        hasCaseFoldedCollision || allowTarget.reason === "ambiguous" ? "ambiguous" : "unresolved";
       warnings.push(
         `Legacy channel allowFrom channel/account is ${reason}; left in place at ${filePath}`,
       );

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -105,24 +105,35 @@ function parseAllowFromFilename(
       continue;
     }
     const accountKey = stem.slice(channel.length + 1);
-    const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
-      try {
-        return safeAccountKey(accountId) === accountKey;
-      } catch {
-        // One invalid configured candidate must not abort every legacy migration.
-        // With no valid match, the source remains in place as unresolved below.
-        return false;
+    // Normalize the filename segment the same way as configured account ids
+    // so that raw spellings (e.g. HY_RIN_Bot) match their canonical safe key.
+    let normalizedAccountKey: string | undefined;
+    try {
+      normalizedAccountKey = safeAccountKey(accountKey);
+    } catch {
+      // Pathological filename segment; skip this channel safely.
+    }
+    if (normalizedAccountKey) {
+      const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
+        try {
+          return safeAccountKey(accountId) === normalizedAccountKey;
+        } catch {
+          // One invalid configured candidate must not abort every legacy migration.
+          // With no valid match, the source remains in place as unresolved below.
+          return false;
+        }
+      });
+      if (matchingAccountIds.length === 1 && matchingAccountIds[0]) {
+        targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
+      } else if (matchingAccountIds.length > 1) {
+        hasAccountCollision = true;
+      } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
+        // Bundled <channel>-default files resolve without config.
+        // This implicit fallback applies only when the filename suffix is the
+        // literal canonical "default"; a non-canonical spelling (e.g. DEFAULT)
+        // that did not match any configured account remains unresolved.
+        targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
       }
-    });
-    if (matchingAccountIds.length === 1 && matchingAccountIds[0]) {
-      targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
-    } else if (matchingAccountIds.length > 1) {
-      hasAccountCollision = true;
-    } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
-      // "default" is canonical, so bundled `<channel>-default` files resolve without config.
-      // Keep this on CHANNEL_IDS: knownChannelIds also includes configured and pairing-file ids.
-      // After safeAccountKey finds no match, those other channels must remain unresolved.
-      targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
     }
   }
   if (hasAccountCollision || targets.length > 1) {

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -134,10 +134,11 @@ function parseAllowFromFilename(
       continue;
     }
     const accountKey = stem.slice(channel.length + 1);
-    // Fold case only: accountKey is already lossy, so re-encoding can misattribute access.
+    // Fold case only: either side may contain punctuation that safe-key encoding would conflate.
     const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
       try {
-        return safeAccountKey(accountId) === accountKey.toLowerCase();
+        safeAccountKey(accountId);
+        return accountId.toLowerCase() === accountKey.toLowerCase();
       } catch {
         // One invalid configured candidate must not abort every legacy migration.
         // With no valid match, the source remains in place as unresolved below.

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -105,35 +105,25 @@ function parseAllowFromFilename(
       continue;
     }
     const accountKey = stem.slice(channel.length + 1);
-    // Normalize the filename segment the same way as configured account ids
-    // so that raw spellings (e.g. HY_RIN_Bot) match their canonical safe key.
-    let normalizedAccountKey: string | undefined;
-    try {
-      normalizedAccountKey = safeAccountKey(accountKey);
-    } catch {
-      // Pathological filename segment; skip this channel safely.
-    }
-    if (normalizedAccountKey) {
-      const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
-        try {
-          return safeAccountKey(accountId) === normalizedAccountKey;
-        } catch {
-          // One invalid configured candidate must not abort every legacy migration.
-          // With no valid match, the source remains in place as unresolved below.
-          return false;
-        }
-      });
-      if (matchingAccountIds.length === 1 && matchingAccountIds[0]) {
-        targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
-      } else if (matchingAccountIds.length > 1) {
-        hasAccountCollision = true;
-      } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
-        // Bundled <channel>-default files resolve without config.
-        // This implicit fallback applies only when the filename suffix is the
-        // literal canonical "default"; a non-canonical spelling (e.g. DEFAULT)
-        // that did not match any configured account remains unresolved.
-        targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
+    // Fold case only: accountKey is already lossy, so re-encoding can misattribute access.
+    const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
+      try {
+        return safeAccountKey(accountId) === accountKey.toLowerCase();
+      } catch {
+        // One invalid configured candidate must not abort every legacy migration.
+        // With no valid match, the source remains in place as unresolved below.
+        return false;
       }
+    });
+    if (matchingAccountIds.length === 1 && matchingAccountIds[0]) {
+      targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
+    } else if (matchingAccountIds.length > 1) {
+      hasAccountCollision = true;
+    } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
+      // "default" is canonical, so bundled `<channel>-default` files resolve without config.
+      // Keep this on CHANNEL_IDS: knownChannelIds also includes configured and pairing-file ids.
+      // After safeAccountKey finds no match, those other channels must remain unresolved.
+      targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
     }
   }
   if (hasAccountCollision || targets.length > 1) {

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -138,6 +138,9 @@ function parseAllowFromFilename(
     const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
       try {
         safeAccountKey(accountId);
+        if (accountId === DEFAULT_ACCOUNT_ID && accountKey !== DEFAULT_ACCOUNT_ID) {
+          return false;
+        }
         return accountId.toLowerCase() === accountKey.toLowerCase();
       } catch {
         // One invalid configured candidate must not abort every legacy migration.


### PR DESCRIPTION
Closes #110187

## What Problem This Solves

Fixes an upgrade failure where a legacy account-scoped pairing allowlist file with a case-preserved account suffix, such as `telegram-HY_RIN_Bot-allowFrom.json`, could not be matched to the configured Telegram account. The migration left the file in place, emitted a warning, and gateway startup refused to report ready on every retry.

## Why This Change Was Made

The legacy pairing migration compared the filename suffix verbatim with a normalized account key. The repair accepts case-only differences, but determines ownership from case-insensitive equality between the raw filename account suffix and the raw configured account ID.

`safeAccountKey` still validates configured candidates, but its lossy output is never used for equality. This matters in both directions: `ops..bot` must not become `ops_bot`, and a canonical-looking `ops_bot` filename must not be attributed to configured account `ops.bot`. When both `ops/bot` and `ops_bot` are configured, the raw `ops_bot` owner remains distinguishable and receives only its own file.

The migration also treats the complete set of case-equivalent source filenames as one attribution decision. If two real files differ only by account-suffix case—even when one is the exact lowercase spelling—every member remains ambiguous and untouched. This prevents multiple source allowlists from being merged and deleted on case-sensitive filesystems.

Provenance caveat: the shipped `v2026.7.1` writer already used `safeAccountKey` and therefore emitted lowercase canonical filenames. The reported uppercase file is real observed upgrade state, but its producer has not been identified in repository history. This PR recovers bounded case-only state without broadening punctuation or multi-source attribution.

## User Impact

A single case-preserved filename whose raw suffix identifies exactly one configured account can upgrade normally: Doctor/startup imports the allowlist into shared SQLite state and removes the source.

Multiple case-equivalent files remain ambiguous and untouched. Punctuation-normalized lookalikes, unknown accounts, non-canonical implicit-default spellings, and other unresolved ownership remain on disk for operator recovery rather than risking cross-account authorization.

## Evidence

Exact head: `584cd74e8b8bb037587fe55fd0e67259d27c0a28`

The branch is rebased onto current `origin/main`.

Focused proof:

```console
$ node scripts/run-vitest.mjs src/infra/state-migrations.channel-pairing.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  11 passed (11)

$ node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  92 passed (92)

$ node scripts/run-vitest.mjs src/commands/doctor-config-preflight.state-migration.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  29 passed (29)

$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- src/infra/state-migrations.channel-pairing.ts src/infra/state-migrations.channel-pairing.test.ts src/commands/doctor-state-migrations.test.ts
# passed

$ git diff --check origin/main...HEAD
# passed
```

Source-blind CLI validation ran `openclaw doctor --fix --non-interactive --yes` with isolated state roots on a verified case-sensitive APFS volume:

| Scenario | Observable result |
|---|---|
| `AmbiguousAcct` + `AMBIGUOUSACCT` | both files retained; reported ambiguous; no SQLite rows |
| exact `exactacct` + `ExactAcct` | both files retained; reported ambiguous; no SQLite rows |
| singleton `HY_RIN_Bot` | source removed; `hy_rin_bot:user-e` imported |
| filename `ops..bot`, configured `ops_bot` | source retained; unresolved; no SQLite rows |
| filename `ops_bot`, configured `ops.bot` | source retained; unresolved; no SQLite rows |
| filename `Ops_Bot`, configured `ops/bot` and `ops_bot` | source removed; imported only as `ops_bot:user-h` |
| filename `DEFAULT`, configured/default candidate | source retained; unresolved; no SQLite rows |

The unique canonical safe-key fallback suggested during review is intentionally not retained: it would let punctuation normalization create authorization ownership between distinct raw account IDs such as `ops_bot` and `ops.bot`. The migration accepts only case differences; ambiguous or punctuation-derived ownership remains an operator decision.

The regression suite covers both punctuation-normalization directions, exact raw ownership beside a punctuation lookalike, case-folded source collision sets, singleton case recovery, and source retention/deletion.

Final branch-level Codex autoreview at maximum priority P1 reported no accepted/actionable findings.

PR surface against current base:

- Production: `+43 / -3` — records collision-set, raw-owner, and literal-default safety before import/removal.
- Tests: `+129 / -9`
- Total: `+172 / -12` across 3 files

## AI Assistance

- AI-assisted: Yes
- Human maintainer reviewed and narrowed the final attribution and migration behavior: Yes
