### PR TITLE
fix(ui): make settings drill-in chevrons visible in dark mode

### DIFF
--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -268,6 +268,13 @@
 .settings-row__chevron svg {
   width: 14px;
   height: 14px;
+  /* Icons rely on currentColor; without this the SVG falls back to black fill
+     and disappears in dark mode. */
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Indented child rows (e.g. per-item options under a parent toggle). */


### PR DESCRIPTION
## What Problem This Solves

The drill-in chevron arrows on settings navigation rows (e.g. the Starter Automations list on the Automations page, channel drill-in rows) render as near-invisible black shapes in dark mode.

The chevron SVGs in `ui/src/components/icons.ts` carry no fill/stroke attributes by convention — every icon host element is expected to apply `stroke: currentColor; fill: none`. The `.settings-row__chevron svg` rule in `ui/src/styles/settings.css` only set width/height, so the SVG fell back to the default black fill.

## Why This Change Was Made

Dark-mode users cannot see the drill-in affordance on settings nav rows.

## User Impact

Chevrons on all `settings-row--nav` drill-in rows (Automations starters, Channels, generic settings rows) now render as the intended muted outline stroke in both light and dark mode.

## Evidence

Before (dark mode, Automations → Starter Automations):

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-chevron-dark-mode/before.png)

After:

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-chevron-dark-mode/after.png)

Captured via `pnpm dev:ui:mock` + Playwright (dark color scheme). Autoreview (Codex gpt-5.6-sol) clean: no accepted/actionable findings.
