### PR TITLE
fix(whatsapp): preserve inbound messages across restarts

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -28,7 +28,6 @@ import {
   type ManagedWhatsAppListener,
 } from "../connection-controller.js";
 import { resolveWhatsAppInboundPolicy } from "../inbound-policy.js";
-import { WHATSAPP_INBOUND_DEDUPE_TTL_MS } from "../inbound/dedupe.js";
 import { normalizeWebInboundMessage } from "../inbound/message-aliases.js";
 import {
   attachWebInboxToSocket,
@@ -150,6 +149,7 @@ function isRetryableAuthUnstableError(error: unknown): error is WhatsAppAuthUnst
 }
 
 const DEFAULT_TRANSPORT_TIMEOUT_MS = 5 * 60 * 1000;
+const WHATSAPP_RECONNECT_CATCH_UP_MAX_MS = 20 * 60_000;
 
 export async function monitorWebChannel(
   verbose: boolean,
@@ -226,7 +226,7 @@ export async function monitorWebChannel(
   const messageTimeoutMs = tuning.messageTimeoutMs ?? 30 * 60 * 1000;
   const reconnectCatchUpWindowMs = Math.min(
     Math.max(messageTimeoutMs, 60_000),
-    WHATSAPP_INBOUND_DEDUPE_TTL_MS,
+    WHATSAPP_RECONNECT_CATCH_UP_MAX_MS,
   );
   const watchdogCheckMs = tuning.watchdogCheckMs ?? 60 * 1000;
   const controller = new WhatsAppConnectionController({

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { hasVisibleInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
 import {
+  bindIngressLifecycleToReplyOptions,
   deliverInboundReplyWithMessageSendContext,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -18,6 +19,7 @@ import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-histor
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import { resolveWhatsAppIngressLifecycle } from "../../inbound/ingress-lifecycle.js";
 import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import {
   type DeliverableWhatsAppOutboundPayload,
@@ -529,6 +531,7 @@ export function createWhatsAppReplyPlan(params: {
   statusReactionController?: StatusReactionController | null;
 }) {
   const admission = requireWhatsAppInboundAdmission(params.msg);
+  const ingressLifecycle = resolveWhatsAppIngressLifecycle(params.msg);
   const conversationId = admission.conversation.id;
   const conversationKind = admission.conversation.kind;
   const statusReactionController = params.statusReactionController ?? null;
@@ -733,6 +736,7 @@ export function createWhatsAppReplyPlan(params: {
     },
   };
   const replyOptions = {
+    ...(ingressLifecycle ? bindIngressLifecycleToReplyOptions(ingressLifecycle) : {}),
     // Message-tool-only unmentioned group turns have no automatic visible reply.
     // Suppress composing there so silent background runs do not leak presence.
     suppressTyping:

--- a/extensions/whatsapp/src/inbound/dedupe.ts
+++ b/extensions/whatsapp/src/inbound/dedupe.ts
@@ -1,21 +1,8 @@
 // Whatsapp plugin module implements dedupe behavior.
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
-import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 
-export const WHATSAPP_INBOUND_DEDUPE_TTL_MS = 20 * 60_000;
-const RECENT_WEB_MESSAGE_MAX = 5000;
 const RECENT_OUTBOUND_MESSAGE_TTL_MS = 20 * 60_000;
 const RECENT_OUTBOUND_MESSAGE_MAX = 5000;
-
-type WhatsAppInboundReplayKeys = string | readonly string[];
-
-export const whatsAppInboundReplayGuard = createChannelReplayGuard<WhatsAppInboundReplayKeys>({
-  dedupe: {
-    ttlMs: WHATSAPP_INBOUND_DEDUPE_TTL_MS,
-    memoryMaxSize: RECENT_WEB_MESSAGE_MAX,
-  },
-  buildReplayKey: (keys) => keys,
-});
 const recentOutboundMessages = createDedupeCache({
   ttlMs: RECENT_OUTBOUND_MESSAGE_TTL_MS,
   maxSize: RECENT_OUTBOUND_MESSAGE_MAX,
@@ -43,7 +30,6 @@ function buildMessageKey(params: {
 }
 
 export function resetWebInboundDedupe(): void {
-  whatsAppInboundReplayGuard.clearMemory();
   recentOutboundMessages.clear();
 }
 

--- a/extensions/whatsapp/src/inbound/dedupe.ts
+++ b/extensions/whatsapp/src/inbound/dedupe.ts
@@ -8,7 +8,7 @@ const recentOutboundMessages = createDedupeCache({
   maxSize: RECENT_OUTBOUND_MESSAGE_MAX,
 });
 
-export class WhatsAppRetryableInboundError extends Error {
+class WhatsAppRetryableInboundError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "WhatsAppRetryableInboundError";

--- a/extensions/whatsapp/src/inbound/dedupe.ts
+++ b/extensions/whatsapp/src/inbound/dedupe.ts
@@ -8,13 +8,6 @@ const recentOutboundMessages = createDedupeCache({
   maxSize: RECENT_OUTBOUND_MESSAGE_MAX,
 });
 
-class WhatsAppRetryableInboundError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "WhatsAppRetryableInboundError";
-  }
-}
-
 function buildMessageKey(params: {
   accountId: string;
   remoteJid: string;

--- a/extensions/whatsapp/src/inbound/durable-payload.ts
+++ b/extensions/whatsapp/src/inbound/durable-payload.ts
@@ -1,0 +1,51 @@
+// Whatsapp plugin module owns durable inbound payload serialization.
+import type { WAMessage } from "baileys";
+import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
+import { BufferJSON } from "../session.runtime.js";
+
+export type SerializedWhatsAppDurableInboundMessage = PluginJsonValue;
+
+export class WhatsAppIngressPermanentError extends Error {
+  constructor(
+    readonly reason: "invalid-payload" | "missing-message-key" | "event-id-mismatch",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "WhatsAppIngressPermanentError";
+  }
+}
+
+export function serializeWhatsAppDurableInboundMessage(
+  message: WAMessage,
+): SerializedWhatsAppDurableInboundMessage {
+  const timestamp = message.messageTimestamp;
+  let serializedMessage = message;
+  if (timestamp != null && typeof timestamp === "object") {
+    try {
+      const numericTimestamp = Number(timestamp);
+      if (Number.isFinite(numericTimestamp)) {
+        // Protobuf Long methods do not survive JSON. Persist the exact seconds
+        // value so append-age admission sees the same timestamp after replay.
+        serializedMessage = { ...message, messageTimestamp: numericTimestamp };
+      }
+    } catch {
+      // Leave malformed timestamp handling to the normal inbound admission path.
+    }
+  }
+  return JSON.parse(JSON.stringify(serializedMessage, BufferJSON.replacer)) as PluginJsonValue;
+}
+
+export function deserializeWhatsAppDurableInboundMessage(
+  message: SerializedWhatsAppDurableInboundMessage,
+): WAMessage {
+  try {
+    return JSON.parse(JSON.stringify(message), BufferJSON.reviver) as WAMessage;
+  } catch (error) {
+    throw new WhatsAppIngressPermanentError(
+      "invalid-payload",
+      "WhatsApp ingress row contains an invalid serialized message",
+      { cause: error },
+    );
+  }
+}

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -1,0 +1,154 @@
+// WhatsApp durable ingress drain adapter: complete-on-return and failure propagation.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  createWhatsAppIngressDrain,
+  type WhatsAppDurableInboundCompletedMetadata,
+  type WhatsAppDurableInboundMetadata,
+  type WhatsAppDurableInboundPayload,
+} from "./durable-receive.js";
+
+async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-whatsapp-durable-"));
+  try {
+    return await fn(stateDir);
+  } finally {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function payload(id: string): WhatsAppDurableInboundPayload {
+  return {
+    message: {
+      key: { remoteJid: "1@s.whatsapp.net", id, fromMe: false },
+      message: { conversation: "hi" },
+    },
+    receivedAt: 1,
+  };
+}
+
+describe("createWhatsAppIngressDrain", () => {
+  it("releases claims when processClaimed throws (callback failure at-least-once)", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<
+        WhatsAppDurableInboundPayload,
+        WhatsAppDurableInboundMetadata,
+        WhatsAppDurableInboundCompletedMetadata
+      >({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      await queue.enqueue("msg-1", payload("msg-1"));
+
+      const drain = createWhatsAppIngressDrain({
+        queue,
+        processClaimed: async () => {
+          throw new Error("downstream callback rejected");
+        },
+      });
+
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      const status = await queue.enqueue("msg-1", payload("msg-1"));
+      expect(status.kind).not.toBe("completed");
+      const pending = await queue.listPending({ limit: "all" });
+      expect(pending.some((row) => row.id === "msg-1")).toBe(true);
+      drain.dispose();
+    });
+  });
+
+  it("releases claims when processClaimed surfaces dedupe contention", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<
+        WhatsAppDurableInboundPayload,
+        WhatsAppDurableInboundMetadata,
+        WhatsAppDurableInboundCompletedMetadata
+      >({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      await queue.enqueue("msg-2", payload("msg-2"));
+
+      const drain = createWhatsAppIngressDrain({
+        queue,
+        processClaimed: async () => {
+          // monitor maps "inflight" contention to this throw for drain-owned claims.
+          throw new Error("whatsapp inbound dedupe claim contended (inflight)");
+        },
+      });
+
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      const pending = await queue.listPending({ limit: "all" });
+      expect(pending.some((row) => row.id === "msg-2")).toBe(true);
+      const status = await queue.enqueue("msg-2", payload("msg-2"));
+      expect(status.kind).not.toBe("completed");
+      drain.dispose();
+    });
+  });
+
+  it("tombstones after successful processClaimed return", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<
+        WhatsAppDurableInboundPayload,
+        WhatsAppDurableInboundMetadata,
+        WhatsAppDurableInboundCompletedMetadata
+      >({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      await queue.enqueue("msg-3", payload("msg-3"));
+
+      const drain = createWhatsAppIngressDrain({
+        queue,
+        processClaimed: async () => {},
+      });
+
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      const status = await queue.enqueue("msg-3", payload("msg-3"));
+      expect(status.kind).toBe("completed");
+      drain.dispose();
+    });
+  });
+
+  it("releases claim and increments attempts when processClaimed surfaces flush failure", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<
+        WhatsAppDurableInboundPayload,
+        WhatsAppDurableInboundMetadata,
+        WhatsAppDurableInboundCompletedMetadata
+      >({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      await queue.enqueue("msg-flush-fail", payload("msg-flush-fail"));
+
+      const drain = createWhatsAppIngressDrain({
+        queue,
+        processClaimed: async () => {
+          throw new Error("downstream flush rejected");
+        },
+      });
+
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      const pending = await queue.listPending({ limit: "all" });
+      const row = pending.find((entry) => entry.id === "msg-flush-fail");
+      expect(row).toBeDefined();
+      expect((row?.attempts ?? 0) >= 1).toBe(true);
+      drain.dispose();
+    });
+  });
+});

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -1,15 +1,20 @@
-// WhatsApp durable ingress drain adapter: complete-on-return and failure propagation.
+// WhatsApp durable ingress drain adapter: completion, retry, and lane serialization.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { WAMessage } from "baileys";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { describe, expect, it } from "vitest";
 import {
+  createWhatsAppDurableInboundMessageId,
   createWhatsAppIngressDrain,
-  type WhatsAppDurableInboundCompletedMetadata,
-  type WhatsAppDurableInboundMetadata,
+  deserializeWhatsAppDurableInboundMessage,
+  enqueueWhatsAppDurableInbound,
+  serializeWhatsAppDurableInboundMessage,
   type WhatsAppDurableInboundPayload,
 } from "./durable-receive.js";
+
+const REMOTE_JID = "1@s.whatsapp.net";
 
 async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-whatsapp-durable-"));
@@ -20,33 +25,38 @@ async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T
   }
 }
 
-function payload(id: string): WhatsAppDurableInboundPayload {
+function message(id: string, remoteJid = REMOTE_JID): WAMessage {
   return {
-    message: {
-      key: { remoteJid: "1@s.whatsapp.net", id, fromMe: false },
-      message: { conversation: "hi" },
-    },
+    key: { remoteJid, id, fromMe: false },
+    message: { conversation: "hi" },
+  };
+}
+
+function eventId(id: string, remoteJid = REMOTE_JID): string {
+  return createWhatsAppDurableInboundMessageId({ remoteJid, id });
+}
+
+function payload(id: string, remoteJid = REMOTE_JID): WhatsAppDurableInboundPayload {
+  return {
+    message: serializeWhatsAppDurableInboundMessage(message(id, remoteJid)),
     receivedAt: 1,
   };
 }
 
 describe("createWhatsAppIngressDrain", () => {
-  it("releases claims when processClaimed throws (callback failure at-least-once)", async () => {
+  it("releases claims when dispatch throws before adoption", async () => {
     await withTempState(async (stateDir) => {
-      const queue = createChannelIngressQueueForTests<
-        WhatsAppDurableInboundPayload,
-        WhatsAppDurableInboundMetadata,
-        WhatsAppDurableInboundCompletedMetadata
-      >({
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
         accountId: "acct",
         stateDir,
       });
-      await queue.enqueue("msg-1", payload("msg-1"));
+      const id = eventId("msg-1");
+      await queue.enqueue(id, payload("msg-1"), { laneKey: REMOTE_JID });
 
       const drain = createWhatsAppIngressDrain({
         queue,
-        processClaimed: async () => {
+        dispatch: async () => {
           throw new Error("downstream callback rejected");
         },
       });
@@ -54,101 +64,164 @@ describe("createWhatsAppIngressDrain", () => {
       await drain.drainOnce();
       await drain.waitForIdle();
 
-      const status = await queue.enqueue("msg-1", payload("msg-1"));
+      const status = await queue.enqueue(id, payload("msg-1"), { laneKey: REMOTE_JID });
       expect(status.kind).not.toBe("completed");
       const pending = await queue.listPending({ limit: "all" });
-      expect(pending.some((row) => row.id === "msg-1")).toBe(true);
+      expect(pending.some((row) => row.id === id)).toBe(true);
       drain.dispose();
     });
   });
 
-  it("releases claims when processClaimed surfaces dedupe contention", async () => {
+  it("propagates failed-retryable results as claim release", async () => {
     await withTempState(async (stateDir) => {
-      const queue = createChannelIngressQueueForTests<
-        WhatsAppDurableInboundPayload,
-        WhatsAppDurableInboundMetadata,
-        WhatsAppDurableInboundCompletedMetadata
-      >({
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
         accountId: "acct",
         stateDir,
       });
-      await queue.enqueue("msg-2", payload("msg-2"));
+      const id = eventId("msg-2");
+      await queue.enqueue(id, payload("msg-2"), { laneKey: REMOTE_JID });
 
       const drain = createWhatsAppIngressDrain({
         queue,
-        processClaimed: async () => {
-          // monitor maps "inflight" contention to this throw for drain-owned claims.
-          throw new Error("whatsapp inbound dedupe claim contended (inflight)");
-        },
+        dispatch: async () => ({
+          kind: "failed-retryable",
+          error: new Error("downstream flush rejected"),
+        }),
       });
 
       await drain.drainOnce();
       await drain.waitForIdle();
 
       const pending = await queue.listPending({ limit: "all" });
-      expect(pending.some((row) => row.id === "msg-2")).toBe(true);
-      const status = await queue.enqueue("msg-2", payload("msg-2"));
-      expect(status.kind).not.toBe("completed");
+      const row = pending.find((entry) => entry.id === id);
+      expect(row).toBeDefined();
+      expect((row?.attempts ?? 0) >= 1).toBe(true);
       drain.dispose();
     });
   });
 
-  it("tombstones after successful processClaimed return", async () => {
+  it("tombstones after successful dispatch return", async () => {
     await withTempState(async (stateDir) => {
-      const queue = createChannelIngressQueueForTests<
-        WhatsAppDurableInboundPayload,
-        WhatsAppDurableInboundMetadata,
-        WhatsAppDurableInboundCompletedMetadata
-      >({
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
         accountId: "acct",
         stateDir,
       });
-      await queue.enqueue("msg-3", payload("msg-3"));
+      const id = eventId("msg-3");
+      await queue.enqueue(id, payload("msg-3"), { laneKey: REMOTE_JID });
 
       const drain = createWhatsAppIngressDrain({
         queue,
-        processClaimed: async () => {},
+        dispatch: async () => {},
       });
 
       await drain.drainOnce();
       await drain.waitForIdle();
 
-      const status = await queue.enqueue("msg-3", payload("msg-3"));
+      const status = await queue.enqueue(id, payload("msg-3"), { laneKey: REMOTE_JID });
       expect(status.kind).toBe("completed");
       drain.dispose();
     });
   });
 
-  it("releases claim and increments attempts when processClaimed surfaces flush failure", async () => {
+  it("keeps a second same-lane message pending until the first turn adopts", async () => {
     await withTempState(async (stateDir) => {
-      const queue = createChannelIngressQueueForTests<
-        WhatsAppDurableInboundPayload,
-        WhatsAppDurableInboundMetadata,
-        WhatsAppDurableInboundCompletedMetadata
-      >({
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
         accountId: "acct",
         stateDir,
       });
-      await queue.enqueue("msg-flush-fail", payload("msg-flush-fail"));
+      const firstId = eventId("msg-4a");
+      const secondId = eventId("msg-4b");
+      await queue.enqueue(firstId, payload("msg-4a"), {
+        laneKey: REMOTE_JID,
+        receivedAt: 1,
+      });
+      await queue.enqueue(secondId, payload("msg-4b"), {
+        laneKey: REMOTE_JID,
+        receivedAt: 2,
+      });
 
+      const dispatched: string[] = [];
+      let adoptFirst: (() => void | Promise<void>) | undefined;
       const drain = createWhatsAppIngressDrain({
         queue,
-        processClaimed: async () => {
-          throw new Error("downstream flush rejected");
+        dispatch: async (inbound, _payload, lifecycle) => {
+          const id = inbound.key.id;
+          if (!id) {
+            throw new Error("expected transport id");
+          }
+          dispatched.push(id);
+          if (id === "msg-4a") {
+            adoptFirst = lifecycle.onAdopted;
+            return { kind: "deferred" };
+          }
         },
       });
 
       await drain.drainOnce();
       await drain.waitForIdle();
 
-      const pending = await queue.listPending({ limit: "all" });
-      const row = pending.find((entry) => entry.id === "msg-flush-fail");
-      expect(row).toBeDefined();
-      expect((row?.attempts ?? 0) >= 1).toBe(true);
+      // Core drain serializes a conversation lane: msg-4b cannot reach the
+      // channel debouncer until msg-4a transfers into the reply lane.
+      expect(dispatched).toEqual(["msg-4a"]);
+      expect((await queue.listClaims()).map((row) => row.id)).toEqual([firstId]);
+      expect((await queue.listPending({ limit: "all" })).map((row) => row.id)).toEqual([secondId]);
+
+      if (!adoptFirst) {
+        throw new Error("expected first adoption callback");
+      }
+      await adoptFirst();
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      expect(dispatched).toEqual(["msg-4a", "msg-4b"]);
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
       drain.dispose();
+    });
+  });
+});
+
+describe("WhatsApp durable message serialization", () => {
+  it("preserves Long-like protobuf timestamps as seconds", () => {
+    const timestamp = 1_700_000_000;
+    const longLike = { low: timestamp, high: 0, unsigned: true, valueOf: () => timestamp };
+    const serialized = serializeWhatsAppDurableInboundMessage({
+      ...message("long-timestamp"),
+      messageTimestamp: longLike,
+    } as unknown as WAMessage);
+
+    expect(deserializeWhatsAppDurableInboundMessage(serialized).messageTimestamp).toBe(timestamp);
+  });
+
+  it("persists receive-time skip decisions", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+
+      await enqueueWhatsAppDurableInbound({
+        queue,
+        message: message("stale-append"),
+        upsertType: "append",
+        skipStaleAppend: true,
+        skipRecentOutboundEcho: true,
+        receivedAt: 1,
+      });
+
+      await expect(queue.listPending()).resolves.toMatchObject([
+        {
+          payload: {
+            upsertType: "append",
+            skipStaleAppend: true,
+            skipRecentOutboundEcho: true,
+          },
+        },
+      ]);
     });
   });
 });

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -6,11 +6,13 @@ import type { WAMessage } from "baileys";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { describe, expect, it } from "vitest";
 import {
+  deserializeWhatsAppDurableInboundMessage,
+  serializeWhatsAppDurableInboundMessage,
+} from "./durable-payload.js";
+import {
   createWhatsAppDurableInboundMessageId,
   createWhatsAppIngressDrain,
-  deserializeWhatsAppDurableInboundMessage,
   enqueueWhatsAppDurableInbound,
-  serializeWhatsAppDurableInboundMessage,
   type WhatsAppDurableInboundPayload,
 } from "./durable-receive.js";
 

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -157,8 +157,9 @@ describe("createWhatsAppIngressDrain", () => {
           dispatched.push(id);
           if (id === "msg-4a") {
             adoptFirst = lifecycle.onAdopted;
-            return { kind: "deferred" };
+            return { kind: "deferred" as const };
           }
+          return undefined;
         },
       });
 

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -1,7 +1,13 @@
 // Whatsapp plugin module implements durable receive behavior.
 import { createHash } from "node:crypto";
 import type { WAMessage } from "baileys";
-import { createDurableInboundReceiveJournalFromQueue } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createChannelIngressDrain,
+  createDurableInboundReceiveJournalFromQueue,
+  type ChannelIngressDrain,
+  type ChannelIngressQueue,
+  type ChannelIngressQueueClaim,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 import { getWhatsAppRuntime } from "../runtime.js";
 import { BufferJSON } from "../session.runtime.js";
@@ -29,7 +35,7 @@ export type WhatsAppDurableInboundMetadata = {
   readReceipt?: WhatsAppReadReceiptTarget;
 };
 
-type WhatsAppDurableInboundCompletedMetadata = {
+export type WhatsAppDurableInboundCompletedMetadata = {
   readReceipt?: WhatsAppReadReceiptTarget;
 };
 
@@ -56,7 +62,25 @@ export function deserializeWhatsAppDurableInboundMessage(
   return JSON.parse(JSON.stringify(message), BufferJSON.reviver) as WAMessage;
 }
 
-export function createWhatsAppDurableInboundReceiveJournal(accountId: string) {
+export type WhatsAppDurableInboundStores = {
+  journal: ReturnType<
+    typeof createDurableInboundReceiveJournalFromQueue<
+      WhatsAppDurableInboundPayload,
+      WhatsAppDurableInboundMetadata,
+      WhatsAppDurableInboundCompletedMetadata
+    >
+  >;
+  queue: ChannelIngressQueue<
+    WhatsAppDurableInboundPayload,
+    WhatsAppDurableInboundMetadata,
+    WhatsAppDurableInboundCompletedMetadata
+  >;
+};
+
+/** Journal for accept-side dedupe + the queue the core drain claims against. */
+export function createWhatsAppDurableInboundStores(
+  accountId: string,
+): WhatsAppDurableInboundStores {
   const accountPart = hashNamespacePart(accountId);
   const runtime = getWhatsAppRuntime();
   const queue = runtime.state.openChannelIngressQueue<
@@ -67,7 +91,7 @@ export function createWhatsAppDurableInboundReceiveJournal(accountId: string) {
     accountId: accountPart,
     stateDir: runtime.state.resolveStateDir(),
   });
-  return createDurableInboundReceiveJournalFromQueue({
+  const journal = createDurableInboundReceiveJournalFromQueue({
     queue,
     retention: {
       pendingTtlMs: WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS,
@@ -76,6 +100,40 @@ export function createWhatsAppDurableInboundReceiveJournal(accountId: string) {
       pendingMaxEntries: WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
       completedMaxEntries: WHATSAPP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES,
       failedMaxEntries: WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
+    },
+  });
+  return { journal, queue };
+}
+
+export type WhatsAppDurableClaim = ChannelIngressQueueClaim<
+  WhatsAppDurableInboundPayload,
+  WhatsAppDurableInboundMetadata
+>;
+
+/**
+ * Core drain over the WhatsApp inbound queue.
+ * Completes on dispatch return (full processing), not lifecycle.onAdopted —
+ * matches prior finalize-after-flush tombstone timing.
+ */
+export function createWhatsAppIngressDrain(params: {
+  queue: WhatsAppDurableInboundStores["queue"];
+  processClaimed: (claim: WhatsAppDurableClaim) => Promise<void>;
+  onLog?: (message: string) => void;
+  abortSignal?: AbortSignal;
+}): ChannelIngressDrain {
+  return createChannelIngressDrain({
+    queue: params.queue,
+    ...(params.onLog ? { onLog: params.onLog } : {}),
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    // No supersede: WhatsApp never had pre-adoption supersede semantics.
+    dispatchClaimedEvent: async (event) => {
+      try {
+        await params.processClaimed(event);
+        // Tombstone after full processing returns (not turn adoption).
+        return { kind: "completed" as const };
+      } catch (error) {
+        return { kind: "failed-retryable" as const, error };
+      }
     },
   });
 }

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -8,7 +8,6 @@ import {
   type ChannelIngressDrain,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
-import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 import { getWhatsAppRuntime } from "../runtime.js";
 import {
   deserializeWhatsAppDurableInboundMessage,

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -10,14 +10,17 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 import { getWhatsAppRuntime } from "../runtime.js";
-import { BufferJSON } from "../session.runtime.js";
+import {
+  deserializeWhatsAppDurableInboundMessage,
+  serializeWhatsAppDurableInboundMessage,
+  WhatsAppIngressPermanentError,
+  type SerializedWhatsAppDurableInboundMessage,
+} from "./durable-payload.js";
 
 const WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES = 450;
 const WHATSAPP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES = 5000;
 const WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const WHATSAPP_DURABLE_INBOUND_COMPLETED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-
-type SerializedWhatsAppDurableInboundMessage = PluginJsonValue;
 
 export type WhatsAppReadReceiptTarget = {
   remoteJid: string;
@@ -52,17 +55,6 @@ type WhatsAppIngressFacts = {
   laneKey: string;
 };
 
-class WhatsAppIngressPermanentError extends Error {
-  constructor(
-    readonly reason: "invalid-payload" | "missing-message-key" | "event-id-mismatch",
-    message: string,
-    options?: ErrorOptions,
-  ) {
-    super(message, options);
-    this.name = "WhatsAppIngressPermanentError";
-  }
-}
-
 function hashNamespacePart(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
 }
@@ -72,40 +64,6 @@ export function createWhatsAppDurableInboundMessageId(params: {
   id: string;
 }): string {
   return createHash("sha256").update(`${params.remoteJid}\n${params.id}`).digest("hex");
-}
-
-function serializeWhatsAppDurableInboundMessage(
-  message: WAMessage,
-): SerializedWhatsAppDurableInboundMessage {
-  const timestamp = message.messageTimestamp;
-  let serializedMessage = message;
-  if (timestamp != null && typeof timestamp === "object") {
-    try {
-      const numericTimestamp = Number(timestamp);
-      if (Number.isFinite(numericTimestamp)) {
-        // Protobuf Long methods do not survive JSON. Persist the exact seconds
-        // value so append-age admission sees the same timestamp after replay.
-        serializedMessage = { ...message, messageTimestamp: numericTimestamp };
-      }
-    } catch {
-      // Leave malformed timestamp handling to the normal inbound admission path.
-    }
-  }
-  return JSON.parse(JSON.stringify(serializedMessage, BufferJSON.replacer)) as PluginJsonValue;
-}
-
-function deserializeWhatsAppDurableInboundMessage(
-  message: SerializedWhatsAppDurableInboundMessage,
-): WAMessage {
-  try {
-    return JSON.parse(JSON.stringify(message), BufferJSON.reviver) as WAMessage;
-  } catch (error) {
-    throw new WhatsAppIngressPermanentError(
-      "invalid-payload",
-      "WhatsApp ingress row contains an invalid serialized message",
-      { cause: error },
-    );
-  }
 }
 
 function inspectWhatsAppIngressMessage(message: WAMessage): WhatsAppIngressFacts {

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -3,19 +3,21 @@ import { createHash } from "node:crypto";
 import type { WAMessage } from "baileys";
 import {
   createChannelIngressDrain,
-  createDurableInboundReceiveJournalFromQueue,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressDrain,
   type ChannelIngressQueue,
-  type ChannelIngressQueueClaim,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 import { getWhatsAppRuntime } from "../runtime.js";
 import { BufferJSON } from "../session.runtime.js";
 
 const WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES = 450;
-const WHATSAPP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES = 450;
+const WHATSAPP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES = 5000;
 const WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const WHATSAPP_DURABLE_INBOUND_COMPLETED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type SerializedWhatsAppDurableInboundMessage = PluginJsonValue;
 
 export type WhatsAppReadReceiptTarget = {
   remoteJid: string;
@@ -23,21 +25,43 @@ export type WhatsAppReadReceiptTarget = {
   participant?: string;
 };
 
-type SerializedWhatsAppDurableInboundMessage = PluginJsonValue;
-
 export type WhatsAppDurableInboundPayload = {
   message: SerializedWhatsAppDurableInboundMessage;
   upsertType?: string;
+  skipStaleAppend?: boolean;
+  skipRecentOutboundEcho?: boolean;
   receivedAt: number;
+  receiveOrder?: number;
 };
 
-export type WhatsAppDurableInboundMetadata = {
-  readReceipt?: WhatsAppReadReceiptTarget;
+export type WhatsAppIngressLifecycle = {
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onAdoptionFinalizing: () => void;
+  onAbandoned: () => void | Promise<void>;
 };
 
-export type WhatsAppDurableInboundCompletedMetadata = {
-  readReceipt?: WhatsAppReadReceiptTarget;
+type WhatsAppIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type WhatsAppIngressFacts = {
+  eventId: string;
+  laneKey: string;
 };
+
+export class WhatsAppIngressPermanentError extends Error {
+  constructor(
+    readonly reason: "invalid-payload" | "missing-message-key" | "event-id-mismatch",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "WhatsAppIngressPermanentError";
+  }
+}
 
 function hashNamespacePart(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
@@ -53,87 +77,144 @@ export function createWhatsAppDurableInboundMessageId(params: {
 export function serializeWhatsAppDurableInboundMessage(
   message: WAMessage,
 ): SerializedWhatsAppDurableInboundMessage {
-  return JSON.parse(JSON.stringify(message, BufferJSON.replacer)) as PluginJsonValue;
+  const timestamp = message.messageTimestamp;
+  let serializedMessage = message;
+  if (timestamp != null && typeof timestamp === "object") {
+    try {
+      const numericTimestamp = Number(timestamp);
+      if (Number.isFinite(numericTimestamp)) {
+        // Protobuf Long methods do not survive JSON. Persist the exact seconds
+        // value so append-age admission sees the same timestamp after replay.
+        serializedMessage = { ...message, messageTimestamp: numericTimestamp };
+      }
+    } catch {
+      // Leave malformed timestamp handling to the normal inbound admission path.
+    }
+  }
+  return JSON.parse(JSON.stringify(serializedMessage, BufferJSON.replacer)) as PluginJsonValue;
 }
 
 export function deserializeWhatsAppDurableInboundMessage(
   message: SerializedWhatsAppDurableInboundMessage,
 ): WAMessage {
-  return JSON.parse(JSON.stringify(message), BufferJSON.reviver) as WAMessage;
+  try {
+    return JSON.parse(JSON.stringify(message), BufferJSON.reviver) as WAMessage;
+  } catch (error) {
+    throw new WhatsAppIngressPermanentError(
+      "invalid-payload",
+      "WhatsApp ingress row contains an invalid serialized message",
+      { cause: error },
+    );
+  }
 }
 
-export type WhatsAppDurableInboundStores = {
-  journal: ReturnType<
-    typeof createDurableInboundReceiveJournalFromQueue<
-      WhatsAppDurableInboundPayload,
-      WhatsAppDurableInboundMetadata,
-      WhatsAppDurableInboundCompletedMetadata
-    >
-  >;
-  queue: ChannelIngressQueue<
-    WhatsAppDurableInboundPayload,
-    WhatsAppDurableInboundMetadata,
-    WhatsAppDurableInboundCompletedMetadata
-  >;
-};
+function inspectWhatsAppIngressMessage(message: WAMessage): WhatsAppIngressFacts {
+  const remoteJid = message.key?.remoteJid?.trim();
+  const id = message.key?.id?.trim();
+  if (!remoteJid || !id) {
+    throw new WhatsAppIngressPermanentError(
+      "missing-message-key",
+      "WhatsApp ingress message is missing key.remoteJid or key.id",
+    );
+  }
+  return {
+    eventId: createWhatsAppDurableInboundMessageId({ remoteJid, id }),
+    laneKey: remoteJid,
+  };
+}
 
-/** Journal for accept-side dedupe + the queue the core drain claims against. */
-export function createWhatsAppDurableInboundStores(
-  accountId: string,
-): WhatsAppDurableInboundStores {
-  const accountPart = hashNamespacePart(accountId);
-  const runtime = getWhatsAppRuntime();
-  const queue = runtime.state.openChannelIngressQueue<
-    WhatsAppDurableInboundPayload,
-    WhatsAppDurableInboundMetadata,
-    WhatsAppDurableInboundCompletedMetadata
-  >({
-    accountId: accountPart,
-    stateDir: runtime.state.resolveStateDir(),
+export type WhatsAppDurableInboundQueue = ChannelIngressQueue<WhatsAppDurableInboundPayload>;
+
+/** Account-scoped queue shared with the pre-drain WhatsApp receive journal. */
+export function createWhatsAppDurableInboundQueue(accountId: string): WhatsAppDurableInboundQueue {
+  return getWhatsAppRuntime().state.openChannelIngressQueue<WhatsAppDurableInboundPayload>({
+    accountId: hashNamespacePart(accountId),
+    stateDir: getWhatsAppRuntime().state.resolveStateDir(),
   });
-  const journal = createDurableInboundReceiveJournalFromQueue({
-    queue,
-    retention: {
-      pendingTtlMs: WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS,
-      completedTtlMs: WHATSAPP_DURABLE_INBOUND_COMPLETED_TTL_MS,
-      failedTtlMs: WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS,
-      pendingMaxEntries: WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
-      completedMaxEntries: WHATSAPP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES,
-      failedMaxEntries: WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
+}
+
+/** Raw receive chokepoint: append first, then let the drain normalize and dispatch. */
+export async function enqueueWhatsAppDurableInbound(params: {
+  queue: WhatsAppDurableInboundQueue;
+  message: WAMessage;
+  upsertType?: string;
+  skipStaleAppend?: boolean;
+  skipRecentOutboundEcho?: boolean;
+  receivedAt?: number;
+  receiveOrder?: number;
+}) {
+  const facts = inspectWhatsAppIngressMessage(params.message);
+  const receivedAt = params.receivedAt ?? Date.now();
+  await params.queue.prune({
+    pendingTtlMs: WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS,
+    completedTtlMs: WHATSAPP_DURABLE_INBOUND_COMPLETED_TTL_MS,
+    failedTtlMs: WHATSAPP_DURABLE_INBOUND_PENDING_TTL_MS,
+    pendingMaxEntries: WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
+    completedMaxEntries: WHATSAPP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES,
+    failedMaxEntries: WHATSAPP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
+  });
+  return await params.queue.enqueue(
+    facts.eventId,
+    {
+      message: serializeWhatsAppDurableInboundMessage(params.message),
+      upsertType: params.upsertType,
+      ...(params.skipStaleAppend === undefined ? {} : { skipStaleAppend: params.skipStaleAppend }),
+      ...(params.skipRecentOutboundEcho === undefined
+        ? {}
+        : { skipRecentOutboundEcho: params.skipRecentOutboundEcho }),
+      receivedAt,
+      ...(params.receiveOrder === undefined ? {} : { receiveOrder: params.receiveOrder }),
     },
-  });
-  return { journal, queue };
+    { receivedAt, laneKey: facts.laneKey },
+  );
 }
 
-export type WhatsAppDurableClaim = ChannelIngressQueueClaim<
-  WhatsAppDurableInboundPayload,
-  WhatsAppDurableInboundMetadata
->;
+function resolveWhatsAppIngressNonRetryableFailure(error: unknown) {
+  return error instanceof WhatsAppIngressPermanentError
+    ? { reason: error.reason, message: error.message }
+    : null;
+}
 
-/**
- * Core drain over the WhatsApp inbound queue.
- * Completes on dispatch return (full processing), not lifecycle.onAdopted —
- * matches prior finalize-after-flush tombstone timing.
- */
+/** Core drain with per-conversation lanes and completion at reply-lane adoption. */
 export function createWhatsAppIngressDrain(params: {
-  queue: WhatsAppDurableInboundStores["queue"];
-  processClaimed: (claim: WhatsAppDurableClaim) => Promise<void>;
+  queue: WhatsAppDurableInboundQueue;
+  dispatch: (
+    message: WAMessage,
+    payload: WhatsAppDurableInboundPayload,
+    lifecycle: WhatsAppIngressLifecycle,
+  ) => Promise<WhatsAppIngressDispatchResult | void> | WhatsAppIngressDispatchResult | void;
   onLog?: (message: string) => void;
   abortSignal?: AbortSignal;
 }): ChannelIngressDrain {
-  return createChannelIngressDrain({
+  return createChannelIngressDrain<WhatsAppDurableInboundPayload>({
     queue: params.queue,
+    retryPolicy: {
+      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+    },
+    resolveNonRetryableFailure: resolveWhatsAppIngressNonRetryableFailure,
+    deriveLaneKey: (record) => {
+      try {
+        return inspectWhatsAppIngressMessage(
+          deserializeWhatsAppDurableInboundMessage(record.payload.message),
+        ).laneKey;
+      } catch {
+        return record.id;
+      }
+    },
     ...(params.onLog ? { onLog: params.onLog } : {}),
     ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-    // No supersede: WhatsApp never had pre-adoption supersede semantics.
-    dispatchClaimedEvent: async (event) => {
-      try {
-        await params.processClaimed(event);
-        // Tombstone after full processing returns (not turn adoption).
-        return { kind: "completed" as const };
-      } catch (error) {
-        return { kind: "failed-retryable" as const, error };
+    // No supersede: every WhatsApp transport event remains independently deliverable.
+    dispatchClaimedEvent: async (record, lifecycle) => {
+      const message = deserializeWhatsAppDurableInboundMessage(record.payload.message);
+      const facts = inspectWhatsAppIngressMessage(message);
+      if (facts.eventId !== record.id) {
+        throw new WhatsAppIngressPermanentError(
+          "event-id-mismatch",
+          "WhatsApp ingress row id does not match its transport message key",
+        );
       }
+      return await params.dispatch(message, record.payload, lifecycle);
     },
   });
 }

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -52,7 +52,7 @@ type WhatsAppIngressFacts = {
   laneKey: string;
 };
 
-export class WhatsAppIngressPermanentError extends Error {
+class WhatsAppIngressPermanentError extends Error {
   constructor(
     readonly reason: "invalid-payload" | "missing-message-key" | "event-id-mismatch",
     message: string,
@@ -74,7 +74,7 @@ export function createWhatsAppDurableInboundMessageId(params: {
   return createHash("sha256").update(`${params.remoteJid}\n${params.id}`).digest("hex");
 }
 
-export function serializeWhatsAppDurableInboundMessage(
+function serializeWhatsAppDurableInboundMessage(
   message: WAMessage,
 ): SerializedWhatsAppDurableInboundMessage {
   const timestamp = message.messageTimestamp;
@@ -94,7 +94,7 @@ export function serializeWhatsAppDurableInboundMessage(
   return JSON.parse(JSON.stringify(serializedMessage, BufferJSON.replacer)) as PluginJsonValue;
 }
 
-export function deserializeWhatsAppDurableInboundMessage(
+function deserializeWhatsAppDurableInboundMessage(
   message: SerializedWhatsAppDurableInboundMessage,
 ): WAMessage {
   try {

--- a/extensions/whatsapp/src/inbound/ingress-lifecycle.ts
+++ b/extensions/whatsapp/src/inbound/ingress-lifecycle.ts
@@ -1,0 +1,23 @@
+import type { WhatsAppIngressLifecycle } from "./durable-receive.js";
+
+const ingressLifecycleKey = Symbol("whatsappIngressLifecycle");
+
+type WhatsAppIngressLifecycleCarrier = {
+  [ingressLifecycleKey]?: WhatsAppIngressLifecycle;
+};
+
+export function attachWhatsAppIngressLifecycle<T extends object>(
+  message: T,
+  lifecycle: WhatsAppIngressLifecycle | undefined,
+): T {
+  if (lifecycle) {
+    (message as WhatsAppIngressLifecycleCarrier)[ingressLifecycleKey] = lifecycle;
+  }
+  return message;
+}
+
+export function resolveWhatsAppIngressLifecycle(
+  message: object,
+): WhatsAppIngressLifecycle | undefined {
+  return (message as WhatsAppIngressLifecycleCarrier)[ingressLifecycleKey];
+}

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -65,7 +65,8 @@ import {
 } from "./dedupe.js";
 import {
   createWhatsAppDurableInboundMessageId,
-  createWhatsAppDurableInboundReceiveJournal,
+  createWhatsAppDurableInboundStores,
+  createWhatsAppIngressDrain,
   deserializeWhatsAppDurableInboundMessage,
   serializeWhatsAppDurableInboundMessage,
   type WhatsAppDurableInboundMetadata,
@@ -458,11 +459,88 @@ export async function attachWebInboxToSocket(
     receiveOrder?: number;
   };
   type QueuedInboundMessage = AdmittedWebInboundCallbackMessage & QueuedInboundMessageMetadata;
-  const durableInboundJournal = createWhatsAppDurableInboundReceiveJournal(options.accountId);
+  const { journal: durableInboundJournal, queue: durableInboundQueue } =
+    createWhatsAppDurableInboundStores(options.accountId);
+  // Drain-owned claims: finalize skips journal complete/release; drain tombstones on return.
+  const drainOwnedDurableIds = new Set<string>();
+  // Per-claim flush waiters so processClaimed sees retryable flush failures the
+  // debouncer would otherwise swallow (onFlush catch + non-throwing chain).
+  type ClaimFlushWaiter = {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+    settled: boolean;
+  };
+  const claimFlushWaiters = new Map<string, ClaimFlushWaiter>();
+  /** Set when enqueue schedules a flush that must settle the claim waiter. */
+  const claimIdsEnqueuedForFlush = new Set<string>();
+  const ensureClaimFlushWaiter = (durableId: string): ClaimFlushWaiter => {
+    const existing = claimFlushWaiters.get(durableId);
+    if (existing) {
+      return existing;
+    }
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    // Prevent unhandled rejection until processClaimed awaits.
+    void promise.catch(() => undefined);
+    const waiter: ClaimFlushWaiter = { promise, resolve, reject, settled: false };
+    claimFlushWaiters.set(durableId, waiter);
+    return waiter;
+  };
+  const settleClaimFlushWaiters = (entries: QueuedInboundMessage[], error?: unknown) => {
+    for (const entry of entries) {
+      if (!isNonEmptyString(entry.durableId)) {
+        continue;
+      }
+      const waiter = claimFlushWaiters.get(entry.durableId);
+      if (!waiter || waiter.settled) {
+        continue;
+      }
+      waiter.settled = true;
+      if (error !== undefined) {
+        waiter.reject(error);
+      } else {
+        waiter.resolve();
+      }
+    }
+  };
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingDebounceKeys = new Set<string>();
   const activeInboundFlushes = new Set<Promise<void>>();
   const pendingMessageHandlers = new Set<Promise<void>>();
+  // Close-path coordination: resolve waiters when debounce work appears so
+  // shutdown can force-flush without timer-driven polling (fake-timer safe).
+  const debounceWorkWaiters = new Set<() => void>();
+  const notifyDebounceWork = () => {
+    if (debounceWorkWaiters.size === 0) {
+      return;
+    }
+    const waiters = [...debounceWorkWaiters];
+    debounceWorkWaiters.clear();
+    for (const resolve of waiters) {
+      resolve();
+    }
+  };
+  const waitForDebounceWorkOrIdle = (handlers: ReadonlyArray<Promise<void>>) => {
+    if (pendingDebounceKeys.size > 0 || activeInboundFlushes.size > 0) {
+      return Promise.resolve();
+    }
+    if (pendingMessageHandlers.size === 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const finish = () => {
+        debounceWorkWaiters.delete(finish);
+        resolve();
+      };
+      debounceWorkWaiters.add(finish);
+      void Promise.allSettled(handlers).then(finish);
+    });
+  };
   let nextReceiveOrder = 0;
   const publishPendingWorkState = (at = Date.now()) => {
     options.onPendingWorkChanged?.(
@@ -506,7 +584,7 @@ export async function attachWebInboxToSocket(
       .filter((claim): claim is ChannelReplayClaimHandle => claim !== undefined);
     const durableEntries = entries.filter(
       (entry): entry is QueuedInboundMessage & { durableId: string } =>
-        isNonEmptyString(entry.durableId),
+        isNonEmptyString(entry.durableId) && !drainOwnedDurableIds.has(entry.durableId),
     );
     const readReceiptEntries = entries.filter(
       (entry): entry is QueuedInboundMessage & { readReceipt: WhatsAppReadReceiptTarget } =>
@@ -524,6 +602,10 @@ export async function attachWebInboxToSocket(
           }),
         ),
       );
+      // Drain-owned failures: throw so dispatchClaimedEvent returns failed-retryable.
+      if (entries.some((entry) => entry.durableId && drainOwnedDurableIds.has(entry.durableId))) {
+        throw retryableError;
+      }
       return;
     }
     await Promise.all([
@@ -549,16 +631,20 @@ export async function attachWebInboxToSocket(
       });
       activeInboundFlushes.add(flushTask);
       publishPendingWorkState();
+      notifyDebounceWork();
+      let flushError: unknown;
       try {
         const orderedEntries = orderDebouncedInboundEntries(entries);
         const last = orderedEntries.at(-1);
         if (!last) {
+          settleClaimFlushWaiters(entries);
           return;
         }
         try {
           if (orderedEntries.length === 1) {
             await options.onMessage(last);
             await finalizeInboundDelivery(orderedEntries);
+            settleClaimFlushWaiters(orderedEntries);
             return;
           }
           const mentioned = new Set<string>();
@@ -604,11 +690,23 @@ export async function attachWebInboxToSocket(
           });
           await options.onMessage(combinedMessage);
           await finalizeInboundDelivery(orderedEntries);
+          settleClaimFlushWaiters(orderedEntries);
         } catch (error) {
-          await finalizeInboundDelivery(orderedEntries, error);
+          flushError = error;
+          try {
+            await finalizeInboundDelivery(orderedEntries, error);
+          } catch (finalizeError) {
+            // Drain-owned retryable path rethrows from finalize — that is the
+            // authoritative outcome for claim waiters.
+            flushError = finalizeError;
+            throw finalizeError;
+          }
           throw error;
         }
       } finally {
+        if (flushError !== undefined) {
+          settleClaimFlushWaiters(entries, flushError);
+        }
         for (const entry of entries) {
           if (entry.debounceKey) {
             pendingDebounceKeys.delete(entry.debounceKey);
@@ -1156,6 +1254,15 @@ export async function attachWebInboxToSocket(
     return msgTsMs < appendAfterMs;
   };
 
+  // Accept-time normalization carried to the drain dispatch. Live delivery must
+  // not re-derive transient facts (LID mappings, group state) that resolved at
+  // receive time — a second lookup can fail and silently drop the message.
+  // Restart replay finds no entry and re-normalizes from the persisted payload.
+  const preparedInboundByDurableId = new Map<
+    string,
+    NonNullable<Awaited<ReturnType<typeof normalizeInboundMessage>>>
+  >();
+
   const processDurableInboundMessage = async (
     msg: WAMessage,
     upsertType: string | undefined,
@@ -1166,7 +1273,11 @@ export async function attachWebInboxToSocket(
       metadata?: WhatsAppDurableInboundMetadata;
     },
   ) => {
-    const inbound = await normalizeInboundMessage(msg);
+    const prepared = stored ? preparedInboundByDurableId.get(stored.id) : undefined;
+    if (stored) {
+      preparedInboundByDurableId.delete(stored.id);
+    }
+    const inbound = prepared ?? (await normalizeInboundMessage(msg));
     if (!inbound) {
       if (stored) {
         await completeUndeliverableDurableInbound(stored.id, stored.metadata);
@@ -1211,9 +1322,18 @@ export async function attachWebInboxToSocket(
           );
           return;
         }
-        if (accepted.kind === "pending" && accepted.record.attempts === 0) {
-          return;
-        }
+        // Enqueued (new or retryable). Hand the accept-time normalization to the
+        // drain dispatch (consumed once; crash replay re-normalizes), then kick
+        // the drain without awaiting idle — a pending handler must not block
+        // later messages in this upsert; the claim guarantees exactly-once.
+        preparedInboundByDurableId.set(durableId, inbound);
+        void pumpDurableInboundDrain().catch((err: unknown) => {
+          inboundLogger.warn(
+            { error: formatError(err) },
+            "whatsapp durable inbound drain pump failed",
+          );
+        });
+        return;
       } catch (err) {
         durableId = undefined;
         const error = formatError(err);
@@ -1227,10 +1347,16 @@ export async function attachWebInboxToSocket(
       }
     }
 
+    // Stored (drain claim) or live fallback without durable journal.
     const enriched = await enrichInboundMessage(msg);
     if (!enriched) {
-      await completeUndeliverableDurableInbound(durableId, durableMetadata);
+      // Pre-migration replay completed undeliverable rows AND sent the receipt.
+      // Drain still tombstones via dispatch return; receipt must not be skipped.
       await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
+      if (stored) {
+        return;
+      }
+      await completeUndeliverableDurableInbound(durableId, durableMetadata);
       return;
     }
 
@@ -1240,13 +1366,29 @@ export async function attachWebInboxToSocket(
       : ({ kind: "invalid" } as const);
     if (dedupeClaim.kind === "duplicate" || dedupeClaim.kind === "inflight") {
       if (dedupeClaim.kind === "duplicate") {
-        await completeUndeliverableDurableInbound(durableId, durableMetadata);
+        // Drain-claimed rows tombstone via the dispatch return; completing here
+        // would double-settle the claim (pre-migration live path still completes).
+        if (!stored) {
+          await completeUndeliverableDurableInbound(durableId, durableMetadata);
+        }
         await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
+        return;
+      }
+      // "inflight": another delivery holds the dedupe claim — keep durable row
+      // pending for replay (pre-migration). Do not complete the drain claim.
+      if (stored) {
+        throw new Error("whatsapp inbound dedupe claim contended (inflight)");
       }
       return;
     }
 
     recordAcceptedInboundActivity(options.accountId);
+    // Keep durableId on the entry so finalize can rethrow drain-owned failures.
+    // drainOwnedDurableIds only suppresses inline journal complete/release.
+    if (durableId && drainOwnedDurableIds.has(durableId)) {
+      ensureClaimFlushWaiter(durableId);
+      claimIdsEnqueuedForFlush.add(durableId);
+    }
     await enqueueInboundMessage(msg, inbound, enriched, {
       durableId,
       readReceipt: deliveryReadReceipt,
@@ -1255,19 +1397,58 @@ export async function attachWebInboxToSocket(
     });
   };
 
-  const replayPendingDurableInboundMessages = async () => {
-    const pending = await durableInboundJournal.pending();
-    for (const record of pending) {
+  const processClaimedDurableInbound = async (claim: {
+    id: string;
+    payload: WhatsAppDurableInboundPayload;
+    metadata?: WhatsAppDurableInboundMetadata;
+  }) => {
+    drainOwnedDurableIds.add(claim.id);
+    // Register before process so flush can settle even if it races enqueue.
+    const flushWaiter = ensureClaimFlushWaiter(claim.id);
+    try {
       await processDurableInboundMessage(
-        deserializeWhatsAppDurableInboundMessage(record.payload.message),
-        record.payload.upsertType,
-        record.payload.receivedAt,
+        deserializeWhatsAppDurableInboundMessage(claim.payload.message),
+        claim.payload.upsertType,
+        claim.payload.receivedAt,
         {
-          id: record.id,
-          payload: record.payload,
-          metadata: record.metadata,
+          id: claim.id,
+          payload: claim.payload,
+          metadata: claim.metadata,
         },
       );
+      // Undeliverable/duplicate early returns never enqueue — complete the waiter.
+      // Enqueued paths wait for this claim's own flush only (preserve debounce window).
+      if (!claimIdsEnqueuedForFlush.has(claim.id) && !flushWaiter.settled) {
+        flushWaiter.settled = true;
+        flushWaiter.resolve();
+      }
+      await flushWaiter.promise;
+    } finally {
+      claimIdsEnqueuedForFlush.delete(claim.id);
+      claimFlushWaiters.delete(claim.id);
+      drainOwnedDurableIds.delete(claim.id);
+    }
+  };
+
+  const durableInboundDrain = createWhatsAppIngressDrain({
+    queue: durableInboundQueue,
+    processClaimed: processClaimedDurableInbound,
+    onLog: (message) => inboundLogger.warn({ message }, "whatsapp ingress drain"),
+  });
+
+  const pumpDurableInboundDrain = async () => {
+    const pumpTask = (async () => {
+      await durableInboundDrain.recoverStaleClaims();
+      await durableInboundDrain.drainOnce();
+      await durableInboundDrain.waitForIdle();
+    })();
+    pendingMessageHandlers.add(pumpTask);
+    publishPendingWorkState();
+    try {
+      await pumpTask;
+    } finally {
+      pendingMessageHandlers.delete(pumpTask);
+      publishPendingWorkState();
     }
   };
 
@@ -1515,6 +1696,7 @@ export async function attachWebInboxToSocket(
       if (inboundDebounceMs > 0 && shouldDebounceInboundMessage(inboundMessage)) {
         pendingDebounceKeys.add(debounceKey);
         publishPendingWorkState();
+        notifyDebounceWork();
       }
     }
     if (inboundMessage.event.id) {
@@ -1584,11 +1766,6 @@ export async function attachWebInboxToSocket(
       publishPendingWorkState();
     });
   };
-  const waitForPendingMessageHandlers = async () => {
-    while (pendingMessageHandlers.size > 0) {
-      await Promise.all(Array.from(pendingMessageHandlers));
-    }
-  };
   const drainDebouncedInboundMessages = async () => {
     while (pendingDebounceKeys.size > 0 || activeInboundFlushes.size > 0) {
       const debounceKeys = Array.from(pendingDebounceKeys);
@@ -1606,8 +1783,32 @@ export async function attachWebInboxToSocket(
   };
   const drainInboundBeforeSocketClose = async () => {
     groupMetadataCacheClosed = true;
-    await waitForPendingMessageHandlers();
+    // Durable pumps (via upsert handlers) park on claim flush waiters until the
+    // debouncer flushes. Interleave force-flush with event-driven wait for
+    // debounce enqueue so close cannot deadlock and stays fake-timer safe.
+    // Debounce-window parity preserved: flushKey, not cancel.
+    for (;;) {
+      await drainDebouncedInboundMessages();
+      if (pendingMessageHandlers.size === 0) {
+        break;
+      }
+      const handlers = Array.from(pendingMessageHandlers);
+      await Promise.race([Promise.allSettled(handlers), waitForDebounceWorkOrIdle(handlers)]);
+      if (
+        pendingMessageHandlers.size === 0 &&
+        pendingDebounceKeys.size === 0 &&
+        activeInboundFlushes.size === 0
+      ) {
+        break;
+      }
+    }
     await drainDebouncedInboundMessages();
+    // Drain-owned claims must finish (or release) before a successor monitor starts.
+    try {
+      await durableInboundDrain.waitForIdle();
+    } finally {
+      durableInboundDrain.dispose();
+    }
   };
   const drainInboundBeforeSocketCloseWithTimeout = async () => {
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -1728,7 +1929,7 @@ export async function attachWebInboxToSocket(
     forgetFullGroupMetadata(update.id);
   }) as unknown as (...args: unknown[]) => void);
 
-  const replayTask = replayPendingDurableInboundMessages().catch((err: unknown) => {
+  const replayTask = pumpDurableInboundDrain().catch((err: unknown) => {
     inboundLogger.error({ error: String(err) }, "failed replaying durable WhatsApp inbound");
     inboundConsoleLog.error(`Failed replaying durable WhatsApp inbound: ${String(err)}`);
   });

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -15,14 +15,13 @@ import {
   formatLocationText,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
-import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
 import {
   asDateTimestampMs,
   parseStrictFiniteNumber,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
-import type { ChannelReplayClaimHandle } from "openclaw/plugin-sdk/persistent-dedupe";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { maybeResolveWhatsAppApprovalReaction } from "../approval-reactions.js";
@@ -57,20 +56,15 @@ import {
   requireAdmittedWhatsAppInboundMessage,
   requireWhatsAppInboundAdmission,
 } from "./admission.js";
-import {
-  isRecentOutboundMessage,
-  rememberRecentOutboundMessage,
-  WhatsAppRetryableInboundError,
-  whatsAppInboundReplayGuard,
-} from "./dedupe.js";
+import { isRecentOutboundMessage, rememberRecentOutboundMessage } from "./dedupe.js";
 import {
   createWhatsAppDurableInboundMessageId,
-  createWhatsAppDurableInboundStores,
+  createWhatsAppDurableInboundQueue,
   createWhatsAppIngressDrain,
-  deserializeWhatsAppDurableInboundMessage,
-  serializeWhatsAppDurableInboundMessage,
-  type WhatsAppDurableInboundMetadata,
+  enqueueWhatsAppDurableInbound,
   type WhatsAppDurableInboundPayload,
+  type WhatsAppDurableInboundQueue,
+  type WhatsAppIngressLifecycle,
   type WhatsAppReadReceiptTarget,
 } from "./durable-receive.js";
 import {
@@ -83,6 +77,7 @@ import {
   extractText,
   hasInboundUserContent,
 } from "./extract.js";
+import { attachWhatsAppIngressLifecycle } from "./ingress-lifecycle.js";
 import { attachEmitterListener, closeInboundMonitorSocket } from "./lifecycle.js";
 import { downloadInboundMedia, downloadQuotedInboundMedia } from "./media.js";
 import {
@@ -110,7 +105,7 @@ const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress
 const GROUP_META_TTL_MS = 5 * 60 * 1000;
 const BAILEYS_MESSAGE_TTL_MS = 10 * 60 * 1000;
 const INBOUND_CLOSE_DRAIN_TIMEOUT_MS = 5_000;
-const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
+const WHATSAPP_INGRESS_DRAIN_INTERVAL_MS = 1_000;
 const WHATSAPP_GROUP_METADATA_CACHE_MAX_ENTRIES = 500;
 
 type WhatsAppGroupMetadataCacheEntry = {
@@ -118,23 +113,6 @@ type WhatsAppGroupMetadataCacheEntry = {
   expires: number;
 };
 
-function resolveRetryableWhatsAppInboundError(
-  error: unknown,
-): WhatsAppRetryableInboundError | null {
-  if (error instanceof WhatsAppRetryableInboundError) {
-    return error;
-  }
-  const hasSessionInitConflict = collectErrorGraphCandidates(error, (current) => [
-    current.cause,
-    current.error,
-  ]).some((candidate) =>
-    REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(formatErrorMessage(candidate)),
-  );
-  if (!hasSessionInitConflict) {
-    return null;
-  }
-  return new WhatsAppRetryableInboundError(formatErrorMessage(error), { cause: error });
-}
 export type WhatsAppGroupMetadataCache = Map<string, WhatsAppGroupMetadataCacheEntry>;
 type WhatsAppBaileysCacheEntry<T> = {
   expiresAt: number;
@@ -305,10 +283,6 @@ function shouldClearSocketRefAfterSendFailure(err: unknown): boolean {
   return /closed|reset|disconnect|no active socket/i.test(formatError(err));
 }
 
-function isNonEmptyString(value: string | undefined): value is string {
-  return Boolean(value);
-}
-
 type AdmittedWebInboundCallbackMessage = WebInboundMessage & {
   admission: AdmittedWebInboundMessage["admission"];
 };
@@ -357,6 +331,7 @@ type MonitorWebInboxOptions = {
   recentMessageKeys?: WhatsAppBaileysMessageCache;
   baileysGroupMetaCache?: WhatsAppBaileysGroupMetadataCache;
   onPendingWorkChanged?: (pendingWorkCount: number, at?: number) => void;
+  durableInboundQueue?: WhatsAppDurableInboundQueue;
 };
 
 type AttachWebInboxToSocketOptions = Omit<
@@ -452,62 +427,14 @@ export async function attachWebInboxToSocket(
   };
   type QueuedInboundMessageMetadata = {
     admission: AdmittedWebInboundCallbackMessage["admission"];
-    replayClaim?: ChannelReplayClaimHandle;
     debounceKey?: string;
-    durableId?: string;
+    turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
     readReceipt?: WhatsAppReadReceiptTarget;
     receiveOrder?: number;
   };
   type QueuedInboundMessage = AdmittedWebInboundCallbackMessage & QueuedInboundMessageMetadata;
-  const { journal: durableInboundJournal, queue: durableInboundQueue } =
-    createWhatsAppDurableInboundStores(options.accountId);
-  // Drain-owned claims: finalize skips journal complete/release; drain tombstones on return.
-  const drainOwnedDurableIds = new Set<string>();
-  // Per-claim flush waiters so processClaimed sees retryable flush failures the
-  // debouncer would otherwise swallow (onFlush catch + non-throwing chain).
-  type ClaimFlushWaiter = {
-    promise: Promise<void>;
-    resolve: () => void;
-    reject: (error: unknown) => void;
-    settled: boolean;
-  };
-  const claimFlushWaiters = new Map<string, ClaimFlushWaiter>();
-  /** Set when enqueue schedules a flush that must settle the claim waiter. */
-  const claimIdsEnqueuedForFlush = new Set<string>();
-  const ensureClaimFlushWaiter = (durableId: string): ClaimFlushWaiter => {
-    const existing = claimFlushWaiters.get(durableId);
-    if (existing) {
-      return existing;
-    }
-    let resolve!: () => void;
-    let reject!: (error: unknown) => void;
-    const promise = new Promise<void>((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    // Prevent unhandled rejection until processClaimed awaits.
-    void promise.catch(() => undefined);
-    const waiter: ClaimFlushWaiter = { promise, resolve, reject, settled: false };
-    claimFlushWaiters.set(durableId, waiter);
-    return waiter;
-  };
-  const settleClaimFlushWaiters = (entries: QueuedInboundMessage[], error?: unknown) => {
-    for (const entry of entries) {
-      if (!isNonEmptyString(entry.durableId)) {
-        continue;
-      }
-      const waiter = claimFlushWaiters.get(entry.durableId);
-      if (!waiter || waiter.settled) {
-        continue;
-      }
-      waiter.settled = true;
-      if (error !== undefined) {
-        waiter.reject(error);
-      } else {
-        waiter.resolve();
-      }
-    }
-  };
+  const durableInboundQueue =
+    options.durableInboundQueue ?? createWhatsAppDurableInboundQueue(options.accountId);
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingDebounceKeys = new Set<string>();
   const activeInboundFlushes = new Set<Promise<void>>();
@@ -575,49 +502,63 @@ export async function attachWebInboxToSocket(
       return (a.receiveOrder ?? 0) - (b.receiveOrder ?? 0);
     });
 
-  const finalizeInboundDelivery = async (
-    entries: QueuedInboundMessage[],
-    error?: unknown,
-  ): Promise<void> => {
-    const replayClaims = entries
-      .map((entry) => entry.replayClaim)
-      .filter((claim): claim is ChannelReplayClaimHandle => claim !== undefined);
-    const durableEntries = entries.filter(
-      (entry): entry is QueuedInboundMessage & { durableId: string } =>
-        isNonEmptyString(entry.durableId) && !drainOwnedDurableIds.has(entry.durableId),
-    );
-    const readReceiptEntries = entries.filter(
-      (entry): entry is QueuedInboundMessage & { readReceipt: WhatsAppReadReceiptTarget } =>
-        Boolean(entry.readReceipt),
-    );
-    const retryableError = resolveRetryableWhatsAppInboundError(error);
-    if (retryableError) {
-      for (const claim of replayClaims) {
-        claim.release({ error: retryableError });
-      }
-      await Promise.all(
-        durableEntries.map((entry) =>
-          durableInboundJournal.release(entry.durableId, {
-            lastError: formatError(retryableError),
-          }),
-        ),
-      );
-      // Drain-owned failures: throw so dispatchClaimedEvent returns failed-retryable.
-      if (entries.some((entry) => entry.durableId && drainOwnedDurableIds.has(entry.durableId))) {
-        throw retryableError;
-      }
-      return;
+  const buildFlushIngressLifecycle = (entries: QueuedInboundMessage[]) => {
+    const lifecycles = entries
+      .map((entry) => entry.turnAdoptionLifecycle)
+      .filter((lifecycle) => lifecycle !== undefined);
+    const [firstLifecycle] = lifecycles;
+    if (!firstLifecycle) {
+      return {
+        lifecycle: undefined,
+        settle: async () => {},
+        abandon: async () => {},
+      };
     }
-    await Promise.all([
-      ...replayClaims.map((claim) => claim.commit()),
-      ...durableEntries.map((entry) =>
-        durableInboundJournal.complete(
-          entry.durableId,
-          entry.readReceipt ? { metadata: { readReceipt: entry.readReceipt } } : undefined,
-        ),
-      ),
-    ]);
-    await Promise.all(readReceiptEntries.map((entry) => maybeMarkInboundAsRead(entry.readReceipt)));
+    let handedOff = false;
+    const adoptAll = async () => {
+      for (const lifecycle of lifecycles) {
+        await lifecycle.onAdopted();
+      }
+    };
+    return {
+      lifecycle: {
+        abortSignal:
+          lifecycles.length === 1
+            ? firstLifecycle.abortSignal
+            : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+        onAdopted: async () => {
+          handedOff = true;
+          await adoptAll();
+        },
+        onDeferred: () => {
+          handedOff = true;
+          for (const lifecycle of lifecycles) {
+            lifecycle.onDeferred();
+          }
+        },
+        onAdoptionFinalizing: () => {
+          for (const lifecycle of lifecycles) {
+            lifecycle.onAdoptionFinalizing();
+          }
+        },
+        onAbandoned: async () => {
+          handedOff = true;
+          await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAbandoned()));
+        },
+      } satisfies WhatsAppIngressLifecycle,
+      // Gated or otherwise terminal no-dispatch turns still own every merged claim.
+      settle: async () => {
+        if (!handedOff) {
+          await adoptAll();
+        }
+      },
+      abandon: async () => {
+        if (!handedOff) {
+          handedOff = true;
+          await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAbandoned()));
+        }
+      },
+    };
   };
 
   const debouncer = createInboundDebouncer<QueuedInboundMessage>({
@@ -632,19 +573,20 @@ export async function attachWebInboxToSocket(
       activeInboundFlushes.add(flushTask);
       publishPendingWorkState();
       notifyDebounceWork();
-      let flushError: unknown;
       try {
         const orderedEntries = orderDebouncedInboundEntries(entries);
         const last = orderedEntries.at(-1);
         if (!last) {
-          settleClaimFlushWaiters(entries);
           return;
         }
+        const { lifecycle, settle, abandon } = buildFlushIngressLifecycle(orderedEntries);
         try {
           if (orderedEntries.length === 1) {
-            await options.onMessage(last);
-            await finalizeInboundDelivery(orderedEntries);
-            settleClaimFlushWaiters(orderedEntries);
+            await options.onMessage(attachWhatsAppIngressLifecycle(last, lifecycle));
+            await settle();
+            await Promise.all(
+              orderedEntries.map((entry) => maybeMarkInboundAsRead(entry.readReceipt)),
+            );
             return;
           }
           const mentioned = new Set<string>();
@@ -675,38 +617,33 @@ export async function attachWebInboxToSocket(
                   mentions: combinedMentions,
                 }
               : undefined;
-          const combinedMessage: QueuedInboundMessage = withDeprecatedWebInboundMessageFlatAliases({
-            ...last,
-            payload: {
-              ...last.payload,
-              body: combinedBody,
-              commandBody: combinedCommandBody,
-            },
-            group: combinedGroup,
-            event: {
-              ...last.event,
-              isBatched: true,
-            },
-          });
+          const combinedMessage: QueuedInboundMessage = attachWhatsAppIngressLifecycle(
+            withDeprecatedWebInboundMessageFlatAliases({
+              ...last,
+              ...(lifecycle ? { turnAdoptionLifecycle: lifecycle } : {}),
+              payload: {
+                ...last.payload,
+                body: combinedBody,
+                commandBody: combinedCommandBody,
+              },
+              group: combinedGroup,
+              event: {
+                ...last.event,
+                isBatched: true,
+              },
+            }),
+            lifecycle,
+          );
           await options.onMessage(combinedMessage);
-          await finalizeInboundDelivery(orderedEntries);
-          settleClaimFlushWaiters(orderedEntries);
+          await settle();
+          await Promise.all(
+            orderedEntries.map((entry) => maybeMarkInboundAsRead(entry.readReceipt)),
+          );
         } catch (error) {
-          flushError = error;
-          try {
-            await finalizeInboundDelivery(orderedEntries, error);
-          } catch (finalizeError) {
-            // Drain-owned retryable path rethrows from finalize — that is the
-            // authoritative outcome for claim waiters.
-            flushError = finalizeError;
-            throw finalizeError;
-          }
+          await abandon();
           throw error;
         }
       } finally {
-        if (flushError !== undefined) {
-          settleClaimFlushWaiters(entries, flushError);
-        }
         for (const entry of entries) {
           if (entry.debounceKey) {
             pendingDebounceKeys.delete(entry.debounceKey);
@@ -1063,6 +1000,28 @@ export async function attachWebInboxToSocket(
     access: AcceptedInboundAccessControlResult;
   };
 
+  const shouldSkipRecentOutboundEcho = (msg: WAMessage): boolean => {
+    const id = msg.key?.id ?? undefined;
+    const remoteJid = msg.key?.remoteJid;
+    if (
+      !msg.key?.fromMe ||
+      !id ||
+      !remoteJid ||
+      !isRecentOutboundMessage({
+        accountId: options.accountId,
+        remoteJid,
+        messageId: id,
+      })
+    ) {
+      return false;
+    }
+    logWhatsAppVerbose(
+      options.verbose,
+      `Skipping recent outbound WhatsApp echo ${id} for ${remoteJid}`,
+    );
+    return true;
+  };
+
   const normalizeInboundMessage = async (
     msg: WAMessage,
   ): Promise<NormalizedInboundMessage | null> => {
@@ -1079,19 +1038,7 @@ export async function attachWebInboxToSocket(
     // Drop echoes of messages the gateway itself sent (tracked by sendTrackedMessage).
     // Applies to both groups and DMs/self-chat — without this, self-chat mode
     // re-processes the bot's own replies as new inbound user messages.
-    if (
-      Boolean(msg.key?.fromMe) &&
-      id &&
-      isRecentOutboundMessage({
-        accountId: options.accountId,
-        remoteJid,
-        messageId: id,
-      })
-    ) {
-      logWhatsAppVerbose(
-        options.verbose,
-        `Skipping recent outbound WhatsApp echo ${id} for ${remoteJid}`,
-      );
+    if (shouldSkipRecentOutboundEcho(msg)) {
       return null;
     }
     // Gate pairing access-control on extractable inbound user content. Baileys
@@ -1215,28 +1162,6 @@ export async function attachWebInboxToSocket(
     await maybeMarkInboundAsRead(target);
   };
 
-  const completeUndeliverableDurableInbound = async (
-    durableId: string | undefined,
-    metadata: WhatsAppDurableInboundMetadata | undefined,
-  ) => {
-    if (!durableId) {
-      return;
-    }
-    await durableInboundJournal.complete(
-      durableId,
-      metadata?.readReceipt ? { metadata: { readReceipt: metadata.readReceipt } } : undefined,
-    );
-  };
-
-  const buildDurableInboundPayload = (
-    msg: WAMessage,
-    upsertType: string | undefined,
-  ): WhatsAppDurableInboundPayload => ({
-    message: serializeWhatsAppDurableInboundMessage(msg),
-    ...(upsertType ? { upsertType } : {}),
-    receivedAt: Date.now(),
-  });
-
   const shouldSkipStaleAppend = (msg: WAMessage, upsertType: string | undefined): boolean => {
     if (upsertType !== "append") {
       return false;
@@ -1254,203 +1179,10 @@ export async function attachWebInboxToSocket(
     return msgTsMs < appendAfterMs;
   };
 
-  // Accept-time normalization carried to the drain dispatch. Live delivery must
-  // not re-derive transient facts (LID mappings, group state) that resolved at
-  // receive time — a second lookup can fail and silently drop the message.
-  // Restart replay finds no entry and re-normalizes from the persisted payload.
-  const preparedInboundByDurableId = new Map<
-    string,
-    NonNullable<Awaited<ReturnType<typeof normalizeInboundMessage>>>
-  >();
-
-  const processDurableInboundMessage = async (
-    msg: WAMessage,
-    upsertType: string | undefined,
-    receiveOrder: number | undefined,
-    stored?: {
-      id: string;
-      payload: WhatsAppDurableInboundPayload;
-      metadata?: WhatsAppDurableInboundMetadata;
-    },
-  ) => {
-    const prepared = stored ? preparedInboundByDurableId.get(stored.id) : undefined;
-    if (stored) {
-      preparedInboundByDurableId.delete(stored.id);
-    }
-    const inbound = prepared ?? (await normalizeInboundMessage(msg));
-    if (!inbound) {
-      if (stored) {
-        await completeUndeliverableDurableInbound(stored.id, stored.metadata);
-      }
-      return;
-    }
-
-    const readReceipt = stored?.metadata?.readReceipt ?? buildReadReceiptTarget(inbound);
-    const deliveryReadReceipt = inbound.access.isSelfChat ? undefined : readReceipt;
-
-    if (!stored && shouldSkipStaleAppend(msg, upsertType)) {
-      await maybeMarkNonSelfChatReadReceipt(inbound, readReceipt);
-      return;
-    }
-
-    let durableId =
-      stored?.id ??
-      (inbound.id
-        ? createWhatsAppDurableInboundMessageId({
-            remoteJid: inbound.remoteJid,
-            id: inbound.id,
-          })
-        : undefined);
-    const durableMetadata: WhatsAppDurableInboundMetadata | undefined = deliveryReadReceipt
-      ? { readReceipt: deliveryReadReceipt }
-      : undefined;
-
-    if (durableId && !stored) {
-      try {
-        const accepted = await durableInboundJournal.accept(
-          durableId,
-          buildDurableInboundPayload(msg, upsertType),
-          {
-            metadata: durableMetadata,
-            receivedAt: inbound.messageTimestampMs,
-          },
-        );
-        if (accepted.kind === "completed") {
-          await maybeMarkNonSelfChatReadReceipt(
-            inbound,
-            accepted.record.metadata?.readReceipt ?? deliveryReadReceipt,
-          );
-          return;
-        }
-        // Enqueued (new or retryable). Hand the accept-time normalization to the
-        // drain dispatch (consumed once; crash replay re-normalizes), then kick
-        // the drain without awaiting idle — a pending handler must not block
-        // later messages in this upsert; the claim guarantees exactly-once.
-        preparedInboundByDurableId.set(durableId, inbound);
-        void pumpDurableInboundDrain().catch((err: unknown) => {
-          inboundLogger.warn(
-            { error: formatError(err) },
-            "whatsapp durable inbound drain pump failed",
-          );
-        });
-        return;
-      } catch (err) {
-        durableId = undefined;
-        const error = formatError(err);
-        inboundLogger.warn(
-          { error },
-          "failed persisting durable WhatsApp inbound; delivering live",
-        );
-        inboundConsoleLog.warn(
-          `Failed persisting durable WhatsApp inbound; delivering live: ${error}`,
-        );
-      }
-    }
-
-    // Stored (drain claim) or live fallback without durable journal.
-    const enriched = await enrichInboundMessage(msg);
-    if (!enriched) {
-      // Pre-migration replay completed undeliverable rows AND sent the receipt.
-      // Drain still tombstones via dispatch return; receipt must not be skipped.
-      await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
-      if (stored) {
-        return;
-      }
-      await completeUndeliverableDurableInbound(durableId, durableMetadata);
-      return;
-    }
-
-    const dedupeKey = inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : "";
-    const dedupeClaim = dedupeKey
-      ? await whatsAppInboundReplayGuard.claim(dedupeKey)
-      : ({ kind: "invalid" } as const);
-    if (dedupeClaim.kind === "duplicate" || dedupeClaim.kind === "inflight") {
-      if (dedupeClaim.kind === "duplicate") {
-        // Drain-claimed rows tombstone via the dispatch return; completing here
-        // would double-settle the claim (pre-migration live path still completes).
-        if (!stored) {
-          await completeUndeliverableDurableInbound(durableId, durableMetadata);
-        }
-        await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
-        return;
-      }
-      // "inflight": another delivery holds the dedupe claim — keep durable row
-      // pending for replay (pre-migration). Do not complete the drain claim.
-      if (stored) {
-        throw new Error("whatsapp inbound dedupe claim contended (inflight)");
-      }
-      return;
-    }
-
-    recordAcceptedInboundActivity(options.accountId);
-    // Keep durableId on the entry so finalize can rethrow drain-owned failures.
-    // drainOwnedDurableIds only suppresses inline journal complete/release.
-    if (durableId && drainOwnedDurableIds.has(durableId)) {
-      ensureClaimFlushWaiter(durableId);
-      claimIdsEnqueuedForFlush.add(durableId);
-    }
-    await enqueueInboundMessage(msg, inbound, enriched, {
-      durableId,
-      readReceipt: deliveryReadReceipt,
-      receiveOrder,
-      ...(dedupeClaim.kind === "claimed" ? { replayClaim: dedupeClaim.handle } : {}),
-    });
-  };
-
-  const processClaimedDurableInbound = async (claim: {
-    id: string;
-    payload: WhatsAppDurableInboundPayload;
-    metadata?: WhatsAppDurableInboundMetadata;
-  }) => {
-    drainOwnedDurableIds.add(claim.id);
-    // Register before process so flush can settle even if it races enqueue.
-    const flushWaiter = ensureClaimFlushWaiter(claim.id);
-    try {
-      await processDurableInboundMessage(
-        deserializeWhatsAppDurableInboundMessage(claim.payload.message),
-        claim.payload.upsertType,
-        claim.payload.receivedAt,
-        {
-          id: claim.id,
-          payload: claim.payload,
-          metadata: claim.metadata,
-        },
-      );
-      // Undeliverable/duplicate early returns never enqueue — complete the waiter.
-      // Enqueued paths wait for this claim's own flush only (preserve debounce window).
-      if (!claimIdsEnqueuedForFlush.has(claim.id) && !flushWaiter.settled) {
-        flushWaiter.settled = true;
-        flushWaiter.resolve();
-      }
-      await flushWaiter.promise;
-    } finally {
-      claimIdsEnqueuedForFlush.delete(claim.id);
-      claimFlushWaiters.delete(claim.id);
-      drainOwnedDurableIds.delete(claim.id);
-    }
-  };
-
-  const durableInboundDrain = createWhatsAppIngressDrain({
-    queue: durableInboundQueue,
-    processClaimed: processClaimedDurableInbound,
-    onLog: (message) => inboundLogger.warn({ message }, "whatsapp ingress drain"),
-  });
-
-  const pumpDurableInboundDrain = async () => {
-    const pumpTask = (async () => {
-      await durableInboundDrain.recoverStaleClaims();
-      await durableInboundDrain.drainOnce();
-      await durableInboundDrain.waitForIdle();
-    })();
-    pendingMessageHandlers.add(pumpTask);
-    publishPendingWorkState();
-    try {
-      await pumpTask;
-    } finally {
-      pendingMessageHandlers.delete(pumpTask);
-      publishPendingWorkState();
-    }
-  };
+  // Live rows keep receive-time identity facts until their first drain attempt.
+  // Restart replay has no entry and re-normalizes from the persisted payload.
+  type PreparedInbound = NonNullable<Awaited<ReturnType<typeof normalizeInboundMessage>>>;
+  const preparedInboundByDurableId = new Map<string, Promise<PreparedInbound | null | undefined>>();
 
   type EnrichedInboundMessage = {
     body: string;
@@ -1542,10 +1274,9 @@ export async function attachWebInboxToSocket(
     inbound: NormalizedInboundMessage,
     enriched: EnrichedInboundMessage,
     durable: {
-      durableId?: string;
       readReceipt?: WhatsAppReadReceiptTarget;
       receiveOrder?: number;
-      replayClaim?: ChannelReplayClaimHandle;
+      turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
     },
   ) => {
     const chatJid = inbound.remoteJid;
@@ -1685,8 +1416,7 @@ export async function attachWebInboxToSocket(
           }
         : undefined,
       group,
-      replayClaim: durable.replayClaim,
-      durableId: durable.durableId,
+      turnAdoptionLifecycle: durable.turnAdoptionLifecycle,
       readReceipt: durable.readReceipt,
       receiveOrder: durable.receiveOrder,
     });
@@ -1716,17 +1446,150 @@ export async function attachWebInboxToSocket(
         },
       );
     }
-    try {
-      const task = Promise.resolve(debouncer.enqueue(inboundMessage));
-      void task.catch((err: unknown) => {
-        inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
-        inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
-      });
-    } catch (err) {
-      inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
-      inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
-    }
+    await debouncer.enqueue(inboundMessage);
   };
+
+  const dispatchInboundMessage = async (
+    msg: WAMessage,
+    context: Pick<
+      WhatsAppDurableInboundPayload,
+      "upsertType" | "skipStaleAppend" | "skipRecentOutboundEcho" | "receivedAt" | "receiveOrder"
+    > & {
+      eventId?: string;
+      lifecycle?: WhatsAppIngressLifecycle;
+    },
+  ): Promise<"completed" | "deferred"> => {
+    rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
+    if (context.skipRecentOutboundEcho === true) {
+      return "completed";
+    }
+    const preparation = context.eventId
+      ? preparedInboundByDurableId.get(context.eventId)
+      : undefined;
+    if (context.eventId) {
+      preparedInboundByDurableId.delete(context.eventId);
+    }
+    const prepared = await preparation;
+    if (prepared === null) {
+      return "completed";
+    }
+    const inbound = prepared ?? (await normalizeInboundMessage(msg));
+    if (!inbound) {
+      return "completed";
+    }
+    const readReceipt = buildReadReceiptTarget(inbound);
+    const deliveryReadReceipt = inbound.access.isSelfChat ? undefined : readReceipt;
+    if (context.skipStaleAppend === true) {
+      await maybeMarkNonSelfChatReadReceipt(inbound, readReceipt);
+      return "completed";
+    }
+
+    const enriched = await enrichInboundMessage(msg);
+    if (!enriched) {
+      await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
+      return "completed";
+    }
+
+    recordAcceptedInboundActivity(options.accountId);
+    await enqueueInboundMessage(msg, inbound, enriched, {
+      readReceipt: deliveryReadReceipt,
+      receiveOrder: context.receiveOrder ?? context.receivedAt,
+      turnAdoptionLifecycle: context.lifecycle,
+    });
+    return "deferred";
+  };
+
+  let durableInboundDrain!: ReturnType<typeof createWhatsAppIngressDrain>;
+  let durableDrainPass: Promise<void> | undefined;
+  let durableDrainRequested = false;
+  let durableDrainClosed = false;
+  const requestDurableInboundDrain = (): Promise<void> => {
+    if (durableDrainClosed) {
+      return Promise.resolve();
+    }
+    durableDrainRequested = true;
+    if (!durableDrainPass) {
+      let passFailed = false;
+      const task = (async () => {
+        await durableInboundDrain.recoverStaleClaims();
+        while (durableDrainRequested) {
+          durableDrainRequested = false;
+          const result = await durableInboundDrain.drainOnce();
+          if (result.started > 0) {
+            await durableInboundDrain.waitForIdle();
+            durableDrainRequested = true;
+          }
+        }
+      })().catch((error: unknown) => {
+        passFailed = true;
+        throw error;
+      });
+      durableDrainPass = task;
+      pendingMessageHandlers.add(task);
+      publishPendingWorkState();
+      void task
+        .finally(() => {
+          if (durableDrainPass === task) {
+            durableDrainPass = undefined;
+          }
+          pendingMessageHandlers.delete(task);
+          publishPendingWorkState();
+          if (durableDrainRequested && !passFailed) {
+            void requestDurableInboundDrain().catch((error: unknown) => {
+              inboundLogger.error(
+                { error: formatError(error) },
+                "whatsapp durable inbound drain failed",
+              );
+            });
+          }
+        })
+        .catch(() => undefined);
+    }
+    return durableDrainPass;
+  };
+  const requestDrainAfterLaneSettlement = () => {
+    void requestDurableInboundDrain().catch((error: unknown) => {
+      inboundLogger.error({ error: formatError(error) }, "whatsapp durable inbound drain failed");
+    });
+  };
+  const continueDrainAfterLaneSettlement = (
+    lifecycle: WhatsAppIngressLifecycle,
+  ): WhatsAppIngressLifecycle => ({
+    abortSignal: lifecycle.abortSignal,
+    onAdopted: async () => {
+      await lifecycle.onAdopted();
+      requestDrainAfterLaneSettlement();
+    },
+    onDeferred: lifecycle.onDeferred,
+    onAdoptionFinalizing: lifecycle.onAdoptionFinalizing,
+    onAbandoned: async () => {
+      await lifecycle.onAbandoned();
+      requestDrainAfterLaneSettlement();
+    },
+  });
+  durableInboundDrain = createWhatsAppIngressDrain({
+    queue: durableInboundQueue,
+    dispatch: async (msg, payload, lifecycle) => {
+      const remoteJid = msg.key?.remoteJid;
+      const id = msg.key?.id;
+      return {
+        kind: await dispatchInboundMessage(msg, {
+          ...payload,
+          ...(remoteJid && id
+            ? { eventId: createWhatsAppDurableInboundMessageId({ remoteJid, id }) }
+            : {}),
+          lifecycle: continueDrainAfterLaneSettlement(lifecycle),
+        }),
+      };
+    },
+    onLog: (message) => inboundLogger.warn({ message }, "whatsapp ingress drain"),
+  });
+  const durableDrainTimer = setInterval(() => {
+    void requestDurableInboundDrain().catch((error: unknown) => {
+      inboundLogger.error({ error: formatError(error) }, "whatsapp durable inbound drain failed");
+    });
+  }, WHATSAPP_INGRESS_DRAIN_INTERVAL_MS);
+  durableDrainTimer.unref?.();
 
   const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
     if (upsert.type !== "notify" && upsert.type !== "append") {
@@ -1751,7 +1614,88 @@ export async function attachWebInboxToSocket(
         continue;
       }
 
-      await processDurableInboundMessage(msg, upsert.type, receiveOrder);
+      const receivedAt = Date.now();
+      const skipStaleAppend = shouldSkipStaleAppend(msg, upsert.type);
+      const skipRecentOutboundEcho = shouldSkipRecentOutboundEcho(msg);
+      const remoteJid = msg.key?.remoteJid;
+      const id = msg.key?.id;
+      const durableId =
+        remoteJid && id ? createWhatsAppDurableInboundMessageId({ remoteJid, id }) : undefined;
+      let resolvePrepared: ((inbound: PreparedInbound | null | undefined) => void) | undefined;
+      if (durableId) {
+        preparedInboundByDurableId.set(
+          durableId,
+          new Promise((resolve) => {
+            resolvePrepared = resolve;
+          }),
+        );
+      }
+      const finishPreparation = (
+        inbound: PreparedInbound | null | undefined,
+        keepForDrain = false,
+      ) => {
+        resolvePrepared?.(inbound);
+        if (!keepForDrain && durableId) {
+          preparedInboundByDurableId.delete(durableId);
+        }
+      };
+      let result: Awaited<ReturnType<typeof enqueueWhatsAppDurableInbound>>;
+      try {
+        result = await enqueueWhatsAppDurableInbound({
+          queue: durableInboundQueue,
+          message: msg,
+          upsertType: upsert.type,
+          skipStaleAppend,
+          skipRecentOutboundEcho,
+          receivedAt,
+          receiveOrder,
+        });
+      } catch (error) {
+        finishPreparation(undefined);
+        const formattedError = formatError(error);
+        inboundLogger.warn(
+          { error: formattedError },
+          "failed persisting durable WhatsApp inbound; delivering live",
+        );
+        inboundConsoleLog.warn(
+          `Failed persisting durable WhatsApp inbound; delivering live: ${formattedError}`,
+        );
+        await dispatchInboundMessage(msg, {
+          upsertType: upsert.type,
+          skipStaleAppend,
+          skipRecentOutboundEcho,
+          receivedAt,
+          receiveOrder,
+        });
+        continue;
+      }
+      if (result.kind === "completed") {
+        finishPreparation(undefined);
+        const inbound = await normalizeInboundMessage(msg);
+        if (inbound) {
+          await maybeMarkNonSelfChatReadReceipt(inbound, buildReadReceiptTarget(inbound));
+        }
+      } else {
+        if (result.kind === "accepted" || result.kind === "pending") {
+          try {
+            finishPreparation(
+              skipRecentOutboundEcho ? null : await normalizeInboundMessage(msg),
+              true,
+            );
+          } catch (error) {
+            finishPreparation(undefined);
+            throw error;
+          }
+        } else {
+          finishPreparation(undefined);
+        }
+        void requestDurableInboundDrain().catch((error: unknown) => {
+          inboundLogger.error(
+            { error: formatError(error) },
+            "whatsapp durable inbound drain failed",
+          );
+        });
+      }
     }
   };
   const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
@@ -1783,10 +1727,9 @@ export async function attachWebInboxToSocket(
   };
   const drainInboundBeforeSocketClose = async () => {
     groupMetadataCacheClosed = true;
-    // Durable pumps (via upsert handlers) park on claim flush waiters until the
-    // debouncer flushes. Interleave force-flush with event-driven wait for
-    // debounce enqueue so close cannot deadlock and stays fake-timer safe.
-    // Debounce-window parity preserved: flushKey, not cancel.
+    clearInterval(durableDrainTimer);
+    // Interleave force-flush with event-driven wait for drain dispatch so close
+    // cannot deadlock inside the debounce window. Debounce semantics stay intact.
     for (;;) {
       await drainDebouncedInboundMessages();
       if (pendingMessageHandlers.size === 0) {
@@ -1803,10 +1746,11 @@ export async function attachWebInboxToSocket(
       }
     }
     await drainDebouncedInboundMessages();
-    // Drain-owned claims must finish (or release) before a successor monitor starts.
+    // Claims must finish (or release) before a successor monitor starts.
     try {
       await durableInboundDrain.waitForIdle();
     } finally {
+      durableDrainClosed = true;
       durableInboundDrain.dispose();
     }
   };
@@ -1929,15 +1873,9 @@ export async function attachWebInboxToSocket(
     forgetFullGroupMetadata(update.id);
   }) as unknown as (...args: unknown[]) => void);
 
-  const replayTask = pumpDurableInboundDrain().catch((err: unknown) => {
+  void requestDurableInboundDrain().catch((err: unknown) => {
     inboundLogger.error({ error: String(err) }, "failed replaying durable WhatsApp inbound");
     inboundConsoleLog.error(`Failed replaying durable WhatsApp inbound: ${String(err)}`);
-  });
-  pendingMessageHandlers.add(replayTask);
-  publishPendingWorkState();
-  void replayTask.finally(() => {
-    pendingMessageHandlers.delete(replayTask);
-    publishPendingWorkState();
   });
 
   const groupHydrationTask = (async () => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -542,7 +542,9 @@ export async function attachWebInboxToSocket(
         },
         onAbandoned: async () => {
           handedOff = true;
-          await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAbandoned()));
+          await Promise.all(
+            lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
+          );
         },
       } satisfies WhatsAppIngressLifecycle,
       // Gated or otherwise terminal no-dispatch turns still own every merged claim.
@@ -554,7 +556,9 @@ export async function attachWebInboxToSocket(
       abandon: async () => {
         if (!handedOff) {
           handedOff = true;
-          await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAbandoned()));
+          await Promise.all(
+            lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
+          );
         }
       },
     };
@@ -1498,7 +1502,6 @@ export async function attachWebInboxToSocket(
     return "deferred";
   };
 
-  let durableInboundDrain!: ReturnType<typeof createWhatsAppIngressDrain>;
   let durableDrainPass: Promise<void> | undefined;
   let durableDrainRequested = false;
   let durableDrainClosed = false;
@@ -1566,7 +1569,8 @@ export async function attachWebInboxToSocket(
       requestDrainAfterLaneSettlement();
     },
   });
-  durableInboundDrain = createWhatsAppIngressDrain({
+  // Lazy closures above only run post-start, so the const-after-use is TDZ-safe.
+  const durableInboundDrain = createWhatsAppIngressDrain({
     queue: durableInboundQueue,
     dispatch: async (msg, payload, lifecycle) => {
       const remoteJid = msg.key?.remoteJid;
@@ -1653,7 +1657,7 @@ export async function attachWebInboxToSocket(
           preparedInboundByDurableId.delete(durableId);
         }
       };
-      let result: Awaited<ReturnType<typeof enqueueWhatsAppDurableInbound>> | undefined;
+      let result: { kind: string } | undefined;
       let appendError: unknown;
       // Bounded retry for transient store blips. The retired live-dispatch
       // fallback is gone deliberately: with the replay guard deleted it
@@ -1661,7 +1665,9 @@ export async function attachWebInboxToSocket(
       // reply/session race for availability against an already-broken store.
       for (const delayMs of [0, 100, 300]) {
         if (delayMs > 0) {
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          await new Promise((resolve) => {
+            setTimeout(resolve, delayMs);
+          });
         }
         try {
           result = await enqueueWhatsAppDurableInbound({

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -15,7 +15,6 @@ import {
   formatLocationText,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
 import {
   asDateTimestampMs,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1786,6 +1786,12 @@ export async function attachWebInboxToSocket(
       if (timeout) {
         clearTimeout(timeout);
       }
+      // A drain timeout abandons the graceful path before its own dispose
+      // runs; a successor monitor must never share this account queue with a
+      // still-live drain. dispose() is idempotent, so the graceful path's own
+      // cleanup stays harmless.
+      durableDrainClosed = true;
+      durableInboundDrain.dispose();
     }
   };
   const handleConnectionUpdate = (update: Partial<import("baileys").ConnectionState>) => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1622,7 +1622,9 @@ export async function attachWebInboxToSocket(
       const durableId =
         remoteJid && id ? createWhatsAppDurableInboundMessageId({ remoteJid, id }) : undefined;
       let resolvePrepared: ((inbound: PreparedInbound | null | undefined) => void) | undefined;
-      if (durableId) {
+      // A redelivery must not clobber the first delivery's in-flight
+      // preparation: the drain consumes exactly one entry per durable id.
+      if (durableId && !preparedInboundByDurableId.has(durableId)) {
         preparedInboundByDurableId.set(
           durableId,
           new Promise((resolve) => {
@@ -1639,34 +1641,42 @@ export async function attachWebInboxToSocket(
           preparedInboundByDurableId.delete(durableId);
         }
       };
-      let result: Awaited<ReturnType<typeof enqueueWhatsAppDurableInbound>>;
-      try {
-        result = await enqueueWhatsAppDurableInbound({
-          queue: durableInboundQueue,
-          message: msg,
-          upsertType: upsert.type,
-          skipStaleAppend,
-          skipRecentOutboundEcho,
-          receivedAt,
-          receiveOrder,
-        });
-      } catch (error) {
+      let result: Awaited<ReturnType<typeof enqueueWhatsAppDurableInbound>> | undefined;
+      let appendError: unknown;
+      // Bounded retry for transient store blips. The retired live-dispatch
+      // fallback is gone deliberately: with the replay guard deleted it
+      // bypassed drain dedupe and lane serialization, trading a duplicate
+      // reply/session race for availability against an already-broken store.
+      for (const delayMs of [0, 100, 300]) {
+        if (delayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+        try {
+          result = await enqueueWhatsAppDurableInbound({
+            queue: durableInboundQueue,
+            message: msg,
+            upsertType: upsert.type,
+            skipStaleAppend,
+            skipRecentOutboundEcho,
+            receivedAt,
+            receiveOrder,
+          });
+          appendError = undefined;
+          break;
+        } catch (error) {
+          appendError = error;
+        }
+      }
+      if (result === undefined) {
         finishPreparation(undefined);
-        const formattedError = formatError(error);
-        inboundLogger.warn(
+        const formattedError = formatError(appendError);
+        inboundLogger.error(
           { error: formattedError },
-          "failed persisting durable WhatsApp inbound; delivering live",
+          "failed persisting durable WhatsApp inbound after retries; message dropped",
         );
-        inboundConsoleLog.warn(
-          `Failed persisting durable WhatsApp inbound; delivering live: ${formattedError}`,
+        inboundConsoleLog.error(
+          `Failed persisting durable WhatsApp inbound after retries; message dropped: ${formattedError}`,
         );
-        await dispatchInboundMessage(msg, {
-          upsertType: upsert.type,
-          skipStaleAppend,
-          skipRecentOutboundEcho,
-          receivedAt,
-          receiveOrder,
-        });
         continue;
       }
       if (result.kind === "completed") {
@@ -1676,7 +1686,7 @@ export async function attachWebInboxToSocket(
           await maybeMarkNonSelfChatReadReceipt(inbound, buildReadReceiptTarget(inbound));
         }
       } else {
-        if (result.kind === "accepted" || result.kind === "pending") {
+        if (result.kind === "accepted") {
           try {
             finishPreparation(
               skipRecentOutboundEcho ? null : await normalizeInboundMessage(msg),
@@ -1687,6 +1697,8 @@ export async function attachWebInboxToSocket(
             throw error;
           }
         } else {
+          // "pending": the first delivery owns preparation; resolving without
+          // keepForDrain avoids orphaning a second map entry forever.
           finishPreparation(undefined);
         }
         void requestDurableInboundDrain().catch((error: unknown) => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1625,6 +1625,16 @@ export async function attachWebInboxToSocket(
       // A redelivery must not clobber the first delivery's in-flight
       // preparation: the drain consumes exactly one entry per durable id.
       if (durableId && !preparedInboundByDurableId.has(durableId)) {
+        // Queue pruning caps pending rows, but evicted rows' entries would
+        // linger here forever on a blocked lane; evict oldest-first well above
+        // the queue's own pending cap. Dispatch falls back to re-normalizing
+        // the journaled payload when its entry is gone.
+        if (preparedInboundByDurableId.size >= 1000) {
+          const oldest = preparedInboundByDurableId.keys().next().value;
+          if (oldest !== undefined) {
+            preparedInboundByDurableId.delete(oldest);
+          }
+        }
         preparedInboundByDurableId.set(
           durableId,
           new Promise((resolve) => {
@@ -1637,7 +1647,10 @@ export async function attachWebInboxToSocket(
         keepForDrain = false,
       ) => {
         resolvePrepared?.(inbound);
-        if (!keepForDrain && durableId) {
+        // Only the delivery that installed the entry may remove it; a
+        // duplicate pending delivery (resolvePrepared undefined) must not
+        // delete the first delivery's kept preparation.
+        if (!keepForDrain && durableId && resolvePrepared) {
           preparedInboundByDurableId.delete(durableId);
         }
       };

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -962,6 +962,36 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("completes shutdown under a long durable debounce without waiting for the window", async () => {
+    // Durable pump tasks await claim flush waiters; close must force-flush
+    // debounced batches before waiting on those pumps (socket-close timeout).
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 60_000,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("debounce-shutdown-durable"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "held in debounce",
+        timestamp: 1_700_000_100,
+        pushName: "Tester",
+      }),
+    );
+    // Let accept+pump reach the flush waiter without exhausting the debounce window.
+    await settleInboundWork();
+
+    const closeStarted = Date.now();
+    await listener.close();
+    const closeElapsedMs = Date.now() - closeStarted;
+
+    expect(closeElapsedMs).toBeLessThan(5_000);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(inboundMessage(onMessage).payload.body).toBe("held in debounce");
+    expect(sock.end).toHaveBeenCalledTimes(1);
+  });
+
   it("lets a drained debounced inbound reply before closing the socket", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -373,12 +373,17 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("continues live delivery when durable persistence rejects a message", async () => {
+  it("retries a transient persistence failure and still delivers through the drain", async () => {
     const onMessage = vi.fn(async () => undefined);
     const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    // One transient rejection absorbs into the bounded retry; the message then
+    // flows durably. The retired live-dispatch fallback is gone: it bypassed
+    // drain dedupe and lane serialization once the replay guard was deleted.
     const durableInboundQueue = {
       ...queue,
-      enqueue: vi.fn().mockRejectedValueOnce(new Error("SQLITE_FULL")),
+      // First attempt rejects; the bounded retry's second attempt must reach
+      // the real queue so the message flows durably.
+      enqueue: vi.fn(queue.enqueue.bind(queue)).mockRejectedValueOnce(new Error("SQLITE_FULL")),
     };
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -13,13 +13,14 @@ import {
 } from "./inbound/monitor.js";
 
 const EXPECTED_WHATSAPP_GROUP_METADATA_CACHE_MAX_ENTRIES = 500;
+import { createWhatsAppDurableInboundQueue } from "./inbound/durable-receive.js";
+import { resolveWhatsAppIngressLifecycle } from "./inbound/ingress-lifecycle.js";
 import type { WebInboundMessage } from "./inbound/types.js";
 import {
   type InboxMonitorOptions,
   buildNotifyMessageUpsert,
   DEFAULT_ACCOUNT_ID,
   DEFAULT_WEB_INBOX_CONFIG,
-  failNextWhatsAppPluginStateRegisterIfAbsent,
   getAuthDir,
   getSock,
   installWebMonitorInboxUnitTestHooks,
@@ -373,10 +374,16 @@ describe("web monitor inbox", () => {
   });
 
   it("continues live delivery when durable persistence rejects a message", async () => {
-    failNextWhatsAppPluginStateRegisterIfAbsent(new Error("PLUGIN_STATE_LIMIT_EXCEEDED"));
     const onMessage = vi.fn(async () => undefined);
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    const durableInboundQueue = {
+      ...queue,
+      enqueue: vi.fn().mockRejectedValueOnce(new Error("SQLITE_FULL")),
+    };
 
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue,
+    });
     const messageId = nextMessageId("durable-fallback");
 
     sock.ev.emit(
@@ -434,6 +441,29 @@ describe("web monitor inbox", () => {
     expect(onMessage).toHaveBeenCalledTimes(1);
 
     finishMessage?.();
+    await listener.close();
+  });
+
+  it("does not redispatch a completed transport-key duplicate", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("durable-completed"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    sock.readMessages.mockClear();
+
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
     await listener.close();
   });
 
@@ -923,10 +953,18 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("flushes pending debounced inbound batches after close", async () => {
+  it("drains serialized same-lane messages after close", async () => {
     vi.useFakeTimers();
     try {
-      const onMessage = vi.fn(async () => undefined);
+      let releaseFirst: (() => void) | undefined;
+      const firstTurn = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const onMessage = vi.fn(async () => {
+        if (onMessage.mock.calls.length === 1) {
+          await firstTurn;
+        }
+      });
       const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
         debounceMs: 50,
       });
@@ -940,6 +978,10 @@ describe("web monitor inbox", () => {
           pushName: "Tester",
         }),
       );
+      await vi.advanceTimersByTimeAsync(50);
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("first");
+
       sock.ev.emit(
         "messages.upsert",
         buildNotifyMessageUpsert({
@@ -951,12 +993,15 @@ describe("web monitor inbox", () => {
         }),
       );
 
-      await listener.close();
-      await vi.advanceTimersByTimeAsync(50);
-      await waitForMessageCalls(onMessage, 1);
-      const inbound = inboundMessage(onMessage);
-      expect(inbound.payload.body).toBe("first\nsecond");
-      expect(inbound.admission?.conversation.kind).toBe("direct");
+      const closePromise = listener.close();
+      expect(onMessage).toHaveBeenCalledTimes(1);
+
+      releaseFirst?.();
+      await closePromise;
+
+      expect(onMessage).toHaveBeenCalledTimes(2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("second");
+      expect(inboundMessage(onMessage, 1).admission?.conversation.kind).toBe("direct");
     } finally {
       vi.useRealTimers();
     }
@@ -992,12 +1037,19 @@ describe("web monitor inbox", () => {
     expect(sock.end).toHaveBeenCalledTimes(1);
   });
 
-  it("lets a drained debounced inbound reply before closing the socket", async () => {
+  it("lets serialized same-lane replies drain before closing the socket", async () => {
     vi.useFakeTimers();
     try {
+      let releaseFirst: (() => void) | undefined;
+      const firstTurn = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
       const onMessage = vi.fn(async (msg) => {
         await msg.platform.reply("pong");
         await msg.platform.sendMedia({ text: "media" });
+        if (onMessage.mock.calls.length === 1) {
+          await firstTurn;
+        }
       });
       const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
         debounceMs: 50,
@@ -1012,6 +1064,10 @@ describe("web monitor inbox", () => {
           pushName: "Tester",
         }),
       );
+      await vi.advanceTimersByTimeAsync(50);
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("first");
+
       sock.ev.emit(
         "messages.upsert",
         buildNotifyMessageUpsert({
@@ -1023,14 +1079,24 @@ describe("web monitor inbox", () => {
         }),
       );
 
-      await listener.close();
-
+      const closePromise = listener.close();
       expect(onMessage).toHaveBeenCalledTimes(1);
-      expect(inboundMessage(onMessage).payload.body).toBe("first\nsecond");
+
+      releaseFirst?.();
+      await closePromise;
+
+      expect(onMessage).toHaveBeenCalledTimes(2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("second");
       expect(sock.sendMessage).toHaveBeenNthCalledWith(1, "999@s.whatsapp.net", {
         text: "pong",
       });
       expect(sock.sendMessage).toHaveBeenNthCalledWith(2, "999@s.whatsapp.net", {
+        text: "media",
+      });
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(3, "999@s.whatsapp.net", {
+        text: "pong",
+      });
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(4, "999@s.whatsapp.net", {
         text: "media",
       });
       expect(sock.end).toHaveBeenCalledTimes(1);
@@ -1850,6 +1916,7 @@ describe("web monitor inbox", () => {
     await waitForMessageCalls(onMessage, 1);
 
     expect(getPNForLID).toHaveBeenCalledWith("999@lid");
+    expect(getPNForLID).toHaveBeenCalledTimes(1);
     const inbound = inboundMessage(onMessage);
     expect(inbound.payload.body).toBe("ping");
     expect(inbound.admission?.conversation.id).toBe("+999");
@@ -1914,18 +1981,21 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("does not block follow-up messages when handler is pending", async () => {
-    let resolveFirst: (() => void) | null = null;
-    const onMessage = vi.fn(async () => {
-      if (!resolveFirst) {
-        await new Promise<void>((resolve) => {
-          resolveFirst = resolve;
-        });
+  it("keeps a same-lane follow-up pending until the first handler adopts", async () => {
+    let adoptFirst: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (!adoptFirst) {
+        const lifecycle = resolveWhatsAppIngressLifecycle(message);
+        if (!lifecycle) {
+          throw new Error("expected durable ingress lifecycle");
+        }
+        lifecycle.onDeferred();
+        adoptFirst = lifecycle.onAdopted;
       }
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    const upsert = {
+    sock.ev.emit("messages.upsert", {
       type: "notify",
       messages: [
         {
@@ -1933,20 +2003,31 @@ describe("web monitor inbox", () => {
           message: { conversation: "ping" },
           messageTimestamp: 1_700_000_000,
         },
+      ],
+    });
+    await waitForMessageCalls(onMessage, 1);
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
         {
           key: { id: "abc2", fromMe: false, remoteJid: "999@s.whatsapp.net" },
           message: { conversation: "pong" },
           messageTimestamp: 1_700_000_001,
         },
       ],
-    };
+    });
+    await settleInboundWork();
 
-    sock.ev.emit("messages.upsert", upsert);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(inboundMessage(onMessage).payload.body).toBe("ping");
+
+    if (!adoptFirst) {
+      throw new Error("expected first adoption callback");
+    }
+    await adoptFirst();
     await waitForMessageCalls(onMessage, 2);
-
-    expect(onMessage).toHaveBeenCalledTimes(2);
-
-    (resolveFirst as (() => void) | null)?.();
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("pong");
     await listener.close();
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -372,6 +372,30 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("keeps the first delivery's prepared entry when a duplicate arrives", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const messageId = nextMessageId("dup-prepared");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "first",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    // Duplicate delivery of the same message id: its pending verdict must not
+    // delete the first delivery's kept preparation.
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await settleInboundWork();
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(inboundMessage(onMessage).payload.body).toBe("first");
+    await listener.close();
+  });
+
   it("retries a transient persistence failure and still delivers through the drain", async () => {
     const onMessage = vi.fn(async () => undefined);
     const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -5,7 +5,6 @@ import type { GroupMetadata, WAMessageKey } from "baileys";
 import "./monitor-inbox.test-harness.js";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { WhatsAppRetryableInboundError } from "./inbound/dedupe.js";
 import {
   readWhatsAppBaileysCacheEntry,
   type WhatsAppBaileysGroupMetadataCache,
@@ -1844,7 +1843,8 @@ describe("web monitor inbox", () => {
     const onMessage = vi.fn(async () => {
       attempts += 1;
       if (attempts === 1) {
-        throw new WhatsAppRetryableInboundError("retry me");
+        // Any non-permanent error is retryable to the drain classifier.
+        throw new Error("retry me");
       }
     });
 

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -120,10 +120,6 @@ export function getRecordChannelActivityMock(): AnyMockFn {
   return channelActivityMocks.recordChannelActivity;
 }
 
-export function failNextWhatsAppPluginStateRegisterIfAbsent(error: Error) {
-  pluginRuntimeMocks.failNextRegisterIfAbsent(error);
-}
-
 vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
   const actual = await vi.importActual<
     typeof import("openclaw/plugin-sdk/channel-activity-runtime")


### PR DESCRIPTION
Related: #109657

## What Problem This Solves

Fixes an issue where accepted WhatsApp inbound messages used a channel-private journal replay path plus a 20-minute in-memory replay guard, leaving restart recovery, duplicate rejection, and same-conversation ordering outside the shared durable-ingress contract.

## Why This Change Was Made

The WhatsApp journal now drains through the shared channel ingress worker. It derives stable event IDs as `sha256(remoteJid + id)`, uses `remoteJid` conversation lanes, persists receive-time skip decisions in the journal payload, and holds deferred claims until reply-lane adoption. Same-conversation work stays serialized by the core contract.

The old 20-minute/5,000-entry inbound replay guard is removed because seven-day/5,000-entry durable tombstones cover that identity window across restarts. The outbound echo cache is unchanged.

This builds on the durable-drain base authored by @obviyus. Thank you, Ayaan, for the original implementation and issue plan. AI-assisted finishing and validation were used for this PR.

## User Impact

WhatsApp users get durable replay of accepted-but-not-adopted inbound messages after a restart, durable duplicate rejection, and serialized delivery per conversation through the same core path used by other migrated channels. No configuration changes are required.

Live WhatsApp login proof is not included because the QA credential is currently unlinked. That credentialed receive/restart/flush check remains part of the maintainer's manual verification round.

## Evidence

- Exact rebased head: `pnpm test extensions/whatsapp` on Blacksmith Testbox [run 29630942093](https://github.com/openclaw/openclaw/actions/runs/29630942093): 93 files, 1,117 tests passed.
- `extensions/whatsapp/src/inbound/durable-receive.test.ts`: claim release, durable tombstones, and same-lane pending-until-adoption serialization.
- `extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts`: transient persistence retry, close-timeout disposal, prepared-map ownership/bounds, durable replay, and same-lane follow-up regressions.
- `extensions/telegram/src/polling-session.test.ts`: shared same-lane serialization/adoption reference behavior.
- `node scripts/check-deadcode-exports.mjs` and `node scripts/check-deadcode-unused-files.mjs`: zero findings.
- `git diff --check origin/main...HEAD`: clean.
- Mandatory autoreview completed. Its two findings were the already-adjudicated bounded fail-closed persistence policy and intentional same-lane serialization contract; both are explicit, tested design decisions for this landing.
