### PR TITLE
fix(ci): feed candidate identity JSON to validator

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -711,7 +711,7 @@ jobs:
              (.imageArtifactDigest | hex64) and
              (.imageArtifactRunId | tostring | digits) and
              (.imageArtifactRunAttempt | tostring | digits) and
-             (.imageArchiveSha256 | hex64)'
+             (.imageArchiveSha256 | hex64)' \
             <<< "$CANDIDATE_ARTIFACT_JSON" >/dev/null
 
   install_smoke_release_checks:

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4693,6 +4693,52 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(readFileSync(LIVE_E2E_WORKFLOW, "utf8")).toContain("live-cache attempt ${attempt}/2");
   });
 
+  it("executes shared release candidate identity validation with its JSON input", () => {
+    const selectedSha = "a".repeat(40);
+    const candidate = {
+      packageArtifactName: "docker-e2e-package-123-1",
+      packageArtifactId: "123",
+      packageArtifactDigest: "b".repeat(64),
+      packageArtifactRunId: "456",
+      packageArtifactRunAttempt: "1",
+      packageFileName: "openclaw-current.tgz",
+      packageSourceSha: selectedSha,
+      packageSha256: "c".repeat(64),
+      packageVersion: "2026.7.2",
+      imageArtifactName: "docker-e2e-shared-images-123-1",
+      imageArtifactId: "789",
+      imageArtifactDigest: "d".repeat(64),
+      imageArtifactRunId: "456",
+      imageArtifactRunAttempt: "1",
+      imageArchiveSha256: "e".repeat(64),
+    };
+    const validation = workflowStep(
+      workflowJob(RELEASE_CHECKS_WORKFLOW, "prepare_release_package"),
+      "Validate shared release candidate identity",
+    ).run;
+    expect(validation).toBeDefined();
+
+    const valid = spawnSync("bash", ["-c", validation ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CANDIDATE_ARTIFACT_JSON: JSON.stringify(candidate),
+        SELECTED_SHA: selectedSha,
+      },
+    });
+    expect(valid.status, valid.stderr).toBe(0);
+
+    const mismatched = spawnSync("bash", ["-c", validation ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CANDIDATE_ARTIFACT_JSON: JSON.stringify(candidate),
+        SELECTED_SHA: "f".repeat(40),
+      },
+    });
+    expect(mismatched.status).not.toBe(0);
+  });
+
   it("keeps release history checks blobless", () => {
     const fullHistoryCheckouts: Array<[string, string, string]> = [
       [RELEASE_PUBLISH_WORKFLOW, "resolve_release_target", "Checkout release tag"],


### PR DESCRIPTION
## What Problem This Solves

Fresh Full Release Validation produced a valid shared candidate tuple, but `Prepare release package artifact` failed immediately. The validator's jq command ended before its here-string, so jq read EOF and exited 4. This blocked every downstream release check despite valid artifacts.

## Why This Change Was Made

Keep the candidate JSON here-string on the jq command by continuing the shell line. Add a regression test that executes the exact parsed workflow step: a valid immutable tuple must pass, while a mismatched selected SHA must fail.

## User Impact

Full release validation can reuse the shared package and Docker candidate instead of failing before release checks start. Identity enforcement remains fail-closed.

## Evidence

- Reproduced in dry beta validation: https://github.com/openclaw/openclaw/actions/runs/29632830819
- Failing child job: https://github.com/openclaw/openclaw/actions/runs/29633055453/job/88050388089
- Testbox: 91/91 `package-acceptance-workflow` tests passed: https://github.com/openclaw/openclaw/actions/runs/29633185123
- `actionlint .github/workflows/openclaw-release-checks.yml`
- `git diff --check`
- Fresh autoreview: clean, confidence 0.99
