### PR TITLE
fix(qa): discard ignored guarded response bodies

### DIFF
--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -4,9 +4,13 @@ import path from "node:path";
 import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { createQaCrablineTransportAdapter } from "./crabline-transport.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function createSelection(channel: OpenClawCrablineChannelDriverSelection["channel"] = "telegram") {
   return {
@@ -25,6 +29,42 @@ function requireString(value: unknown, label: string): string {
 }
 
 describe("crabline transport", () => {
+  it("cancels a failed inbound response before surfacing the provider error", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+      const cancel = vi.fn(() => {
+        throw new Error("cancel failed");
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(new ReadableStream<Uint8Array>({ cancel }), {
+              status: 503,
+            }),
+        ),
+      );
+
+      try {
+        await expect(
+          transport.sendInbound({
+            conversation: { id: "-1001234567890", kind: "group" },
+            senderId: "100001",
+            senderName: "Alice",
+            text: "Telegram failure marker.",
+          }),
+        ).rejects.toThrow("Crabline telegram inbound injection failed with HTTP 503");
+        expect(cancel).toHaveBeenCalledOnce();
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
   it("configures OpenClaw's Telegram plugin against a Crabline local provider server", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -24,6 +24,7 @@ import {
   resolveTelegramQaSenderId,
 } from "./crabline-provider-targets.js";
 import { QaSuiteInfraError } from "./errors.js";
+import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import {
   QaStateBackedTransportAdapter,
   waitForQaTransportOutboundSequence,
@@ -209,6 +210,7 @@ async function postCrablineInbound(params: {
   });
   try {
     if (!response.ok) {
+      await discardIgnoredResponseBody(response);
       throw new Error(
         `Crabline ${params.adapter.channel} inbound injection failed with HTTP ${response.status}.`,
       );

--- a/extensions/qa-lab/src/ignored-response-body.test.ts
+++ b/extensions/qa-lab/src/ignored-response-body.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { discardIgnoredResponseBody } from "./ignored-response-body.js";
+
+describe("discardIgnoredResponseBody", () => {
+  it("swallows cancellation failures for an unread body", async () => {
+    const cancel = vi.fn(() => {
+      throw new Error("cancel failed");
+    });
+    const response = new Response(new ReadableStream<Uint8Array>({ cancel }));
+
+    await expect(discardIgnoredResponseBody(response)).resolves.toBeUndefined();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not cancel a body a caller already consumed", async () => {
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("done"));
+          controller.close();
+        },
+        cancel,
+      }),
+    );
+    await response.text();
+
+    await discardIgnoredResponseBody(response);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qa-lab/src/ignored-response-body.ts
+++ b/extensions/qa-lab/src/ignored-response-body.ts
@@ -1,0 +1,9 @@
+// Qa Lab HTTP callers discard response bodies they do not inspect before
+// releasing guarded fetch resources. Otherwise the dispatcher must destroy
+// the still-streaming connection during release.
+export async function discardIgnoredResponseBody(response: Response): Promise<void> {
+  if (response.bodyUsed) {
+    return;
+  }
+  await response.body?.cancel().catch(() => undefined);
+}

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -8,7 +8,7 @@ import {
   upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   captureRuntimeParityCell,
   isRuntimeParityResultPass,
@@ -23,6 +23,7 @@ import { createTempDirHarness } from "./temp-dir.test-helper.js";
 const tempDirs = createTempDirHarness();
 
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await tempDirs.cleanup();
 });
 
@@ -127,6 +128,38 @@ function makeRuntimeParityCell(
 }
 
 describe("runtime parity", () => {
+  it("cancels a failed mock-request response before falling back to transcript calls", async () => {
+    const parentPrompt = "Delegate one bounded QA task to a subagent.";
+    const tempRoot = await seedRuntimeParityTranscript({
+      sessionId: "mock-runtime-parity-failure",
+      sessionKey: "agent:qa:mock-runtime-parity-failure",
+      messages: [{ role: "user", content: parentPrompt }],
+    });
+    const cancel = vi.fn(() => {
+      throw new Error("cancel failed");
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new ReadableStream<Uint8Array>({ cancel }), {
+            status: 503,
+          }),
+      ),
+    );
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "openclaw",
+      gateway: { tempRoot },
+      mockBaseUrl: "http://127.0.0.1:43123",
+      scenarioResult: { status: "pass" },
+      wallClockMs: 10,
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cell.toolCalls).toEqual([]);
+  });
+
   it("captures tool results from the canonical SQLite session transcript", async () => {
     const tempRoot = await seedRuntimeParityTranscript({
       sessionId: "capability-flip",

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -14,6 +14,7 @@ import {
   scanGatewayLogSentinels,
   type GatewayLogSentinelFinding,
 } from "./gateway-log-sentinel.js";
+import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import * as parity from "./parity-shared.js";
 
 export type RuntimeId = "openclaw" | "codex";
@@ -1052,6 +1053,7 @@ async function loadRuntimeParityMockToolCalls(
     let payload: unknown;
     try {
       if (!response.ok) {
+        await discardIgnoredResponseBody(response);
         return null;
       }
       payload = await response.json();

--- a/extensions/qa-lab/src/suite-runtime-gateway.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.test.ts
@@ -159,8 +159,14 @@ describe("qa suite gateway helpers", () => {
   });
 
   it("cancels failed suite gateway JSON response bodies before releasing their guard", async () => {
-    const cancelBody = vi.fn();
-    const release = vi.fn(async () => {});
+    const events: string[] = [];
+    const cancelBody = vi.fn(() => {
+      events.push("cancel");
+      throw new Error("cancel failed");
+    });
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(
         new ReadableStream<Uint8Array>({
@@ -176,33 +182,56 @@ describe("qa suite gateway helpers", () => {
     );
     expect(cancelBody).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["cancel", "release"]);
   });
 
-  it("cancels failed gateway health responses before retrying", async () => {
-    const cancelBody = vi.fn();
-    const failedRelease = vi.fn(async () => {});
-    const successRelease = vi.fn(async () => {});
+  it("cancels every ignored gateway health body before releasing its guard", async () => {
+    const events: string[] = [];
+    const failedCancel = vi.fn(() => {
+      events.push("failed:cancel");
+    });
+    const successCancel = vi.fn(() => {
+      events.push("success:cancel");
+    });
+    const failedRelease = vi.fn(async () => {
+      events.push("failed:release");
+    });
+    const successRelease = vi.fn(async () => {
+      events.push("success:release");
+    });
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(
           new ReadableStream<Uint8Array>({
-            cancel: cancelBody,
+            cancel: failedCancel,
           }),
           { status: 503 },
         ),
         release: failedRelease,
       })
       .mockResolvedValueOnce({
-        response: new Response(null, { status: 200 }),
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            cancel: successCancel,
+          }),
+          { status: 200 },
+        ),
         release: successRelease,
       });
 
     await expect(
       waitForGatewayHealthy({ gateway: { baseUrl: "http://127.0.0.1:43123" } } as never, 1_000),
     ).resolves.toBeUndefined();
-    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(failedCancel).toHaveBeenCalledTimes(1);
+    expect(successCancel).toHaveBeenCalledTimes(1);
     expect(failedRelease).toHaveBeenCalledTimes(1);
     expect(successRelease).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      "failed:cancel",
+      "failed:release",
+      "success:cancel",
+      "success:release",
+    ]);
   });
 
   it("bounds a hung gateway health request by the remaining readiness deadline", async () => {

--- a/extensions/qa-lab/src/suite-runtime-gateway.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.test.ts
@@ -158,6 +158,53 @@ describe("qa suite gateway helpers", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels failed suite gateway JSON response bodies before releasing their guard", async () => {
+    const cancelBody = vi.fn();
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          cancel: cancelBody,
+        }),
+        { status: 503 },
+      ),
+      release,
+    });
+
+    await expect(fetchJson("http://127.0.0.1:43123/config")).rejects.toThrow(
+      "request failed 503: http://127.0.0.1:43123/config",
+    );
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels failed gateway health responses before retrying", async () => {
+    const cancelBody = vi.fn();
+    const failedRelease = vi.fn(async () => {});
+    const successRelease = vi.fn(async () => {});
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            cancel: cancelBody,
+          }),
+          { status: 503 },
+        ),
+        release: failedRelease,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(null, { status: 200 }),
+        release: successRelease,
+      });
+
+    await expect(
+      waitForGatewayHealthy({ gateway: { baseUrl: "http://127.0.0.1:43123" } } as never, 1_000),
+    ).resolves.toBeUndefined();
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(failedRelease).toHaveBeenCalledTimes(1);
+    expect(successRelease).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds a hung gateway health request by the remaining readiness deadline", async () => {
     vi.useFakeTimers();
     fetchWithSsrFGuardMock.mockImplementation(

--- a/extensions/qa-lab/src/suite-runtime-gateway.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.ts
@@ -6,6 +6,7 @@ import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord as isPlainObject } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { QaSuiteInfraError, toQaErrorObject } from "./errors.js";
+import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import { applyQaMergePatch } from "./suite-merge-patch.js";
 import { liveTurnTimeoutMs } from "./suite-runtime-agent-common.js";
 import type { QaConfigSnapshot, QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
@@ -27,7 +28,7 @@ async function fetchJson<T>(url: string, timeoutMs = QA_SUITE_FETCH_JSON_TIMEOUT
   });
   try {
     if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
+      await discardIgnoredResponseBody(response);
       throw new Error(`request failed ${response.status}: ${url}`);
     }
     return await readProviderJsonResponse<T>(response, "qa-lab-suite-fetch-json");
@@ -47,10 +48,11 @@ async function waitForGatewayHealthy(env: Pick<QaSuiteRuntimeEnv, "gateway">, ti
         auditContext: "qa-lab-suite-wait-for-gateway-healthy",
       });
       try {
-        if (response.ok) {
+        const ready = response.ok;
+        await discardIgnoredResponseBody(response);
+        if (ready) {
           return;
         }
-        await response.body?.cancel().catch(() => undefined);
       } finally {
         await release();
       }

--- a/extensions/qa-lab/src/suite-runtime-gateway.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.ts
@@ -27,6 +27,7 @@ async function fetchJson<T>(url: string, timeoutMs = QA_SUITE_FETCH_JSON_TIMEOUT
   });
   try {
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       throw new Error(`request failed ${response.status}: ${url}`);
     }
     return await readProviderJsonResponse<T>(response, "qa-lab-suite-fetch-json");
@@ -49,6 +50,7 @@ async function waitForGatewayHealthy(env: Pick<QaSuiteRuntimeEnv, "gateway">, ti
         if (response.ok) {
           return;
         }
+        await response.body?.cancel().catch(() => undefined);
       } finally {
         await release();
       }

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -222,6 +222,37 @@ describe("qa suite", () => {
     expect(stop).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels a successful lab readiness body before releasing its guard", async () => {
+    const events: string[] = [];
+    const stop = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            events.push("cancel");
+          },
+        }),
+        { status: 200 },
+      ),
+      release: async () => {
+        events.push("release");
+      },
+    });
+
+    await expect(
+      qaSuiteProgressTesting.waitForQaLabReadyOrStopOwned({
+        lab: {
+          listenUrl: "http://127.0.0.1:43123",
+          stop,
+        },
+        ownsLab: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(events).toEqual(["cancel", "release"]);
+    expect(stop).not.toHaveBeenCalled();
+  });
+
   it("bounds a hung lab readiness request by the remaining startup deadline", async () => {
     vi.useFakeTimers();
     const stop = vi.fn(async () => {});

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -25,6 +25,7 @@ import {
   type QaCliBackendAuthMode,
   type QaGatewayChildCommand,
 } from "./gateway-child.js";
+import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import type {
   QaLabLatestReport,
   QaLabScenarioOutcome,
@@ -274,7 +275,9 @@ async function waitForQaLabReady(baseUrl: string, timeoutMs = 10_000) {
         auditContext: "qa-lab-suite-wait-for-lab-ready",
       });
       try {
-        if (response.ok) {
+        const ready = response.ok;
+        await discardIgnoredResponseBody(response);
+        if (ready) {
           return;
         }
       } finally {

--- a/src/plugin-sdk/qa-runtime.test.ts
+++ b/src/plugin-sdk/qa-runtime.test.ts
@@ -36,6 +36,7 @@ describe("plugin-sdk qa-runtime", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     cleanupTempDirs(tempDirs);
     restorePrivateQaCliEnv(originalPrivateQaCli);
     if (originalBundledPluginsDir === undefined) {
@@ -337,6 +338,27 @@ describe("plugin-sdk qa-runtime", () => {
       ),
     ).resolves.toBe("http://172.18.0.4:18789/");
     expect(probe.wasCanceled()).toBe(true);
+  });
+
+  it("cancels the guarded default health response before stripping its body", async () => {
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel,
+      }),
+      { status: 503 },
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response),
+    );
+    const module = await import("./qa-runtime.js");
+    const runtime = module.createQaDockerRuntime({ auditContext: "qa-test" });
+
+    await expect(runtime.fetchHealthUrl("http://127.0.0.1:18789/healthz")).resolves.toEqual({
+      ok: false,
+    });
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("cancels waitForHealth response bodies after each probe", async () => {

--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -529,6 +529,7 @@ export function createQaDockerRuntime(params: {
     try {
       return { ok: response.ok };
     } finally {
+      await releaseQaDockerFetchResponse(response);
       await release();
     }
   };


### PR DESCRIPTION
## What Problem This Solves

QA Lab and the shared QA runtime sometimes inspect only an HTTP status and ignore the response body. Releasing an SSRF-guarded fetch while that body is still streaming can retain the underlying connection and guarded resources.

## Why This Change Was Made

The original report correctly fixed one failed suite-gateway branch. Maintainer review found the same lifecycle invariant in the sibling readiness, runtime-parity, Crabline, and shared QA-runtime paths.

This revision adds one QA Lab body-discard helper, reuses the existing shared QA response-release helper, and applies cleanup consistently before guarded release. Cancellation failures remain non-authoritative, so existing HTTP errors and fallback decisions are preserved.

## User Impact

QA probes release ignored streaming responses promptly on both success and failure. Request results, retry behavior, and public configuration remain unchanged.

## Evidence

- Exact pushed head: 96 focused tests passed across QA Lab and the shared QA runtime.
- Live localhost streaming proof: four requests (503, 503, 503, 200); all four response streams closed before completion.
- Equivalent reviewed tree: Blacksmith Testbox changed gate passed in run 29651134212, covering typechecks, full core and extension lint, SDK surface and boundary checks, and repository policy guards.
- Exact pushed tree: build passed; diff check and current-main merge simulation passed.
- Fresh autoreview: no accepted or actionable findings.

The only broad check failure was an existing WhatsApp lifecycle guard violation on a file byte-identical to current main and unrelated to this QA-only diff.

Thanks @ZengWen-DT for identifying and proving the original leak.

AI-assisted: Codex supported maintainer review, implementation, and proof.
