### PR TITLE
fix(canvas): classify deleteSurface and dataModelUpdate as v0.9-only actions

### DIFF
--- a/extensions/canvas/src/a2ui-jsonl.ts
+++ b/extensions/canvas/src/a2ui-jsonl.ts
@@ -9,6 +9,9 @@ const A2UI_ACTION_KEYS = [
   "createSurface",
 ] as const;
 
+/** A2UI v0.9 introduced createSurface / deleteSurface / dataModelUpdate. */
+const V09_ONLY_ACTIONS = new Set<string>(["createSurface", "deleteSurface", "dataModelUpdate"]);
+
 /** A2UI message dialects recognized by the Canvas validator. */
 type A2UIVersion = "v0.8" | "v0.9";
 
@@ -84,8 +87,9 @@ function validateA2UIJsonl(jsonl: string) {
       return;
     }
     // v0.9 requires an explicit version, but keep recognizing legacy
-    // createSurface payloads so older generators still fail closed.
-    if (explicitVersion === "v0.9" || actionKeys[0] === "createSurface") {
+    // createSurface / deleteSurface / dataModelUpdate payloads so older
+    // generators still fail closed.
+    if (explicitVersion === "v0.9" || V09_ONLY_ACTIONS.has(actionKeys[0] ?? "")) {
       sawV09 = true;
     } else {
       sawV08 = true;

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -224,6 +224,18 @@ describe("Canvas tool", () => {
       /OpenClaw currently supports v0\.8 only/,
     ],
     [
+      "legacy deleteSurface JSONL without explicit version",
+      JSON.stringify({ deleteSurface: { surfaceId: "main" } }),
+      /OpenClaw currently supports v0\.8 only/,
+    ],
+    [
+      "legacy dataModelUpdate JSONL without explicit version",
+      JSON.stringify({
+        dataModelUpdate: { surfaceId: "main", contents: [], path: "/" },
+      }),
+      /OpenClaw currently supports v0\.8 only/,
+    ],
+    [
       "A2UI v0.9 deleteSurface JSONL",
       JSON.stringify({ version: "v0.9", deleteSurface: { surfaceId: "main" } }),
       /OpenClaw currently supports v0\.8 only/,


### PR DESCRIPTION
## What Problem This Solves

`deleteSurface` and `dataModelUpdate` are A2UI v0.9 actions — only `surfaceUpdate` and `beginRendering` exist in v0.8. But the validator only checked for `createSurface` as a v0.9 indicator. Unversioned `deleteSurface` and `dataModelUpdate` payloads were incorrectly classified as v0.8 and passed validation, then sent to the native client which cannot process them.

The native client's own schema confirms these are protocol-level action keys:
```js
// a2ui.bundle.js:4087
message: "A2UI Protocol message must have exactly one of: surfaceUpdate, dataModelUpdate, beginRendering, deleteSurface."
```

## Root Cause

`a2ui-jsonl.ts:88` — `if (explicitVersion === "v0.9" || actionKeys[0] === "createSurface")` — only `createSurface` triggered v0.9 detection. `deleteSurface` and `dataModelUpdate` fell through to `sawV08 = true`.

## Fix

Added `V09_ONLY_ACTIONS` set covering all three v0.9-only action keys: `createSurface`, `deleteSurface`, `dataModelUpdate`. The condition now uses `V09_ONLY_ACTIONS.has(actionKeys[0] ?? "")`.

Files changed:
- `extensions/canvas/src/a2ui-jsonl.ts`: Added `V09_ONLY_ACTIONS` set, updated detection condition
- `extensions/canvas/src/tool.test.ts`: Added test cases for unversioned deleteSurface and dataModelUpdate

## Evidence

- Claim proved: Unversioned deleteSurface and dataModelUpdate are now correctly rejected as v0.9-only
- Commands / artifacts:
  - `git diff --check` — clean
  - `node scripts/run-vitest.mjs extensions/canvas/src/tool.test.ts` — 14 passed, 1 skipped
  - Test cases verified: "legacy deleteSurface JSONL without explicit version", "legacy dataModelUpdate JSONL without explicit version", "A2UI v0.9 deleteSurface JSONL"
  - Head: `0514f45b7e9`
