### PR TITLE
fix(ui): sidebar section chevrons after labels, collapsed-only counts

### DIFF
--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -200,19 +200,21 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
             title=${hasError ? errorHelp : nothing}
             @click=${() => params.onToggleSection(sectionId)}
           >
+            <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
             <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
               >${collapsed ? icons.chevronRight : icons.chevronDown}</span
             >
-            <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
             ${renderCatalogHeaderStatus(hasActiveRun, hasUnread)}
-            <span
-              class="sidebar-session-group-count ${hasError
-                ? "sidebar-session-group-count--error"
-                : ""}"
-              data-session-catalog-error=${hasError ? catalog.id : nothing}
-              aria-hidden="true"
-              >${hasError ? icons.alertTriangle : rows.length}</span
-            >
+            ${hasError || (collapsed && rows.length > 0)
+              ? html`<span
+                  class="sidebar-session-group-count ${hasError
+                    ? "sidebar-session-group-count--error"
+                    : ""}"
+                  data-session-catalog-error=${hasError ? catalog.id : nothing}
+                  aria-hidden="true"
+                  >${hasError ? icons.alertTriangle : rows.length}</span
+                >`
+              : nothing}
           </button>
           <button
             type="button"

--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -361,13 +361,13 @@ export abstract class AppSidebarSessionListElement extends AppSidebarMenusElemen
                   aria-label=${label}
                   @click=${() => this.toggleSessionSection(section.id)}
                 >
+                  <span class="sidebar-recent-sessions__label-text">${label}</span>
                   <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
                     >${collapsed ? icons.chevronRight : icons.chevronDown}</span
                   >
-                  <span class="sidebar-recent-sessions__label-text">${label}</span>
-                  ${section.work && totalRowCount === 0
-                    ? nothing
-                    : html`<span class="sidebar-session-group-count">${totalRowCount}</span>`}
+                  ${collapsed && totalRowCount > 0
+                    ? html`<span class="sidebar-session-group-count">${totalRowCount}</span>`
+                    : nothing}
                   ${collapsedRunningDot
                     ? html`<span
                         class="session-run-spinner sidebar-session-group-running"

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -272,9 +272,8 @@ suite("Codex native session catalog", () => {
       expect(await section.getByText("Worktree fix session", { exact: true }).count()).toBe(1);
       const toggle = section.locator(".sidebar-session-group-toggle");
       expect(await toggle.getAttribute("title")).toBeNull();
-      await expect
-        .poll(() => section.locator(".sidebar-session-group-count").textContent())
-        .toBe("4");
+      // Counts only render while a section is collapsed.
+      expect(await section.locator(".sidebar-session-group-count").count()).toBe(0);
 
       const groupingToggle = section.locator('[data-session-catalog-grouping-toggle="codex"]');
       await groupingToggle.click();

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1266,7 +1266,9 @@ html.openclaw-native-macos
   align-items: center;
   gap: 8px;
   min-height: 24px;
-  padding: 0 10px;
+  /* 9px left matches .sidebar-recent-session__link text inset so zone labels
+     and session titles share one left edge. */
+  padding: 0 10px 0 9px;
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
 }
 
@@ -1283,10 +1285,6 @@ html.openclaw-native-macos
   top: 0;
   z-index: 2;
   background: var(--sidebar-bg);
-}
-
-.sidebar-recent-sessions__head .sidebar-recent-sessions__label-text {
-  flex: 1 1 auto;
 }
 
 .sidebar-session-group-toggle {
@@ -1317,13 +1315,11 @@ html.openclaw-native-macos
 }
 
 .sidebar-session-group-count {
-  width: 26px;
   flex: 0 0 auto;
   color: var(--muted);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   opacity: 0.7;
-  text-align: center;
 }
 
 .sidebar-session-group-count--error {


### PR DESCRIPTION
## What Problem This Solves

Sidebar section headers (Threads, Groups, Coding, and native-session catalogs) rendered the collapse chevron before the label, so section labels sat indented relative to the session titles below them instead of sharing one left edge. Headers also always showed a row count, which is redundant noise while a section is expanded and its rows are visible.

## Why This Change Was Made

Requested by the maintainer: chevron should follow the label so section labels and session titles align in one grid, and the counter should only appear when a section is collapsed (when the count is the only signal of hidden content).

## User Impact

- Section labels now left-align with session titles below them (`THREADS`, then chevron).
- Row counts render only while a section is collapsed and non-empty (`THREADS › 6`); expanded sections show just the label and chevron.
- Catalog error indicators (alert triangle) still render regardless of collapse state.
- Header left inset now matches the session-row text inset (9px) so both columns share one grid line.

Before / after (expanded) and after (collapsed):

| Before | After (expanded) | After (collapsed) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/before-expanded.png) | ![after expanded](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after-expanded.png) | ![after collapsed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after-collapsed.png) |

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 107 tests pass.
- Live-verified in the Control UI mock harness (`dev:ui:mock`): expanded zones show label + chevron with no count; collapsed Threads/Coding show `THREADS › 6` / `CODING › 1`; screenshots above are from that harness.
- `ui/src/e2e/codex-sessions.e2e.test.ts` updated: the expanded catalog section now asserts the count element is absent (counts are collapsed-only).
- Codex autoreview (gpt-5.6-sol) clean: no accepted/actionable findings.
