### PR TITLE
fix(canvas): surface eval errors instead of silently swallowing them

### DIFF
--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -293,4 +293,28 @@ describe("Canvas tool", () => {
     );
     expect(mocks.imageResultFromFile).not.toHaveBeenCalled();
   });
+
+  it("surfaces an explicit null eval result", async () => {
+    mocks.callGatewayTool.mockResolvedValue({ payload: { result: null } });
+    const tool = createCanvasTool();
+
+    const result = await tool.execute("tool-call-1", {
+      action: "eval",
+      javaScript: "null",
+    });
+
+    expect(result.details).toEqual({ ok: true, result: null });
+  });
+
+  it("surfaces an empty-string eval error", async () => {
+    mocks.callGatewayTool.mockResolvedValue({ payload: { error: "" } });
+    const tool = createCanvasTool();
+
+    const result = await tool.execute("tool-call-1", {
+      action: "eval",
+      javaScript: "throw ''",
+    });
+
+    expect(result.details).toMatchObject({ ok: false });
+  });
 });

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -158,14 +158,26 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
             required: true,
           });
           const raw = (await invoke("canvas.eval", { javaScript })) as {
-            payload?: { result?: string };
+            payload?: { result?: unknown; error?: string };
           };
+          // Surface eval errors when the runtime reports them.
+          // Use property presence so even an empty string error is observable.
+          if (raw?.payload != null && "error" in raw.payload) {
+            const error = typeof raw.payload.error === "string" ? raw.payload.error : undefined;
+            return jsonResult({ ok: false, ...(error !== undefined ? { error } : {}) });
+          }
+          const hasResult = raw?.payload != null && "result" in raw.payload;
           const result = raw?.payload?.result;
           if (typeof result === "string") {
             return {
               content: [{ type: "text", text: result }],
               details: { result },
             };
+          }
+          // Non-string results (number, object, explicit null, etc.) are
+          // still successful; surface them so the agent can inspect them.
+          if (hasResult) {
+            return jsonResult({ ok: true, result });
           }
           return jsonResult({ ok: true });
         }


### PR DESCRIPTION
## What Problem This Solves

`canvas.eval` returns generic `{ ok: true }` for node-reported errors, non-string results, and empty-string errors — the agent cannot distinguish failure from void success.

## Root Cause

The `raw` cast only recognized `{ payload?: { result?: string } }`. Non-string results, absent results, and runtime errors all fell through to generic success.

## Fix

- **Error first**: `"error" in payload` presence check — surfaces every runtime error including empty strings
- **String results**: unchanged (text content with details)
- **Non-string results**: `"result" in payload` presence check — surfaces number, object, explicit null as `{ ok: true, result }`
- **Void eval**: no error + no result → `{ ok: true }`

Files changed:
- `extensions/canvas/src/tool.ts`: Refactored `case "eval"` handler
- `extensions/canvas/src/tool.test.ts`: Added regression tests

## Evidence

### Unit tests (current head: `d66eb9dd58`)
```
node scripts/run-vitest.mjs extensions/canvas/src/tool.test.ts
Test Files  1 passed (1)
     Tests  15 passed | 1 skipped (16)
```
New tests: "surfaces an explicit null eval result", "surfaces an empty-string eval error"

### Node-side response shape verification

Inspected Android node implementation at `apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt:162-163`:

```kotlin
val result = canvas.eval(js)
GatewaySession.InvokeResult.ok("""{"result":${result.toJsonString()}}""")
```

Android node wraps all `canvas.eval` results as `{"result": <json>}`. When JS evaluates to `null` or throws (Android WebView returns `"null"` for exceptions), the payload is `{"result": null}`. Without this PR, a `null` result is silently swallowed (falsy check on line 163). With this PR, explicit `null` is surfaced as `{ ok: true, result: null }`.

The `error` property check handles Gateway-level error injection (timeout, node unavailable, protocol errors) where the Gateway wraps a node error into the payload envelope. This path is exercised by Gateway protocol handlers (`InvokeResult.error(...)`).

### Proof gap

Real paired Canvas node proof requires: running Gateway + paired Android/iOS/Linux Canvas node. No Canvas node available in current Windows environment (no Android emulator, no iOS device, no Linux Canvas IPC socket). This is user-assisted-proof: needs a real device.

### Risk checklist
- [x] Backwards compatible — all existing eval behavior preserved for string results
- [x] Focused tests cover null result and empty-string error
- [x] Merge risk: Low — additive result normalization at plugin boundary, no protocol changes
- [x] Android node response shapes verified from source

@clawsweeper re-review