### PR TITLE
fix(cron): clean up recurring jobs converted to one-shot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron one-shot update cleanup:** apply the one-shot cleanup default when recurring jobs are converted to `at` schedules through the Gateway, CLI, or Control UI, while preserving explicit keep-after-run requests. Fixes #110411.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron one-shot update cleanup:** apply the one-shot cleanup default when recurring jobs are converted to `at` schedules through the Gateway, CLI, or Control UI, while preserving explicit keep-after-run requests. Fixes #110411.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -59,6 +59,7 @@ vi.mock("../runtime.js", () => ({
 
 type CronUpdatePatch = {
   patch?: {
+    deleteAfterRun?: boolean;
     schedule?: { kind?: string; expr?: string; tz?: string; staggerMs?: number };
     payload?: {
       kind?: string;

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1608,6 +1608,21 @@ describe("cron cli", () => {
       kind: "at",
       at: "2026-03-23T22:00:00.000Z",
     });
+    expect(patch?.patch).not.toHaveProperty("deleteAfterRun");
+  });
+
+  it("preserves an explicit keep policy when converting to --at", async () => {
+    const patch = await runCronEditAndGetPatch([
+      "--at",
+      "2026-03-23T23:00:00Z",
+      "--keep-after-run",
+    ]);
+
+    expect(patch?.patch?.schedule).toEqual({
+      kind: "at",
+      at: "2026-03-23T23:00:00.000Z",
+    });
+    expect(patch?.patch?.deleteAfterRun).toBe(false);
   });
 
   it("rejects --tz with --every on cron edit", async () => {

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -367,6 +367,60 @@ describe("CronService", () => {
     await stopCronAndCleanup(cron, store);
   });
 
+  it("deletes a recurring job converted to at when retention is omitted", async () => {
+    const { store, cron, events } = await createMainOneShotHarness();
+    const job = await cron.add({
+      name: "converted one-shot delete",
+      enabled: true,
+      deleteAfterRun: false,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "converted" },
+    });
+    const atMs = Date.parse("2025-12-13T00:00:02.000Z");
+
+    const updated = await cron.update(job.id, {
+      schedule: { kind: "at", at: new Date(atMs).toISOString() },
+    });
+    expect(updated.deleteAfterRun).toBe(true);
+
+    vi.setSystemTime(atMs);
+    await vi.runOnlyPendingTimersAsync();
+    await events.waitFor((evt) => evt.jobId === job.id && evt.action === "removed");
+
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs.find((candidate) => candidate.id === job.id)).toBeUndefined();
+    await stopCronAndCleanup(cron, store);
+  });
+
+  it("keeps a recurring job converted to at when explicitly requested", async () => {
+    const { store, cron, events } = await createMainOneShotHarness();
+    const job = await cron.add({
+      name: "converted one-shot keep",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "converted" },
+    });
+    const atMs = Date.parse("2025-12-13T00:00:02.000Z");
+
+    const updated = await cron.update(job.id, {
+      schedule: { kind: "at", at: new Date(atMs).toISOString() },
+      deleteAfterRun: false,
+    });
+    expect(updated.deleteAfterRun).toBe(false);
+
+    vi.setSystemTime(atMs);
+    await vi.runOnlyPendingTimersAsync();
+    await events.waitFor((evt) => evt.jobId === job.id && evt.action === "finished");
+
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs.find((candidate) => candidate.id === job.id)?.enabled).toBe(false);
+    await stopCronAndCleanup(cron, store);
+  });
+
   it("wakeMode now waits for heartbeat completion when available", async () => {
     let now = 0;
     const nowMs = () => {

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -73,11 +73,11 @@ describe("applyJobPatch schedule retention", () => {
     {
       label: "at to on-exit",
       previous: { kind: "at" as const, at: "2026-07-19T09:00:00.000Z" },
-      next: { kind: "on-exit" as const },
+      next: { kind: "on-exit" as const, command: "true" },
     },
     {
       label: "on-exit to at",
-      previous: { kind: "on-exit" as const },
+      previous: { kind: "on-exit" as const, command: "true" },
       next: { kind: "at" as const, at: "2026-07-20T09:00:00.000Z" },
     },
   ])("preserves one-shot retention for $label", ({ previous, next }) => {

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -23,6 +23,72 @@ function makeJob(overrides: Partial<CronJob> = {}): CronJob {
   };
 }
 
+describe("applyJobPatch schedule retention", () => {
+  it.each([
+    { schedule: { kind: "every" as const, everyMs: 60_000 }, deleteAfterRun: undefined },
+    { schedule: { kind: "every" as const, everyMs: 60_000 }, deleteAfterRun: false },
+    { schedule: { kind: "cron" as const, expr: "0 * * * *" }, deleteAfterRun: undefined },
+    { schedule: { kind: "cron" as const, expr: "0 * * * *" }, deleteAfterRun: false },
+  ])("defaults $schedule.kind to cleanup when converting it to at", (previous) => {
+    const job = makeJob(previous);
+
+    applyJobPatch(job, { schedule: { kind: "at", at: "2026-07-19T09:00:00.000Z" } });
+
+    expect(job.schedule.kind).toBe("at");
+    expect(job.deleteAfterRun).toBe(true);
+  });
+
+  it("preserves an explicit keep policy when converting a recurring job to at", () => {
+    const job = makeJob({ deleteAfterRun: true });
+
+    applyJobPatch(job, {
+      schedule: { kind: "at", at: "2026-07-19T09:00:00.000Z" },
+      deleteAfterRun: false,
+    });
+
+    expect(job.deleteAfterRun).toBe(false);
+  });
+
+  it.each([
+    { kind: "every" as const, everyMs: 60_000 },
+    { kind: "cron" as const, expr: "0 * * * *" },
+  ])("clears the at-only default when converting to $kind", (schedule) => {
+    const job = makeJob({
+      schedule: { kind: "at", at: "2026-07-19T09:00:00.000Z" },
+      deleteAfterRun: true,
+    });
+
+    applyJobPatch(job, { schedule });
+
+    expect(job.schedule.kind).toBe(schedule.kind);
+    expect(Object.hasOwn(job, "deleteAfterRun")).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "at to at",
+      previous: { kind: "at" as const, at: "2026-07-19T09:00:00.000Z" },
+      next: { kind: "at" as const, at: "2026-07-20T09:00:00.000Z" },
+    },
+    {
+      label: "at to on-exit",
+      previous: { kind: "at" as const, at: "2026-07-19T09:00:00.000Z" },
+      next: { kind: "on-exit" as const },
+    },
+    {
+      label: "on-exit to at",
+      previous: { kind: "on-exit" as const },
+      next: { kind: "at" as const, at: "2026-07-20T09:00:00.000Z" },
+    },
+  ])("preserves one-shot retention for $label", ({ previous, next }) => {
+    const job = makeJob({ schedule: previous, deleteAfterRun: false });
+
+    applyJobPatch(job, { schedule: next });
+
+    expect(job.deleteAfterRun).toBe(false);
+  });
+});
+
 describe("applyJobPatch delivery merge", () => {
   it("threads explicit delivery threadId patches into delivery", () => {
     const job = makeJob();

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -983,6 +983,7 @@ export function applyJobPatch(
     cronConfig?: CronConfig;
   },
 ) {
+  const previousScheduleKind = job.schedule.kind;
   if ("name" in patch) {
     job.name = normalizeRequiredName(patch.name);
   }
@@ -1008,8 +1009,21 @@ export function applyJobPatch(
   if (typeof patch.enabled === "boolean") {
     job.enabled = patch.enabled;
   }
-  if (typeof patch.deleteAfterRun === "boolean") {
+  const hasDeleteAfterRunPatch = typeof patch.deleteAfterRun === "boolean";
+  if (hasDeleteAfterRunPatch) {
     job.deleteAfterRun = patch.deleteAfterRun;
+  } else if (
+    patch.schedule?.kind === "at" &&
+    (previousScheduleKind === "every" || previousScheduleKind === "cron")
+  ) {
+    // A schedule-kind transition starts a new retention contract. Do not let a
+    // recurring job's ignored/stale flag defeat the one-shot cleanup default.
+    job.deleteAfterRun = true;
+  } else if (
+    previousScheduleKind === "at" &&
+    (patch.schedule?.kind === "every" || patch.schedule?.kind === "cron")
+  ) {
+    delete job.deleteAfterRun;
   }
   if (patch.schedule) {
     if (patch.schedule.kind === "cron") {

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -293,6 +293,61 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
     }
   });
 
+  it("defaults recurring jobs converted to one-time cleanup", async () => {
+    const existingJob = {
+      ...cronJob("recurring-to-once", "Recurring retention", { kind: "every", everyMs: 60_000 }),
+      deleteAfterRun: false,
+    };
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse([existingJob]),
+        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+        "cron.update": { id: existingJob.id },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+      await jobTitle(page, existingJob.name).click();
+      await page.locator("details.cron-advanced > summary").click();
+      expect(
+        await page
+          .locator("wa-switch.settings-toggle")
+          .filter({ hasText: "Delete after run" })
+          .count(),
+      ).toBe(0);
+
+      await page.locator('[data-test-id="cron-schedule-kind-at"]').click();
+      await page.locator("#cron-schedule-at").fill("2026-07-19T09:00");
+      const expectedAt = await page.evaluate(() => new Date("2026-07-19T09:00").toISOString());
+      const deleteToggle = page.locator("wa-switch.settings-toggle").filter({
+        hasText: "Delete after run",
+      });
+      await expect
+        .poll(() => deleteToggle.evaluate((element) => Reflect.get(element, "checked")))
+        .toBe(true);
+
+      await page.locator('[data-test-id="cron-submit"]').click();
+      const request = await gateway.waitForRequest("cron.update");
+      const params = requestParams(request);
+      expect(params.id).toBe(existingJob.id);
+      expect(requireRecord(params.patch)).toMatchObject({
+        deleteAfterRun: true,
+        schedule: { kind: "at", at: expectedAt },
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("shows why a requested run was not started", async () => {
     const existingJob = cronJob(
       "already-running-job",

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -719,11 +719,11 @@ describe("cron controller", () => {
       name: "edited job",
       description: "",
       agentId: null,
-      deleteAfterRun: false,
       schedule: { kind: "cron", expr: "0 8 * * *", staggerMs: 0 },
       payload: { kind: "systemEvent", text: "updated" },
       delivery: { mode: "none" },
     });
+    expect(requestPatch(updateCall)).not.toHaveProperty("deleteAfterRun");
     expect(state.cronEditingJobId).toBeNull();
   });
 

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -109,7 +109,7 @@ const DEFAULT_CRON_FORM: CronFormState = {
   sessionKey: "",
   clearAgent: false,
   enabled: true,
-  deleteAfterRun: true,
+  deleteAfterRun: false,
   scheduleKind: "every",
   scheduleAt: "",
   everyAmount: "30",
@@ -756,7 +756,7 @@ function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
     sessionKey: job.sessionKey ?? "",
     clearAgent: false,
     enabled: job.enabled,
-    deleteAfterRun: job.deleteAfterRun ?? false,
+    deleteAfterRun: job.deleteAfterRun ?? job.schedule.kind === "at",
     scheduleKind: job.schedule.kind,
     scheduleAt: "",
     everyAmount: prev.everyAmount,
@@ -1063,7 +1063,9 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
       agentId: agentId === null ? null : agentId || undefined,
       sessionKey,
       enabled: form.enabled,
-      deleteAfterRun: form.deleteAfterRun,
+      ...(form.scheduleKind === "at" || form.scheduleKind === "on-exit"
+        ? { deleteAfterRun: form.deleteAfterRun }
+        : {}),
       sessionTarget: form.sessionTarget,
       wakeMode: form.wakeMode,
       delivery,

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -128,6 +128,14 @@ function selectSegmented(control: HTMLElement) {
   group.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+function findToggleByLabel(container: Element, label: string) {
+  return (
+    Array.from(container.querySelectorAll("wa-switch.settings-toggle")).find((toggle) =>
+      toggle.textContent?.includes(label),
+    ) ?? null
+  );
+}
+
 describe("cron view list pane", () => {
   it("uses agent-scoped summary values", () => {
     const container = renderView({
@@ -559,7 +567,18 @@ describe("cron view editor", () => {
     selectSegmented(
       getElement(everyContainer, '[data-test-id="cron-schedule-kind-cron"]', HTMLElement),
     );
-    expect(onFormChange).toHaveBeenCalledWith({ scheduleKind: "cron" });
+    expect(onFormChange).toHaveBeenCalledWith({
+      scheduleKind: "cron",
+      deleteAfterRun: false,
+    });
+
+    selectSegmented(
+      getElement(everyContainer, '[data-test-id="cron-schedule-kind-at"]', HTMLElement),
+    );
+    expect(onFormChange).toHaveBeenCalledWith({
+      scheduleKind: "at",
+      deleteAfterRun: true,
+    });
 
     const atContainer = renderView({
       createOpen: true,
@@ -569,9 +588,18 @@ describe("cron view editor", () => {
 
     const cronContainer = renderView({
       createOpen: true,
-      form: { ...DEFAULT_CRON_FORM, scheduleKind: "cron" },
+      form: { ...DEFAULT_CRON_FORM, scheduleKind: "cron", deleteAfterRun: true },
+      onFormChange,
     });
     expect(cronContainer.querySelector("#cron-cron-expr")).not.toBeNull();
+    expect(findToggleByLabel(cronContainer, "Delete after run")).toBeNull();
+    selectSegmented(
+      getElement(cronContainer, '[data-test-id="cron-schedule-kind-every"]', HTMLElement),
+    );
+    expect(onFormChange).toHaveBeenCalledWith({
+      scheduleKind: "every",
+      deleteAfterRun: false,
+    });
 
     // on-exit jobs keep a pill so they can convert to an editable schedule;
     // the on-exit pill only exists while it is the current value.
@@ -582,7 +610,18 @@ describe("cron view editor", () => {
     expect(
       onExitContainer.querySelector('[data-test-id="cron-schedule-kind-on-exit"]'),
     ).not.toBeNull();
+    expect(findToggleByLabel(onExitContainer, "Delete after run")).not.toBeNull();
     expect(everyContainer.querySelector('[data-test-id="cron-schedule-kind-on-exit"]')).toBeNull();
+    const onExitFormChange = vi.fn();
+    const keptOnExitContainer = renderView({
+      createOpen: true,
+      form: { ...DEFAULT_CRON_FORM, scheduleKind: "on-exit", deleteAfterRun: false },
+      onFormChange: onExitFormChange,
+    });
+    selectSegmented(
+      getElement(keptOnExitContainer, '[data-test-id="cron-schedule-kind-at"]', HTMLElement),
+    );
+    expect(onExitFormChange).toHaveBeenCalledWith({ scheduleKind: "at" });
   });
 
   it("shows a live schedule summary when inputs are valid", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -1306,7 +1306,15 @@ function renderScheduleSection(props: CronProps) {
           value: form.scheduleKind,
           options: kinds,
           ariaLabel: t("cron.form.repeat"),
-          onChange: (value) => props.onFormChange({ scheduleKind: value }),
+          onChange: (value) =>
+            props.onFormChange({
+              scheduleKind: value,
+              ...(value === "at" && (form.scheduleKind === "every" || form.scheduleKind === "cron")
+                ? { deleteAfterRun: true }
+                : value === "every" || value === "cron"
+                  ? { deleteAfterRun: false }
+                  : {}),
+            }),
         }),
       })}
       ${form.scheduleKind === "at"
@@ -1613,12 +1621,14 @@ function renderAdvanced(
                 `,
               })
             : nothing}
-          ${renderToggleRow({
-            label: t("cron.form.deleteAfterRun"),
-            checked: props.form.deleteAfterRun,
-            help: t("cron.form.deleteAfterRunHelp"),
-            onChange: (checked) => props.onFormChange({ deleteAfterRun: checked }),
-          })}
+          ${props.form.scheduleKind === "at" || props.form.scheduleKind === "on-exit"
+            ? renderToggleRow({
+                label: t("cron.form.deleteAfterRun"),
+                checked: props.form.deleteAfterRun,
+                help: t("cron.form.deleteAfterRunHelp"),
+                onChange: (checked) => props.onFormChange({ deleteAfterRun: checked }),
+              })
+            : nothing}
           ${renderToggleRow({
             label: t("cron.form.clearAgentOverride"),
             checked: props.form.clearAgent,

--- a/ui/src/test-helpers/cron.ts
+++ b/ui/src/test-helpers/cron.ts
@@ -7,7 +7,7 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   sessionKey: "",
   clearAgent: false,
   enabled: true,
-  deleteAfterRun: true,
+  deleteAfterRun: false,
   scheduleKind: "every",
   scheduleAt: "",
   everyAmount: "30",


### PR DESCRIPTION
Closes #110411

## What Problem This Solves

Fixes an issue where users converting a recurring automation to a one-time schedule would keep the recurring job's stale retention setting, so a successful one-time run could remain disabled instead of cleaning itself up.

## Why This Change Was Made

Schedule-kind transitions now establish the target schedule's retention contract: recurring-to-`at` defaults to cleanup, explicit keep-after-run requests remain authoritative, and `at`-to-recurring removes the irrelevant one-shot default. Control UI applies the same transition rules, hides the retention toggle for recurring schedules, and omits meaningless recurring retention fields.

## User Impact

One-time automations created by editing recurring jobs now delete themselves after a successful run by default. Users can still explicitly keep them. Existing `at` and `on-exit` retention choices remain unchanged.

## Evidence

- 39 focused cron service assertions: schedule transition matrix plus natural timer cleanup/retention.
- 112 focused Control UI controller/view assertions.
- 104 focused cron CLI assertions, including omitted versus explicit keep-after-run patches.
- 5 Chromium mocked-Gateway E2E scenarios; the regression flow edits a stored recurring job, selects One time, verifies cleanup is enabled, and checks the exact `cron.update` payload.
- Full changed gate green on Blacksmith Testbox: typechecks, core/UI lint, generated contracts, boundaries, and database/runtime guards ([run 29631488377](https://github.com/openclaw/openclaw/actions/runs/29631488377)).
- Exact-head hosted CI green.
- Sanitized mocked-Gateway before/after screenshots captured. Public attachment is blocked: the approved Crabbox broker reports `artifact_upload_unavailable` because no artifact backend is configured, and the existing authenticated Chrome MCP endpoint is offline. No unapproved host was used.
