### PR TITLE
fix: report unavailable Codex runtime in model status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -30,24 +30,24 @@ openclaw models scan
 
 ### Status
 
-`openclaw models status` shows the resolved default/fallbacks plus an auth overview. When provider usage snapshots are available, the OAuth/API-key status section includes provider usage windows and quota snapshots. Current usage-window providers: Anthropic, GitHub Copilot, Gemini CLI, OpenAI, MiniMax, Xiaomi, and z.ai. Usage auth comes from provider-specific hooks when available; otherwise OpenClaw falls back to matching OAuth/API-key credentials from auth profiles, env, or config.
+`openclaw models status` shows the resolved default/fallbacks plus an auth overview. For plugin-owned agent runtimes such as Codex, it also checks whether the owning plugin is enabled and passed startup payload verification. A route with valid credentials but an unavailable runtime reports `status: unavailable` instead of `usable`; JSON output includes separate `authStatus`, `runtimeStatus`, and bounded runtime diagnostics. When provider usage snapshots are available, the OAuth/API-key status section includes provider usage windows and quota snapshots. Current usage-window providers: Anthropic, GitHub Copilot, Gemini CLI, OpenAI, MiniMax, Xiaomi, and z.ai. Usage auth comes from provider-specific hooks when available; otherwise OpenClaw falls back to matching OAuth/API-key credentials from auth profiles, env, or config.
 
 In `--json` output, `auth.providers` is the env/config/store-aware provider overview, while `auth.oauth` is auth-store profile health only.
 
 Options:
 
-| Flag                      | Effect                                                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `--json`                  | JSON output; auth-profile, provider, and startup diagnostics go to stderr so stdout stays pipeable into `jq`. |
-| `--plain`                 | Plain text output.                                                                                            |
-| `--check`                 | Exit non-zero if auth is expiring/expired: `1` = expired/missing, `2` = expiring.                             |
-| `--probe`                 | Live probe of configured auth profiles. Real requests; may consume tokens and trigger rate limits.            |
-| `--probe-provider <name>` | Probe one provider only.                                                                                      |
-| `--probe-profile <id>`    | Probe specific auth profile ids (repeat or comma-separated).                                                  |
-| `--probe-timeout <ms>`    | Per-probe timeout.                                                                                            |
-| `--probe-concurrency <n>` | Concurrent probes.                                                                                            |
-| `--probe-max-tokens <n>`  | Probe max tokens (best effort).                                                                               |
-| `--agent <id>`            | Configured agent id; overrides `OPENCLAW_AGENT_DIR`.                                                          |
+| Flag                      | Effect                                                                                                                                   |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--json`                  | JSON output; auth-profile, provider, and startup diagnostics go to stderr so stdout stays pipeable into `jq`.                            |
+| `--plain`                 | Plain text output.                                                                                                                       |
+| `--check`                 | Exit non-zero if auth is expiring/expired or a selected agent runtime is unavailable: `1` = unavailable/expired/missing, `2` = expiring. |
+| `--probe`                 | Live probe of configured auth profiles. Real requests; may consume tokens and trigger rate limits.                                       |
+| `--probe-provider <name>` | Probe one provider only.                                                                                                                 |
+| `--probe-profile <id>`    | Probe specific auth profile ids (repeat or comma-separated).                                                                             |
+| `--probe-timeout <ms>`    | Per-probe timeout.                                                                                                                       |
+| `--probe-concurrency <n>` | Concurrent probes.                                                                                                                       |
+| `--probe-max-tokens <n>`  | Probe max tokens (best effort).                                                                                                          |
+| `--agent <id>`            | Configured agent id; overrides `OPENCLAW_AGENT_DIR`.                                                                                     |
 
 Probe rows can come from auth profiles, env credentials, or `models.json`. Probe status buckets: `ok`, `auth`, `rate_limit`, `billing`, `timeout`, `format`, `unknown`, `no_model`.
 

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -27,10 +27,12 @@ vi.mock("../../plugins/activation-planner.js", () => ({
 
 describe("ensureSelectedAgentHarnessPlugin", () => {
   let ensureSelectedAgentHarnessPlugin: typeof import("./runtime-plugin.js").ensureSelectedAgentHarnessPlugin;
+  let resolveAgentHarnessRuntimeAvailability: typeof import("./runtime-plugin.js").resolveAgentHarnessRuntimeAvailability;
 
   beforeAll(async () => {
     vi.resetModules();
-    ({ ensureSelectedAgentHarnessPlugin } = await import("./runtime-plugin.js"));
+    ({ ensureSelectedAgentHarnessPlugin, resolveAgentHarnessRuntimeAvailability } =
+      await import("./runtime-plugin.js"));
   });
 
   beforeEach(() => {
@@ -99,6 +101,114 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
         onlyPluginIds: ["codex", "openai", "memory-core"],
       }),
     );
+  });
+
+  it("reports a manifest-owned harness as statically available", () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(undefined);
+
+    expect(
+      resolveAgentHarnessRuntimeAvailability({
+        runtime: "codex",
+        provider: "openai",
+        workspaceDir: "/tmp/workspace",
+        payloadFailures: [],
+        payloadCheckedPluginIds: ["codex"],
+        selectedPluginRootDirs: new Map([["codex", "/tmp/plugins/codex"]]),
+      }),
+    ).toEqual({
+      status: "available",
+      ownerPluginIds: ["codex"],
+    });
+  });
+
+  it("reports a harness unavailable when no enabled owner plugin can activate", () => {
+    mocks.resolveManifestActivationPlan.mockReturnValueOnce({ entries: [] });
+
+    expect(
+      resolveAgentHarnessRuntimeAvailability({
+        runtime: "codex",
+        provider: "openai",
+        workspaceDir: "/tmp/workspace",
+        payloadFailures: [],
+        payloadCheckedPluginIds: [],
+        selectedPluginRootDirs: new Map(),
+      }),
+    ).toEqual({
+      status: "unavailable",
+      ownerPluginIds: [],
+      reason: "owner-plugin-not-activatable",
+      detail: 'No enabled plugin owns agent harness "codex".',
+    });
+  });
+
+  it("reports a harness unavailable when startup quarantined an owner payload", () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(undefined);
+
+    expect(
+      resolveAgentHarnessRuntimeAvailability({
+        runtime: "codex",
+        provider: "openai",
+        workspaceDir: "/tmp/workspace",
+        payloadFailures: [
+          {
+            pluginId: "codex",
+            installPath: "/tmp/plugins/codex",
+            reason: "missing-package-dir",
+          },
+        ],
+        payloadCheckedPluginIds: ["codex"],
+        selectedPluginRootDirs: new Map([["codex", "/tmp/plugins/codex"]]),
+      }),
+    ).toEqual({
+      status: "unavailable",
+      ownerPluginIds: ["codex"],
+      reason: "owner-plugin-degraded",
+      detail: 'Agent harness "codex" owner plugin "codex" is unavailable (missing-package-dir).',
+    });
+  });
+
+  it("ignores a payload failure from a stale artifact with the same plugin id", () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(undefined);
+
+    expect(
+      resolveAgentHarnessRuntimeAvailability({
+        runtime: "codex",
+        provider: "openai",
+        workspaceDir: "/tmp/workspace",
+        payloadFailures: [
+          {
+            pluginId: "codex",
+            installPath: "/tmp/plugins/stale-codex",
+            reason: "missing-package-dir",
+          },
+        ],
+        payloadCheckedPluginIds: ["codex"],
+        selectedPluginRootDirs: new Map([["codex", "/tmp/plugins/active-codex"]]),
+      }),
+    ).toEqual({
+      status: "available",
+      ownerPluginIds: ["codex"],
+    });
+  });
+
+  it("reports a selected owner unavailable when its payload was not checked", () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(undefined);
+
+    expect(
+      resolveAgentHarnessRuntimeAvailability({
+        runtime: "codex",
+        provider: "openai",
+        workspaceDir: "/tmp/workspace",
+        payloadFailures: [],
+        payloadCheckedPluginIds: [],
+        selectedPluginRootDirs: new Map([["codex", "/tmp/plugins/codex"]]),
+      }),
+    ).toEqual({
+      status: "unavailable",
+      ownerPluginIds: ["codex"],
+      reason: "owner-plugin-unverified",
+      detail: 'Agent harness "codex" owner plugin "codex" payload was not verified.',
+    });
   });
 
   it("loads a session-pinned Codex harness for an unrelated outer provider", async () => {

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -16,6 +16,10 @@ import {
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProviderRef,
 } from "../../plugins/providers.js";
+import {
+  pluginInstallPathMatchesRoot,
+  type PluginVerificationFailureReason,
+} from "../../plugins/runtime-degraded-state.js";
 import { isDefaultAgentRuntimeId, OPENCLAW_AGENT_RUNTIME_ID } from "../agent-runtime-id.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import { isCliRuntimeAliasForProvider } from "../model-runtime-aliases.js";
@@ -128,6 +132,82 @@ export function resolveAgentHarnessOwnerPluginIds(params: {
       (pluginId) => pluginId !== "codex" && safeProviderOwnerPluginIds.includes(pluginId),
     ),
   ]);
+}
+
+export type AgentHarnessRuntimeAvailability =
+  | {
+      status: "available";
+      ownerPluginIds: string[];
+    }
+  | {
+      status: "unavailable";
+      ownerPluginIds: string[];
+      reason: "owner-plugin-not-activatable" | "owner-plugin-unverified" | "owner-plugin-degraded";
+      detail: string;
+    };
+
+export type AgentHarnessRuntimePayloadFailure = {
+  pluginId: string;
+  installPath?: string;
+  reason: PluginVerificationFailureReason;
+};
+
+/**
+ * Resolves whether manifest-owned harness code is loadable without importing it.
+ * Callers must pass the result of a payload check performed for this invocation.
+ */
+export function resolveAgentHarnessRuntimeAvailability(params: {
+  runtime: string;
+  provider: string;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  payloadFailures: readonly AgentHarnessRuntimePayloadFailure[];
+  payloadCheckedPluginIds: readonly string[];
+  selectedPluginRootDirs: ReadonlyMap<string, string>;
+}): AgentHarnessRuntimeAvailability {
+  const runtime = params.runtime.trim();
+  const ownerPluginIds = resolveAgentHarnessOwnerPluginIds({
+    ...params,
+    runtime,
+  });
+  if (ownerPluginIds.length === 0) {
+    return {
+      status: "unavailable",
+      ownerPluginIds,
+      reason: "owner-plugin-not-activatable",
+      detail: `No enabled plugin owns agent harness "${runtime}".`,
+    };
+  }
+  const checkedPluginIds = new Set(params.payloadCheckedPluginIds);
+  const unverifiedOwner = ownerPluginIds.find(
+    (pluginId) => !params.selectedPluginRootDirs.has(pluginId) || !checkedPluginIds.has(pluginId),
+  );
+  if (unverifiedOwner) {
+    return {
+      status: "unavailable",
+      ownerPluginIds,
+      reason: "owner-plugin-unverified",
+      detail: `Agent harness "${runtime}" owner plugin "${unverifiedOwner}" payload was not verified.`,
+    };
+  }
+  const failedOwner = params.payloadFailures.find((failure) => {
+    if (!ownerPluginIds.includes(failure.pluginId)) {
+      return false;
+    }
+    const selectedRootDir = params.selectedPluginRootDirs.get(failure.pluginId);
+    return selectedRootDir
+      ? pluginInstallPathMatchesRoot(failure.installPath, selectedRootDir)
+      : false;
+  });
+  if (failedOwner) {
+    return {
+      status: "unavailable",
+      ownerPluginIds,
+      reason: "owner-plugin-degraded",
+      detail: `Agent harness "${runtime}" owner plugin "${failedOwner.pluginId}" is unavailable (${failedOwner.reason}).`,
+    };
+  }
+  return { status: "available", ownerPluginIds };
 }
 
 function withRuntimePluginIdsAllowed(params: {

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
-import { runPluginPayloadSmokeCheck } from "./plugin-payload-validation.js";
+import {
+  runPluginPayloadSmokeCheck,
+  runPluginPayloadSmokeCheckForManifestRecords,
+} from "./plugin-payload-validation.js";
 
 type BundleFormat = "codex" | "claude" | "cursor";
 type FormatMarkedBundleInstallRecord = PluginInstallRecord & {
@@ -109,6 +112,21 @@ describe("runPluginPayloadSmokeCheck", () => {
     });
     expect(result.failures).toEqual([]);
     expect(result.checked).toEqual(["discord"]);
+  });
+
+  it("checks a selected manifest root without an installed-index record", async () => {
+    const dir = path.join(tmpRoot, "codex");
+    await writePackage(
+      dir,
+      { name: "@openclaw/codex", openclaw: { extensions: ["./index.js"] } },
+      "export default {};",
+    );
+    const result = await runPluginPayloadSmokeCheckForManifestRecords({
+      plugins: [{ id: "codex", rootDir: dir }],
+      env: {},
+    });
+
+    expect(result).toEqual({ checked: ["codex"], failures: [] });
   });
 
   it("reports a failure when the package directory is missing", async () => {

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "../../plugins/bundle-manifest.js";
+import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import type { PluginBundleFormat } from "../../plugins/manifest-types.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
@@ -105,6 +106,24 @@ export async function runPluginPayloadSmokeCheck(params: {
   }
 
   return { checked, failures };
+}
+
+/** Verifies the exact manifest records selected for this process. */
+export async function runPluginPayloadSmokeCheckForManifestRecords(params: {
+  plugins: readonly Pick<PluginManifestRecord, "id" | "rootDir" | "format">[];
+  env: NodeJS.ProcessEnv;
+}): Promise<PluginPayloadSmokeResult> {
+  const records = Object.fromEntries(
+    params.plugins.map((plugin) => [
+      plugin.id,
+      {
+        source: plugin.format === "bundle" ? "marketplace" : "npm",
+        installPath: plugin.rootDir,
+        ...(plugin.format === "bundle" ? { clawhubFamily: "bundle-plugin" as const } : {}),
+      } satisfies PluginInstallRecord,
+    ]),
+  );
+  return await runPluginPayloadSmokeCheck({ records, env: params.env });
 }
 
 type PackagePayloadManifest = PackageManifest & { main?: unknown; exports?: unknown };

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -24,6 +24,11 @@ import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js"
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import {
+  resolveAgentHarnessOwnerPluginIds,
+  resolveAgentHarnessRuntimeAvailability,
+  type AgentHarnessRuntimeAvailability,
+} from "../../agents/harness/runtime-plugin.js";
+import {
   createModelAuthAvailabilityResolver,
   type ModelAuthAvailabilityEvaluation,
   type ModelAuthAvailabilityResolver,
@@ -129,17 +134,20 @@ type StatusProviderRouteAuth =
       kind: "legacy";
       evaluation: ModelAuthAvailabilityEvaluation;
       usesCodexRuntimeAuth: boolean;
+      runtimeAvailability?: AgentHarnessRuntimeAvailability;
     }
   | {
       kind: "route";
       route: ProviderModelRouteCandidate;
       evaluation: ModelAuthAvailabilityEvaluation;
       usesCodexRuntimeAuth: boolean;
+      runtimeAvailability?: AgentHarnessRuntimeAvailability;
     }
   | {
       kind: "indeterminate";
       evaluation: ModelAuthAvailabilityEvaluation;
       usesCodexRuntimeAuth: boolean;
+      runtimeAvailability?: AgentHarnessRuntimeAvailability;
     }
   | {
       kind: "incompatible";
@@ -147,6 +155,7 @@ type StatusProviderRouteAuth =
       message: string;
       evaluation: ModelAuthAvailabilityEvaluation;
       usesCodexRuntimeAuth: false;
+      runtimeAvailability?: undefined;
     };
 
 type StatusProviderUseRef = {
@@ -163,6 +172,28 @@ type StatusProviderUse = {
   allowCodexRuntimeFallback: boolean;
   routeAuth: StatusProviderRouteAuth;
 };
+
+type StatusRuntimeAuthStatus = "usable" | "missing" | "indeterminate";
+
+type StatusRuntimeAuthRouteBase = {
+  provider: string;
+  runtime: string;
+  authProvider: string;
+  effective: ProviderAuthOverview["effective"];
+};
+
+type StatusRuntimeAuthRoute =
+  | (StatusRuntimeAuthRouteBase & {
+      status: StatusRuntimeAuthStatus;
+    })
+  | (StatusRuntimeAuthRouteBase & {
+      status: "unavailable";
+      authStatus: StatusRuntimeAuthStatus;
+      runtimeStatus: "unavailable";
+      runtimeReason: Extract<AgentHarnessRuntimeAvailability, { status: "unavailable" }>["reason"];
+      runtimeDetail: string;
+      runtimePluginIds: string[];
+    });
 
 type StatusModelRouteIssue =
   | {
@@ -362,6 +393,49 @@ export async function modelsStatusCommand(
     workspaceDir,
     env: process.env,
   });
+  const selectedPluginRootDirs = new Map(
+    [...metadataSnapshot.byPluginId].map(([pluginId, plugin]) => [pluginId, plugin.rootDir]),
+  );
+  const { runPluginPayloadSmokeCheckForManifestRecords } =
+    await import("../../cli/update-cli/plugin-payload-validation.js");
+  const codexRuntimeAvailabilityByProvider = new Map<
+    string,
+    Promise<AgentHarnessRuntimeAvailability>
+  >();
+  const resolveCodexRuntimeAvailability = (
+    provider: string,
+  ): Promise<AgentHarnessRuntimeAvailability> => {
+    const cached = codexRuntimeAvailabilityByProvider.get(provider);
+    if (cached) {
+      return cached;
+    }
+    const pending = (async () => {
+      const ownerPluginIds = resolveAgentHarnessOwnerPluginIds({
+        runtime: "codex",
+        provider,
+        config: cfg,
+        workspaceDir,
+      });
+      const pluginPayloadSmoke = await runPluginPayloadSmokeCheckForManifestRecords({
+        plugins: ownerPluginIds.flatMap((pluginId) => {
+          const plugin = metadataSnapshot.byPluginId.get(pluginId);
+          return plugin ? [plugin] : [];
+        }),
+        env: process.env,
+      });
+      return resolveAgentHarnessRuntimeAvailability({
+        runtime: "codex",
+        provider,
+        config: cfg,
+        workspaceDir,
+        payloadFailures: pluginPayloadSmoke.failures,
+        payloadCheckedPluginIds: pluginPayloadSmoke.checked,
+        selectedPluginRootDirs,
+      });
+    })();
+    codexRuntimeAvailabilityByProvider.set(provider, pending);
+    return pending;
+  };
   const cleanupPluginMetadataSnapshot = installCommandPluginMetadataSnapshot({
     snapshot: metadataSnapshot,
     config: cfg,
@@ -571,94 +645,104 @@ export async function modelsStatusCommand(
         metadataSnapshot,
       });
     let authResolver = createStatusAuthResolver(store);
-    const resolveProviderUses = (resolver: ModelAuthAvailabilityResolver): StatusProviderUse[] =>
-      providerUseRefs.map((usage) => {
-        const observedRoutes = routeSourcesByModel.get(
-          modelCatalogLogicalKey({ provider: usage.provider, id: usage.model }),
-        );
-        const ref = {
-          modelId: usage.model,
-          ...(observedRoutes ? { observedRoutes } : {}),
-        };
-        // Image tools own their provider auth behavior. The text-route artifact
-        // must not reinterpret image auth as an OpenAI text transport.
-        const rawEvaluation: ModelAuthAvailabilityEvaluation =
-          usage.routeScope === "text"
-            ? resolver.evaluateModelAuth(usage.provider, ref)
-            : {
-                availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
-                routeResolution: null,
-              };
-        const routeAuth: StatusProviderRouteAuth = (() => {
-          if (rawEvaluation.routeResolution?.kind === "incompatible") {
-            return {
-              kind: "incompatible",
-              code: rawEvaluation.routeResolution.code,
-              message: rawEvaluation.routeResolution.message,
-              evaluation: rawEvaluation,
-              usesCodexRuntimeAuth: false,
-            };
-          }
-          const usesCodexRuntimeAuth =
-            usage.allowCodexRuntimeFallback &&
-            resolveAgentHarnessPolicy({
-              provider: usage.provider,
-              modelId: usage.model,
-              ...(rawEvaluation.selectedRoute
-                ? {
-                    modelApi: rawEvaluation.selectedRoute.api,
-                    modelBaseUrl: rawEvaluation.selectedRoute.baseUrl,
-                  }
-                : {}),
-              config: cfg,
-              agentId: workspaceAgentId,
-            }).runtime === "codex";
-          if (
-            usesCodexRuntimeAuth &&
-            usage.provider !== OPENAI_PROVIDER_ID &&
-            usage.provider !== "codex"
-          ) {
-            return {
-              kind: "incompatible",
-              code: "unsupported-codex-runtime-provider",
-              message: `The Codex runtime does not support provider ${usage.provider}.`,
-              evaluation: rawEvaluation,
-              usesCodexRuntimeAuth: false,
-            };
-          }
-          const evaluation = rawEvaluation;
-          if (evaluation.selectedRoute) {
-            return {
-              kind: "route",
-              route: evaluation.selectedRoute,
-              evaluation,
-              usesCodexRuntimeAuth,
-            };
-          }
-          if (
-            evaluation.routeResolution?.kind === "routes" ||
-            evaluation.routeResolution?.kind === "indeterminate"
-          ) {
-            return {
-              kind: "indeterminate",
-              evaluation,
-              usesCodexRuntimeAuth,
-            };
-          }
-          return {
-            kind: "legacy",
-            evaluation,
-            usesCodexRuntimeAuth,
+    const resolveProviderUses = async (
+      resolver: ModelAuthAvailabilityResolver,
+    ): Promise<StatusProviderUse[]> =>
+      await Promise.all(
+        providerUseRefs.map(async (usage) => {
+          const observedRoutes = routeSourcesByModel.get(
+            modelCatalogLogicalKey({ provider: usage.provider, id: usage.model }),
+          );
+          const ref = {
+            modelId: usage.model,
+            ...(observedRoutes ? { observedRoutes } : {}),
           };
-        })();
-        return {
-          provider: usage.provider,
-          model: usage.model,
-          allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
-          routeAuth,
-        };
-      });
-    let providerUses = resolveProviderUses(authResolver);
+          // Image tools own their provider auth behavior. The text-route artifact
+          // must not reinterpret image auth as an OpenAI text transport.
+          const rawEvaluation: ModelAuthAvailabilityEvaluation =
+            usage.routeScope === "text"
+              ? resolver.evaluateModelAuth(usage.provider, ref)
+              : {
+                  availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
+                  routeResolution: null,
+                };
+          const routeAuth: StatusProviderRouteAuth = await (async () => {
+            if (rawEvaluation.routeResolution?.kind === "incompatible") {
+              return {
+                kind: "incompatible",
+                code: rawEvaluation.routeResolution.code,
+                message: rawEvaluation.routeResolution.message,
+                evaluation: rawEvaluation,
+                usesCodexRuntimeAuth: false,
+              };
+            }
+            const usesCodexRuntimeAuth =
+              usage.allowCodexRuntimeFallback &&
+              resolveAgentHarnessPolicy({
+                provider: usage.provider,
+                modelId: usage.model,
+                ...(rawEvaluation.selectedRoute
+                  ? {
+                      modelApi: rawEvaluation.selectedRoute.api,
+                      modelBaseUrl: rawEvaluation.selectedRoute.baseUrl,
+                    }
+                  : {}),
+                config: cfg,
+                agentId: workspaceAgentId,
+              }).runtime === "codex";
+            if (
+              usesCodexRuntimeAuth &&
+              usage.provider !== OPENAI_PROVIDER_ID &&
+              usage.provider !== "codex"
+            ) {
+              return {
+                kind: "incompatible",
+                code: "unsupported-codex-runtime-provider",
+                message: `The Codex runtime does not support provider ${usage.provider}.`,
+                evaluation: rawEvaluation,
+                usesCodexRuntimeAuth: false,
+              };
+            }
+            const runtimeAvailability = usesCodexRuntimeAuth
+              ? await resolveCodexRuntimeAvailability(usage.provider)
+              : undefined;
+            const evaluation = rawEvaluation;
+            if (evaluation.selectedRoute) {
+              return {
+                kind: "route",
+                route: evaluation.selectedRoute,
+                evaluation,
+                usesCodexRuntimeAuth,
+                runtimeAvailability,
+              };
+            }
+            if (
+              evaluation.routeResolution?.kind === "routes" ||
+              evaluation.routeResolution?.kind === "indeterminate"
+            ) {
+              return {
+                kind: "indeterminate",
+                evaluation,
+                usesCodexRuntimeAuth,
+                runtimeAvailability,
+              };
+            }
+            return {
+              kind: "legacy",
+              evaluation,
+              usesCodexRuntimeAuth,
+              runtimeAvailability,
+            };
+          })();
+          return {
+            provider: usage.provider,
+            model: usage.model,
+            allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
+            routeAuth,
+          };
+        }),
+      );
+    let providerUses = await resolveProviderUses(authResolver);
     const syntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
     const runtimeSyntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
     const cliRuntimeAuthUsages = providerUses
@@ -762,7 +846,7 @@ export async function modelsStatusCommand(
         ...store,
         profiles: { ...store.profiles, ...syntheticProfiles },
       });
-      providerUses = resolveProviderUses(authResolver);
+      providerUses = await resolveProviderUses(authResolver);
       codexRuntimeAuthUsages = providerUses.filter((usage) => usage.routeAuth.usesCodexRuntimeAuth);
     }
 
@@ -894,51 +978,66 @@ export async function modelsStatusCommand(
       usages.push(usage);
       codexRuntimeUsagesByProvider.set(usage.provider, usages);
     }
-    const runtimeAuthRoutes = Array.from(
-      new Map([
-        ...Array.from(codexRuntimeUsagesByProvider.entries()).map(([provider, usages]) => {
-          const representative =
-            usages.find((usage) => usage.routeAuth.evaluation.availability === true) ?? usages[0];
-          const effective = resolveRuntimeAuthRouteEffective(
-            codexProvider,
-            representative?.routeAuth.evaluation,
-          );
-          const availabilities = usages.map((usage) => usage.routeAuth.evaluation.availability);
-          return [
-            `${provider}:codex:${codexProvider}`,
-            {
-              provider,
-              runtime: "codex",
-              authProvider: codexProvider,
-              status: availabilities.every((availability) => availability === true)
+    const runtimeAuthRouteEntries: Array<readonly [string, StatusRuntimeAuthRoute]> = [
+      ...Array.from(codexRuntimeUsagesByProvider.entries()).map(([provider, usages]) => {
+        const representative =
+          usages.find((usage) => usage.routeAuth.evaluation.availability === true) ?? usages[0];
+        const effective = resolveRuntimeAuthRouteEffective(
+          codexProvider,
+          representative?.routeAuth.evaluation,
+        );
+        const availabilities = usages.map((usage) => usage.routeAuth.evaluation.availability);
+        const authStatus = availabilities.every((availability) => availability === true)
+          ? "usable"
+          : availabilities.some((availability) => availability === false)
+            ? "missing"
+            : "indeterminate";
+        const runtimeAvailability = representative?.routeAuth.runtimeAvailability;
+        const route: StatusRuntimeAuthRoute =
+          runtimeAvailability?.status === "unavailable"
+            ? {
+                provider,
+                runtime: "codex",
+                authProvider: codexProvider,
+                status: "unavailable",
+                effective,
+                authStatus,
+                runtimeStatus: runtimeAvailability.status,
+                runtimeReason: runtimeAvailability.reason,
+                runtimeDetail: runtimeAvailability.detail,
+                runtimePluginIds: runtimeAvailability.ownerPluginIds,
+              }
+            : {
+                provider,
+                runtime: "codex",
+                authProvider: codexProvider,
+                status: authStatus,
+                effective,
+              };
+        return [`${provider}:codex:${codexProvider}`, route] as const;
+      }),
+      ...cliRuntimeAuthUsages.map((usage) => {
+        const evaluation = authResolver.evaluateModelAuth(usage.runtime);
+        const effective = resolveRuntimeAuthRouteEffective(usage.runtime, evaluation);
+        return [
+          `${usage.provider}:${usage.runtime}:${usage.runtime}`,
+          {
+            provider: usage.provider,
+            runtime: usage.runtime,
+            authProvider: usage.runtime,
+            status:
+              evaluation.availability === true
                 ? "usable"
-                : availabilities.some((availability) => availability === false)
+                : evaluation.availability === false
                   ? "missing"
                   : "indeterminate",
-              effective,
-            },
-          ] as const;
-        }),
-        ...cliRuntimeAuthUsages.map((usage) => {
-          const evaluation = authResolver.evaluateModelAuth(usage.runtime);
-          const effective = resolveRuntimeAuthRouteEffective(usage.runtime, evaluation);
-          return [
-            `${usage.provider}:${usage.runtime}:${usage.runtime}`,
-            {
-              provider: usage.provider,
-              runtime: usage.runtime,
-              authProvider: usage.runtime,
-              status:
-                evaluation.availability === true
-                  ? "usable"
-                  : evaluation.availability === false
-                    ? "missing"
-                    : "indeterminate",
-              effective,
-            },
-          ] as const;
-        }),
-      ]).values(),
+            effective,
+          },
+        ] as const;
+      }),
+    ];
+    const runtimeAuthRoutes = Array.from(
+      new Map<string, StatusRuntimeAuthRoute>(runtimeAuthRouteEntries).values(),
     ).toSorted((a, b) => a.provider.localeCompare(b.provider));
     const modelRouteIssues = providerUses.flatMap<StatusModelRouteIssue>((usage) => {
       const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
@@ -1172,6 +1271,7 @@ export async function modelsStatusCommand(
         ) ||
         routeAuthHealth.has("missing") ||
         routeAuthHealth.has("indeterminate") ||
+        runtimeAuthRoutes.some((route) => route.status === "unavailable") ||
         missingProvidersInUse.length > 0;
       const hasExpiring = routeAuthHealth.has("expiring");
       if (hasExpiredOrMissing) {
@@ -1410,6 +1510,17 @@ export async function modelsStatusCommand(
       runtime.log("");
       runtime.log(colorize(rich, theme.heading, "Runtime auth"));
       for (const route of runtimeAuthRoutes) {
+        const runtimeAvailability =
+          route.status === "unavailable"
+            ? `${formatSeparator()}${formatKeyValue(
+                "auth",
+                route.authStatus,
+              )}${formatSeparator()}${formatKeyValue("runtime", route.runtimeStatus)}${
+                route.runtimeDetail
+                  ? `${formatSeparator()}${colorize(rich, theme.muted, route.runtimeDetail)}`
+                  : ""
+              }`
+            : "";
         runtime.log(
           `- ${theme.heading(route.provider)} via ${colorize(
             rich,
@@ -1422,7 +1533,7 @@ export async function modelsStatusCommand(
               theme.muted,
               route.effective.detail,
             )}`,
-          )}${formatSeparator()}${formatKeyValue("status", route.status)}`,
+          )}${formatSeparator()}${formatKeyValue("status", route.status)}${runtimeAvailability}`,
         );
       }
     }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -154,6 +154,14 @@ const mocks = vi.hoisted(() => {
     loadProviderUsageSummary: vi.fn().mockResolvedValue(undefined),
     resolveRuntimeSyntheticAuthProviderRefs: vi.fn().mockReturnValue([]),
     resolveProviderSyntheticAuthWithPlugin: vi.fn().mockReturnValue(undefined),
+    resolveAgentHarnessOwnerPluginIds: vi.fn().mockReturnValue(["codex"]),
+    runPluginPayloadSmokeCheckForManifestRecords: vi
+      .fn()
+      .mockResolvedValue({ checked: ["codex"], failures: [] }),
+    resolveAgentHarnessRuntimeAvailability: vi.fn().mockReturnValue({
+      status: "available",
+      ownerPluginIds: ["codex"],
+    }),
     loadModelCatalog: vi.fn().mockResolvedValue([]),
     modelCatalogRouteVariants: undefined as unknown[] | undefined,
     openAIModelRouteOverride: undefined as ((params: unknown) => unknown) | undefined,
@@ -275,6 +283,13 @@ vi.mock("../../plugins/synthetic-auth.runtime.js", () => ({
 }));
 vi.mock("../../plugins/provider-runtime.js", () => ({
   resolveProviderSyntheticAuthWithPlugin: mocks.resolveProviderSyntheticAuthWithPlugin,
+}));
+vi.mock("../../agents/harness/runtime-plugin.js", () => ({
+  resolveAgentHarnessOwnerPluginIds: mocks.resolveAgentHarnessOwnerPluginIds,
+  resolveAgentHarnessRuntimeAvailability: mocks.resolveAgentHarnessRuntimeAvailability,
+}));
+vi.mock("../../cli/update-cli/plugin-payload-validation.js", () => ({
+  runPluginPayloadSmokeCheckForManifestRecords: mocks.runPluginPayloadSmokeCheckForManifestRecords,
 }));
 vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalogSnapshot: async (...args: unknown[]) => {
@@ -768,6 +783,90 @@ describe("modelsStatusCommand auth overview", () => {
     ]);
     expect(localRuntime.exit).toHaveBeenCalledWith(1);
     expect(textRuntime.log.mock.calls.flat().join("\n")).not.toContain("set an API key env var");
+  });
+
+  it("reports usable Codex auth as unavailable when its harness plugin is quarantined", async () => {
+    const localRuntime = createRuntime();
+    const textRuntime = createRuntime();
+    const payloadFailure = {
+      pluginId: "codex",
+      installPath: "/private/plugin",
+      reason: "missing-package-dir" as const,
+      detail: "missing",
+    };
+    mocks.runPluginPayloadSmokeCheckForManifestRecords
+      .mockResolvedValueOnce({ checked: ["codex"], failures: [payloadFailure] })
+      .mockResolvedValueOnce({ checked: ["codex"], failures: [payloadFailure] });
+    const resolveAvailability = (params: {
+      payloadFailures: Array<{ pluginId: string; reason: string }>;
+    }) =>
+      params.payloadFailures.some((failure) => failure.pluginId === "codex")
+        ? {
+            status: "unavailable",
+            ownerPluginIds: ["codex", "openai"],
+            reason: "owner-plugin-degraded",
+            detail:
+              'Agent harness "codex" owner plugin "codex" is unavailable (missing-package-dir).',
+          }
+        : { status: "available", ownerPluginIds: ["codex", "openai"] };
+    mocks.resolveAgentHarnessRuntimeAvailability
+      .mockImplementationOnce(resolveAvailability)
+      .mockImplementationOnce(resolveAvailability);
+    await withOpenAIStatusFixture(
+      {
+        primary: "openai/gpt-5.5",
+        profiles: {
+          "openai:default": {
+            type: "oauth",
+            provider: "openai",
+            access: "oauth-access",
+            refresh: "oauth-refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      async () => {
+        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+        await modelsStatusCommand({ check: true }, textRuntime as never);
+      },
+    );
+
+    expect(mocks.runPluginPayloadSmokeCheckForManifestRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ env: process.env }),
+    );
+    expect(mocks.resolveAgentHarnessRuntimeAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: "codex",
+        provider: "openai",
+        payloadFailures: [payloadFailure],
+        payloadCheckedPluginIds: ["codex"],
+        selectedPluginRootDirs: expect.any(Map),
+      }),
+    );
+    const payload = parseFirstJsonLog(localRuntime);
+    expect(payload.auth.runtimeAuthRoutes).toEqual([
+      {
+        provider: "openai",
+        runtime: "codex",
+        authProvider: "openai",
+        status: "unavailable",
+        authStatus: "usable",
+        runtimeStatus: "unavailable",
+        runtimeReason: "owner-plugin-degraded",
+        runtimeDetail:
+          'Agent harness "codex" owner plugin "codex" is unavailable (missing-package-dir).',
+        runtimePluginIds: ["codex", "openai"],
+        effective: {
+          kind: "profiles",
+          detail: "/tmp/openclaw-agent/auth-profiles.json",
+        },
+      },
+    ]);
+    expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    expect(textRuntime.exit).toHaveBeenCalledWith(1);
+    expect(textRuntime.log.mock.calls.flat().join("\n")).toContain("status=unavailable");
+    expect(textRuntime.log.mock.calls.flat().join("\n")).toContain("auth=usable");
+    expect(textRuntime.log.mock.calls.flat().join("\n")).toContain("runtime=unavailable");
   });
 
   it("evaluates mixed primary and fallback OpenAI routes independently", async () => {

--- a/src/plugins/runtime-degraded-state.ts
+++ b/src/plugins/runtime-degraded-state.ts
@@ -93,9 +93,11 @@ export function clearActiveDegradedPlugin(pluginId: string): void {
   activeDegradedPlugins = activeDegradedPlugins.filter((entry) => entry.pluginId !== pluginId);
 }
 
-/** Matches install-record and discovered roots across symlink/path aliases. */
-export function degradedPluginMatchesRoot(plugin: DegradedPlugin, rootDir: string): boolean {
-  const installPath = plugin.diagnostic.installPath;
+/** Matches an install-record path and discovered root across symlink/path aliases. */
+export function pluginInstallPathMatchesRoot(
+  installPath: string | undefined,
+  rootDir: string,
+): boolean {
   if (!installPath) {
     return false;
   }
@@ -107,6 +109,11 @@ export function degradedPluginMatchesRoot(plugin: DegradedPlugin, rootDir: strin
     }
   };
   return canonicalize(installPath) === canonicalize(rootDir);
+}
+
+/** Matches install-record and discovered roots across symlink/path aliases. */
+export function degradedPluginMatchesRoot(plugin: DegradedPlugin, rootDir: string): boolean {
+  return pluginInstallPathMatchesRoot(plugin.diagnostic.installPath, rootDir);
 }
 
 /** Removes the known private install root before diagnostics leave the Gateway process. */


### PR DESCRIPTION
Closes #110439

## What Problem This Solves

Fixes an issue where users with valid OpenAI OAuth could see a Codex route reported as usable even when the required Codex harness plugin was disabled, missing, damaged, or quarantined.

A live turn could then use the OpenClaw harness instead, concealing the unavailable Codex runtime from status checks.

## Why This Change Was Made

`models status` now verifies the exact selected harness-owner plugin artifacts without executing plugin code. It reports credential health separately from runtime availability and makes `models status --check` fail when the selected runtime is unavailable.

Payload failures are correlated with the selected physical plugin root so stale installations with the same plugin ID cannot produce false failures. Selected owners that were not verified cannot produce a false-healthy result.

This does not change runtime fallback policy. Healthy-route JSON output remains unchanged.

## User Impact

Users can now distinguish valid Codex credentials from an unavailable Codex runtime.

When the harness plugin is unavailable:

- JSON reports separate auth and runtime states.
- Human-readable output explains the unavailable runtime.
- `models status --check` exits with status `1`.
- Diagnostics remain bounded and do not expose credentials or private plugin paths.

## Evidence

- `node scripts/run-vitest.mjs src/cli/update-cli/plugin-payload-validation.test.ts src/agents/harness/runtime-plugin.test.ts src/commands/models/list.status.test.ts`
  - 82 tests passed across three Vitest shards.
- `node scripts/check-changed.mjs`
  - Passed remotely on Blacksmith Testbox, including core and test typechecks, lint, formatting, plugin boundaries, import-cycle checks, and repository guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`
  - Clean: no accepted or actionable findings.
- The four-commit stack has the exact tree hash validated before the history was split.
- Documentation and changelog coverage are included.

AI-assisted: yes.
