### PR TITLE
fix: OCM local builds accept workspace dependencies

### DIFF
--- a/scripts/ocm-npm-workspace-deps.mjs
+++ b/scripts/ocm-npm-workspace-deps.mjs
@@ -4,10 +4,11 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const WORKSPACE_DIRS_ENV = "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS";
 const REAL_NPM_ENV = "OPENCLAW_OCM_REAL_NPM_BIN";
+const INTERNAL_NPM_BIN_ENV = "OCM_INTERNAL_NPM_BIN";
 const ALLOW_UNRELEASED_CHANGELOG_ENV = "OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG";
 const RUNTIME_BUILD_PROFILE_ENV = "OPENCLAW_OCM_RUNTIME_BUILD_PROFILE";
 const supportedRuntimeBuildProfiles = new Set(["sourcePerformance"]);
@@ -74,6 +75,7 @@ export function resolveNpmEnvironment(args, env = process.env) {
   }
   return {
     ...env,
+    [INTERNAL_NPM_BIN_ENV]: fileURLToPath(import.meta.url),
     [ALLOW_UNRELEASED_CHANGELOG_ENV]: "1",
   };
 }

--- a/test/scripts/ocm-npm-workspace-deps.test.ts
+++ b/test/scripts/ocm-npm-workspace-deps.test.ts
@@ -24,6 +24,7 @@ describe("OCM npm workspace dependency adapter", () => {
     expect(resolveNpmEnvironment(["install"], env)).toBe(env);
     expect(resolveNpmEnvironment(["pack", "--silent"], env)).toEqual({
       KEEP: "value",
+      OCM_INTERNAL_NPM_BIN: adapterPath,
       OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG: "1",
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators building an OpenClaw runtime through OCM would have the build rejected as an unsafe plain source pack when OpenClaw used local workspace dependencies such as `@openclaw/ai`.

## Why This Change Was Made

The repository-owned OCM npm adapter now identifies itself to the nested npm `pack` lifecycle. This satisfies the existing fail-closed prepack contract without weakening plain-pack or publish protection, and leaves non-pack adapter commands unchanged.

## User Impact

OCM `runtime build-local` can build current OpenClaw checkouts with workspace dependencies without requiring a manual self-contained tarball workaround.

## Evidence

- Regression test failed before the implementation because delegated `pack` omitted `OCM_INTERNAL_NPM_BIN`: https://github.com/openclaw/openclaw/actions/runs/29631356205
- Exact-head focused suites: 24/24 passed on Blacksmith Testbox `tbx_01kxssy02js9axgzcrx6jz9z02`: https://github.com/openclaw/openclaw/actions/runs/29631709278
- `pnpm check:changed`: passed on Blacksmith Testbox `tbx_01kxssmkhpbkqh7cg2r7g1gsbb` (format, test-root types, script declarations, lint, dependency and package-boundary guards)
- Real behavior: checksum-verified official OCM `v0.2.28` completed `runtime build-local` and `runtime verify` against the patched checkout; the installed runtime reported `healthy: true` on Testbox `tbx_01kxss8e7t0g0wew00neae4e7r`
- Autoreview: clean, no accepted/actionable findings, correctness confidence 0.97

### Real behavior proof

- Behavior addressed: OCM local runtime builds falsely rejected the adapter-managed `@openclaw/ai` workspace dependency.
- Real environment tested: Linux Node 24 Blacksmith Testbox with the checksum-verified official OCM `v0.2.28` release binary.
- Exact steps or command run after this patch: `ocm runtime build-local contract-proof --repo "$PWD" --raw`, followed by `ocm runtime verify contract-proof --raw`.
- Evidence after fix: OCM created the installed package runtime and verification reported `healthy: true`.
- Observed result after fix: the full OpenClaw prepack, workspace dependency installation, and runtime verification completed successfully.
- What was not tested: other operating systems; the change is limited to environment passed to npm during adapter-managed `pack`.
