### PR TITLE
fix: default loopDetection.enabled to true

### DIFF
--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -42,7 +42,7 @@ export const UNKNOWN_TOOL_THRESHOLD = 10;
 const CRITICAL_THRESHOLD = 20;
 const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
-  enabled: false,
+  enabled: true,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   unknownToolThreshold: UNKNOWN_TOOL_THRESHOLD,


### PR DESCRIPTION
[Bob] Fix #110337 — default `loopDetection.enabled` to `true`.

### Problem
Agents on expensive models ($3/1M input) can burn $30-50/hour stuck in tool retry loops when `loopDetection.enabled` defaults to `false`.

### Change
One-line change in `src/agents/tool-loop-detection.ts`: `enabled: false` → `enabled: true`.

### Why safe
- `native-hook-relay.ts:645` already treats missing/undefined config as enabled (`loopDetection?.enabled !== false`)
- Existing tests that explicitly set `enabled: false` continue to work (opt-out still honored)
- Warning/critical/circuit-breaker thresholds (10/20/30) are generous enough to avoid false positives
