### PR TITLE
fix(tlon): release failed upload response bodies

### DIFF
--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -55,15 +55,22 @@ function createMemexResponse(
   );
 }
 
-function createGuardedResult(response: Response, finalUrl: string) {
+function createGuardedResult(
+  response: Response,
+  finalUrl: string,
+  release: () => Promise<void> = mockRelease,
+) {
   return {
     response,
     finalUrl,
-    release: mockRelease,
+    release,
   };
 }
 
-function responseWithCancelableBody(status: number, cancelBody: () => void): Response {
+function responseWithCancelableBody(
+  status: number,
+  cancelBody: () => void | PromiseLike<void>,
+): Response {
   return new Response(
     new ReadableStream<Uint8Array>({
       cancel: cancelBody,
@@ -118,16 +125,16 @@ describe("uploadFile memex upload hardening", () => {
   });
 
   it("routes the memex upload URL through the SSRF guard", async () => {
+    const lookupResponse = createMemexResponse("https://uploads.tlon.network/put");
+    const lookupCancel = vi.spyOn(lookupResponse.body!, "cancel");
+    const uploadCancel = vi.fn();
     mockGuardedFetch
       .mockResolvedValueOnce(
-        createGuardedResult(
-          createMemexResponse("https://uploads.tlon.network/put"),
-          "https://memex.tlon.network/v1/zod/upload",
-        ),
+        createGuardedResult(lookupResponse, "https://memex.tlon.network/v1/zod/upload"),
       )
       .mockResolvedValueOnce(
         createGuardedResult(
-          new Response(null, { status: 200 }),
+          responseWithCancelableBody(200, uploadCancel),
           "https://uploads.tlon.network/put",
         ),
       );
@@ -168,15 +175,24 @@ describe("uploadFile memex upload hardening", () => {
     expect(secondCall?.maxRedirects).toBe(0);
     expect(secondCall?.timeoutMs).toBe(300_000);
     expect(secondCall?.init?.body).toBeInstanceOf(Blob);
+    expect(lookupCancel).not.toHaveBeenCalled();
+    expect(uploadCancel).toHaveBeenCalledTimes(1);
     expect(mockRelease).toHaveBeenCalledTimes(2);
   });
 
   it("cancels failed Memex upload URL responses before releasing their guard", async () => {
-    const cancelBody = vi.fn();
+    const events: string[] = [];
+    const cancelBody = vi.fn(() => {
+      events.push("cancel");
+    });
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
     mockGuardedFetch.mockResolvedValueOnce(
       createGuardedResult(
         responseWithCancelableBody(500, cancelBody),
         "https://memex.tlon.network/v1/zod/upload",
+        release,
       ),
     );
 
@@ -189,7 +205,8 @@ describe("uploadFile memex upload hardening", () => {
     ).rejects.toThrow("Memex upload request failed: 500");
 
     expect(cancelBody).toHaveBeenCalledTimes(1);
-    expect(mockRelease).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["cancel", "release"]);
   });
 
   it("surfaces guarded upload failures for hosted Memex targets", async () => {
@@ -569,10 +586,13 @@ describe("uploadFile custom S3 upload hardening", () => {
   });
 
   it("routes the custom S3 signed URL through the SSRF guard", async () => {
+    const cancelBody = vi.fn(async () => {
+      throw new Error("stream cancellation failed");
+    });
     mockGetSignedUrl.mockResolvedValueOnce("https://s3.example.com/uploads/file?sig=abc");
     mockGuardedFetch.mockResolvedValueOnce(
       createGuardedResult(
-        new Response(null, { status: 200 }),
+        responseWithCancelableBody(200, cancelBody),
         "https://s3.example.com/uploads/file?sig=abc",
       ),
     );
@@ -599,6 +619,7 @@ describe("uploadFile custom S3 upload hardening", () => {
     expect(uploadCall?.maxRedirects).toBe(0);
     expect(uploadCall?.timeoutMs).toBe(300_000);
     expect(uploadCall?.policy).toBeUndefined();
+    expect(cancelBody).toHaveBeenCalledTimes(1);
     expect(mockRelease).toHaveBeenCalledTimes(1);
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
   });

--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -63,6 +63,15 @@ function createGuardedResult(response: Response, finalUrl: string) {
   };
 }
 
+function responseWithCancelableBody(status: number, cancelBody: () => void): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      cancel: cancelBody,
+    }),
+    { status },
+  );
+}
+
 function guardedFetchCall(index: number): Parameters<typeof fetchWithSsrFGuard>[0] {
   const call = mockGuardedFetch.mock.calls[index]?.at(0);
   if (call === undefined) {
@@ -162,6 +171,27 @@ describe("uploadFile memex upload hardening", () => {
     expect(mockRelease).toHaveBeenCalledTimes(2);
   });
 
+  it("cancels failed Memex upload URL responses before releasing their guard", async () => {
+    const cancelBody = vi.fn();
+    mockGuardedFetch.mockResolvedValueOnce(
+      createGuardedResult(
+        responseWithCancelableBody(500, cancelBody),
+        "https://memex.tlon.network/v1/zod/upload",
+      ),
+    );
+
+    await expect(
+      uploadFile({
+        blob: new Blob(["image-bytes"], { type: "image/png" }),
+        fileName: "avatar.png",
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow("Memex upload request failed: 500");
+
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces guarded upload failures for hosted Memex targets", async () => {
     mockGuardedFetch
       .mockResolvedValueOnce(
@@ -188,6 +218,62 @@ describe("uploadFile memex upload hardening", () => {
     expect(uploadCall?.capture).toBe(false);
     expect(uploadCall?.maxRedirects).toBe(0);
     expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels failed Memex upload responses before releasing their guard", async () => {
+    const cancelBody = vi.fn();
+    mockGuardedFetch
+      .mockResolvedValueOnce(
+        createGuardedResult(
+          createMemexResponse("https://uploads.tlon.network/put"),
+          "https://memex.tlon.network/v1/zod/upload",
+        ),
+      )
+      .mockResolvedValueOnce(
+        createGuardedResult(
+          responseWithCancelableBody(500, cancelBody),
+          "https://uploads.tlon.network/put",
+        ),
+      );
+
+    await expect(
+      uploadFile({
+        blob: new Blob(["image-bytes"], { type: "image/png" }),
+        fileName: "avatar.png",
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow("Upload failed: 500");
+
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(mockRelease).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels hosted upload responses when their final URL is untrusted", async () => {
+    const cancelBody = vi.fn();
+    mockGuardedFetch
+      .mockResolvedValueOnce(
+        createGuardedResult(
+          createMemexResponse("https://uploads.tlon.network/put"),
+          "https://memex.tlon.network/v1/zod/upload",
+        ),
+      )
+      .mockResolvedValueOnce(
+        createGuardedResult(
+          responseWithCancelableBody(200, cancelBody),
+          "https://evil.example/put",
+        ),
+      );
+
+    await expect(
+      uploadFile({
+        blob: new Blob(["image-bytes"], { type: "image/png" }),
+        fileName: "avatar.png",
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow("Memex final upload URL must target a trusted hosted Tlon domain");
+
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(mockRelease).toHaveBeenCalledTimes(2);
   });
 
   it("rejects Memex upload targets outside the hosted Tlon domain allowlist", async () => {
@@ -532,6 +618,28 @@ describe("uploadFile custom S3 upload hardening", () => {
     expect(mockGuardedFetch).toHaveBeenCalledTimes(1);
     expect(mockRelease).not.toHaveBeenCalled();
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it("cancels failed custom S3 upload responses before releasing their guard", async () => {
+    const cancelBody = vi.fn();
+    mockGetSignedUrl.mockResolvedValueOnce("https://s3.example.com/uploads/file?sig=abc");
+    mockGuardedFetch.mockResolvedValueOnce(
+      createGuardedResult(
+        responseWithCancelableBody(500, cancelBody),
+        "https://s3.example.com/uploads/file?sig=abc",
+      ),
+    );
+
+    await expect(
+      uploadFile({
+        blob: new Blob(["image-bytes"], { type: "image/png" }),
+        fileName: "avatar.png",
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow("Upload failed: 500");
+
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
   });
 
   it("passes the private-network opt-in to guarded custom S3 uploads", async () => {

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -261,6 +261,7 @@ async function getMemexUploadUrl(params: {
     });
     release = guarded.release;
     if (!guarded.response.ok) {
+      await guarded.response.body?.cancel().catch(() => undefined);
       throw new Error(`Memex upload request failed: ${guarded.response.status}`);
     }
 
@@ -328,8 +329,14 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
         timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
       });
       release = guarded.release;
-      assertTrustedMemexUploadUrl(guarded.finalUrl, "Memex final upload URL");
+      try {
+        assertTrustedMemexUploadUrl(guarded.finalUrl, "Memex final upload URL");
+      } catch (error) {
+        await guarded.response.body?.cancel().catch(() => undefined);
+        throw error;
+      }
       if (!guarded.response.ok) {
+        await guarded.response.body?.cancel().catch(() => undefined);
         throw new Error(`Upload failed: ${guarded.response.status}`);
       }
     } finally {
@@ -388,6 +395,7 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
     });
     release = guarded.release;
     if (!guarded.response.ok) {
+      await guarded.response.body?.cancel().catch(() => undefined);
       throw new Error(`Upload failed: ${guarded.response.status}`);
     }
   } finally {

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -58,6 +58,25 @@ const TLON_UPLOAD_TIMEOUT_MS = 300_000;
 
 let currentClientConfig: ClientConfig | null = null;
 
+async function releaseUploadResponse(
+  guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined,
+): Promise<void> {
+  if (!guarded) {
+    return;
+  }
+  try {
+    // Guard release closes the dispatcher, not an unread response stream. Settle terminal
+    // upload bodies first so a streaming response cannot delay dispatcher cleanup.
+    if (!guarded.response.bodyUsed) {
+      await guarded.response.body?.cancel();
+    }
+  } catch {
+    // Response cancellation is best-effort; dispatcher release must still run.
+  } finally {
+    await guarded.release();
+  }
+}
+
 export function configureClient(params: ClientConfig): void {
   currentClientConfig = {
     ...params,
@@ -240,9 +259,9 @@ async function getMemexUploadUrl(params: {
   }
 
   const endpoint = `${MEMEX_BASE_URL}/v1/${params.config.shipName}/upload`;
-  let release: (() => Promise<void>) | undefined;
+  let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined;
   try {
-    const guarded = await fetchWithSsrFGuard({
+    guarded = await fetchWithSsrFGuard({
       url: endpoint,
       init: {
         method: "PUT",
@@ -259,9 +278,7 @@ async function getMemexUploadUrl(params: {
       maxRedirects: 0,
       timeoutMs: TLON_MEMEX_UPLOAD_URL_TIMEOUT_MS,
     });
-    release = guarded.release;
     if (!guarded.response.ok) {
-      await guarded.response.body?.cancel().catch(() => undefined);
       throw new Error(`Memex upload request failed: ${guarded.response.status}`);
     }
 
@@ -276,7 +293,7 @@ async function getMemexUploadUrl(params: {
 
     return { hostedUrl: data.filePath, uploadUrl: data.url };
   } finally {
-    await release?.();
+    await releaseUploadResponse(guarded);
   }
 }
 
@@ -311,9 +328,9 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
     });
     const trustedUploadUrl = assertTrustedMemexUploadUrl(uploadUrl, "Memex upload URL");
 
-    let release: (() => Promise<void>) | undefined;
+    let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined;
     try {
-      const guarded = await fetchWithSsrFGuard({
+      guarded = await fetchWithSsrFGuard({
         url: trustedUploadUrl,
         init: {
           method: "PUT",
@@ -328,19 +345,12 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
         maxRedirects: 0,
         timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
       });
-      release = guarded.release;
-      try {
-        assertTrustedMemexUploadUrl(guarded.finalUrl, "Memex final upload URL");
-      } catch (error) {
-        await guarded.response.body?.cancel().catch(() => undefined);
-        throw error;
-      }
+      assertTrustedMemexUploadUrl(guarded.finalUrl, "Memex final upload URL");
       if (!guarded.response.ok) {
-        await guarded.response.body?.cancel().catch(() => undefined);
         throw new Error(`Upload failed: ${guarded.response.status}`);
       }
     } finally {
-      await release?.();
+      await releaseUploadResponse(guarded);
     }
 
     return { url: assertTrustedMemexUploadUrl(hostedUrl, "Memex hosted URL") };
@@ -378,9 +388,9 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
     expiresIn: 3600,
   });
 
-  let release: (() => Promise<void>) | undefined;
+  let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined;
   try {
-    const guarded = await fetchWithSsrFGuard({
+    guarded = await fetchWithSsrFGuard({
       url: signedUrl,
       init: {
         method: "PUT",
@@ -393,13 +403,11 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
       policy: privateNetworkPolicy,
       timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
     });
-    release = guarded.release;
     if (!guarded.response.ok) {
-      await guarded.response.body?.cancel().catch(() => undefined);
       throw new Error(`Upload failed: ${guarded.response.status}`);
     }
   } finally {
-    await release?.();
+    await releaseUploadResponse(guarded);
   }
 
   const publicUrl = storageConfig.publicUrlBase


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where failed Tlon Memex or custom S3 uploads discard an unread HTTP response body before releasing their request guard.

## Why This Change Was Made

Each terminal failed upload response now cancels its unread body before guard release, including a rejected hosted-upload final URL. Successful URLs, upload targets, error text, and retry behavior are unchanged.

## User Impact

Failed Tlon uploads no longer retain HTTP connections while an upstream response body remains open.

## Evidence

Focused regression test:

```
node scripts/run-vitest.mjs extensions/tlon/src/tlon-api.test.ts
19 passed
```

Manual real-behavior proof drove the production `uploadFile` custom-S3 path and real SSRF guard against a real localhost streaming 500 server. Only external auth, storage discovery, and URL-signing seams were supplied so the production upload path could reach the loopback server:

```
before: upload-error=Upload failed: 500 connection-closed=false
after:  upload-error=Upload failed: 500 connection-closed=true
```

The original upload error remained unchanged. No live Tlon or S3 credentials were used.

AI-assisted: Codex helped implement the change; proof was run manually.
