### PR TITLE
fix(microsoft-foundry): bound az subprocess lifetime on exec timeout

### DIFF
--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -52,6 +52,7 @@ export function execAz(args: string[]): string {
         encoding: "utf-8",
         timeout: 30_000,
         shell: process.platform === "win32",
+        killSignal: "SIGKILL",
       }),
     ) ?? ""
   );

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ProviderAuthMethod } from "openclaw/plugin-sdk/core";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { azLoginDeviceCodeWithOptions, getAccessTokenResultAsync } from "./cli.js";
+import { azLoginDeviceCodeWithOptions, execAz, getAccessTokenResultAsync } from "./cli.js";
 import plugin from "./index.js";
 import {
   promptApiKeyEndpointAndModel,
@@ -375,6 +375,17 @@ describe("microsoft-foundry plugin", () => {
 
     expect(execFileMock.mock.calls[0]?.[1]).toEqual(
       expect.arrayContaining(["--scope", FOUNDRY_ANTHROPIC_SCOPE]),
+    );
+  });
+
+  it("hard-stops a synchronous Azure CLI command at its timeout", () => {
+    execFileSyncMock.mockReturnValue("ok");
+    execAz(["version", "--output", "none"]);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "az",
+      ["version", "--output", "none"],
+      expect.objectContaining({ timeout: 30_000, killSignal: "SIGKILL" }),
     );
   });
 

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -3,7 +3,7 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { azLoginDeviceCodeWithOptions, getAccessTokenResultAsync } from "./cli.js";
+import { azLoginDeviceCodeWithOptions, execAz, getAccessTokenResultAsync } from "./cli.js";
 import plugin from "./index.js";
 import {
   promptApiKeyEndpointAndModel,
@@ -386,6 +386,48 @@ describe("microsoft-foundry plugin", () => {
       expect.arrayContaining(["--scope", FOUNDRY_ANTHROPIC_SCOPE]),
     );
   });
+
+  it("bounds synchronous Azure CLI commands with SIGKILL", () => {
+    execFileSyncMock.mockReturnValue("ok");
+
+    execAz(["version", "--output", "none"]);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "az",
+      ["version", "--output", "none"],
+      expect.objectContaining({
+        encoding: "utf-8",
+        timeout: 30_000,
+        killSignal: "SIGKILL",
+      }),
+    );
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "terminates a SIGTERM-immune synchronous child at timeout",
+    async () => {
+      const real = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+      const startedAt = Date.now();
+      let timeoutError: unknown;
+
+      try {
+        real.execFileSync(
+          process.execPath,
+          ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"],
+          { encoding: "utf-8", timeout: 500, killSignal: "SIGKILL" },
+        );
+      } catch (error) {
+        timeoutError = error;
+      }
+
+      expect(timeoutError).toMatchObject({
+        code: "ETIMEDOUT",
+        signal: "SIGKILL",
+        status: null,
+      });
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    },
+  );
 
   it("fails clearly when the selected Azure subscription is not in the enabled list", async () => {
     const provider = registerProvider();


### PR DESCRIPTION
## What Problem This Solves

`execAz()` uses synchronous `execFileSync()` with a 30-second timeout. Node sends the configured kill signal when that timeout expires. With the default `SIGTERM`, a child that ignores termination can keep the synchronous gateway path blocked after the intended deadline.

## Why This Change Was Made

Set `killSignal: "SIGKILL"` on the existing synchronous Azure CLI invocation. This preserves the command, timeout, shell, encoding, return value, and error behavior while making the existing deadline terminal.

The asynchronous sibling already uses the shared process runtime and its two-phase termination policy, so it does not need the synchronous option.

## Evidence Map

| Layer | Evidence |
| --- | --- |
| Changed surface | `execAz()` in `extensions/microsoft-foundry/cli.ts` |
| Owner boundary | Microsoft Foundry owns its Azure CLI invocation policy locally |
| Callers | Azure CLI installation, account, subscription, and access-token probes |
| Callee contract | Node `execFileSync()` honors `timeout` with the configured `killSignal` |
| Sibling | `execAzAsync()` remains on the shared async process runtime |
| Focused suite | 109/109 Microsoft Foundry tests passed |
| Real behavior | 3/3 runs terminated a real SIGTERM-immune child with `SIGKILL` inside the bound |
| Remote changed gate | Passed on the same stable patch |
| Static proof | Formatting and `git diff --check` passed |
| Autoreview | Secret scan passed; the exact-head model review produced no finding or heartbeat before the 30-minute infrastructure ceiling and was stopped without rerun |

## Repair Shape

- Root cause: the synchronous subprocess deadline used a non-terminal signal.
- Architectural owner: the Microsoft Foundry Azure CLI wrapper.
- Canonical fix: make the existing timeout terminal at its producer.
- Removed paths: none; no fallback or parallel execution path was added.
- Production delta: +1 line.
- Tests: +43/-1 lines, including direct option proof and a real child-process regression.
- Sibling coverage: the asynchronous path was inspected and already has force-kill escalation.

## User Impact

Timed-out synchronous `az` commands no longer keep the gateway thread blocked because the child ignored `SIGTERM`. Successful commands are unchanged.
