### PR TITLE
feat(feeds): add local marketplace watches

### DIFF
--- a/src/cli/plugins-cli.lazy.test.ts
+++ b/src/cli/plugins-cli.lazy.test.ts
@@ -134,4 +134,55 @@ describe("plugins cli lazy runtime boundary", () => {
       expect.objectContaining({ feedProfile: "acme", expectedSha256: "abc123", json: true }),
     );
   });
+
+  it("loads the marketplace watch command only for watch actions", async () => {
+    const runMarketplaceWatchAddCommand = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("./plugins-marketplace-watch-command.js", () => ({
+      runMarketplaceWatchAddCommand,
+    }));
+
+    const { registerPluginsCli } = await import("./plugins-cli.js");
+    const program = new Command();
+    registerPluginsCli(program);
+
+    await program.parseAsync(
+      [
+        "plugins",
+        "marketplace",
+        "watch",
+        "add",
+        "demo",
+        "--feed-profile",
+        "acme",
+        "--offline",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    expect(runMarketplaceWatchAddCommand).toHaveBeenCalledWith(
+      "demo",
+      expect.objectContaining({ feedProfile: "acme", offline: true, json: true }),
+    );
+  });
+
+  it("routes bounded marketplace update list options", async () => {
+    const runMarketplaceUpdateListCommand = vi.fn();
+    vi.doMock("./plugins-marketplace-watch-command.js", () => ({
+      runMarketplaceUpdateListCommand,
+    }));
+
+    const { registerPluginsCli } = await import("./plugins-cli.js");
+    const program = new Command();
+    registerPluginsCli(program);
+
+    await program.parseAsync(
+      ["plugins", "marketplace", "updates", "list", "--unread", "--limit", "25", "--json"],
+      { from: "user" },
+    );
+
+    expect(runMarketplaceUpdateListCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ unread: true, limit: 25, json: true }),
+    );
+  });
 });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -319,6 +319,102 @@ export function registerPluginsCli(program: Command) {
       await runPluginMarketplaceRefreshCommand(opts);
     });
 
+  const watch = marketplace.command("watch").description("Manage local marketplace item watches");
+
+  watch
+    .command("add")
+    .description("Watch a plugin in an accepted signed marketplace feed")
+    .argument("<plugin-id>", "Stable plugin id")
+    .option("--feed-profile <name>", "Configured marketplace feed profile")
+    .option("--feed-url <url>", "Explicit hosted marketplace feed URL")
+    .option("--offline", "Use the latest accepted signed snapshot", false)
+    .option("--json", "Print JSON")
+    .action(async (itemId: string, opts) => {
+      const { runMarketplaceWatchAddCommand } =
+        await import("./plugins-marketplace-watch-command.js");
+      await runMarketplaceWatchAddCommand(itemId, opts);
+    });
+
+  watch
+    .command("remove")
+    .description("Stop watching a marketplace plugin")
+    .argument("<plugin-id>", "Stable plugin id")
+    .option("--feed-id <id>", "Feed id when the plugin is watched in multiple feeds")
+    .option("--json", "Print JSON")
+    .action(async (itemId: string, opts) => {
+      const { runMarketplaceWatchRemoveCommand } =
+        await import("./plugins-marketplace-watch-command.js");
+      runMarketplaceWatchRemoveCommand(itemId, opts);
+    });
+
+  watch
+    .command("list")
+    .description("List local marketplace item watches")
+    .option("--json", "Print JSON")
+    .action(async (opts) => {
+      const { runMarketplaceWatchListCommand } =
+        await import("./plugins-marketplace-watch-command.js");
+      runMarketplaceWatchListCommand(opts);
+    });
+
+  for (const [command, muted] of [
+    ["mute", true],
+    ["unmute", false],
+  ] as const) {
+    watch
+      .command(command)
+      .description(`${muted ? "Mute" : "Unmute"} local updates for a watched plugin`)
+      .argument("<plugin-id>", "Stable plugin id")
+      .option("--feed-id <id>", "Feed id when the plugin is watched in multiple feeds")
+      .option("--json", "Print JSON")
+      .action(async (itemId: string, opts) => {
+        const { runMarketplaceWatchMuteCommand } =
+          await import("./plugins-marketplace-watch-command.js");
+        runMarketplaceWatchMuteCommand(itemId, muted, opts);
+      });
+  }
+
+  const updates = marketplace
+    .command("updates")
+    .description("Inspect verified local marketplace feed updates");
+
+  updates
+    .command("list")
+    .description("List local marketplace feed updates")
+    .option("--unread", "Only show unread updates", false)
+    .option("--all", "Include dismissed updates", false)
+    .option("--limit <n>", "Maximum updates (1-100)", (value) =>
+      parseStrictPositiveIntOption(value, "--limit"),
+    )
+    .option("--json", "Print JSON")
+    .action(async (opts) => {
+      const { runMarketplaceUpdateListCommand } =
+        await import("./plugins-marketplace-watch-command.js");
+      runMarketplaceUpdateListCommand(opts);
+    });
+
+  updates
+    .command("read")
+    .description("Mark a local marketplace feed update as read")
+    .argument("<event-id>", "Update event id")
+    .option("--json", "Print JSON")
+    .action(async (eventId: string, opts: { json?: boolean }) => {
+      const { runMarketplaceUpdateReadCommand } =
+        await import("./plugins-marketplace-watch-command.js");
+      runMarketplaceUpdateReadCommand(eventId, opts.json);
+    });
+
+  updates
+    .command("dismiss")
+    .description("Dismiss a local marketplace feed update")
+    .argument("<event-id>", "Update event id")
+    .option("--json", "Print JSON")
+    .action(async (eventId: string, opts: { json?: boolean }) => {
+      const { runMarketplaceUpdateDismissCommand } =
+        await import("./plugins-marketplace-watch-command.js");
+      runMarketplaceUpdateDismissCommand(eventId, opts.json);
+    });
+
   marketplace
     .command("list")
     .description("List plugins published by a marketplace source")

--- a/src/cli/plugins-marketplace-watch-command.ts
+++ b/src/cli/plugins-marketplace-watch-command.ts
@@ -1,0 +1,205 @@
+import { theme } from "../../packages/terminal-core/src/theme.js";
+import { getRuntimeConfig } from "../config/config.js";
+import {
+  addMarketplaceFeedWatch,
+  dismissMarketplaceFeedUpdate,
+  listMarketplaceFeedUpdates,
+  listMarketplaceFeedWatches,
+  markMarketplaceFeedUpdateRead,
+  removeMarketplaceFeedWatch,
+  setMarketplaceFeedWatchMuted,
+  type MarketplaceFeedWatch,
+} from "../plugins/official-external-plugin-catalog-watch-store.js";
+import { defaultRuntime } from "../runtime.js";
+
+export type MarketplaceWatchAddOptions = {
+  feedProfile?: string;
+  feedUrl?: string;
+  json?: boolean;
+  offline?: boolean;
+};
+
+export type MarketplaceWatchTargetOptions = {
+  feedId?: string;
+  json?: boolean;
+};
+
+export type MarketplaceWatchListOptions = {
+  json?: boolean;
+};
+
+export type MarketplaceUpdateListOptions = {
+  all?: boolean;
+  json?: boolean;
+  limit?: number;
+  unread?: boolean;
+};
+
+function fail(message: string): never {
+  defaultRuntime.error(message);
+  defaultRuntime.exit(1);
+  throw new Error(message);
+}
+
+function selectWatch(itemId: string, feedId?: string): MarketplaceFeedWatch {
+  const matches = listMarketplaceFeedWatches().filter(
+    (watch) =>
+      watch.itemKind === "plugin" &&
+      watch.itemId === itemId &&
+      (feedId === undefined || watch.feedId === feedId),
+  );
+  if (matches.length === 0) {
+    return fail(`No marketplace watch found for plugin ${itemId}.`);
+  }
+  if (matches.length > 1) {
+    return fail(`Plugin ${itemId} is watched in multiple feeds; pass --feed-id.`);
+  }
+  return matches[0]!;
+}
+
+export async function runMarketplaceWatchAddCommand(
+  itemId: string,
+  opts: MarketplaceWatchAddOptions,
+): Promise<void> {
+  const catalog = await import("../plugins/official-external-plugin-catalog.js");
+  const config = getRuntimeConfig();
+  const result = await catalog.loadConfiguredHostedOfficialExternalPluginCatalogEntries(config, {
+    ...(opts.feedProfile ? { feedProfile: opts.feedProfile } : {}),
+    ...(opts.feedUrl ? { feedUrl: opts.feedUrl } : {}),
+    ...(opts.offline ? { offline: true } : {}),
+  });
+  if (result.source === "bundled-fallback") {
+    return fail("Marketplace watches require an accepted signed feed snapshot.");
+  }
+  if (result.trust?.mode !== "signed") {
+    return fail("Marketplace watches require an accepted signed feed snapshot.");
+  }
+  const entry = result.entries.find(
+    (candidate) => catalog.resolveOfficialExternalPluginId(candidate) === itemId,
+  );
+  if (!entry) {
+    return fail(`Plugin ${itemId} was not found in feed ${result.feed.id}.`);
+  }
+  const added = addMarketplaceFeedWatch({
+    feedId: result.feed.id,
+    ...(opts.feedProfile ? { feedProfile: opts.feedProfile } : {}),
+    feedUrl: result.metadata.url,
+    itemKind: "plugin",
+    itemId,
+    sequence: result.feed.sequence,
+    baselineEntry: entry,
+  });
+  if (opts.json) {
+    defaultRuntime.writeJson(added);
+    return;
+  }
+  const action = added.created ? theme.success("Watching") : theme.muted("Already watching");
+  defaultRuntime.log(`${action} ${theme.command(itemId)} in ${result.feed.id}.`);
+}
+
+export function runMarketplaceWatchRemoveCommand(
+  itemId: string,
+  opts: MarketplaceWatchTargetOptions,
+): void {
+  const watch = selectWatch(itemId, opts.feedId);
+  const removed = removeMarketplaceFeedWatch({
+    feedId: watch.feedId,
+    itemKind: watch.itemKind,
+    itemId: watch.itemId,
+  });
+  if (opts.json) {
+    defaultRuntime.writeJson({ removed, watch });
+    return;
+  }
+  defaultRuntime.log(`${theme.success("Stopped watching")} ${theme.command(itemId)}.`);
+}
+
+export function runMarketplaceWatchListCommand(opts: MarketplaceWatchListOptions): void {
+  const watches = listMarketplaceFeedWatches();
+  if (opts.json) {
+    defaultRuntime.writeJson({ watches, count: watches.length });
+    return;
+  }
+  if (watches.length === 0) {
+    defaultRuntime.log(theme.muted("No marketplace item watches."));
+    return;
+  }
+  defaultRuntime.log(
+    watches
+      .map((watch) => {
+        const muted = watch.muted ? theme.muted(" muted") : "";
+        return `${theme.command(watch.itemId)} ${theme.muted(watch.feedId)}${muted}`;
+      })
+      .join("\n"),
+  );
+}
+
+export function runMarketplaceWatchMuteCommand(
+  itemId: string,
+  muted: boolean,
+  opts: MarketplaceWatchTargetOptions,
+): void {
+  const watch = selectWatch(itemId, opts.feedId);
+  const changed = setMarketplaceFeedWatchMuted({
+    feedId: watch.feedId,
+    itemKind: watch.itemKind,
+    itemId: watch.itemId,
+    muted,
+  });
+  if (opts.json) {
+    defaultRuntime.writeJson({ changed, muted, watch });
+    return;
+  }
+  defaultRuntime.log(
+    `${theme.success(muted ? "Muted" : "Unmuted")} ${theme.command(itemId)} updates.`,
+  );
+}
+
+export function runMarketplaceUpdateListCommand(opts: MarketplaceUpdateListOptions): void {
+  const updates = listMarketplaceFeedUpdates({
+    ...(opts.all ? { includeDismissed: true } : {}),
+    ...(opts.limit ? { limit: opts.limit } : {}),
+    ...(opts.unread ? { unreadOnly: true } : {}),
+  });
+  if (opts.json) {
+    defaultRuntime.writeJson({ updates, count: updates.length });
+    return;
+  }
+  if (updates.length === 0) {
+    defaultRuntime.log(theme.muted("No marketplace feed updates."));
+    return;
+  }
+  defaultRuntime.log(
+    updates
+      .map((update) => {
+        const unread = update.readAt ? "" : "* ";
+        const version = update.itemVersion ? ` ${theme.muted(update.itemVersion)}` : "";
+        return `${unread}${theme.command(update.eventId)} ${update.reason} ${update.itemId}${version}`;
+      })
+      .join("\n"),
+  );
+}
+
+export function runMarketplaceUpdateReadCommand(eventId: string, json?: boolean): void {
+  const changed = markMarketplaceFeedUpdateRead(eventId);
+  if (!changed) {
+    return fail(`Marketplace feed update ${eventId} was not found.`);
+  }
+  if (json) {
+    defaultRuntime.writeJson({ eventId, read: true });
+    return;
+  }
+  defaultRuntime.log(`${theme.success("Read")} ${theme.command(eventId)}.`);
+}
+
+export function runMarketplaceUpdateDismissCommand(eventId: string, json?: boolean): void {
+  const changed = dismissMarketplaceFeedUpdate(eventId);
+  if (!changed) {
+    return fail(`Marketplace feed update ${eventId} was not found.`);
+  }
+  if (json) {
+    defaultRuntime.writeJson({ eventId, dismissed: true });
+    return;
+  }
+  defaultRuntime.log(`${theme.success("Dismissed")} ${theme.command(eventId)}.`);
+}

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -166,6 +166,8 @@ function describeStateSchemaMigration(migration: OpenClawStateDatabaseSchemaMigr
       return "session watch cursors → provenance column";
     case "strict-tables-v3":
       return "tables → SQLite STRICT typing";
+    case "marketplace-feed-watches-v6":
+      return "local marketplace feed watches and update history";
   }
   return migration.kind satisfies never;
 }

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1950,6 +1950,7 @@ describe("state migrations", () => {
     expect(detected.preview.filter((line) => line.startsWith("- Shared SQLite schema:"))).toEqual([
       "- Shared SQLite schema: audit event ledger → versioned message lifecycle schema",
       "- Shared SQLite schema: tables → SQLite STRICT typing",
+      "- Shared SQLite schema: local marketplace feed watches and update history",
     ]);
 
     const result = await runLegacyStateMigrations({ detected, config: cfg, env });

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -8,8 +8,10 @@ import {
   type OfficialExternalPluginCatalogFeed,
 } from "./official-external-plugin-catalog.js";
 
-const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-feed.v1";
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-shard-root.v1";
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES = 16;
 
 type OfficialExternalPluginCatalogEnvelopeSignature = {
@@ -22,6 +24,31 @@ type OfficialExternalPluginCatalogTrustedSigningKey = {
   publicKey: string;
 };
 
+type OfficialExternalPluginCatalogEnvelopeVerificationError = {
+  ok: false;
+  error:
+    | "invalid-envelope"
+    | "unsupported-payload"
+    | "invalid-payload"
+    | "missing-trust-key"
+    | "invalid-signature";
+  message: string;
+  authenticatedPayload?: unknown;
+};
+
+export type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
+  | {
+      ok: true;
+      payloadType: string;
+      payload: unknown;
+      payloadBytes: Buffer;
+      signedBy: string;
+      signedByKeyIds?: readonly string[];
+      signatureCount?: number;
+      threshold?: number;
+    }
+  | OfficialExternalPluginCatalogEnvelopeVerificationError;
+
 type OfficialExternalPluginCatalogEnvelopeVerificationResult =
   | {
       ok: true;
@@ -31,17 +58,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationResult =
       signatureCount?: number;
       threshold?: number;
     }
-  | {
-      ok: false;
-      error:
-        | "invalid-envelope"
-        | "unsupported-payload"
-        | "invalid-payload"
-        | "missing-trust-key"
-        | "invalid-signature";
-      message: string;
-      authenticatedPayload?: unknown;
-    };
+  | OfficialExternalPluginCatalogEnvelopeVerificationError;
 function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   payloadType: string;
   payloadBytes: Buffer;
@@ -49,13 +66,14 @@ function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   return dssePreAuthenticationEncoding(params.payloadType, params.payloadBytes);
 }
 
-export function verifyOfficialExternalPluginCatalogSignedEnvelope(
+export function verifyOfficialExternalPluginCatalogEnvelopePayload(
   raw: unknown,
   params: {
     trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    acceptedPayloadTypes: ReadonlySet<string>;
     threshold?: number;
   },
-): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+): OfficialExternalPluginCatalogEnvelopePayloadVerificationResult {
   const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw);
   if (!envelope) {
     return {
@@ -64,7 +82,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       message: "hosted catalog signed envelope is malformed",
     };
   }
-  if (envelope.payloadType !== OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+  if (!params.acceptedPayloadTypes.has(envelope.payloadType)) {
     return {
       ok: false,
       error: "unsupported-payload",
@@ -112,17 +130,18 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   }
   if (trustedSignaturePublicKeys.size >= threshold) {
     const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
-    if (!decoded?.feed) {
+    if (!decoded) {
       return {
         ok: false,
         error: "invalid-payload",
         message: "hosted catalog signed envelope payload is invalid",
-        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
       };
     }
     return {
       ok: true,
-      feed: decoded.feed,
+      payloadType: envelope.payloadType,
+      payload: decoded.raw,
+      payloadBytes,
       signedBy: trustedSignatureKeyIds[0] ?? "",
       ...(threshold > 1
         ? {
@@ -150,6 +169,40 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
         error: "missing-trust-key",
         message: "hosted catalog signed envelope was not signed by a trusted key",
       };
+}
+
+export function verifyOfficialExternalPluginCatalogSignedEnvelope(
+  raw: unknown,
+  params: {
+    trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    threshold?: number;
+  },
+): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+  const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
+    ...params,
+    acceptedPayloadTypes: new Set([OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE]),
+  });
+  if (!verification.ok) {
+    return verification;
+  }
+  if (!isOfficialExternalPluginCatalogFeed(verification.payload)) {
+    return {
+      ok: false,
+      error: "invalid-payload",
+      message: "hosted catalog signed envelope payload is invalid",
+      authenticatedPayload: verification.payload,
+    };
+  }
+  return {
+    ok: true,
+    feed: verification.payload,
+    signedBy: verification.signedBy,
+    ...(verification.signedByKeyIds ? { signedByKeyIds: verification.signedByKeyIds } : {}),
+    ...(verification.signatureCount !== undefined
+      ? { signatureCount: verification.signatureCount }
+      : {}),
+    ...(verification.threshold !== undefined ? { threshold: verification.threshold } : {}),
+  };
 }
 
 function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
@@ -220,13 +273,10 @@ function decodeOfficialExternalPluginCatalogEnvelopePayloadBytes(payload: string
 
 function decodeOfficialExternalPluginCatalogEnvelopePayload(
   payloadBytes: Buffer,
-): { raw: unknown; feed: OfficialExternalPluginCatalogFeed | null } | null {
+): { raw: unknown } | null {
   try {
     const raw = JSON.parse(payloadBytes.toString("utf8")) as unknown;
-    return {
-      raw,
-      feed: isOfficialExternalPluginCatalogFeed(raw) ? raw : null,
-    };
+    return { raw };
   } catch {
     return null;
   }

--- a/src/plugins/official-external-plugin-catalog-shards.test.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.test.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  parseOfficialExternalPluginCatalogShardRoot,
+  parseOfficialExternalPluginCatalogShardedSnapshot,
+  serializeOfficialExternalPluginCatalogShardedSnapshot,
+  validateOfficialExternalPluginCatalogShardSet,
+} from "./official-external-plugin-catalog-shards.js";
+
+function shardBody(index: number, ids: readonly string[]): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    sequence: 7,
+    index,
+    entries: ids.map((id) => ({ type: "plugin", id })),
+  });
+}
+
+function rootFor(shardBodies: readonly string[]) {
+  return {
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    sequence: 7,
+    generatedAt: "2026-07-17T12:00:00Z",
+    expiresAt: "2026-07-24T12:00:00Z",
+    metadata: { description: "ClawHub plugins" },
+    entryCount: shardBodies.length,
+    shards: shardBodies.map((body, index) => ({
+      index,
+      url: `https://clawhub.ai/v1/feeds/plugins/shards/${index}.json`,
+      sha256: createHash("sha256").update(body).digest("hex"),
+      byteLength: Buffer.byteLength(body, "utf8"),
+      entryCount: 1,
+    })),
+  };
+}
+
+describe("official external plugin catalog shards", () => {
+  it("assembles a complete deterministically ordered shard set", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"]), shardBody(1, ["@acme/beta"])];
+    const root = parseOfficialExternalPluginCatalogShardRoot(rootFor(bodies));
+
+    expect(validateOfficialExternalPluginCatalogShardSet(root, bodies)).toMatchObject({
+      schemaVersion: 1,
+      id: "clawhub-official",
+      sequence: 7,
+      entries: [{ id: "@acme/alpha" }, { id: "@acme/beta" }],
+    });
+  });
+
+  it("rejects cross-shard ordering and duplicate identities", () => {
+    const unordered = [shardBody(0, ["@acme/beta"]), shardBody(1, ["@acme/alpha"])];
+    expect(() =>
+      validateOfficialExternalPluginCatalogShardSet(
+        parseOfficialExternalPluginCatalogShardRoot(rootFor(unordered)),
+        unordered,
+      ),
+    ).toThrow("shard set ordering is invalid");
+
+    const duplicated = [shardBody(0, ["@acme/alpha"]), shardBody(1, ["@acme/alpha"])];
+    expect(() =>
+      validateOfficialExternalPluginCatalogShardSet(
+        parseOfficialExternalPluginCatalogShardRoot(rootFor(duplicated)),
+        duplicated,
+      ),
+    ).toThrow("identity is duplicated");
+  });
+
+  it("rejects malformed roots before any shard fetch", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"])];
+    expect(() =>
+      parseOfficialExternalPluginCatalogShardRoot({
+        ...rootFor(bodies),
+        unexpected: true,
+      }),
+    ).toThrow("shard root is malformed");
+    expect(() =>
+      parseOfficialExternalPluginCatalogShardRoot({
+        ...rootFor(bodies),
+        shards: [{ ...rootFor(bodies).shards[0], sha256: "ABC" }],
+      }),
+    ).toThrow("lowercase SHA-256 hex");
+  });
+
+  it("round-trips the exact authenticated root and shard bytes for fallback", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"])];
+    const rootBody = '{"signed":"root"}';
+    const serialized = serializeOfficialExternalPluginCatalogShardedSnapshot({
+      rootBody,
+      shardBodies: bodies,
+    });
+
+    expect(parseOfficialExternalPluginCatalogShardedSnapshot(JSON.parse(serialized))).toEqual({
+      kind: "official-external-plugin-catalog-shards-v1",
+      rootBody,
+      shardBodies: bodies,
+    });
+  });
+});

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import { isRecord } from "../utils.js";
+import type {
+  OfficialExternalPluginCatalogEntry,
+  OfficialExternalPluginCatalogFeed,
+} from "./official-external-plugin-catalog.js";
+
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES = 1024 * 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS = 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES = 1_000_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES = 256 * 1024 * 1024;
+const SHARDED_SNAPSHOT_KIND = "official-external-plugin-catalog-shards-v1";
+
+export type OfficialExternalPluginCatalogShardDescriptor = {
+  index: number;
+  url: string;
+  sha256: string;
+  byteLength: number;
+  entryCount: number;
+};
+
+export type OfficialExternalPluginCatalogShardRoot = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  metadata: { description: string | null };
+  entryCount: number;
+  shards: readonly OfficialExternalPluginCatalogShardDescriptor[];
+};
+
+type OfficialExternalPluginCatalogShard = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  index: number;
+  entries: readonly OfficialExternalPluginCatalogEntry[];
+};
+
+export type OfficialExternalPluginCatalogShardedSnapshot = {
+  kind: typeof SHARDED_SNAPSHOT_KIND;
+  rootBody: string;
+  shardBodies: readonly string[];
+};
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).toSorted();
+  const expected = [...keys].toSorted();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function requireNonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function parseRfc3339Instant(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length > 64) {
+    throw new Error(`${label} is invalid`);
+  }
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/u.exec(
+      value,
+    );
+  if (!match) {
+    throw new Error(`${label} is invalid`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = Number(match[8] ?? "0");
+  const offsetMinute = Number(match[9] ?? "0");
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth[month - 1]! ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59 ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function parseShardDescriptor(
+  value: unknown,
+  expectedIndex: number,
+): OfficialExternalPluginCatalogShardDescriptor {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["index", "url", "sha256", "byteLength", "entryCount"])
+  ) {
+    throw new Error("hosted catalog shard descriptor is malformed");
+  }
+  const index = requireNonNegativeInteger(value.index, "hosted catalog shard index");
+  if (index !== expectedIndex) {
+    throw new Error("hosted catalog shard indexes must be contiguous");
+  }
+  if (typeof value.sha256 !== "string" || !/^[a-f0-9]{64}$/u.test(value.sha256)) {
+    throw new Error("hosted catalog shard digest must be lowercase SHA-256 hex");
+  }
+  const byteLength = requireNonNegativeInteger(value.byteLength, "hosted catalog shard byteLength");
+  if (byteLength < 1 || byteLength > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES) {
+    throw new Error("hosted catalog shard byteLength is invalid");
+  }
+  const entryCount = requireNonNegativeInteger(value.entryCount, "hosted catalog shard entryCount");
+  if (entryCount < 1 || entryCount > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES) {
+    throw new Error("hosted catalog shard entryCount is invalid");
+  }
+  if (typeof value.url !== "string" || Buffer.byteLength(value.url, "utf8") > 2048) {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS");
+  }
+  let url: URL;
+  try {
+    url = new URL(value.url);
+  } catch {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS");
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS without credentials");
+  }
+  return {
+    index,
+    url: url.href,
+    sha256: value.sha256,
+    byteLength,
+    entryCount,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogShardRoot(
+  value: unknown,
+): OfficialExternalPluginCatalogShardRoot {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "schemaVersion",
+      "feedId",
+      "sequence",
+      "generatedAt",
+      "expiresAt",
+      "metadata",
+      "entryCount",
+      "shards",
+    ]) ||
+    value.schemaVersion !== 1 ||
+    typeof value.feedId !== "string" ||
+    value.feedId.trim().length === 0 ||
+    value.feedId.length > 256 ||
+    !isRecord(value.metadata) ||
+    !hasExactKeys(value.metadata, ["description"]) ||
+    (value.metadata.description !== null && typeof value.metadata.description !== "string") ||
+    !Array.isArray(value.shards)
+  ) {
+    throw new Error("hosted catalog shard root is malformed");
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+    OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES
+  ) {
+    throw new Error("hosted catalog shard root exceeds its byte limit");
+  }
+  if (
+    typeof value.metadata.description === "string" &&
+    Buffer.byteLength(value.metadata.description, "utf8") > 1024
+  ) {
+    throw new Error("hosted catalog shard root description exceeds its limit");
+  }
+  const sequence = requireNonNegativeInteger(value.sequence, "hosted catalog shard root sequence");
+  const generatedAt = parseRfc3339Instant(
+    value.generatedAt,
+    "hosted catalog shard root generatedAt",
+  );
+  const expiresAt = parseRfc3339Instant(value.expiresAt, "hosted catalog shard root expiresAt");
+  if (Date.parse(expiresAt) <= Date.parse(generatedAt)) {
+    throw new Error("hosted catalog shard root validity window is invalid");
+  }
+  const entryCount = requireNonNegativeInteger(
+    value.entryCount,
+    "hosted catalog shard root entryCount",
+  );
+  if (entryCount > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES) {
+    throw new Error("hosted catalog shard root entryCount exceeds its limit");
+  }
+  if (value.shards.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS) {
+    throw new Error("hosted catalog shard root exceeds its shard limit");
+  }
+  if ((entryCount === 0) !== (value.shards.length === 0)) {
+    throw new Error("hosted catalog empty shard roots must have no shard descriptors");
+  }
+  const shards = value.shards.map(parseShardDescriptor);
+  const urls = new Set<string>();
+  const digests = new Set<string>();
+  let describedEntries = 0;
+  let describedBytes = 0;
+  for (const shard of shards) {
+    if (urls.has(shard.url) || digests.has(shard.sha256)) {
+      throw new Error("hosted catalog shard descriptors must be unique");
+    }
+    urls.add(shard.url);
+    digests.add(shard.sha256);
+    describedEntries += shard.entryCount;
+    describedBytes += shard.byteLength;
+  }
+  if (describedEntries !== entryCount) {
+    throw new Error("hosted catalog shard root entryCount does not match its descriptors");
+  }
+  if (describedBytes > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES) {
+    throw new Error("hosted catalog shard set exceeds its aggregate byte limit");
+  }
+  return {
+    schemaVersion: 1,
+    feedId: value.feedId,
+    sequence,
+    generatedAt,
+    expiresAt,
+    metadata: { description: value.metadata.description },
+    entryCount,
+    shards,
+  };
+}
+
+function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["schemaVersion", "feedId", "sequence", "index", "entries"]) ||
+    value.schemaVersion !== 1 ||
+    typeof value.feedId !== "string" ||
+    value.feedId.trim().length === 0 ||
+    !Array.isArray(value.entries)
+  ) {
+    throw new Error("hosted catalog shard is malformed");
+  }
+  const sequence = requireNonNegativeInteger(value.sequence, "hosted catalog shard sequence");
+  const index = requireNonNegativeInteger(value.index, "hosted catalog shard index");
+  if (
+    value.entries.length < 1 ||
+    value.entries.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES
+  ) {
+    throw new Error("hosted catalog shard entry count is invalid");
+  }
+  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  let previousId: string | undefined;
+  for (const entry of value.entries) {
+    if (
+      !isRecord(entry) ||
+      entry.type !== "plugin" ||
+      typeof entry.id !== "string" ||
+      entry.id.trim().length === 0
+    ) {
+      throw new Error("hosted catalog shard entry is invalid");
+    }
+    if (previousId !== undefined && previousId.localeCompare(entry.id) >= 0) {
+      throw new Error("hosted catalog shard entries must use deterministic id ordering");
+    }
+    previousId = entry.id;
+    entries.push(entry);
+  }
+  return { schemaVersion: 1, feedId: value.feedId, sequence, index, entries };
+}
+
+export function validateOfficialExternalPluginCatalogShardSet(
+  root: OfficialExternalPluginCatalogShardRoot,
+  shardBodies: readonly string[],
+): OfficialExternalPluginCatalogFeed {
+  if (shardBodies.length !== root.shards.length) {
+    throw new Error("hosted catalog shard set is incomplete");
+  }
+  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const identities = new Set<string>();
+  let previousId: string | undefined;
+  for (const [index, body] of shardBodies.entries()) {
+    const descriptor = root.shards[index];
+    if (!descriptor) {
+      throw new Error("hosted catalog shard set is incomplete");
+    }
+    const bytes = Buffer.from(body, "utf8");
+    if (
+      bytes.length !== descriptor.byteLength ||
+      createHash("sha256").update(bytes).digest("hex") !== descriptor.sha256
+    ) {
+      throw new Error("hosted catalog shard bytes do not match their signed descriptor");
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(body) as unknown;
+    } catch {
+      throw new Error("hosted catalog shard payload is not valid JSON");
+    }
+    const shard = parseShard(raw);
+    if (
+      shard.feedId !== root.feedId ||
+      shard.sequence !== root.sequence ||
+      shard.index !== index ||
+      shard.entries.length !== descriptor.entryCount
+    ) {
+      throw new Error("hosted catalog shard does not match its signed root");
+    }
+    for (const entry of shard.entries) {
+      const identity = `${entry.type}\0${entry.id}`;
+      if (identities.has(identity)) {
+        throw new Error("hosted catalog shard set identity is duplicated");
+      }
+      identities.add(identity);
+      if (previousId !== undefined && previousId.localeCompare(entry.id as string) >= 0) {
+        throw new Error("hosted catalog shard set ordering is invalid");
+      }
+      previousId = entry.id as string;
+      entries.push(entry);
+    }
+  }
+  if (entries.length !== root.entryCount) {
+    throw new Error("hosted catalog shard set entry count is incomplete");
+  }
+  return {
+    schemaVersion: 1,
+    id: root.feedId,
+    sequence: root.sequence,
+    generatedAt: root.generatedAt,
+    ...(root.metadata.description === null ? {} : { description: root.metadata.description }),
+    entries,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogShardedSnapshot(
+  value: unknown,
+): OfficialExternalPluginCatalogShardedSnapshot | null {
+  if (!isRecord(value) || value.kind !== SHARDED_SNAPSHOT_KIND) {
+    return null;
+  }
+  if (
+    !hasExactKeys(value, ["kind", "rootBody", "shardBodies"]) ||
+    typeof value.rootBody !== "string" ||
+    !Array.isArray(value.shardBodies) ||
+    !value.shardBodies.every((body): body is string => typeof body === "string")
+  ) {
+    throw new Error("hosted catalog sharded snapshot is malformed");
+  }
+  return { kind: SHARDED_SNAPSHOT_KIND, rootBody: value.rootBody, shardBodies: value.shardBodies };
+}
+
+export function serializeOfficialExternalPluginCatalogShardedSnapshot(params: {
+  rootBody: string;
+  shardBodies: readonly string[];
+}): string {
+  return JSON.stringify({
+    kind: SHARDED_SNAPSHOT_KIND,
+    rootBody: params.rootBody,
+    shardBodies: params.shardBodies,
+  });
+}

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -12,6 +12,7 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { materializeMarketplaceFeedWatchUpdates } from "./official-external-plugin-catalog-watch-store.js";
 import {
   type HostedOfficialExternalPluginCatalogMetadata,
   type HostedOfficialExternalPluginCatalogSnapshot,
@@ -294,6 +295,14 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
               }),
             ),
         );
+        if (snapshot.trust?.mode === "signed" && snapshot.monotonic?.mode === "signed-feed") {
+          materializeMarketplaceFeedWatchUpdates({
+            db: database.db,
+            feedUrl: snapshot.metadata.url,
+            nextBody: snapshot.body,
+            now,
+          });
+        }
       }, resolveStateDatabaseOptions(options));
     },
   };

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -114,17 +114,28 @@ function decodeBase64Payload(payload: string): string {
 function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicState | undefined {
   try {
     const document = JSON.parse(body) as {
+      kind?: unknown;
+      rootBody?: unknown;
       payload?: unknown;
       sequence?: unknown;
       generatedAt?: unknown;
     };
-    const feed =
-      typeof document.payload === "string"
-        ? (JSON.parse(decodeBase64Payload(document.payload)) as {
+    const wireDocument =
+      document.kind === "official-external-plugin-catalog-shards-v1" &&
+      typeof document.rootBody === "string"
+        ? (JSON.parse(document.rootBody) as {
+            payload?: unknown;
             sequence?: unknown;
             generatedAt?: unknown;
           })
         : document;
+    const feed =
+      typeof wireDocument.payload === "string"
+        ? (JSON.parse(decodeBase64Payload(wireDocument.payload)) as {
+            sequence?: unknown;
+            generatedAt?: unknown;
+          })
+        : wireDocument;
     if (!isOfficialExternalPluginCatalogSequence(feed.sequence)) {
       return undefined;
     }

--- a/src/plugins/official-external-plugin-catalog-watch-store.test.ts
+++ b/src/plugins/official-external-plugin-catalog-watch-store.test.ts
@@ -1,0 +1,315 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
+import {
+  addMarketplaceFeedWatch,
+  dismissMarketplaceFeedUpdate,
+  listMarketplaceFeedUpdates,
+  listMarketplaceFeedWatches,
+  markMarketplaceFeedUpdateRead,
+  removeMarketplaceFeedWatch,
+  setMarketplaceFeedWatchMuted,
+} from "./official-external-plugin-catalog-watch-store.js";
+
+const tempDirs: string[] = [];
+const feedUrl = "https://clawhub.ai/v1/feeds/plugins";
+const feedId = "clawhub-official";
+
+function tempDatabasePath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-feed-watch-"));
+  tempDirs.push(dir);
+  return path.join(dir, "state.sqlite");
+}
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "demo",
+    title: "Demo",
+    kind: "plugin",
+    name: "@acme/demo",
+    version: "1.0.0",
+    state: "community",
+    publisher: { id: "acme", trust: "community" },
+    install: {
+      candidates: [
+        {
+          sourceRef: "public-npm",
+          package: "@acme/demo",
+          version: "1.0.0",
+          integrity: "sha512-ZGVtbw==",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function feedBody(sequence: number, entries = [entry()]): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    id: feedId,
+    generatedAt: new Date(Date.UTC(2026, 6, 17, 0, sequence)).toISOString(),
+    sequence,
+    entries,
+  });
+}
+
+function snapshot(body: string, sequence: number) {
+  return {
+    body,
+    metadata: {
+      url: feedUrl,
+      status: 200,
+      checksum: `sha256:${sequence}`,
+    },
+    savedAt: new Date(Date.UTC(2026, 6, 17, 0, sequence)).toISOString(),
+    trust: {
+      mode: "signed" as const,
+      signedBy: "clawhub-feed-2026",
+      signatureCount: 1,
+      threshold: 1,
+      verifiedAt: new Date(Date.UTC(2026, 6, 17, 0, sequence)).toISOString(),
+    },
+    monotonic: {
+      mode: "signed-feed" as const,
+      sequence,
+      generatedAt: new Date(Date.UTC(2026, 6, 17, 0, sequence)).toISOString(),
+    },
+  };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("marketplace feed watch store", () => {
+  it("suppresses the baseline and materializes verified version, blocked, and removal updates", async () => {
+    const stateDatabasePath = tempDatabasePath();
+    const options = { stateDatabasePath };
+    const snapshots = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(options);
+
+    await snapshots.write(snapshot(feedBody(1), 1));
+    const added = addMarketplaceFeedWatch(
+      {
+        feedId,
+        feedProfile: "clawhub-public",
+        feedUrl,
+        itemKind: "plugin",
+        itemId: "demo",
+        sequence: 1,
+        baselineEntry: entry(),
+      },
+      options,
+    );
+    expect(added.created).toBe(true);
+    expect(listMarketplaceFeedUpdates({}, options)).toEqual([]);
+    const version11 = {
+      version: "1.1.0",
+      install: {
+        candidates: [
+          {
+            sourceRef: "public-npm",
+            package: "@acme/demo",
+            version: "1.1.0",
+            integrity: "sha512-djEuMS4w",
+          },
+        ],
+      },
+    };
+
+    await snapshots.write(snapshot(feedBody(2, [entry(version11)]), 2));
+    await snapshots.write(
+      snapshot(
+        feedBody(3, [
+          entry({
+            version: "1.1.0",
+            install: {
+              candidates: [
+                {
+                  integrity: "sha512-djEuMS4w",
+                  version: "1.1.0",
+                  package: "@acme/demo",
+                  sourceRef: "public-npm",
+                },
+              ],
+            },
+            title: "Renamed Demo",
+            description: "cosmetic",
+          }),
+        ]),
+        3,
+      ),
+    );
+    await snapshots.write(snapshot(feedBody(4, [entry({ ...version11, state: "blocked" })]), 4));
+    await snapshots.write(snapshot(feedBody(5, []), 5));
+
+    const updates = listMarketplaceFeedUpdates({}, options);
+    expect(updates.map((update) => update.reason)).toEqual(["removed", "blocked", "updated"]);
+    expect(updates.map((update) => update.feedSequence)).toEqual([5, 4, 2]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([
+      { itemId: "demo", lastSequence: 5, muted: false },
+    ]);
+
+    const eventId = updates[0]!.eventId;
+    expect(markMarketplaceFeedUpdateRead(eventId, options)).toBe(true);
+    expect(markMarketplaceFeedUpdateRead(eventId, options)).toBe(true);
+    expect(listMarketplaceFeedUpdates({ unreadOnly: true }, options)).toHaveLength(2);
+    expect(dismissMarketplaceFeedUpdate(eventId, options)).toBe(true);
+    expect(dismissMarketplaceFeedUpdate(eventId, options)).toBe(true);
+    expect(markMarketplaceFeedUpdateRead("missing-event", options)).toBe(false);
+    expect(listMarketplaceFeedUpdates({}, options)).toHaveLength(2);
+    expect(listMarketplaceFeedUpdates({ includeDismissed: true }, options)).toHaveLength(3);
+  });
+
+  it("keeps watch operations idempotent and persists mute state", async () => {
+    const stateDatabasePath = tempDatabasePath();
+    const options = { stateDatabasePath };
+    const input = {
+      feedId,
+      feedProfile: "clawhub-public",
+      feedUrl,
+      itemKind: "plugin" as const,
+      itemId: "demo",
+      sequence: 7,
+      baselineEntry: entry(),
+    };
+
+    expect(addMarketplaceFeedWatch(input, options).created).toBe(true);
+    expect(addMarketplaceFeedWatch({ ...input, sequence: 8 }, options)).toMatchObject({
+      created: false,
+      watch: { lastSequence: 7 },
+    });
+    expect(
+      setMarketplaceFeedWatchMuted(
+        { feedId, itemKind: "plugin", itemId: "demo", muted: true },
+        options,
+      ),
+    ).toBe(true);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ muted: true }]);
+    expect(
+      removeMarketplaceFeedWatch({ feedId, itemKind: "plugin", itemId: "demo" }, options),
+    ).toBe(true);
+    expect(
+      removeMarketplaceFeedWatch({ feedId, itemKind: "plugin", itemId: "demo" }, options),
+    ).toBe(false);
+  });
+
+  it("advances a muted watch baseline without creating update events", async () => {
+    const stateDatabasePath = tempDatabasePath();
+    const options = { stateDatabasePath };
+    const snapshots = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(options);
+    await snapshots.write(snapshot(feedBody(1), 1));
+    addMarketplaceFeedWatch(
+      {
+        feedId,
+        feedUrl,
+        itemKind: "plugin",
+        itemId: "demo",
+        sequence: 1,
+        baselineEntry: entry(),
+      },
+      options,
+    );
+    setMarketplaceFeedWatchMuted(
+      { feedId, itemKind: "plugin", itemId: "demo", muted: true },
+      options,
+    );
+
+    await snapshots.write(snapshot(feedBody(2, [entry({ version: "2.0.0" })]), 2));
+    expect(listMarketplaceFeedUpdates({}, options)).toEqual([]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ lastSequence: 2, muted: true }]);
+
+    setMarketplaceFeedWatchMuted(
+      { feedId, itemKind: "plugin", itemId: "demo", muted: false },
+      options,
+    );
+    await snapshots.write(snapshot(feedBody(3, [entry({ version: "3.0.0" })]), 3));
+    expect(listMarketplaceFeedUpdates({}, options)).toMatchObject([
+      { feedSequence: 3, reason: "updated" },
+    ]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ lastSequence: 3, muted: false }]);
+  });
+
+  it("does not advance a watch from another source reusing the same feed id", async () => {
+    const stateDatabasePath = tempDatabasePath();
+    const options = { stateDatabasePath };
+    const snapshots = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(options);
+    await snapshots.write(snapshot(feedBody(1), 1));
+    addMarketplaceFeedWatch(
+      {
+        feedId,
+        feedUrl,
+        itemKind: "plugin",
+        itemId: "demo",
+        sequence: 1,
+        baselineEntry: entry(),
+      },
+      options,
+    );
+
+    const imposterUrl = "https://packages.example.test/v1/feeds/plugins";
+    await snapshots.write({
+      ...snapshot(feedBody(2, [entry({ version: "2.0.0" })]), 2),
+      metadata: { url: imposterUrl, status: 200, checksum: "sha256:imposter" },
+    });
+    expect(listMarketplaceFeedUpdates({}, options)).toEqual([]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ lastSequence: 1 }]);
+
+    await snapshots.write(snapshot(feedBody(2, [entry({ version: "2.0.0" })]), 2));
+    expect(listMarketplaceFeedUpdates({}, options)).toMatchObject([
+      { feedSequence: 2, reason: "updated" },
+    ]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ lastSequence: 2 }]);
+  });
+
+  it("does not materialize updates from unsigned snapshot writes", async () => {
+    const stateDatabasePath = tempDatabasePath();
+    const options = { stateDatabasePath };
+    const snapshots = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(options);
+    await snapshots.write(snapshot(feedBody(1), 1));
+    addMarketplaceFeedWatch(
+      {
+        feedId,
+        feedUrl,
+        itemKind: "plugin",
+        itemId: "demo",
+        sequence: 1,
+        baselineEntry: entry(),
+      },
+      options,
+    );
+
+    await snapshots.write({
+      body: feedBody(2, [entry({ version: "2.0.0" })]),
+      metadata: { url: feedUrl, status: 200, checksum: "sha256:unsigned" },
+      savedAt: "2026-07-17T00:02:00.000Z",
+    });
+
+    expect(listMarketplaceFeedUpdates({}, options)).toEqual([]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ lastSequence: 1 }]);
+
+    await snapshots.write(
+      snapshot(
+        feedBody(3, [
+          entry({
+            version: "3.0.0",
+            install: {
+              candidates: [{ sourceRef: "public-npm", package: "@acme/demo", version: "3.0.0" }],
+            },
+          }),
+        ]),
+        3,
+      ),
+    );
+    expect(listMarketplaceFeedUpdates({}, options)).toMatchObject([
+      { feedSequence: 3, reason: "updated" },
+    ]);
+    expect(listMarketplaceFeedWatches(options)).toMatchObject([{ lastSequence: 3 }]);
+  });
+});

--- a/src/plugins/official-external-plugin-catalog-watch-store.test.ts
+++ b/src/plugins/official-external-plugin-catalog-watch-store.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -81,6 +82,45 @@ function snapshot(body: string, sequence: number) {
   };
 }
 
+function shardedSnapshotBody(sequence: number, entries = [entry()]): string {
+  const shardBody = JSON.stringify({
+    schemaVersion: 1,
+    feedId,
+    sequence,
+    index: 0,
+    entries,
+  });
+  const sha256 = createHash("sha256").update(shardBody).digest("hex");
+  const root = {
+    schemaVersion: 1,
+    feedId,
+    sequence,
+    generatedAt: new Date(Date.UTC(2026, 6, 17, 0, sequence)).toISOString(),
+    expiresAt: new Date(Date.UTC(2026, 6, 24, 0, sequence)).toISOString(),
+    metadata: { description: "ClawHub plugins" },
+    entryCount: entries.length,
+    shards: [
+      {
+        index: 0,
+        url: `https://clawhub.ai/v1/feeds/plugins/shards/sha256-${sha256}.json`,
+        sha256,
+        byteLength: Buffer.byteLength(shardBody),
+        entryCount: entries.length,
+      },
+    ],
+  };
+  const rootBody = JSON.stringify({
+    payloadType: "openclaw.official-external-plugin-catalog-shard-root.v1",
+    payload: Buffer.from(JSON.stringify(root)).toString("base64url"),
+    signatures: [{ keyid: "clawhub-feed-2026", sig: "test" }],
+  });
+  return JSON.stringify({
+    kind: "official-external-plugin-catalog-shards-v1",
+    rootBody,
+    shardBodies: [shardBody],
+  });
+}
+
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   for (const dir of tempDirs.splice(0)) {
@@ -89,6 +129,32 @@ afterEach(() => {
 });
 
 describe("marketplace feed watch store", () => {
+  it("materializes updates from accepted packed shard snapshots", async () => {
+    const stateDatabasePath = tempDatabasePath();
+    const options = { stateDatabasePath };
+    const snapshots = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(options);
+    await snapshots.write(snapshot(feedBody(1), 1));
+    addMarketplaceFeedWatch(
+      {
+        feedId,
+        feedUrl,
+        itemKind: "plugin",
+        itemId: "demo",
+        sequence: 1,
+        baselineEntry: entry(),
+      },
+      options,
+    );
+
+    await snapshots.write(
+      snapshot(shardedSnapshotBody(2, [entry({ type: "plugin", version: "2.0.0" })]), 2),
+    );
+
+    expect(listMarketplaceFeedUpdates({}, options)).toMatchObject([
+      { feedSequence: 2, itemId: "demo", reason: "updated" },
+    ]);
+  });
+
   it("suppresses the baseline and materializes verified version, blocked, and removal updates", async () => {
     const stateDatabasePath = tempDatabasePath();
     const options = { stateDatabasePath };

--- a/src/plugins/official-external-plugin-catalog-watch-store.ts
+++ b/src/plugins/official-external-plugin-catalog-watch-store.ts
@@ -1,0 +1,513 @@
+// Durable local watches and update history for accepted marketplace feeds.
+import { createHash } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import { stableStringify } from "../agents/stable-stringify.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import {
+  isOfficialExternalPluginCatalogFeed,
+  resolveOfficialExternalPluginId,
+  resolveOfficialExternalPluginLabel,
+  type OfficialExternalPluginCatalogEntry,
+  type OfficialExternalPluginCatalogFeed,
+} from "./official-external-plugin-catalog.js";
+
+const MAX_MARKETPLACE_FEED_WATCHES = 500;
+const MAX_MARKETPLACE_FEED_UPDATES = 500;
+const DEFAULT_MARKETPLACE_FEED_UPDATE_LIMIT = 50;
+const MAX_MARKETPLACE_FEED_UPDATE_LIMIT = 100;
+
+export type MarketplaceFeedItemKind = "plugin" | "skill";
+export type MarketplaceFeedUpdateReason =
+  | "updated"
+  | "removed"
+  | "blocked"
+  | "security-state-changed";
+
+export type MarketplaceFeedWatch = {
+  feedId: string;
+  feedProfile?: string;
+  feedUrl: string;
+  itemKind: MarketplaceFeedItemKind;
+  itemId: string;
+  lastSequence: number;
+  muted: boolean;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type MarketplaceFeedUpdate = {
+  eventId: string;
+  feedId: string;
+  itemKind: MarketplaceFeedItemKind;
+  itemId: string;
+  feedSequence: number;
+  reason: MarketplaceFeedUpdateReason;
+  title?: string;
+  itemVersion?: string;
+  itemState?: string;
+  observedAt: number;
+  readAt?: number;
+  dismissedAt?: number;
+};
+
+export type MarketplaceFeedWatchStoreOptions = {
+  env?: NodeJS.ProcessEnv;
+  stateDatabasePath?: string;
+};
+
+type MarketplaceFeedDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "marketplace_feed_updates" | "marketplace_feed_watches"
+>;
+
+type MarketplaceFeedWatchRow = {
+  feed_id: string;
+  feed_profile: string | null;
+  feed_url: string;
+  item_kind: string;
+  item_id: string;
+  baseline_json: string | null;
+  last_sequence: number | bigint;
+  muted: number | bigint;
+  created_at_ms: number | bigint;
+  updated_at_ms: number | bigint;
+};
+
+type MarketplaceFeedUpdateRow = {
+  event_id: string;
+  feed_id: string;
+  item_kind: string;
+  item_id: string;
+  feed_sequence: number | bigint;
+  reason: string;
+  title: string | null;
+  item_version: string | null;
+  item_state: string | null;
+  observed_at_ms: number | bigint;
+  read_at_ms: number | bigint | null;
+  dismissed_at_ms: number | bigint | null;
+};
+
+function databaseOptions(options: MarketplaceFeedWatchStoreOptions): OpenClawStateDatabaseOptions {
+  return {
+    ...(options.env ? { env: options.env } : {}),
+    ...(options.stateDatabasePath ? { path: options.stateDatabasePath } : {}),
+  };
+}
+
+function stateDb(db: DatabaseSync) {
+  return getNodeSqliteKysely<MarketplaceFeedDatabase>(db);
+}
+
+function toWatch(row: MarketplaceFeedWatchRow): MarketplaceFeedWatch {
+  return {
+    feedId: row.feed_id,
+    ...(row.feed_profile ? { feedProfile: row.feed_profile } : {}),
+    feedUrl: row.feed_url,
+    itemKind: row.item_kind as MarketplaceFeedItemKind,
+    itemId: row.item_id,
+    lastSequence: Number(row.last_sequence),
+    muted: Number(row.muted) === 1,
+    createdAt: Number(row.created_at_ms),
+    updatedAt: Number(row.updated_at_ms),
+  };
+}
+
+function toUpdate(row: MarketplaceFeedUpdateRow): MarketplaceFeedUpdate {
+  return {
+    eventId: row.event_id,
+    feedId: row.feed_id,
+    itemKind: row.item_kind as MarketplaceFeedItemKind,
+    itemId: row.item_id,
+    feedSequence: Number(row.feed_sequence),
+    reason: row.reason as MarketplaceFeedUpdateReason,
+    ...(row.title ? { title: row.title } : {}),
+    ...(row.item_version ? { itemVersion: row.item_version } : {}),
+    ...(row.item_state ? { itemState: row.item_state } : {}),
+    observedAt: Number(row.observed_at_ms),
+    ...(row.read_at_ms === null ? {} : { readAt: Number(row.read_at_ms) }),
+    ...(row.dismissed_at_ms === null ? {} : { dismissedAt: Number(row.dismissed_at_ms) }),
+  };
+}
+
+function selectWatchRows(db: DatabaseSync): MarketplaceFeedWatchRow[] {
+  return executeSqliteQuerySync(
+    db,
+    stateDb(db)
+      .selectFrom("marketplace_feed_watches")
+      .selectAll()
+      .orderBy("feed_id")
+      .orderBy("item_kind")
+      .orderBy("item_id"),
+  ).rows;
+}
+
+export function listMarketplaceFeedWatches(
+  options: MarketplaceFeedWatchStoreOptions = {},
+): MarketplaceFeedWatch[] {
+  const { db } = openOpenClawStateDatabase(databaseOptions(options));
+  return selectWatchRows(db).map(toWatch);
+}
+
+export function addMarketplaceFeedWatch(
+  watch: {
+    feedId: string;
+    feedProfile?: string;
+    feedUrl: string;
+    itemKind: MarketplaceFeedItemKind;
+    itemId: string;
+    sequence: number;
+    baselineEntry: OfficialExternalPluginCatalogEntry;
+  },
+  options: MarketplaceFeedWatchStoreOptions = {},
+): { created: boolean; watch: MarketplaceFeedWatch } {
+  const now = Date.now();
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      stateDb(db)
+        .selectFrom("marketplace_feed_watches")
+        .selectAll()
+        .where("feed_id", "=", watch.feedId)
+        .where("item_kind", "=", watch.itemKind)
+        .where("item_id", "=", watch.itemId),
+    ) as MarketplaceFeedWatchRow | undefined;
+    if (existing) {
+      return { created: false, watch: toWatch(existing) };
+    }
+    if (selectWatchRows(db).length >= MAX_MARKETPLACE_FEED_WATCHES) {
+      throw new Error(`marketplace feed watch limit reached (${MAX_MARKETPLACE_FEED_WATCHES})`);
+    }
+    executeSqliteQuerySync(
+      db,
+      stateDb(db)
+        .insertInto("marketplace_feed_watches")
+        .values({
+          feed_id: watch.feedId,
+          feed_profile: watch.feedProfile ?? null,
+          feed_url: watch.feedUrl,
+          item_kind: watch.itemKind,
+          item_id: watch.itemId,
+          baseline_json: stableStringify(watch.baselineEntry),
+          last_sequence: watch.sequence,
+          muted: 0,
+          created_at_ms: now,
+          updated_at_ms: now,
+        }),
+    );
+    return {
+      created: true,
+      watch: {
+        feedId: watch.feedId,
+        ...(watch.feedProfile ? { feedProfile: watch.feedProfile } : {}),
+        feedUrl: watch.feedUrl,
+        itemKind: watch.itemKind,
+        itemId: watch.itemId,
+        lastSequence: watch.sequence,
+        muted: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    };
+  }, databaseOptions(options));
+}
+
+export function removeMarketplaceFeedWatch(
+  key: { feedId: string; itemKind: MarketplaceFeedItemKind; itemId: string },
+  options: MarketplaceFeedWatchStoreOptions = {},
+): boolean {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const result = executeSqliteQuerySync(
+      db,
+      stateDb(db)
+        .deleteFrom("marketplace_feed_watches")
+        .where("feed_id", "=", key.feedId)
+        .where("item_kind", "=", key.itemKind)
+        .where("item_id", "=", key.itemId),
+    );
+    return Number(result.numAffectedRows ?? 0) > 0;
+  }, databaseOptions(options));
+}
+
+export function setMarketplaceFeedWatchMuted(
+  key: { feedId: string; itemKind: MarketplaceFeedItemKind; itemId: string; muted: boolean },
+  options: MarketplaceFeedWatchStoreOptions = {},
+): boolean {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const result = executeSqliteQuerySync(
+      db,
+      stateDb(db)
+        .updateTable("marketplace_feed_watches")
+        .set({ muted: key.muted ? 1 : 0, updated_at_ms: Date.now() })
+        .where("feed_id", "=", key.feedId)
+        .where("item_kind", "=", key.itemKind)
+        .where("item_id", "=", key.itemId),
+    );
+    return Number(result.numAffectedRows ?? 0) > 0;
+  }, databaseOptions(options));
+}
+
+function boundedUpdateLimit(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_MARKETPLACE_FEED_UPDATE_LIMIT;
+  }
+  if (!Number.isInteger(value) || value < 1 || value > MAX_MARKETPLACE_FEED_UPDATE_LIMIT) {
+    throw new Error(
+      `marketplace feed update limit must be between 1 and ${MAX_MARKETPLACE_FEED_UPDATE_LIMIT}`,
+    );
+  }
+  return value;
+}
+
+export function listMarketplaceFeedUpdates(
+  query: { includeDismissed?: boolean; limit?: number; unreadOnly?: boolean } = {},
+  options: MarketplaceFeedWatchStoreOptions = {},
+): MarketplaceFeedUpdate[] {
+  const { db } = openOpenClawStateDatabase(databaseOptions(options));
+  let statement = stateDb(db)
+    .selectFrom("marketplace_feed_updates")
+    .selectAll()
+    .orderBy("observed_at_ms", "desc")
+    .orderBy("event_id", "desc")
+    .limit(boundedUpdateLimit(query.limit));
+  if (!query.includeDismissed) {
+    statement = statement.where("dismissed_at_ms", "is", null);
+  }
+  if (query.unreadOnly) {
+    statement = statement.where("read_at_ms", "is", null);
+  }
+  return executeSqliteQuerySync(db, statement).rows.map(toUpdate);
+}
+
+function updateEventTimestamp(
+  eventId: string,
+  field: "dismissed_at_ms" | "read_at_ms",
+  options: MarketplaceFeedWatchStoreOptions,
+): boolean {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      stateDb(db)
+        .selectFrom("marketplace_feed_updates")
+        .selectAll()
+        .where("event_id", "=", eventId),
+    ) as MarketplaceFeedUpdateRow | undefined;
+    if (!existing) {
+      return false;
+    }
+    if (existing[field] !== null) {
+      return true;
+    }
+    const result = executeSqliteQuerySync(
+      db,
+      stateDb(db)
+        .updateTable("marketplace_feed_updates")
+        .set({ [field]: Date.now() })
+        .where("event_id", "=", eventId),
+    );
+    return Number(result.numAffectedRows ?? 0) > 0;
+  }, databaseOptions(options));
+}
+
+export function markMarketplaceFeedUpdateRead(
+  eventId: string,
+  options: MarketplaceFeedWatchStoreOptions = {},
+): boolean {
+  return updateEventTimestamp(eventId, "read_at_ms", options);
+}
+
+export function dismissMarketplaceFeedUpdate(
+  eventId: string,
+  options: MarketplaceFeedWatchStoreOptions = {},
+): boolean {
+  return updateEventTimestamp(eventId, "dismissed_at_ms", options);
+}
+
+function decodeFeedBody(body: string): OfficialExternalPluginCatalogFeed | undefined {
+  try {
+    const document = JSON.parse(body) as { payload?: unknown };
+    const candidate =
+      typeof document.payload === "string"
+        ? JSON.parse(
+            Buffer.from(
+              document.payload.replace(/-/gu, "+").replace(/_/gu, "/"),
+              "base64",
+            ).toString("utf8"),
+          )
+        : document;
+    return isOfficialExternalPluginCatalogFeed(candidate) ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function entriesById(
+  feed: OfficialExternalPluginCatalogFeed,
+): Map<string, OfficialExternalPluginCatalogEntry> {
+  const entries = new Map<string, OfficialExternalPluginCatalogEntry>();
+  for (const entry of feed.entries) {
+    const id = resolveOfficialExternalPluginId(entry);
+    if (id) {
+      entries.set(id, entry);
+    }
+  }
+  return entries;
+}
+
+function decodeBaselineEntry(body: string | null): OfficialExternalPluginCatalogEntry | undefined {
+  if (body === null) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(body) as OfficialExternalPluginCatalogEntry;
+  } catch {
+    return undefined;
+  }
+}
+
+function classifyChange(
+  previous: OfficialExternalPluginCatalogEntry | undefined,
+  next: OfficialExternalPluginCatalogEntry | undefined,
+): MarketplaceFeedUpdateReason | undefined {
+  if (!previous) {
+    return undefined;
+  }
+  if (!next) {
+    return "removed";
+  }
+  if (next.state === "blocked" && previous.state !== "blocked") {
+    return "blocked";
+  }
+  if (
+    stableStringify({ publisher: previous.publisher, state: previous.state }) !==
+    stableStringify({ publisher: next.publisher, state: next.state })
+  ) {
+    return "security-state-changed";
+  }
+  if (
+    stableStringify({
+      install: previous.install,
+      name: previous.name,
+      version: previous.version,
+    }) !== stableStringify({ install: next.install, name: next.name, version: next.version })
+  ) {
+    return "updated";
+  }
+  return undefined;
+}
+
+function buildEventId(params: {
+  feedId: string;
+  itemId: string;
+  sequence: number;
+  reason: MarketplaceFeedUpdateReason;
+}): string {
+  return createHash("sha256")
+    .update(`${params.feedId}\0plugin\0${params.itemId}\0${params.sequence}\0${params.reason}`)
+    .digest("hex");
+}
+
+function pruneUpdateHistory(db: DatabaseSync): void {
+  const rows = executeSqliteQuerySync(
+    db,
+    stateDb(db)
+      .selectFrom("marketplace_feed_updates")
+      .select("event_id")
+      .orderBy("observed_at_ms", "desc")
+      .orderBy("event_id", "desc"),
+  ).rows;
+  const staleIds = rows.slice(MAX_MARKETPLACE_FEED_UPDATES).map((row) => row.event_id);
+  if (staleIds.length === 0) {
+    return;
+  }
+  executeSqliteQuerySync(
+    db,
+    stateDb(db).deleteFrom("marketplace_feed_updates").where("event_id", "in", staleIds),
+  );
+}
+
+/** Materializes watched changes inside the same transaction as snapshot acceptance. */
+export function materializeMarketplaceFeedWatchUpdates(params: {
+  db: DatabaseSync;
+  feedUrl: string;
+  nextBody: string;
+  now: number;
+}): number {
+  const nextFeed = decodeFeedBody(params.nextBody);
+  if (!nextFeed) {
+    return 0;
+  }
+  const db = stateDb(params.db);
+  const watches = executeSqliteQuerySync(
+    params.db,
+    db
+      .selectFrom("marketplace_feed_watches")
+      .selectAll()
+      .where("feed_id", "=", nextFeed.id)
+      .where("feed_url", "=", params.feedUrl)
+      .where("item_kind", "=", "plugin")
+      .where("last_sequence", "<", nextFeed.sequence),
+  ).rows;
+  if (watches.length === 0) {
+    return 0;
+  }
+  const nextEntries = entriesById(nextFeed);
+  let created = 0;
+  for (const watch of watches) {
+    const next = nextEntries.get(watch.item_id);
+    const reason = classifyChange(decodeBaselineEntry(watch.baseline_json), next);
+    if (reason && watch.muted !== 1) {
+      const result = executeSqliteQuerySync(
+        params.db,
+        db
+          .insertInto("marketplace_feed_updates")
+          .orIgnore()
+          .values({
+            event_id: buildEventId({
+              feedId: nextFeed.id,
+              itemId: watch.item_id,
+              sequence: nextFeed.sequence,
+              reason,
+            }),
+            feed_id: nextFeed.id,
+            item_kind: "plugin",
+            item_id: watch.item_id,
+            feed_sequence: nextFeed.sequence,
+            reason,
+            title: next ? resolveOfficialExternalPluginLabel(next) : null,
+            item_version: next?.version ?? null,
+            item_state: next?.state ?? null,
+            observed_at_ms: params.now,
+            read_at_ms: null,
+            dismissed_at_ms: null,
+          }),
+      );
+      created += Number(result.numAffectedRows ?? 0);
+    }
+    executeSqliteQuerySync(
+      params.db,
+      db
+        .updateTable("marketplace_feed_watches")
+        .set({
+          baseline_json: next ? stableStringify(next) : null,
+          last_sequence: nextFeed.sequence,
+          updated_at_ms: params.now,
+        })
+        .where("feed_id", "=", nextFeed.id)
+        .where("item_kind", "=", "plugin")
+        .where("item_id", "=", watch.item_id),
+    );
+  }
+  pruneUpdateHistory(params.db);
+  return created;
+}

--- a/src/plugins/official-external-plugin-catalog-watch-store.ts
+++ b/src/plugins/official-external-plugin-catalog-watch-store.ts
@@ -14,6 +14,11 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import {
+  parseOfficialExternalPluginCatalogShardRoot,
+  parseOfficialExternalPluginCatalogShardedSnapshot,
+  validateOfficialExternalPluginCatalogShardSet,
+} from "./official-external-plugin-catalog-shards.js";
+import {
   isOfficialExternalPluginCatalogFeed,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginLabel,
@@ -336,6 +341,17 @@ export function dismissMarketplaceFeedUpdate(
 function decodeFeedBody(body: string): OfficialExternalPluginCatalogFeed | undefined {
   try {
     const document = JSON.parse(body) as { payload?: unknown };
+    const snapshot = parseOfficialExternalPluginCatalogShardedSnapshot(document);
+    if (snapshot) {
+      const rootEnvelope = JSON.parse(snapshot.rootBody) as { payload?: unknown };
+      if (typeof rootEnvelope.payload !== "string") {
+        return undefined;
+      }
+      const root = parseOfficialExternalPluginCatalogShardRoot(
+        JSON.parse(Buffer.from(rootEnvelope.payload, "base64url").toString("utf8")),
+      );
+      return validateOfficialExternalPluginCatalogShardSet(root, snapshot.shardBodies);
+    }
     const candidate =
       typeof document.payload === "string"
         ? JSON.parse(

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -189,59 +189,36 @@ function signedHostedCatalogDocument(params: {
   };
 }
 
-function shardedHostedCatalogFixture() {
-  const shardBodies = [
-    JSON.stringify({
+function shardedHostedCatalogFixture(shardCount = 2) {
+  const shardBodies = Array.from({ length: shardCount }, (_, index) => {
+    const name = index === 0 ? "alpha" : index === 1 ? "beta" : `plugin-${index}`;
+    const title = index === 0 ? "Alpha" : index === 1 ? "Beta" : `Plugin ${index}`;
+    return JSON.stringify({
       schemaVersion: 1,
       feedId: "openclaw-official-external-plugins",
       sequence: 12,
-      index: 0,
+      index,
       entries: [
         {
           type: "plugin",
-          id: "@acme/alpha",
-          title: "Alpha",
-          version: "1.0.0",
+          id: `@acme/${name}`,
+          title,
+          version: `${index + 1}.0.0`,
           state: "available",
           publisher: { id: "acme", trust: "official" },
           install: {
             candidates: [
               {
                 sourceRef: "acme-npm",
-                package: "@acme/alpha",
-                version: "1.0.0",
+                package: `@acme/${name}`,
+                version: `${index + 1}.0.0`,
               },
             ],
           },
         },
       ],
-    }),
-    JSON.stringify({
-      schemaVersion: 1,
-      feedId: "openclaw-official-external-plugins",
-      sequence: 12,
-      index: 1,
-      entries: [
-        {
-          type: "plugin",
-          id: "@acme/beta",
-          title: "Beta",
-          version: "2.0.0",
-          state: "available",
-          publisher: { id: "acme", trust: "official" },
-          install: {
-            candidates: [
-              {
-                sourceRef: "acme-npm",
-                package: "@acme/beta",
-                version: "2.0.0",
-              },
-            ],
-          },
-        },
-      ],
-    }),
-  ];
+    });
+  });
   const shards = shardBodies.map((body, index) => ({
     index,
     url: `https://packages.acme.example/openclaw/shards/${index}.json`,
@@ -258,7 +235,7 @@ function shardedHostedCatalogFixture() {
       generatedAt: "2026-06-22T00:00:12.000Z",
       expiresAt: "2026-06-29T00:00:12.000Z",
       metadata: { description: "Acme plugins" },
-      entryCount: 2,
+      entryCount: shardCount,
       shards,
     },
   });
@@ -742,6 +719,45 @@ describe("official external plugin catalog", () => {
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain("shard bytes do not match their signed descriptor");
     }
+  });
+
+  it("stops queued shard downloads after the first failure", async () => {
+    const fixture = shardedHostedCatalogFixture(8);
+    const fetchedUrls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      fetchedUrls.push(url);
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, { status: 200 });
+      }
+      if (url.endsWith("/0.json")) {
+        return new Response(null, { status: 503 });
+      }
+      if (init?.signal?.aborted) {
+        throw init.signal.reason instanceof Error ? init.signal.reason : new Error("aborted");
+      }
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () =>
+            reject(
+              init.signal?.reason instanceof Error ? init.signal.reason : new Error("aborted"),
+            ),
+          { once: true },
+        );
+      });
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchedUrls.some((url) => /\/[4-7]\.json$/u.test(url))).toBe(false);
   });
 
   it("rejects signed catalog shard URLs outside the root origin before fetching them", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -33,6 +33,8 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 }
 
 const HOSTED_CATALOG_PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
+const HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-shard-root.v1";
 
 type HostedCatalogConfig = NonNullable<
   NonNullable<
@@ -140,6 +142,127 @@ function signedHostedCatalogFeed(params: {
     }),
     ...keys,
   };
+}
+
+function signedHostedCatalogDocument(params: {
+  document: unknown;
+  payloadType: string;
+  privateKeyPem?: string;
+}): { body: string; privateKeyPem: string; publicKeyPem: string } {
+  const keys = params.privateKeyPem
+    ? {
+        privateKeyPem: params.privateKeyPem,
+        publicKeyPem: crypto
+          .createPublicKey(params.privateKeyPem)
+          .export({ type: "spki", format: "pem" }),
+      }
+    : (() => {
+        const generated = crypto.generateKeyPairSync("ed25519", {
+          publicKeyEncoding: { type: "spki", format: "pem" },
+          privateKeyEncoding: { type: "pkcs8", format: "pem" },
+        });
+        return { privateKeyPem: generated.privateKey, publicKeyPem: generated.publicKey };
+      })();
+  const payloadBytes = Buffer.from(JSON.stringify(params.document), "utf8");
+  const payloadTypeBytes = Buffer.from(params.payloadType, "utf8");
+  const signingInput = Buffer.concat([
+    Buffer.from(
+      `DSSEv1 ${payloadTypeBytes.length} ${params.payloadType} ${payloadBytes.length} `,
+      "utf8",
+    ),
+    payloadBytes,
+  ]);
+  return {
+    body: JSON.stringify({
+      payloadType: params.payloadType,
+      payload: payloadBytes.toString("base64url"),
+      signatures: [
+        {
+          keyid: "acme-root",
+          sig: crypto
+            .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
+            .toString("base64url"),
+        },
+      ],
+    }),
+    ...keys,
+  };
+}
+
+function shardedHostedCatalogFixture() {
+  const shardBodies = [
+    JSON.stringify({
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      index: 0,
+      entries: [
+        {
+          type: "plugin",
+          id: "@acme/alpha",
+          title: "Alpha",
+          version: "1.0.0",
+          state: "available",
+          publisher: { id: "acme", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "acme-npm",
+                package: "@acme/alpha",
+                version: "1.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    JSON.stringify({
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      index: 1,
+      entries: [
+        {
+          type: "plugin",
+          id: "@acme/beta",
+          title: "Beta",
+          version: "2.0.0",
+          state: "available",
+          publisher: { id: "acme", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "acme-npm",
+                package: "@acme/beta",
+                version: "2.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  ];
+  const shards = shardBodies.map((body, index) => ({
+    index,
+    url: `https://packages.acme.example/openclaw/shards/${index}.json`,
+    sha256: crypto.createHash("sha256").update(body).digest("hex"),
+    byteLength: Buffer.byteLength(body, "utf8"),
+    entryCount: 1,
+  }));
+  const signedRoot = signedHostedCatalogDocument({
+    payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+    document: {
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      generatedAt: "2026-06-22T00:00:12.000Z",
+      expiresAt: "2026-06-29T00:00:12.000Z",
+      metadata: { description: "Acme plugins" },
+      entryCount: 2,
+      shards,
+    },
+  });
+  return { shardBodies, shards, signedRoot };
 }
 
 function signedCatalogConfig(publicKeyPem: string): HostedCatalogConfig {
@@ -530,6 +653,144 @@ describe("official external plugin catalog", () => {
     } finally {
       closeOpenClawStateDatabaseForTest();
       rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads signed catalog shards and re-verifies their durable offline snapshot", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, {
+          status: 200,
+          headers: { etag: '"root-12"' },
+        });
+      }
+      const shard = fixture.shards.find((candidate) => candidate.url === url);
+      if (!shard) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(fixture.shardBodies[shard.index], { status: 200 });
+    });
+
+    const live = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore,
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(live.source).toBe("hosted");
+    expect(live.entries.map((entry) => entry.id)).toEqual(["@acme/alpha", "@acme/beta"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const snapshot = await snapshotStore.read("https://packages.acme.example/openclaw/feed");
+    expect(JSON.parse(snapshot?.body ?? "null")).toMatchObject({
+      kind: "official-external-plugin-catalog-shards-v1",
+      rootBody: fixture.signedRoot.body,
+      shardBodies: fixture.shardBodies,
+    });
+
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      offline: true,
+      snapshotStore,
+      now: () => new Date("2026-06-23T00:00:00.000Z"),
+    });
+    expect(offline.source).toBe("hosted-snapshot");
+    expect(offline.entries.map((entry) => entry.id)).toEqual(["@acme/alpha", "@acme/beta"]);
+
+    const expiredOffline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      offline: true,
+      snapshotStore,
+      now: () => new Date("2026-06-30T00:00:00.000Z"),
+    });
+    expect(expiredOffline.source).toBe("bundled-fallback");
+    expect(expiredOffline.entries).toEqual([]);
+  });
+
+  it("fails closed when catalog shard bytes do not match the signed root", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, { status: 200 });
+      }
+      const shard = fixture.shards.find((candidate) => candidate.url === url);
+      return new Response(
+        shard?.index === 0
+          ? fixture.shardBodies[0]?.replace('"Alpha"', '"Alphx"')
+          : fixture.shardBodies[1],
+        { status: 200 },
+      );
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard bytes do not match their signed descriptor");
+    }
+  });
+
+  it("rejects signed catalog shard URLs outside the root origin before fetching them", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const root = JSON.parse(
+      Buffer.from(JSON.parse(fixture.signedRoot.body).payload as string, "base64url").toString(
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    const shards = root.shards as Array<Record<string, unknown>>;
+    shards[0] = { ...shards[0], url: "https://cdn.example.net/catalog/0.json" };
+    const signedRoot = signedHostedCatalogDocument({
+      document: root,
+      payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      privateKeyPem: fixture.signedRoot.privateKeyPem,
+    });
+    const fetchImpl = vi.fn(async () => new Response(signedRoot.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard URL must use the signed root origin");
+    }
+  });
+
+  it("rejects expired signed shard roots before fetching any shard", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const fetchImpl = vi.fn(async () => new Response(fixture.signedRoot.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-30T00:00:00.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard root has expired");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import pLimit from "p-limit";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -961,10 +960,23 @@ async function loadHostedCatalogShardBodies(params: {
     }
   }
   const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
-  const limit = pLimit(DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY);
-  return await Promise.all(
-    params.root.shards.map((descriptor) =>
-      limit(async () => {
+  const controller = new AbortController();
+  const bodies = Array.from({ length: params.root.shards.length }, () => "");
+  let nextIndex = 0;
+  let firstError: unknown;
+  let failed = false;
+  const worker = async () => {
+    while (!controller.signal.aborted) {
+      const index = nextIndex;
+      if (index >= params.root.shards.length) {
+        return;
+      }
+      nextIndex += 1;
+      const descriptor = params.root.shards[index];
+      if (!descriptor) {
+        return;
+      }
+      try {
         let response: Response | undefined;
         let release: (() => Promise<void>) | undefined;
         try {
@@ -975,6 +987,7 @@ async function loadHostedCatalogShardBodies(params: {
             requireHttps: true,
             maxRedirects: 2,
             timeoutMs: params.timeoutMs,
+            signal: controller.signal,
             policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
             auditContext: "official-external-plugin-catalog-shard",
           });
@@ -986,7 +999,7 @@ async function loadHostedCatalogShardBodies(params: {
           if (!response.ok) {
             throw new Error(`hosted catalog shard returned HTTP ${response.status}`);
           }
-          return await readHostedCatalogResponseText({
+          bodies[index] = await readHostedCatalogResponseText({
             response,
             maxBytes: descriptor.byteLength,
             chunkTimeoutMs: params.chunkTimeoutMs,
@@ -997,9 +1010,31 @@ async function loadHostedCatalogShardBodies(params: {
           }
           await release?.().catch(() => undefined);
         }
-      }),
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          firstError = error;
+          controller.abort(error);
+        }
+        return;
+      }
+    }
+  };
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(
+          DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY,
+          params.root.shards.length,
+        ),
+      },
+      worker,
     ),
   );
+  if (failed) {
+    throw firstError;
+  }
+  return bodies;
 }
 
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import pLimit from "p-limit";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -14,6 +15,7 @@ import type {
   PluginPackageInstall,
 } from "./manifest.js";
 import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS } from "./official-external-plugin-bundled-catalogs.js";
+import type { OfficialExternalPluginCatalogShardRoot } from "./official-external-plugin-catalog-shards.js";
 
 type ManifestKey = typeof MANIFEST_KEY;
 
@@ -271,7 +273,9 @@ const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalP
   };
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY = 4;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
 const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
 
@@ -672,17 +676,36 @@ async function parseHostedCatalogFeedBody(params: {
   body: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
   verifiedAt: string;
+  loadShardBodies?: (root: OfficialExternalPluginCatalogShardRoot) => Promise<readonly string[]>;
 }): Promise<{
   feed: OfficialExternalPluginCatalogFeed;
   trust?: HostedOfficialExternalPluginCatalogTrustState;
+  snapshotBody?: string;
+  wireBody?: string;
 }> {
-  const raw = JSON.parse(params.body) as unknown;
+  const document = JSON.parse(params.body) as unknown;
   if (params.verification?.mode === "signed") {
-    const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
-      await import("./official-external-plugin-catalog-envelope.js");
+    const {
+      OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+      OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      verifyOfficialExternalPluginCatalogEnvelopePayload,
+    } = await import("./official-external-plugin-catalog-envelope.js");
+    const {
+      parseOfficialExternalPluginCatalogShardedSnapshot,
+      parseOfficialExternalPluginCatalogShardRoot,
+      serializeOfficialExternalPluginCatalogShardedSnapshot,
+      validateOfficialExternalPluginCatalogShardSet,
+    } = await import("./official-external-plugin-catalog-shards.js");
+    const snapshot = parseOfficialExternalPluginCatalogShardedSnapshot(document);
+    const wireBody = snapshot?.rootBody ?? params.body;
+    const raw = snapshot ? (JSON.parse(snapshot.rootBody) as unknown) : document;
     const threshold = params.verification.threshold ?? 1;
-    const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+    const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
       trustedKeys: params.verification.keys,
+      acceptedPayloadTypes: new Set([
+        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      ]),
       threshold,
     });
     if (!verification.ok) {
@@ -697,8 +720,42 @@ async function parseHostedCatalogFeedBody(params: {
       }
       throw new Error(verification.message);
     }
+    let feed: OfficialExternalPluginCatalogFeed;
+    let snapshotBody: string | undefined;
+    if (verification.payloadType === OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+      if (!isOfficialExternalPluginCatalogFeed(verification.payload)) {
+        const invalidTimestampSequence = readOfficialExternalPluginCatalogInvalidTimestampSequence(
+          verification.payload,
+        );
+        if (invalidTimestampSequence !== undefined) {
+          throw new HostedCatalogFeedTimestampError(
+            "hosted catalog signed envelope payload is invalid",
+            invalidTimestampSequence,
+          );
+        }
+        throw new Error("hosted catalog signed envelope payload is invalid");
+      }
+      feed = verification.payload;
+    } else {
+      const root = parseOfficialExternalPluginCatalogShardRoot(verification.payload);
+      if (Date.parse(root.expiresAt) <= Date.parse(params.verifiedAt)) {
+        throw new Error("hosted catalog shard root has expired");
+      }
+      const shardBodies = snapshot?.shardBodies ?? (await params.loadShardBodies?.(root));
+      if (!shardBodies) {
+        throw new Error("hosted catalog shard set is unavailable");
+      }
+      feed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      snapshotBody =
+        snapshot === null
+          ? serializeOfficialExternalPluginCatalogShardedSnapshot({
+              rootBody: params.body,
+              shardBodies,
+            })
+          : params.body;
+    }
     return {
-      feed: verification.feed,
+      feed,
       trust: {
         mode: "signed",
         signedBy: verification.signedBy,
@@ -706,12 +763,14 @@ async function parseHostedCatalogFeedBody(params: {
         threshold,
         verifiedAt: params.verifiedAt,
       },
+      ...(snapshotBody ? { snapshotBody } : {}),
+      ...(snapshot ? { wireBody } : {}),
     };
   }
-  if (!isOfficialExternalPluginCatalogFeed(raw)) {
+  if (!isOfficialExternalPluginCatalogFeed(document)) {
     throw new Error("hosted catalog feed did not match a supported schema version");
   }
-  return { feed: raw };
+  return { feed: document };
 }
 
 class HostedCatalogFeedTimestampError extends Error {
@@ -751,6 +810,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
   requireManifestInstallSourceRef?: boolean;
   verification?: OfficialExternalPluginCatalogFeedVerification;
+  now?: () => Date;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   assertSnapshotMatchesRequestValidators({
     snapshot: params.snapshot,
@@ -761,14 +821,15 @@ async function loadHostedCatalogSnapshotResult(params: {
   if (checksum !== params.snapshot.metadata.checksum) {
     throw new Error("hosted catalog snapshot checksum mismatch");
   }
-  if (params.expectedSha256 && params.expectedSha256 !== checksum) {
-    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
-  }
   const parsed = await parseHostedCatalogFeedBody({
     body: params.snapshot.body,
     verification: params.verification,
-    verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
+    verifiedAt: (params.now?.() ?? new Date()).toISOString(),
   });
+  const wireChecksum = sha256Hex(parsed.wireBody ?? params.snapshot.body);
+  if (params.expectedSha256 && params.expectedSha256 !== wireChecksum) {
+    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
+  }
   return {
     source: "hosted-snapshot",
     entries: dedupeOfficialExternalPluginCatalogEntries(
@@ -781,7 +842,7 @@ async function loadHostedCatalogSnapshotResult(params: {
       ),
     ),
     feed: parsed.feed,
-    metadata: params.snapshot.metadata,
+    metadata: { ...params.snapshot.metadata, checksum: wireChecksum },
     snapshot: params.snapshot,
     ...(parsed.trust ? { trust: parsed.trust } : {}),
     error: formatHostedCatalogError(params.error),
@@ -832,6 +893,7 @@ async function snapshotOrBundledFallbackResult(params: {
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
   requireManifestInstallSourceRef?: boolean;
   verification?: OfficialExternalPluginCatalogFeedVerification;
+  now?: () => Date;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   if (params.snapshotStore) {
     try {
@@ -846,6 +908,7 @@ async function snapshotOrBundledFallbackResult(params: {
           catalogConfig: params.catalogConfig,
           requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
           verification: params.verification,
+          now: params.now,
         });
       }
     } catch (snapshotErr) {
@@ -881,6 +944,62 @@ async function resolveHostedCatalogSnapshotStore(params: {
     ...(params.stateDir ? { stateDir: params.stateDir } : {}),
     ...(params.stateDatabasePath ? { stateDatabasePath: params.stateDatabasePath } : {}),
   });
+}
+
+async function loadHostedCatalogShardBodies(params: {
+  root: OfficialExternalPluginCatalogShardRoot;
+  rootUrl: string;
+  hostnameAllowlist: readonly string[];
+  fetchImpl?: FetchLike;
+  timeoutMs: number;
+  chunkTimeoutMs: number;
+}): Promise<readonly string[]> {
+  const rootOrigin = new URL(params.rootUrl).origin;
+  for (const descriptor of params.root.shards) {
+    if (new URL(descriptor.url).origin !== rootOrigin) {
+      throw new Error("hosted catalog shard URL must use the signed root origin");
+    }
+  }
+  const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
+  const limit = pLimit(DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY);
+  return await Promise.all(
+    params.root.shards.map((descriptor) =>
+      limit(async () => {
+        let response: Response | undefined;
+        let release: (() => Promise<void>) | undefined;
+        try {
+          const guarded = await fetchWithSsrFGuard({
+            url: descriptor.url,
+            fetchImpl: params.fetchImpl,
+            init: { method: "GET" },
+            requireHttps: true,
+            maxRedirects: 2,
+            timeoutMs: params.timeoutMs,
+            policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
+            auditContext: "official-external-plugin-catalog-shard",
+          });
+          response = guarded.response;
+          release = guarded.release;
+          if (new URL(guarded.finalUrl).origin !== rootOrigin) {
+            throw new Error("hosted catalog shard redirect changed the signed root origin");
+          }
+          if (!response.ok) {
+            throw new Error(`hosted catalog shard returned HTTP ${response.status}`);
+          }
+          return await readHostedCatalogResponseText({
+            response,
+            maxBytes: descriptor.byteLength,
+            chunkTimeoutMs: params.chunkTimeoutMs,
+          });
+        } finally {
+          if (response?.bodyUsed !== true) {
+            await response?.body?.cancel().catch(() => undefined);
+          }
+          await release?.().catch(() => undefined);
+        }
+      }),
+    ),
+  );
 }
 
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
@@ -938,6 +1057,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       catalogConfig: params?.catalogConfig,
       requireManifestInstallSourceRef,
       verification: source.verification,
+      now: params?.now,
     });
   }
   const headers = new Headers();
@@ -975,6 +1095,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     });
     response = guarded.response;
     release = guarded.release;
+    const rootFinalUrl = guarded.finalUrl;
     const base = metadataBase(response);
     if (response.status === 304) {
       return await snapshotOrBundledFallbackResult({
@@ -988,6 +1109,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
         verification: source.verification,
+        now: params?.now,
       });
     }
     if (!response.ok) {
@@ -1002,11 +1124,16 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
         verification: source.verification,
+        now: params?.now,
       });
     }
     const body = await readHostedCatalogResponseText({
       response,
-      maxBytes: params?.maxBytes ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES,
+      maxBytes:
+        params?.maxBytes ??
+        (source.verification?.mode === "signed"
+          ? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES
+          : DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES),
       chunkTimeoutMs:
         params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
     });
@@ -1024,6 +1151,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
         verification: source.verification,
+        now: params?.now,
       });
     }
     const verifiedAt = (params?.now?.() ?? new Date()).toISOString();
@@ -1031,6 +1159,18 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       body,
       verification: source.verification,
       verifiedAt,
+      loadShardBodies: async (root) =>
+        await loadHostedCatalogShardBodies({
+          root,
+          rootUrl: rootFinalUrl,
+          hostnameAllowlist: source.hostnameAllowlist,
+          fetchImpl: params?.fetchImpl,
+          timeoutMs:
+            params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+          chunkTimeoutMs:
+            params?.chunkTimeoutMs ??
+            DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
+        }),
     }).catch(async (err: unknown) => {
       return await snapshotOrBundledFallbackResult({
         error: err,
@@ -1043,6 +1183,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
         verification: source.verification,
+        now: params?.now,
       });
     });
     if ("source" in parsed) {
@@ -1075,10 +1216,15 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
       },
     );
+    const snapshotBody = parsed.snapshotBody ?? body;
+    const snapshotMetadata = {
+      ...metadata,
+      checksum: sha256Hex(snapshotBody),
+    };
     await snapshotStore
       ?.write({
-        body,
-        metadata,
+        body: snapshotBody,
+        metadata: snapshotMetadata,
         savedAt: verifiedAt,
         ...(parsed.trust ? { trust: parsed.trust } : {}),
         ...(parsed.trust?.mode === "signed"
@@ -1123,6 +1269,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       catalogConfig: params?.catalogConfig,
       requireManifestInstallSourceRef,
       verification: source.verification,
+      now: params?.now,
     });
   } finally {
     if (response?.bodyUsed !== true) {

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -2,7 +2,8 @@ import type { DatabaseSync } from "node:sqlite";
 import type { SqliteWalMaintenance } from "../infra/sqlite-wal.js";
 
 // v5 records durable cloud-worker result refs on pending workspace fences.
-export const OPENCLAW_STATE_SCHEMA_VERSION = 5;
+// v6 adds local marketplace feed watches and their bounded update history.
+export const OPENCLAW_STATE_SCHEMA_VERSION = 6;
 export const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 /** Maximum time one synchronous SQLite call may wait for a lock. */
 export const OPENCLAW_SQLITE_BUSY_TIMEOUT_MS = 5_000;
@@ -27,6 +28,7 @@ export type OpenClawStateDatabaseSchemaMigration = {
     | "audit-events-v2"
     | "operator-approvals-system-agent"
     | "session-watch-cursor-provenance-v4"
+    | "marketplace-feed-watches-v6"
     | "strict-tables-v3";
   path: string;
 };

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -168,6 +168,9 @@ export function detectOpenClawStateDatabaseSchemaMigrations(
     if (sessionWatchMigration.needsSessionWatchCursorProvenanceMigration(db, userVersion)) {
       migrations.push({ kind: "session-watch-cursor-provenance-v4", path: pathname });
     }
+    if (tableExists(db, "audit_events") && userVersion < OPENCLAW_STATE_SCHEMA_VERSION) {
+      migrations.push({ kind: "marketplace-feed-watches-v6", path: pathname });
+    }
     migrations.push(
       ...operatorApprovalMigration.detectOperatorApprovalSchemaMigration(db, pathname),
     );

--- a/src/state/openclaw-state-db.feed-watches.test.ts
+++ b/src/state/openclaw-state-db.feed-watches.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  detectOpenClawStateDatabaseSchemaMigrations,
+  openOpenClawStateDatabase,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "./openclaw-state-db.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("OpenClaw state feed watch migration", () => {
+  it("adds v5 watch tables after the v4 cursor migration without losing snapshots", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-feed-watch-"));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, "state.sqlite");
+    const opened = openOpenClawStateDatabase({ path: databasePath });
+    opened.db
+      .prepare(
+        `INSERT INTO official_external_plugin_catalog_snapshots (
+          feed_url, body, status, etag, last_modified, checksum, saved_at,
+          trust_mode, trust_key_id, trust_signature_count, trust_threshold,
+          trust_verified_at, updated_at_ms
+        ) VALUES (?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "https://clawhub.ai/v1/feeds/plugins",
+        '{"sequence":7}',
+        200,
+        "sha256:accepted",
+        "2026-07-17T00:00:00.000Z",
+        "signed",
+        "clawhub-feed-2026",
+        1,
+        1,
+        "2026-07-17T00:00:00.000Z",
+        1,
+      );
+    closeOpenClawStateDatabaseForTest();
+
+    const sqlite = requireNodeSqlite();
+    const legacy = new sqlite.DatabaseSync(databasePath);
+    legacy.exec(`
+      DROP TABLE marketplace_feed_updates;
+      DROP TABLE marketplace_feed_watches;
+      PRAGMA user_version = 3;
+      UPDATE schema_meta SET schema_version = 3 WHERE meta_key = 'primary';
+    `);
+    legacy.close();
+
+    expect(detectOpenClawStateDatabaseSchemaMigrations({ path: databasePath })).toEqual([
+      { kind: "session-watch-cursor-provenance-v4", path: databasePath },
+      { kind: "marketplace-feed-watches-v6", path: databasePath },
+    ]);
+
+    const migrated = openOpenClawStateDatabase({ path: databasePath });
+    expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+    expect(
+      migrated.db
+        .prepare(
+          "SELECT checksum FROM official_external_plugin_catalog_snapshots WHERE feed_url = ?",
+        )
+        .get("https://clawhub.ai/v1/feeds/plugins"),
+    ).toEqual({ checksum: "sha256:accepted" });
+    expect(
+      migrated.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name IN (?, ?) ORDER BY name",
+        )
+        .all("marketplace_feed_updates", "marketplace_feed_watches"),
+    ).toEqual([{ name: "marketplace_feed_updates" }, { name: "marketplace_feed_watches" }]);
+  });
+});

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -683,6 +683,34 @@ export interface ManagedOutgoingImageRecords {
   updated_at: string | null;
 }
 
+export interface MarketplaceFeedUpdates {
+  dismissed_at_ms: number | null;
+  event_id: string;
+  feed_id: string;
+  feed_sequence: number;
+  item_id: string;
+  item_kind: string;
+  item_state: string | null;
+  item_version: string | null;
+  observed_at_ms: number;
+  read_at_ms: number | null;
+  reason: string;
+  title: string | null;
+}
+
+export interface MarketplaceFeedWatches {
+  baseline_json: string | null;
+  created_at_ms: number;
+  feed_id: string;
+  feed_profile: string | null;
+  feed_url: string;
+  item_id: string;
+  item_kind: string;
+  last_sequence: number;
+  muted: Generated<number>;
+  updated_at_ms: number;
+}
+
 export interface McpOauthStores {
   format_version: number;
   store_json: string;
@@ -1381,6 +1409,8 @@ export interface DB {
   installed_plugin_index: InstalledPluginIndex;
   macos_port_guardian_records: MacosPortGuardianRecords;
   managed_outgoing_image_records: ManagedOutgoingImageRecords;
+  marketplace_feed_updates: MarketplaceFeedUpdates;
+  marketplace_feed_watches: MarketplaceFeedWatches;
   mcp_oauth_stores: McpOauthStores;
   media_blobs: MediaBlobs;
   migration_runs: MigrationRuns;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1083,11 +1083,13 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([
       { kind: "strict-tables-v3", path: databasePath },
       { kind: "session-watch-cursor-provenance-v4", path: databasePath },
+      { kind: "marketplace-feed-watches-v6", path: databasePath },
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
         "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
         "Migrated shared state tables to SQLite STRICT typing (1)",
+        "Added local marketplace feed watch and update history tables",
       ],
       warnings: [],
     });
@@ -1115,10 +1117,12 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([
       { kind: "session-watch-cursor-provenance-v4", path: seeded.databasePath },
+      { kind: "marketplace-feed-watches-v6", path: seeded.databasePath },
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
         "Migrated shared state session watch cursors → provenance column (1 ambient, 3 sentinels removed)",
+        "Added local marketplace feed watch and update history tables",
       ],
       warnings: [],
     });
@@ -1596,6 +1600,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([
       { kind: "audit-events-v2", path: databasePath },
       { kind: "strict-tables-v3", path: databasePath },
+      { kind: "marketplace-feed-watches-v6", path: databasePath },
     ]);
     expect(() => openOpenClawStateDatabase(options)).toThrow(/legacy audit event schema/);
 
@@ -1603,6 +1608,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       changes: [
         "Migrated shared state audit event ledger → versioned message lifecycle schema",
         "Migrated shared state tables to SQLite STRICT typing (3)",
+        "Added local marketplace feed watch and update history tables",
       ],
       warnings: [],
     });

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -188,6 +188,9 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
               `Migrated shared state tables to SQLite STRICT typing (${strictMigration.migratedTables.length})`,
             );
           }
+          if (previousVersion < OPENCLAW_STATE_SCHEMA_VERSION) {
+            applied.push("Added local marketplace feed watch and update history tables");
+          }
         }
         markCurrentStateSchemaVersion(db);
         return applied;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -828,6 +828,51 @@ CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
 CREATE INDEX IF NOT EXISTS idx_official_external_plugin_catalog_snapshots_updated
   ON official_external_plugin_catalog_snapshots(updated_at_ms DESC, feed_url);
 
+CREATE TABLE IF NOT EXISTS marketplace_feed_watches (
+  feed_id TEXT NOT NULL,
+  item_kind TEXT NOT NULL CHECK (item_kind IN ('plugin', 'skill')),
+  item_id TEXT NOT NULL,
+  baseline_json TEXT,
+  feed_url TEXT NOT NULL,
+  feed_profile TEXT,
+  last_sequence INTEGER NOT NULL CHECK (last_sequence >= 0),
+  muted INTEGER NOT NULL DEFAULT 0 CHECK (muted IN (0, 1)),
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (feed_id, item_kind, item_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_watches_profile
+  ON marketplace_feed_watches(feed_profile, feed_id, item_kind, item_id);
+
+CREATE TABLE IF NOT EXISTS marketplace_feed_updates (
+  event_id TEXT NOT NULL PRIMARY KEY,
+  feed_id TEXT NOT NULL,
+  item_kind TEXT NOT NULL CHECK (item_kind IN ('plugin', 'skill')),
+  item_id TEXT NOT NULL,
+  feed_sequence INTEGER NOT NULL CHECK (feed_sequence >= 0),
+  reason TEXT NOT NULL CHECK (
+    reason IN ('updated', 'removed', 'blocked', 'security-state-changed')
+  ),
+  title TEXT,
+  item_version TEXT,
+  item_state TEXT,
+  observed_at_ms INTEGER NOT NULL,
+  read_at_ms INTEGER,
+  dismissed_at_ms INTEGER,
+  UNIQUE (feed_id, item_kind, item_id, feed_sequence, reason)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_updates_observed
+  ON marketplace_feed_updates(observed_at_ms DESC, event_id);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_updates_unread
+  ON marketplace_feed_updates(observed_at_ms DESC, event_id)
+  WHERE read_at_ms IS NULL AND dismissed_at_ms IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_updates_item
+  ON marketplace_feed_updates(feed_id, item_kind, item_id, feed_sequence DESC);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -823,6 +823,51 @@ CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
 CREATE INDEX IF NOT EXISTS idx_official_external_plugin_catalog_snapshots_updated
   ON official_external_plugin_catalog_snapshots(updated_at_ms DESC, feed_url);
 
+CREATE TABLE IF NOT EXISTS marketplace_feed_watches (
+  feed_id TEXT NOT NULL,
+  item_kind TEXT NOT NULL CHECK (item_kind IN ('plugin', 'skill')),
+  item_id TEXT NOT NULL,
+  baseline_json TEXT,
+  feed_url TEXT NOT NULL,
+  feed_profile TEXT,
+  last_sequence INTEGER NOT NULL CHECK (last_sequence >= 0),
+  muted INTEGER NOT NULL DEFAULT 0 CHECK (muted IN (0, 1)),
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (feed_id, item_kind, item_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_watches_profile
+  ON marketplace_feed_watches(feed_profile, feed_id, item_kind, item_id);
+
+CREATE TABLE IF NOT EXISTS marketplace_feed_updates (
+  event_id TEXT NOT NULL PRIMARY KEY,
+  feed_id TEXT NOT NULL,
+  item_kind TEXT NOT NULL CHECK (item_kind IN ('plugin', 'skill')),
+  item_id TEXT NOT NULL,
+  feed_sequence INTEGER NOT NULL CHECK (feed_sequence >= 0),
+  reason TEXT NOT NULL CHECK (
+    reason IN ('updated', 'removed', 'blocked', 'security-state-changed')
+  ),
+  title TEXT,
+  item_version TEXT,
+  item_state TEXT,
+  observed_at_ms INTEGER NOT NULL,
+  read_at_ms INTEGER,
+  dismissed_at_ms INTEGER,
+  UNIQUE (feed_id, item_kind, item_id, feed_sequence, reason)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_updates_observed
+  ON marketplace_feed_updates(observed_at_ms DESC, event_id);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_updates_unread
+  ON marketplace_feed_updates(observed_at_ms DESC, event_id)
+  WHERE read_at_ms IS NULL AND dismissed_at_ms IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_feed_updates_item
+  ON marketplace_feed_updates(feed_id, item_kind, item_id, feed_sequence DESC);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,


### PR DESCRIPTION
## What Problem This Solves

Signed marketplace feeds can be refreshed and inspected, but users cannot durably watch individual entries or review verified changes later. That leaves update awareness as a manual full-catalog comparison.

## Why This Change Was Made

This adds the first client-side watch slice described by the feeds notification plan:

- durable local plugin watches and bounded update history in shared SQLite schema v5
- verified refresh materialization for version/install, removal, blocked, and publisher/security-state changes
- per-watch accepted baselines so unsigned intermediate writes and skipped sequences cannot lose changes
- source binding by feed ID and URL, plus idempotent read/dismiss and functional mute behavior
- `plugins marketplace watch ...` and `plugins marketplace updates ...` operator commands

Only accepted signed plugin feeds can create or advance watches. The schema keeps `item_kind` generic for skills, but this PR does not claim skill watches before a signed skill-feed producer exists.

## User Impact

Users can watch a marketplace plugin, refresh its signed feed normally, list verified local updates, and mark those updates read or dismissed. Muted watches keep their trusted baseline current without producing update events. History is bounded to 500 watches and 500 updates.

This remains local client state. It does not add a hosted inbox, push delivery, polling daemon, or server-side notification service.

## Evidence

- 87 shared-state and schema migration tests
- 53 doctor/state migration tests
- 50 marketplace, signed-feed, and watch-store tests
- 6 lazy CLI routing tests
- generated Kysely schema verification
- type-aware `oxlint` and `oxfmt --check`
- `codex review --uncommitted`: clean after addressing event-ID usability, mute semantics, unsigned-baseline continuity, and source isolation

Core `tsgo` was also attempted. Its only branch-owned exhaustive-switch finding was fixed; the remaining diagnostics came from the reused dependency tree being out of sync with this checkout (unrelated missing/older package types).

## Real behavior proof

Behavior or issue addressed:
A plugin watched from an accepted signed marketplace feed must retain its baseline in local SQLite and materialize a verified update when a newer signed sequence changes that plugin.

Real environment tested:
Ubuntu 24.04 under WSL2, Node 24.15.0, PR head `d1c1d82a01a3ab58dc3c3b7bcf2ffc97729572f0`, isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`, a short-lived mutable public JSON HTTPS endpoint serving two DSSE/Ed25519-signed feed revisions, and the real OpenClaw config loader, hosted-feed loader, command handlers, and shared SQLite store. The ephemeral private key remained local with mode 0600 and was deleted after the run; the public fixture was deleted.

Exact steps or command run after this patch:
1. Generate an ephemeral Ed25519 key and signed feed sequence 1 containing `proof-plugin` version `1.0.0`.
2. Publish it at `https://jsonblob.com/api/jsonBlob/<redacted>`; configure profile `proof` with the matching public key and `proof-npm` source.
3. Invoke `loadConfiguredHostedOfficialExternalPluginCatalogEntries(loadConfig(), { feedProfile: "proof", timeoutMs: 30000 })` to accept the real HTTPS snapshot. The timeout override was needed because this WSL network exceeded the command's fixed 5-second fetch budget.
4. In a new Node process, invoke `runMarketplaceWatchAddCommand("proof-plugin", { feedProfile: "proof", offline: true, json: true })` against that accepted signed snapshot.
5. In another process, list watches and updates; the watch persisted at sequence 1 and no update existed yet.
6. Replace the bytes at the same HTTPS URL with signed sequence 2, changing the version to `1.1.0`, and invoke the production hosted-feed loader again with the same explicit proof timeout.
7. In another process, invoke the update and watch list command handlers.

Evidence after fix:
```text
accepted sequence 1:
{
  "source": "hosted",
  "feedId": "openclaw-proof-feed-110438",
  "sequence": 1,
  "trust": { "mode": "signed", "signedBy": "proof-root-2026", "signatureCount": 1, "threshold": 1 },
  "entries": [{ "id": "proof-plugin", "version": "1.0.0" }]
}

watch creation:
{
  "created": true,
  "watch": {
    "feedId": "openclaw-proof-feed-110438",
    "feedProfile": "proof",
    "itemKind": "plugin",
    "itemId": "proof-plugin",
    "lastSequence": 1,
    "muted": false
  }
}

separate process before change:
{ "watches": [{ "itemId": "proof-plugin", "lastSequence": 1 }], "count": 1 }
{ "updates": [], "count": 0 }

accepted sequence 2:
{
  "source": "hosted",
  "feedId": "openclaw-proof-feed-110438",
  "sequence": 2,
  "trust": { "mode": "signed", "signedBy": "proof-root-2026", "signatureCount": 1, "threshold": 1 },
  "entries": [{ "id": "proof-plugin", "version": "1.1.0" }]
}

separate process after change:
{
  "updates": [{
    "feedId": "openclaw-proof-feed-110438",
    "itemKind": "plugin",
    "itemId": "proof-plugin",
    "feedSequence": 2,
    "reason": "updated",
    "title": "Signed Feed Proof Plugin",
    "itemVersion": "1.1.0",
    "itemState": "available"
  }],
  "count": 1
}
{ "watches": [{ "itemId": "proof-plugin", "lastSequence": 2 }], "count": 1 }
```

Observed result after fix:
The real HTTPS feed was accepted only after Ed25519 verification, the watch survived independent process restarts in shared SQLite, sequence 1 produced no false update, and signed sequence 2 produced exactly one persisted `updated` event for version `1.1.0` while advancing the watch baseline to sequence 2.

What was not tested:
The packaged/full CLI bootstrap was not used because its source launcher did not reach the action in this checkout within 30 seconds; exported production command handlers were invoked directly. The network loader used a 30-second proof timeout rather than the command's fixed 5-second timeout. Skill watches remain intentionally unsupported. Shared SQLite v5 ownership and downgrade policy still require explicit core maintainer acceptance before merge.


