### PR TITLE
fix(i18n): regenerate derived app catalogs inside native:i18n:sync

### DIFF
--- a/scripts/android-app-i18n.ts
+++ b/scripts/android-app-i18n.ts
@@ -3,7 +3,7 @@ import { readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
-import { NATIVE_I18N_LOCALES } from "./native-app-i18n.ts";
+import { NATIVE_I18N_LOCALES } from "./native-i18n-locales.ts";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -858,6 +858,20 @@ export async function syncIosCatalog(write: boolean): Promise<AppleCatalogBuild>
   return build;
 }
 
+/**
+ * Regenerates every Apple derived artifact (iOS catalog, contradiction report,
+ * InfoPlist strings). Shared by this CLI and native-app-i18n's sync so the
+ * inventory can never be rewritten without its derived catalogs.
+ */
+export async function syncAppleAppI18n(): Promise<{
+  build: AppleCatalogBuild;
+  infoPlistFiles: number;
+}> {
+  const build = await syncIosCatalog(true);
+  const infoPlistFiles = await syncIosInfoPlist(true);
+  return { build, infoPlistFiles };
+}
+
 export async function checkAppleAppI18n() {
   await validateRuntimeInterpolationPaths();
   for (const [sourcePath, contracts] of Object.entries(LOCALIZED_WRAPPER_CONTRACTS)) {
@@ -956,8 +970,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.ar
   if (command === "check") {
     await checkAppleAppI18n();
   } else if (command === "sync-ios" && flag === "--write") {
-    const build = await syncIosCatalog(true);
-    const infoPlistFiles = await syncIosInfoPlist(true);
+    const { build, infoPlistFiles } = await syncAppleAppI18n();
     process.stdout.write(
       `apple-app-i18n: synced iOS catalog and ${infoPlistFiles} InfoPlist files; contradictions=${build.contradictions.length}\n`,
     );

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -5,32 +5,11 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import pMap from "p-map";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { translateNativeEntries } from "./control-ui-i18n.ts";
+import { NATIVE_I18N_LOCALES } from "./native-i18n-locales.ts";
 
 type NativeI18nSurface = "android" | "apple";
 
-export const NATIVE_I18N_LOCALES = [
-  "zh-CN",
-  "zh-TW",
-  "pt-BR",
-  "de",
-  "es",
-  "ja-JP",
-  "ko",
-  "fr",
-  "hi",
-  "ar",
-  "it",
-  "tr",
-  "uk",
-  "id",
-  "pl",
-  "th",
-  "vi",
-  "nl",
-  "fa",
-  "ru",
-  "sv",
-] as const;
+export { NATIVE_I18N_LOCALES };
 
 export type NativeI18nEntry = {
   id: string;
@@ -1641,6 +1620,22 @@ async function main() {
   });
   if (parsed.locale) {
     await syncNativeLocale(parsed.locale, entries);
+  }
+  if (parsed.command === "sync" && parsed.write) {
+    // The inventory and native/*.json feed the generated Android/Apple app
+    // artifacts. Regenerate them in the same write; a sync that stops at the
+    // inventory lands stale derived catalogs and turns the repo-wide
+    // android/apple i18n checks red. Lazy imports keep check/locale-only runs
+    // from loading the derived generators.
+    const [{ syncAndroidAppI18n }, { syncAppleAppI18n }] = await Promise.all([
+      import("./android-app-i18n.ts"),
+      import("./apple-app-i18n.ts"),
+    ]);
+    await syncAndroidAppI18n();
+    const apple = await syncAppleAppI18n();
+    process.stdout.write(
+      `native-app-i18n: synced derived artifacts (android, iOS catalog, ${apple.infoPlistFiles} InfoPlist files); contradictions=${apple.build.contradictions.length}\n`,
+    );
   }
 }
 

--- a/scripts/native-i18n-locales.ts
+++ b/scripts/native-i18n-locales.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared native-app locale list. Lives outside native-app-i18n.ts so the
+ * derived generators (android-app-i18n, apple-app-i18n) can import it without
+ * creating a cycle with native-app-i18n's top-level CLI await, which chains
+ * those generators after rewriting the inventory.
+ */
+export const NATIVE_I18N_LOCALES = [
+  "zh-CN",
+  "zh-TW",
+  "pt-BR",
+  "de",
+  "es",
+  "ja-JP",
+  "ko",
+  "fr",
+  "hi",
+  "ar",
+  "it",
+  "tr",
+  "uk",
+  "id",
+  "pl",
+  "th",
+  "vi",
+  "nl",
+  "fa",
+  "ru",
+  "sv",
+] as const;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where regenerating the native i18n inventory (`pnpm native:i18n:sync`) could land a stale derived iOS catalog: the sync rewrote `apps/.i18n/native-source.json` (and translations) but nothing regenerated `apps/ios/Resources/Localizable.xcstrings` or the Android resources in the same step. Two recent app-string PRs (#110254, #110276) committed exactly that combination, which turned the repo-wide `apple-app-i18n` check red on `main` for every PR until the catalog was regenerated by hand (folded into #110271).

## Why This Change Was Made

The generated-artifact chain is source files → `native-source.json` (+ `native/*.json`) → derived Android/Apple app artifacts. The CI translation workflow already chains all three generators, but direct invocations of `native:i18n:sync` stopped at the inventory. Per the scripts guide ("keep the source-of-truth generator, the package script, and the matching check aligned"), `native-app-i18n.ts sync --write` now chains `syncAndroidAppI18n` and a new exported `syncAppleAppI18n` (iOS catalog + contradiction report + InfoPlist strings), so one command always leaves the whole i18n tree consistent. The shared locale list moves to `scripts/native-i18n-locales.ts` because the android generator statically imported it from the inventory scanner — with the scanner now dynamically importing the derived generators from its top-level CLI await, that static edge was a real deadlocking import cycle (observed as Node's "unsettled top-level await" abort).

## User Impact

No product behavior change — this is developer/CI tooling. Contributors and agents adding native app strings can no longer break `main`'s i18n checks by running the inventory sync without the derived syncs.

## Evidence

- End-to-end proof of the exact failure mode: appended a scratch `String(localized:)` to `apps/ios/Sources/Design/ChatProTab.swift`, ran only `node --import tsx scripts/native-app-i18n.ts sync --write` — the string landed in `native-source.json` **and** `Localizable.xcstrings` (key + all locales) in the same command, and `apple-app-i18n check` passed immediately (iosKeys 1439 → 1440). Scratch reverted.
- Idempotence: on a consistent tree the chained sync exits 0 with zero generated-artifact diff; `native`, `android`, and `apple` checks all pass afterwards.
- `test/scripts/{apple,native,android}-app-i18n.test.ts` and `test/scripts/ci-workflow-guards.test.ts` all green (128 tests). `tsgo` typecheck, `oxfmt`, `oxlint` clean.
