### PR TITLE
fix(gateway): release reader lock in readBoundedResponseText on all paths

### DIFF
--- a/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
@@ -149,3 +149,56 @@ describe("gateway CLI backend live probe helpers", () => {
     }
   });
 });
+
+// Tests for the private readBoundedResponseText helper are exported via
+// the vitest test API symbol.
+const testApi = (globalThis as Record<PropertyKey, unknown>)[
+  Symbol.for("openclaw.liveProbeHelpersTestApi")
+] as { readBoundedResponseText?: (res: Response, limit: number) => Promise<string> } | undefined;
+
+describe("readBoundedResponseText", () => {
+  it("releases reader lock after a complete bounded read", async () => {
+    const { readBoundedResponseText } = testApi ?? {};
+    if (!readBoundedResponseText) {
+      throw new Error("test API not available");
+    }
+    const releaseLock = vi.fn();
+    const cancel = vi.fn(async () => undefined);
+    const response = {
+      body: {
+        getReader: () => ({
+          read: async () => ({ done: true, value: undefined }) as const,
+          cancel,
+          releaseLock,
+        }),
+      },
+    } as unknown as Response;
+
+    await readBoundedResponseText(response, 64);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases reader lock after exceeding the byte limit", async () => {
+    const { readBoundedResponseText } = testApi ?? {};
+    if (!readBoundedResponseText) {
+      throw new Error("test API not available");
+    }
+    const releaseLock = vi.fn();
+    const cancel = vi.fn(async () => undefined);
+    const response = {
+      body: {
+        getReader: () => ({
+          read: async () =>
+            ({ done: false, value: new TextEncoder().encode("more than 5 bytes") }) as const,
+          cancel,
+          releaseLock,
+        }),
+      },
+    } as unknown as Response;
+
+    await expect(readBoundedResponseText(response, 5)).rejects.toThrow(
+      "mcp loopback response body exceeded 5 bytes",
+    );
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.ts
@@ -246,21 +246,39 @@ async function readBoundedResponseText(response: Response, byteLimit: number): P
   if (!reader) {
     return "";
   }
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
+  try {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > byteLimit) {
+        try {
+          await reader.cancel();
+        } catch {
+          // best-effort cancel — releaseLock still runs in finally
+        }
+        throw new Error(`mcp loopback response body exceeded ${byteLimit} bytes`);
+      }
+      chunks.push(Buffer.from(value));
     }
-    totalBytes += value.byteLength;
-    if (totalBytes > byteLimit) {
-      await reader.cancel();
-      throw new Error(`mcp loopback response body exceeded ${byteLimit} bytes`);
+    return Buffer.concat(chunks, totalBytes).toString("utf8");
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // lock-release must not mask the original error or result
     }
-    chunks.push(Buffer.from(value));
   }
-  return Buffer.concat(chunks, totalBytes).toString("utf8");
+}
+
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.liveProbeHelpersTestApi")] = {
+    readBoundedResponseText,
+  };
 }
 
 export async function verifyCliCronMcpLoopbackPreflight(params: {


### PR DESCRIPTION
## Summary
Wrap `readBoundedResponseText` in try-finally so `reader.releaseLock()` is called on every exit path.

## What Problem This Solves
The function acquired a reader lock via `getReader()` but never released it on any of the 4 exit paths: EOF, byte-limit overflow, read errors, and normal return.

**Code evidence**: [live-probe-helpers.ts:244-278](src/gateway/gateway-cli-backend.live-probe-helpers.ts#L244-L278)

## Evidence
- **Before**: 0 releaseLock calls — lock leaked on every MCP loopback call
- **After**: releaseLock in finally block — always released

## Real Behavior Proof

```bash
$ npx vitest run src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
Tests  10 passed (10)
✓ releases reader lock after a complete bounded read
✓ releases reader lock after exceeding the byte limit
```