### PR TITLE
fix(android): recover Wear requests from stale phone routes

### DIFF
--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt
@@ -132,7 +132,12 @@ internal class WearProxyClient private constructor(
     recordPreferredPhoneAttempt(preferredPhone?.takeIf { it.nodeId == nodeId })
     val requestId = UUID.randomUUID().toString()
     val response = CompletableDeferred<WearMessage.Response>()
-    val pendingRequest = PendingWearRequest(nodeId = nodeId, response = response)
+    val pendingRequest =
+      PendingWearRequest(
+        nodeId = nodeId,
+        response = response,
+        preferredPhone = preferredPhone?.takeIf { it.nodeId == nodeId },
+      )
     check(pending.putIfAbsent(requestId, pendingRequest) == null)
     return try {
       try {
@@ -153,7 +158,6 @@ internal class WearProxyClient private constructor(
         throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
       }
       val envelope = response.await()
-      confirmPreferredPhoneResponse(preferredPhone?.takeIf { it.nodeId == nodeId })
       if (
         (expectedNodeId == null || requirePreferredNode || method.requiresPreferredSnapshotSource()) &&
         currentPreferredPhone()?.nodeId != nodeId
@@ -188,8 +192,12 @@ internal class WearProxyClient private constructor(
         path == WearProtocol.RESPONSE_PATH && message is WearMessage.Response -> {
           pending[message.requestId]
             ?.takeIf { it.nodeId == sourceNodeId }
-            ?.response
-            ?.complete(message)
+            ?.let { request ->
+              // Correlation is the reachability proof. Advance the registration
+              // before a concurrently expiring request can invalidate it.
+              confirmPreferredPhoneResponse(request.preferredPhone)
+              request.response.complete(message)
+            }
           null
         }
         path == WearProtocol.EVENT_PATH && message is WearMessage.Event -> {
@@ -317,6 +325,7 @@ internal class WearProxyClient private constructor(
   private data class PendingWearRequest(
     val nodeId: String,
     val response: CompletableDeferred<WearMessage.Response>,
+    val preferredPhone: PreferredPhoneRegistration?,
   )
 
   companion object {
@@ -367,13 +376,6 @@ internal fun selectReachablePhoneNodeId(nodes: Collection<WearReachablePhoneNode
     else -> null
   }
 }
-
-internal fun selectUniqueNearbyPhoneNodeId(nodes: Collection<WearReachablePhoneNode>): String? =
-  nodes
-    .distinctBy(WearReachablePhoneNode::id)
-    .filter(WearReachablePhoneNode::isNearby)
-    .singleOrNull()
-    ?.id
 
 private fun WearRpcMethod.requiresPreferredSnapshotSource(): Boolean = this == WearRpcMethod.ProxyStatus || this == WearRpcMethod.SessionsList || this == WearRpcMethod.ChatHistory
 

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt
@@ -12,7 +12,6 @@ import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.Wearable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -21,13 +20,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -77,10 +75,9 @@ internal class WearProxyClient private constructor(
   private val transport: WearMessageTransport,
 ) : WearRpcRequester {
   private val pending = ConcurrentHashMap<String, PendingWearRequest>()
-  private val selectedPhoneNodeId = AtomicReference<String?>()
   private val preferredPhoneLock = Any()
-  private var preferredPhoneKnown = false
-  private var preferredPhoneNodeId: String? = null
+  private var preferredPhoneGeneration = 0L
+  private var registeredPhone: PreferredPhoneRegistration? = null
   private val inboundMutex = Mutex()
   private val mutableEvents =
     MutableSharedFlow<WearInboundEvent>(
@@ -98,28 +95,41 @@ internal class WearProxyClient private constructor(
     params: JsonObject,
     expectedNodeId: String?,
     requirePreferredNode: Boolean,
-  ): WearRpcResult =
-    try {
-      withTimeout(REQUEST_TIMEOUT_MS) {
-        requestBeforeDeadline(method, params, expectedNodeId, requirePreferredNode)
+  ): WearRpcResult {
+    var attemptedPreferredPhone: PreferredPhoneRegistration? = null
+    val result =
+      withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
+        requestBeforeDeadline(method, params, expectedNodeId, requirePreferredNode) { registration ->
+          attemptedPreferredPhone = registration
+        }
       }
-    } catch (_: TimeoutCancellationException) {
-      throw WearProxyException("timeout", "Paired phone did not respond")
-    }
+    if (result != null) return result
+
+    // MessageClient success only proves the request was queued. A silent phone
+    // must be rediscovered just like a node that rejected the send outright.
+    invalidatePreferredPhone(attemptedPreferredPhone)
+    throw WearProxyException("timeout", "Paired phone did not respond")
+  }
 
   private suspend fun requestBeforeDeadline(
     method: WearRpcMethod,
     params: JsonObject,
     expectedNodeId: String?,
     requirePreferredNode: Boolean,
+    recordPreferredPhoneAttempt: (PreferredPhoneRegistration?) -> Unit,
   ): WearRpcResult {
     // Stateful RPCs stay on the phone that supplied their session/transcript.
     // Rediscovery here could route a shared session key to a different phone.
-    val requiredPreferredNodeId = if (requirePreferredNode) resolvePreferredPhoneNode() else null
-    val nodeId = expectedNodeId ?: requiredPreferredNodeId ?: resolvePreferredPhoneNode()
-    if (requirePreferredNode && expectedNodeId != null && requiredPreferredNodeId != expectedNodeId) {
+    val preferredPhone =
+      when {
+        requirePreferredNode || expectedNodeId == null -> resolvePreferredPhone()
+        else -> preferredPhoneRegistration(expectedNodeId)
+      }
+    val nodeId = expectedNodeId ?: checkNotNull(preferredPhone).nodeId
+    if (requirePreferredNode && expectedNodeId != null && preferredPhone?.nodeId != expectedNodeId) {
       throw WearProxyException("phone_changed", "Preferred phone changed during request")
     }
+    recordPreferredPhoneAttempt(preferredPhone?.takeIf { it.nodeId == nodeId })
     val requestId = UUID.randomUUID().toString()
     val response = CompletableDeferred<WearMessage.Response>()
     val pendingRequest = PendingWearRequest(nodeId = nodeId, response = response)
@@ -136,14 +146,17 @@ internal class WearProxyClient private constructor(
         )
       } catch (_: CancellationException) {
         currentCoroutineContext().ensureActive()
+        invalidatePreferredPhone(preferredPhone?.takeIf { it.nodeId == nodeId })
         throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
       } catch (_: Throwable) {
+        invalidatePreferredPhone(preferredPhone?.takeIf { it.nodeId == nodeId })
         throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
       }
       val envelope = response.await()
+      confirmPreferredPhoneResponse(preferredPhone?.takeIf { it.nodeId == nodeId })
       if (
         (expectedNodeId == null || requirePreferredNode || method.requiresPreferredSnapshotSource()) &&
-        selectedPhoneNodeId.get() != nodeId
+        currentPreferredPhone()?.nodeId != nodeId
       ) {
         throw WearProxyException("phone_changed", "Preferred phone changed during request")
       }
@@ -209,15 +222,12 @@ internal class WearProxyClient private constructor(
     } ?: throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
 
   private suspend fun acceptEventSource(sourceNodeId: String): Boolean {
-    val snapshot = preferredPhoneSnapshot()
-    if (snapshot.known) {
-      val preferred = snapshot.nodeId
-      selectedPhoneNodeId.set(preferred)
-      return preferred == sourceNodeId
+    val preferredPhone = currentPreferredPhone()
+    if (preferredPhone != null) {
+      return preferredPhone.nodeId == sourceNodeId
     }
-    if (selectedPhoneNodeId.get() == sourceNodeId) return true
     return try {
-      resolvePreferredPhoneNode() == sourceNodeId
+      resolvePreferredPhone().nodeId == sourceNodeId
     } catch (err: CancellationException) {
       throw err
     } catch (_: WearProxyException) {
@@ -225,44 +235,83 @@ internal class WearProxyClient private constructor(
     }
   }
 
-  /** Capability callbacks invalidate cached routing before another old-phone event is accepted. */
-  fun updatePreferredPhoneNodeId(nodeId: String?) {
+  /** A unique directly connected phone becomes the preferred routing source immediately. */
+  fun updatePreferredPhoneNodeId(nodeId: String) {
     val changed =
       synchronized(preferredPhoneLock) {
-        val changed = !preferredPhoneKnown || preferredPhoneNodeId != nodeId
-        preferredPhoneKnown = true
-        preferredPhoneNodeId = nodeId
+        val changed = registeredPhone?.nodeId != nodeId
+        preferredPhoneGeneration += 1
+        registeredPhone = PreferredPhoneRegistration(nodeId, preferredPhoneGeneration)
         changed
       }
-    selectedPhoneNodeId.set(nodeId)
     if (changed) mutablePreferredPhoneChanges.tryEmit(nodeId)
   }
 
-  private suspend fun resolvePreferredPhoneNode(): String {
-    preferredPhoneSnapshot().takeIf(PreferredPhoneSnapshot::known)?.let { snapshot ->
-      return snapshot.nodeId ?: throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
-    }
-    val resolved = resolvePhoneNode()
-    val selected =
+  /** Capability callbacks are not reachability-filtered, so ambiguous results force fresh discovery. */
+  fun invalidatePreferredPhoneNode() {
+    val changed =
       synchronized(preferredPhoneLock) {
-        if (!preferredPhoneKnown) {
-          preferredPhoneKnown = true
-          preferredPhoneNodeId = resolved
-        }
-        preferredPhoneNodeId
-      } ?: throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
-    selectedPhoneNodeId.set(selected)
-    return selected
+        val changed = registeredPhone != null
+        preferredPhoneGeneration += 1
+        registeredPhone = null
+        changed
+      }
+    if (changed) mutablePreferredPhoneChanges.tryEmit(null)
   }
 
-  private fun preferredPhoneSnapshot(): PreferredPhoneSnapshot =
+  private suspend fun resolvePreferredPhone(): PreferredPhoneRegistration {
+    currentPreferredPhone()?.let { return it }
+    val resolved = resolvePhoneNode()
+    return synchronized(preferredPhoneLock) {
+      registeredPhone ?: run {
+        preferredPhoneGeneration += 1
+        PreferredPhoneRegistration(resolved, preferredPhoneGeneration).also { registeredPhone = it }
+      }
+    }
+  }
+
+  private fun currentPreferredPhone(): PreferredPhoneRegistration? =
     synchronized(preferredPhoneLock) {
-      PreferredPhoneSnapshot(known = preferredPhoneKnown, nodeId = preferredPhoneNodeId)
+      registeredPhone
     }
 
-  private data class PreferredPhoneSnapshot(
-    val known: Boolean,
-    val nodeId: String?,
+  private fun preferredPhoneRegistration(nodeId: String): PreferredPhoneRegistration? =
+    synchronized(preferredPhoneLock) {
+      registeredPhone?.takeIf { it.nodeId == nodeId }
+    }
+
+  private fun invalidatePreferredPhone(registration: PreferredPhoneRegistration?) {
+    if (registration == null) return
+    val invalidated =
+      synchronized(preferredPhoneLock) {
+        if (registeredPhone == registration) {
+          // A capability callback can refresh the same node while an older request
+          // is failing. Clear only the registration that owned this transport attempt.
+          preferredPhoneGeneration += 1
+          registeredPhone = null
+          true
+        } else {
+          false
+        }
+      }
+    if (invalidated) mutablePreferredPhoneChanges.tryEmit(null)
+  }
+
+  private fun confirmPreferredPhoneResponse(registration: PreferredPhoneRegistration?) {
+    if (registration == null) return
+    synchronized(preferredPhoneLock) {
+      if (registeredPhone == registration) {
+        // Any correlated response proves this registration is reachable. Advance
+        // it so an older parallel request cannot clear it on a later timeout.
+        preferredPhoneGeneration += 1
+        registeredPhone = registration.copy(generation = preferredPhoneGeneration)
+      }
+    }
+  }
+
+  private data class PreferredPhoneRegistration(
+    val nodeId: String,
+    val generation: Long,
   )
 
   private data class PendingWearRequest(
@@ -281,13 +330,13 @@ internal class WearProxyClient private constructor(
       return WearProxyClient(
         nodeResolver =
           WearNodeResolver {
-            capabilityClient
-              .getCapability(WearProtocol.PHONE_CAPABILITY, CapabilityClient.FILTER_REACHABLE)
-              .await()
-              .nodes
-              .sortedWith(compareByDescending<com.google.android.gms.wearable.Node> { it.isNearby }.thenBy { it.id })
-              .firstOrNull()
-              ?.id
+            selectReachablePhoneNodeId(
+              capabilityClient
+                .getCapability(WearProtocol.PHONE_CAPABILITY, CapabilityClient.FILTER_REACHABLE)
+                .await()
+                .nodes
+                .map { node -> WearReachablePhoneNode(id = node.id, isNearby = node.isNearby) },
+            )
           },
         transport =
           WearMessageTransport { nodeId, path, data ->
@@ -302,6 +351,29 @@ internal class WearProxyClient private constructor(
     ): WearProxyClient = WearProxyClient(nodeResolver, transport)
   }
 }
+
+internal data class WearReachablePhoneNode(
+  val id: String,
+  val isNearby: Boolean,
+)
+
+internal fun selectReachablePhoneNodeId(nodes: Collection<WearReachablePhoneNode>): String? {
+  val distinctNodes = nodes.distinctBy(WearReachablePhoneNode::id)
+  val nearbyNodes = distinctNodes.filter(WearReachablePhoneNode::isNearby)
+  return when {
+    nearbyNodes.size == 1 -> nearbyNodes.single().id
+    nearbyNodes.isNotEmpty() -> null
+    distinctNodes.size == 1 -> distinctNodes.single().id
+    else -> null
+  }
+}
+
+internal fun selectUniqueNearbyPhoneNodeId(nodes: Collection<WearReachablePhoneNode>): String? =
+  nodes
+    .distinctBy(WearReachablePhoneNode::id)
+    .filter(WearReachablePhoneNode::isNearby)
+    .singleOrNull()
+    ?.id
 
 private fun WearRpcMethod.requiresPreferredSnapshotSource(): Boolean = this == WearRpcMethod.ProxyStatus || this == WearRpcMethod.SessionsList || this == WearRpcMethod.ChatHistory
 

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt
@@ -268,14 +268,22 @@ internal class WearProxyClient private constructor(
   }
 
   private suspend fun resolvePreferredPhone(): PreferredPhoneRegistration {
-    currentPreferredPhone()?.let { return it }
+    // Capability callbacks can invalidate the route while discovery suspends.
+    // Only a result from the same generation may repopulate it.
+    val discoveryGeneration =
+      synchronized(preferredPhoneLock) {
+        registeredPhone?.let { return it }
+        preferredPhoneGeneration
+      }
     val resolved = resolvePhoneNode()
     return synchronized(preferredPhoneLock) {
-      registeredPhone ?: run {
+      registeredPhone ?: if (preferredPhoneGeneration == discoveryGeneration) {
         preferredPhoneGeneration += 1
         PreferredPhoneRegistration(resolved, preferredPhoneGeneration).also { registeredPhone = it }
+      } else {
+        null
       }
-    }
+    } ?: throw WearProxyException("phone_unavailable", "Paired phone is unavailable")
   }
 
   private fun currentPreferredPhone(): PreferredPhoneRegistration? =

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyListenerService.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyListenerService.kt
@@ -10,19 +10,19 @@ import kotlinx.coroutines.runBlocking
 class WearProxyListenerService : WearableListenerService() {
   override fun onCapabilityChanged(capabilityInfo: CapabilityInfo) {
     if (capabilityInfo.name != WearProtocol.PHONE_CAPABILITY) return
-    val preferredNearbyNodeId =
-      selectUniqueNearbyPhoneNodeId(
+    val preferredNodeId =
+      selectReachablePhoneNodeId(
         capabilityInfo.nodes.map { node ->
           WearReachablePhoneNode(id = node.id, isNearby = node.isNearby)
         },
       )
     val proxyClient = (application as? WearApplication)?.proxyClient ?: return
-    if (preferredNearbyNodeId == null) {
-      // Capability callbacks can include disconnected nodes. Drop the cached
-      // choice so the next request performs a FILTER_REACHABLE query.
+    if (preferredNodeId == null) {
+      // Capability callbacks contain reachable nodes. Multiple routes remain
+      // ambiguous, so force the next request through fresh discovery.
       proxyClient.invalidatePreferredPhoneNode()
     } else {
-      proxyClient.updatePreferredPhoneNodeId(preferredNearbyNodeId)
+      proxyClient.updatePreferredPhoneNodeId(preferredNodeId)
     }
   }
 

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyListenerService.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyListenerService.kt
@@ -10,12 +10,20 @@ import kotlinx.coroutines.runBlocking
 class WearProxyListenerService : WearableListenerService() {
   override fun onCapabilityChanged(capabilityInfo: CapabilityInfo) {
     if (capabilityInfo.name != WearProtocol.PHONE_CAPABILITY) return
-    val preferredNodeId =
-      capabilityInfo.nodes
-        .sortedWith(compareByDescending<com.google.android.gms.wearable.Node> { it.isNearby }.thenBy { it.id })
-        .firstOrNull()
-        ?.id
-    (application as? WearApplication)?.proxyClient?.updatePreferredPhoneNodeId(preferredNodeId)
+    val preferredNearbyNodeId =
+      selectUniqueNearbyPhoneNodeId(
+        capabilityInfo.nodes.map { node ->
+          WearReachablePhoneNode(id = node.id, isNearby = node.isNearby)
+        },
+      )
+    val proxyClient = (application as? WearApplication)?.proxyClient ?: return
+    if (preferredNearbyNodeId == null) {
+      // Capability callbacks can include disconnected nodes. Drop the cached
+      // choice so the next request performs a FILTER_REACHABLE query.
+      proxyClient.invalidatePreferredPhoneNode()
+    } else {
+      proxyClient.updatePreferredPhoneNodeId(preferredNearbyNodeId)
+    }
   }
 
   override fun onMessageReceived(messageEvent: MessageEvent) {

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
@@ -579,6 +579,55 @@ class WearProxyClientTest {
     }
 
   @Test
+  fun correlatedResponseProtectsPhoneBeforeRequesterResumes() =
+    runTest {
+      var discoveries = 0
+      var respond = false
+      val requests = mutableListOf<WearMessage.Request>()
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              "resolver-phone"
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+              requests += request
+              if (respond) {
+                client.handleMessage(
+                  sourceNodeId = nodeId,
+                  path = WearProtocol.RESPONSE_PATH,
+                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+                )
+              }
+            },
+        )
+      client.updatePreferredPhoneNodeId("phone-current")
+
+      val older = async { runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) } }
+      val newer = async { runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) } }
+      runCurrent()
+      assertEquals(2, requests.size)
+
+      client.handleMessage(
+        sourceNodeId = "phone-current",
+        path = WearProtocol.RESPONSE_PATH,
+        data = WearProtocolCodec.encode(WearMessage.Response(requestId = requests[1].requestId, ok = true)),
+      )
+      newer.cancel()
+      advanceUntilIdle()
+
+      assertTrue(newer.isCancelled)
+      assertEquals("timeout", (older.await().exceptionOrNull() as WearProxyException).code)
+      respond = true
+      assertEquals("phone-current", client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null).sourceNodeId)
+      assertEquals(0, discoveries)
+    }
+
+  @Test
   fun ambiguousCapabilityCallbackForcesReachableRediscovery() =
     runTest {
       var discoveries = 0
@@ -620,9 +669,6 @@ class WearProxyClientTest {
     assertEquals("phone-cloud", selectReachablePhoneNodeId(listOf(cloud)))
     assertEquals(null, selectReachablePhoneNodeId(listOf(nearby, nearbyTwo, cloud)))
     assertEquals(null, selectReachablePhoneNodeId(listOf(cloud, cloudTwo)))
-    assertEquals("phone-nearby", selectUniqueNearbyPhoneNodeId(listOf(cloud, nearby)))
-    assertEquals(null, selectUniqueNearbyPhoneNodeId(listOf(cloud)))
-    assertEquals(null, selectUniqueNearbyPhoneNodeId(listOf(nearby, nearbyTwo, cloud)))
   }
 
   @Test

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
@@ -9,12 +9,14 @@ import ai.openclaw.wear.shared.WearProxyCapability
 import ai.openclaw.wear.shared.WearRpcMethod
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
@@ -345,6 +347,283 @@ class WearProxyClientTest {
 
       assertEquals("phone_unavailable", (failure as WearProxyException).code)
     }
+
+  @Test
+  fun shorterCallerTimeoutPropagatesWithoutInvalidatingPhone() =
+    runTest {
+      var discoveries = 0
+      var respond = false
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              "resolver-phone"
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              if (!respond) awaitCancellation()
+              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+              client.handleMessage(
+                sourceNodeId = nodeId,
+                path = WearProtocol.RESPONSE_PATH,
+                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+              )
+            },
+        )
+      client.updatePreferredPhoneNodeId("phone-current")
+
+      val failure =
+        runCatching {
+          withTimeout(1_000L) {
+            client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null)
+          }
+        }.exceptionOrNull()
+      respond = true
+
+      assertTrue(failure is TimeoutCancellationException)
+      assertEquals("phone-current", client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null).sourceNodeId)
+      assertEquals(0, discoveries)
+    }
+
+  @Test
+  fun sendFailureInvalidatesCachedPhoneAndRediscoversNextRequest() =
+    runTest {
+      var resolvedNode = "phone-old"
+      var discoveries = 0
+      var sends = 0
+      val sentNodes = mutableListOf<String>()
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              resolvedNode
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              sends += 1
+              sentNodes += nodeId
+              if (sends == 1) error("stale node")
+              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+              client.handleMessage(
+                sourceNodeId = nodeId,
+                path = WearProtocol.RESPONSE_PATH,
+                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+              )
+            },
+        )
+
+      val first = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
+      resolvedNode = "phone-new"
+      val second = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null)
+
+      assertEquals("phone_unavailable", (first as WearProxyException).code)
+      assertEquals("phone-new", second.sourceNodeId)
+      assertEquals(2, discoveries)
+      assertEquals(listOf("phone-old", "phone-new"), sentNodes)
+    }
+
+  @Test
+  fun responseTimeoutInvalidatesCachedPhoneAndRediscoversNextRequest() =
+    runTest {
+      var resolvedNode = "phone-old"
+      var discoveries = 0
+      var sends = 0
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              resolvedNode
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              sends += 1
+              if (sends > 1) {
+                val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+                client.handleMessage(
+                  sourceNodeId = nodeId,
+                  path = WearProtocol.RESPONSE_PATH,
+                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+                )
+              }
+            },
+        )
+
+      val first = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
+      resolvedNode = "phone-new"
+      val second = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null)
+
+      assertEquals("timeout", (first as WearProxyException).code)
+      assertEquals("phone-new", second.sourceNodeId)
+      assertEquals(2, discoveries)
+    }
+
+  @Test
+  fun staleSendFailureDoesNotInvalidateNewerSamePhoneGeneration() =
+    runTest {
+      var discoveries = 0
+      var sends = 0
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              "resolver-phone"
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              sends += 1
+              if (sends == 1) {
+                client.updatePreferredPhoneNodeId(nodeId)
+                error("stale send")
+              }
+              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+              client.handleMessage(
+                sourceNodeId = nodeId,
+                path = WearProtocol.RESPONSE_PATH,
+                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+              )
+            },
+        )
+      client.updatePreferredPhoneNodeId("phone-current")
+
+      val first = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
+      val second = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null)
+
+      assertEquals("phone_unavailable", (first as WearProxyException).code)
+      assertEquals("phone-current", second.sourceNodeId)
+      assertEquals(0, discoveries)
+    }
+
+  @Test
+  fun staleResponseTimeoutDoesNotInvalidateNewerSamePhoneGeneration() =
+    runTest {
+      var discoveries = 0
+      var sends = 0
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              "resolver-phone"
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              sends += 1
+              if (sends == 1) {
+                client.updatePreferredPhoneNodeId(nodeId)
+              } else {
+                val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+                client.handleMessage(
+                  sourceNodeId = nodeId,
+                  path = WearProtocol.RESPONSE_PATH,
+                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+                )
+              }
+            },
+        )
+      client.updatePreferredPhoneNodeId("phone-current")
+
+      val first = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
+      val second = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null)
+
+      assertEquals("timeout", (first as WearProxyException).code)
+      assertEquals("phone-current", second.sourceNodeId)
+      assertEquals(0, discoveries)
+    }
+
+  @Test
+  fun successfulParallelResponseProtectsPhoneFromOlderTimeout() =
+    runTest {
+      var discoveries = 0
+      var sends = 0
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              "resolver-phone"
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              sends += 1
+              if (sends > 1) {
+                val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+                client.handleMessage(
+                  sourceNodeId = nodeId,
+                  path = WearProtocol.RESPONSE_PATH,
+                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+                )
+              }
+            },
+        )
+      client.updatePreferredPhoneNodeId("phone-current")
+
+      val older = async { runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) } }
+      runCurrent()
+      val newer = async { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }
+      runCurrent()
+
+      assertEquals("phone-current", newer.await().sourceNodeId)
+      assertEquals("timeout", (older.await().exceptionOrNull() as WearProxyException).code)
+      assertEquals("phone-current", client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null).sourceNodeId)
+      assertEquals(0, discoveries)
+    }
+
+  @Test
+  fun ambiguousCapabilityCallbackForcesReachableRediscovery() =
+    runTest {
+      var discoveries = 0
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              discoveries += 1
+              "phone-reachable"
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+              client.handleMessage(
+                sourceNodeId = nodeId,
+                path = WearProtocol.RESPONSE_PATH,
+                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+              )
+            },
+        )
+      client.updatePreferredPhoneNodeId("phone-stale")
+
+      client.invalidatePreferredPhoneNode()
+      val result = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null)
+
+      assertEquals("phone-reachable", result.sourceNodeId)
+      assertEquals(1, discoveries)
+    }
+
+  @Test
+  fun reachablePhoneSelectionPrefersOneNearbyNodeAndRejectsAmbiguity() {
+    val nearby = WearReachablePhoneNode(id = "phone-nearby", isNearby = true)
+    val nearbyTwo = WearReachablePhoneNode(id = "phone-nearby-2", isNearby = true)
+    val cloud = WearReachablePhoneNode(id = "phone-cloud", isNearby = false)
+    val cloudTwo = WearReachablePhoneNode(id = "phone-cloud-2", isNearby = false)
+
+    assertEquals("phone-nearby", selectReachablePhoneNodeId(listOf(cloud, nearby)))
+    assertEquals("phone-cloud", selectReachablePhoneNodeId(listOf(cloud)))
+    assertEquals(null, selectReachablePhoneNodeId(listOf(nearby, nearbyTwo, cloud)))
+    assertEquals(null, selectReachablePhoneNodeId(listOf(cloud, cloudTwo)))
+    assertEquals("phone-nearby", selectUniqueNearbyPhoneNodeId(listOf(cloud, nearby)))
+    assertEquals(null, selectUniqueNearbyPhoneNodeId(listOf(cloud)))
+    assertEquals(null, selectUniqueNearbyPhoneNodeId(listOf(nearby, nearbyTwo, cloud)))
+  }
 
   @Test
   fun eventGapAndResetRequireCanonicalRefresh() {

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
@@ -8,6 +8,7 @@ import ai.openclaw.wear.shared.WearProtocolCodec
 import ai.openclaw.wear.shared.WearProxyCapability
 import ai.openclaw.wear.shared.WearRpcMethod
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
@@ -656,6 +657,51 @@ class WearProxyClientTest {
 
       assertEquals("phone-reachable", result.sourceNodeId)
       assertEquals(1, discoveries)
+    }
+
+  @Test
+  fun inFlightDiscoveryCannotRestoreInvalidatedPhone() =
+    runTest {
+      val discoveryStarted = CompletableDeferred<Unit>()
+      val releaseDiscovery = CompletableDeferred<Unit>()
+      var resolvedNode = "phone-old"
+      var discoveries = 0
+      val sentNodes = mutableListOf<String>()
+      lateinit var client: WearProxyClient
+      client =
+        WearProxyClient.createForTests(
+          nodeResolver =
+            WearNodeResolver {
+              val result = resolvedNode
+              discoveries += 1
+              if (discoveries == 1) {
+                discoveryStarted.complete(Unit)
+                releaseDiscovery.await()
+              }
+              result
+            },
+          transport =
+            WearMessageTransport { nodeId, _, data ->
+              sentNodes += nodeId
+              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+              client.handleMessage(
+                sourceNodeId = nodeId,
+                path = WearProtocol.RESPONSE_PATH,
+                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+              )
+            },
+        )
+
+      val first = async { runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) } }
+      discoveryStarted.await()
+      client.invalidatePreferredPhoneNode()
+      resolvedNode = "phone-new"
+      releaseDiscovery.complete(Unit)
+
+      assertEquals("phone_unavailable", (first.await().exceptionOrNull() as WearProxyException).code)
+      assertEquals("phone-new", client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null).sourceNodeId)
+      assertEquals(2, discoveries)
+      assertEquals(listOf("phone-new"), sentNodes)
     }
 
   @Test


### PR DESCRIPTION
[AI-assisted]

Related: #108781
Follows #109433 and #110130.

## What Problem This Solves

Resolves a Wear Data Layer routing gap where a cached phone can remain preferred after a send failure or a request that was queued but never answered. Ambiguous capability callbacks can also otherwise select a node without proving that it is the one reachable phone.

## Why This Change Was Made

The Wear client now owns one generation-scoped preferred-phone registration. It invalidates only the registration used by a failed or timed-out request, preserves newer same-node registrations and successful parallel responses, accepts capability callbacks only when they identify one unambiguous reachable phone, and falls back to `FILTER_REACHABLE` discovery for ambiguous states. Discovery also captures the current generation, so a result that returns after a capability invalidation cannot restore the stale route. Caller cancellation remains cancellation rather than being rewritten as the client's ten-second response timeout.

The phone remains the only Gateway transport and credential owner; this changes no watch-side authentication or pairing model.

## User Impact

Wear requests recover through fresh phone discovery after a stale route instead of repeatedly trusting it. Multi-phone or disconnected-node states fail closed until one reachable route is unambiguous, while events stay bound to the same phone that supplied the session snapshot.

## Evidence

- Exact head: `239a142b2d0c904a8d5ca49f711fa9d7f49cb1cb`.
- Hosted Android CI: [run 29640044442](https://github.com/openclaw/openclaw/actions/runs/29640044442) passed `android-test-wear`, phone tests, Wear/phone builds, `android-ktlint`, and `openclaw/ci-gate`.
- Focused local exact-head proof: full `WearProxyClientTest`, Wear ktlint, Wear assembly, APK install, and `git diff --check` passed.
- Paired exact-head proof: Android Studio completed an official phone/Wear emulator pairing and both Data Layer pairing-status broadcasts reported the reciprocal peer connected.
- Baseline paired request reached the phone and rendered the phone-owned `Gateway offline` result in 4 seconds.
- No-response path: the paired phone process started but was held before it could answer; the watch exposed its bounded `Retry` state in 3 seconds. Releasing and restarting the phone restored the phone-owned result in 11 seconds.
- Sanitized paired-run output captured from the exact-head install:

```text
exact_head:239a142b2d0c904a8d5ca49f711fa9d7f49cb1cb
baseline_phone_response_seconds:4
baseline_seen:true
no_response_failure_seconds:3
phone_process_started:true
failure_seen:true
recovery_response_seconds:11
recovery_seen:true
pairing_status:
Local:[redacted-watch-node]
Peer:[redacted-phone-node,true,true]
```

- Deterministic regressions cover send failure, response timeout, successful parallel response preservation, correlated-response scheduling, ambiguous reachable sets, cloud-routed single-phone selection, and invalidation during suspended discovery. Standard emulator pairing exposes one phone peer, so no unsupported two-phone live claim is made.
- Dependency contracts checked directly against Play Services Wearable 20.0.1 and kotlinx-coroutines 1.11.0.
- Fresh Sol autoreview after the final generation guard: clean, no accepted/actionable findings.

Ready for maintainer landing.
