### PR TITLE
feat(ui): add X (Twitter) link to About page community links

### DIFF
--- a/ui/src/e2e/about.e2e.test.ts
+++ b/ui/src/e2e/about.e2e.test.ts
@@ -96,6 +96,8 @@ describeControlUiE2e("Control UI About mocked Gateway E2E", () => {
       await expect.poll(() => githubLink.getAttribute("rel")).toContain("noopener");
       const discordLink = hero.getByRole("link", { name: "Discord", exact: true });
       await expect.poll(() => discordLink.getAttribute("href")).toBe("https://discord.gg/clawd");
+      const xLink = hero.getByRole("link", { name: "X (Twitter)", exact: true });
+      await expect.poll(() => xLink.getAttribute("href")).toBe("https://x.com/openclaw");
 
       const clawd = page.getByRole("button", { name: "Wave hello to Clawd" });
       await clawd.click();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2048,6 +2048,7 @@ export const en: TranslationMap = {
     linkDocs: "Docs",
     linkGitHub: "GitHub",
     linkDiscord: "Discord",
+    linkX: "X (Twitter)",
     linkChangelog: "Changelog",
     license: "© 2026 OpenClaw Foundation — MIT License.",
     artifactTitle: "Control UI",

--- a/ui/src/pages/about/brand-icons.ts
+++ b/ui/src/pages/about/brand-icons.ts
@@ -18,4 +18,11 @@ export const brandIcons = {
       />
     </svg>
   `,
+  x: html`
+    <svg viewBox="0 0 24 24" class="icon--filled">
+      <path
+        d="M18.24 2.25h3.31l-7.23 8.26 8.5 11.24h-6.66l-5.21-6.82-5.97 6.82H1.67l7.73-8.84L1.25 2.25h6.83l4.71 6.23Zm-1.16 17.52h1.83L7.08 4.13H5.12Z"
+      />
+    </svg>
+  `,
 } as const;

--- a/ui/src/pages/about/view.test.ts
+++ b/ui/src/pages/about/view.test.ts
@@ -56,6 +56,7 @@ describe("renderAbout", () => {
       "https://docs.openclaw.ai",
       "https://github.com/openclaw/openclaw",
       "https://discord.gg/clawd",
+      "https://x.com/openclaw",
       "https://docs.openclaw.ai/releases",
     ]);
     for (const link of links) {

--- a/ui/src/pages/about/view.ts
+++ b/ui/src/pages/about/view.ts
@@ -48,6 +48,11 @@ const ABOUT_LINKS: ReadonlyArray<{ href: string; icon: TemplateResult; label: ()
     label: () => t("aboutPage.linkDiscord"),
   },
   {
+    href: "https://x.com/openclaw",
+    icon: brandIcons.x,
+    label: () => t("aboutPage.linkX"),
+  },
+  {
     href: "https://docs.openclaw.ai/releases",
     icon: icons.scrollText,
     label: () => t("aboutPage.linkChangelog"),


### PR DESCRIPTION
## What Problem This Solves

The About page in Control UI links Website, Docs, GitHub, Discord, and Changelog, but not the official X/Twitter account (`@openclaw`), even though the account is prominently referenced on openclaw.ai.

## Why This Change Was Made

Users looking for the project's social presence had no direct path from the app. Adds an `X (Twitter)` chip to the About hero links, pointing at `https://x.com/openclaw` (handle verified against the official links on openclaw.ai).

## User Impact

New "X (Twitter)" link between Discord and Changelog on Settings -> About, with the X brand mark rendered like the existing GitHub/Discord filled icons. New i18n key `aboutPage.linkX` (English source only; locale bundles are generated post-merge).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/about-x-link/about-x-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/about-x-link/about-x-after.png) |

## Evidence

- Live-verified in the mock dev harness: link renders with `href=https://x.com/openclaw`, `target=_blank`, `rel="noopener noreferrer"` (same external-link plumbing as the sibling links).
- `ui:i18n:baseline` + `ui:i18n:verify` clean (keyless; no baseline drift).
- Extended `ui/src/e2e/about.e2e.test.ts` with an X-link assertion alongside the existing GitHub/Discord checks.
- Autoreview (Codex, gpt-5.6-sol) clean: no accepted/actionable findings.
