### PR TITLE
fix(canvas): stop sending undefined coords on partial placement

### DIFF
--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -168,6 +168,45 @@ describe("Canvas tool", () => {
     );
   });
 
+  it("sends only defined placement coords to canvas.present", async () => {
+    mocks.callGatewayTool.mockResolvedValue({ payload: {} });
+    const tool = createCanvasTool();
+
+    await tool.execute("tool-call-1", {
+      action: "present",
+      width: "640",
+      height: "480",
+    });
+
+    // Only width and height are defined — x and y must not appear.
+    expect(mocks.callGatewayTool).toHaveBeenLastCalledWith(
+      "node.invoke",
+      {},
+      expect.objectContaining({
+        command: "canvas.present",
+        params: {
+          placement: { width: 640, height: 480 },
+        },
+      }),
+    );
+  });
+
+  it("omits placement key when no coords are defined", async () => {
+    mocks.callGatewayTool.mockResolvedValue({ payload: {} });
+    const tool = createCanvasTool();
+
+    await tool.execute("tool-call-1", {
+      action: "present",
+      target: "https://example.com",
+    });
+
+    const callArgs = mocks.callGatewayTool.mock.calls.at(-1)?.[2] as {
+      params?: Record<string, unknown>;
+    };
+    expect(callArgs.params).not.toHaveProperty("placement");
+    expect(callArgs.params).toEqual({ url: "https://example.com" });
+  });
+
   it("preserves an empty canvas eval result", async () => {
     mocks.callGatewayTool.mockResolvedValue({ payload: { result: "" } });
     const tool = createCanvasTool();

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -119,12 +119,23 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
 
       switch (action) {
         case "present": {
-          const placement = {
-            x: readFiniteNumberParam(params, "x"),
-            y: readFiniteNumberParam(params, "y"),
-            width: readFiniteNumberParam(params, "width"),
-            height: readFiniteNumberParam(params, "height"),
-          };
+          const placement: Record<string, number> = {};
+          const px = readFiniteNumberParam(params, "x");
+          if (px !== undefined) {
+            placement.x = px;
+          }
+          const py = readFiniteNumberParam(params, "y");
+          if (py !== undefined) {
+            placement.y = py;
+          }
+          const pw = readFiniteNumberParam(params, "width");
+          if (pw !== undefined) {
+            placement.width = pw;
+          }
+          const ph = readFiniteNumberParam(params, "height");
+          if (ph !== undefined) {
+            placement.height = ph;
+          }
           const invokeParams: Record<string, unknown> = {};
           const presentTarget =
             readStringParam(params, "target", { trim: true }) ??
@@ -132,12 +143,7 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
           if (presentTarget) {
             invokeParams.url = presentTarget;
           }
-          if (
-            Number.isFinite(placement.x) ||
-            Number.isFinite(placement.y) ||
-            Number.isFinite(placement.width) ||
-            Number.isFinite(placement.height)
-          ) {
+          if (Object.keys(placement).length > 0) {
             invokeParams.placement = placement;
           }
           await invoke("canvas.present", invokeParams);


### PR DESCRIPTION
## What Problem This Solves

When an agent calls `canvas present` with only a subset of placement coordinates (e.g. only `width` and `height`), the old code constructed a placement object with `undefined` values for the missing fields. `JSON.stringify` silently strips `undefined` keys, so the node receives incomplete placement data.

## Root Cause

`readFiniteNumberParam` returns `undefined` for absent keys. The code at `tool.ts:122-140` unconditionally set all four fields then checked `Number.isFinite` on each to decide whether to include placement at all — but when some are finite and some aren't, the whole object (with undefined entries) is sent downstream.

## Fix

Only defined placement values are collected into the `placement` record. The gate check uses `Object.keys(placement).length > 0` instead of four individual `Number.isFinite` checks.

Files changed:
- `extensions/canvas/src/tool.ts`: Refactored `case "present"` placement construction
- `extensions/canvas/src/tool.test.ts`: Added focused tests for partial placement behavior

## Evidence

- Claim proved: Partial placement coords no longer send `undefined` to the node
- Commands / artifacts:
  - `git diff --check` — clean
  - `node scripts/run-vitest.mjs extensions/canvas/src/tool.test.ts` — 14 passed, 1 skipped
  - New tests: "sends only defined placement coords" and "omits placement key when no coords are defined"
  - Head: `1aa5d8ffe83`
