### PR TITLE
improve(gateway): bound visible history page reads

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -107,6 +107,7 @@ const rootEntries = [
   // Workflow/package-script entrypoints are not imported from production modules.
   "scripts/openclaw-cross-os-release-checks.ts!",
   "scripts/bench-transcript-cursors.ts!",
+  "scripts/bench-session-history-http.ts!",
   "scripts/bench-sqlite-reliability.ts!",
   // Docker/manual E2E executables and their nested assertion/probe entrypoints.
   "scripts/e2e/*.{js,mjs,ts}!",

--- a/scripts/bench-session-history-http.ts
+++ b/scripts/bench-session-history-http.ts
@@ -1,0 +1,435 @@
+// Benchmarks production HTTP/SSE visible-history reads against a 100k-message session.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer, type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const EVENT_COUNT = 100_000;
+const PAGE_SIZE = 50;
+const RAW_WINDOW = PAGE_SIZE * 20 + 20;
+const RUNS = 12;
+const WARMUPS = 3;
+const CHECKOUT = path.resolve(process.env.OPENCLAW_BENCH_CHECKOUT ?? process.cwd());
+
+type OperationSample = {
+  eventParses: number;
+  heapDeltaBytes: number;
+  latencyMs: number;
+  rssDeltaBytes: number;
+};
+
+type BenchmarkModules = {
+  closeAgentDatabases: () => void;
+  closeStateDatabase: () => void;
+  emitTranscriptUpdate: (update: Record<string, unknown>) => void;
+  handleRequest: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+    options: { auth: { mode: "none" } },
+  ) => Promise<boolean>;
+  openAgentDatabase: (options: { agentId: string; env: NodeJS.ProcessEnv }) => {
+    db: import("node:sqlite").DatabaseSync;
+  };
+};
+
+function targetModule(relativePath: string): string {
+  return pathToFileURL(path.join(CHECKOUT, relativePath)).href;
+}
+
+async function loadBenchmarkModules(): Promise<BenchmarkModules> {
+  const [history, updates, agentDb, stateDb] = await Promise.all([
+    import(targetModule("src/gateway/sessions-history-http.ts")),
+    import(targetModule("src/sessions/transcript-events.ts")),
+    import(targetModule("src/state/openclaw-agent-db.ts")),
+    import(targetModule("src/state/openclaw-state-db.ts")),
+  ]);
+  return {
+    closeAgentDatabases: agentDb.closeOpenClawAgentDatabasesForTest,
+    closeStateDatabase: stateDb.closeOpenClawStateDatabaseForTest,
+    emitTranscriptUpdate: updates.emitSessionTranscriptUpdate,
+    handleRequest: history.handleSessionHistoryHttpRequest,
+    openAgentDatabase: agentDb.openOpenClawAgentDatabase,
+  };
+}
+
+function seedTranscript(
+  db: import("node:sqlite").DatabaseSync,
+  params: { sessionId: string; sessionKey: string; storePath: string },
+): void {
+  const now = Date.now();
+  const insertEvent = db.prepare(
+    "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, ?, ?, ?)",
+  );
+  const insertIdentity = db.prepare(
+    `INSERT INTO transcript_event_identities
+       (session_id, event_id, seq, event_type, parent_id, created_at)
+     VALUES (?, ?, ?, 'message', ?, ?)`,
+  );
+  const insertActive = db.prepare(
+    `INSERT INTO session_transcript_active_events
+       (session_id, active_position, event_seq, message_position)
+     VALUES (?, ?, ?, ?)`,
+  );
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    // Seed the canonical route and session entry used by the production HTTP
+    // handler. The marker keeps both checkouts on their normal SQLite reader.
+    db.prepare(
+      `INSERT INTO sessions
+         (session_id, session_key, session_scope, created_at, updated_at)
+       VALUES (?, ?, 'conversation', ?, ?)`,
+    ).run(params.sessionId, params.sessionKey, now, now);
+    db.prepare(
+      "INSERT INTO session_routes (session_key, session_id, updated_at) VALUES (?, ?, ?)",
+    ).run(params.sessionKey, params.sessionId, now);
+    db.prepare(
+      `INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
+       VALUES (?, ?, ?, ?)`,
+    ).run(
+      params.sessionKey,
+      params.sessionId,
+      JSON.stringify({
+        sessionFile: `sqlite:main:${params.sessionId}:${params.storePath}`,
+        sessionId: params.sessionId,
+        updatedAt: now,
+      }),
+      now,
+    );
+    // Current main may predate the stacked generation table, while the
+    // candidate requires it. Both fixtures otherwise remain byte-identical.
+    if (
+      db
+        .prepare(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_transcript_generations'",
+        )
+        .get()
+    ) {
+      db.prepare(
+        `INSERT INTO session_transcript_generations (session_id, generation, updated_at)
+         VALUES (?, 'benchmark-generation', ?)`,
+      ).run(params.sessionId, now);
+    }
+    // Every raw event is a visible active-path message so deserialization
+    // counts directly describe transcript work instead of a synthetic proxy.
+    for (let seq = 0; seq < EVENT_COUNT; seq += 1) {
+      const eventId = `benchmark-${String(seq)}`;
+      const parentId = seq === 0 ? null : `benchmark-${String(seq - 1)}`;
+      insertEvent.run(
+        params.sessionId,
+        seq,
+        JSON.stringify({
+          id: eventId,
+          message: {
+            content: [
+              { type: "text", text: `message-${String(seq).padStart(6, "0")}-${"x".repeat(49)}` },
+            ],
+            role: "assistant",
+          },
+          parentId,
+          type: "message",
+        }),
+        now + seq,
+      );
+      insertIdentity.run(params.sessionId, eventId, seq, parentId, now + seq);
+      insertActive.run(params.sessionId, seq, seq, seq);
+    }
+    // Mark the materialized projection current at the 100k-event frontier.
+    db.prepare(
+      `INSERT INTO session_transcript_index_state
+         (session_id, indexed_seq, leaf_event_id, needs_rebuild,
+          active_event_count, active_message_count, updated_at)
+       VALUES (?, ?, ?, 0, ?, ?, ?)`,
+    ).run(
+      params.sessionId,
+      EVENT_COUNT - 1,
+      `benchmark-${String(EVENT_COUNT - 1)}`,
+      EVENT_COUNT,
+      EVENT_COUNT,
+      now + EVENT_COUNT,
+    );
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function percentile(values: readonly number[], fraction: number): number {
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * fraction));
+  return Number((sorted[index] ?? 0).toFixed(3));
+}
+
+function summarize(samples: readonly OperationSample[]) {
+  return {
+    eventParses: {
+      max: Math.max(...samples.map((sample) => sample.eventParses)),
+      median: percentile(
+        samples.map((sample) => sample.eventParses),
+        0.5,
+      ),
+      min: Math.min(...samples.map((sample) => sample.eventParses)),
+    },
+    heapDeltaBytesMedian: percentile(
+      samples.map((sample) => sample.heapDeltaBytes),
+      0.5,
+    ),
+    latencyMs: {
+      median: percentile(
+        samples.map((sample) => sample.latencyMs),
+        0.5,
+      ),
+      p95: percentile(
+        samples.map((sample) => sample.latencyMs),
+        0.95,
+      ),
+    },
+    rssDeltaBytesMedian: percentile(
+      samples.map((sample) => sample.rssDeltaBytes),
+      0.5,
+    ),
+    samples,
+  };
+}
+
+function installEventParseCounter(): { read: () => number; reset: () => void } {
+  const originalParse = JSON.parse.bind(JSON);
+  let count = 0;
+  JSON.parse = ((
+    text: string,
+    reviver?: (this: unknown, key: string, value: unknown) => unknown,
+  ) => {
+    if (text.includes('"type":"message"') && text.includes('"id":"benchmark-')) {
+      count += 1;
+    }
+    return originalParse(text, reviver);
+  }) as JSON["parse"];
+  return {
+    read: () => count,
+    reset: () => {
+      count = 0;
+    },
+  };
+}
+
+async function measure(
+  counter: ReturnType<typeof installEventParseCounter>,
+  operation: () => Promise<void>,
+): Promise<OperationSample> {
+  globalThis.gc?.();
+  const before = process.memoryUsage();
+  counter.reset();
+  const startedAt = performance.now();
+  await operation();
+  const latencyMs = performance.now() - startedAt;
+  const after = process.memoryUsage();
+  return {
+    eventParses: counter.read(),
+    heapDeltaBytes: after.heapUsed - before.heapUsed,
+    latencyMs: Number(latencyMs.toFixed(3)),
+    rssDeltaBytes: after.rss - before.rss,
+  };
+}
+
+async function runMeasured(
+  counter: ReturnType<typeof installEventParseCounter>,
+  operation: () => Promise<void>,
+): Promise<OperationSample[]> {
+  for (let index = 0; index < WARMUPS; index += 1) {
+    await measure(counter, operation);
+  }
+  const samples: OperationSample[] = [];
+  for (let index = 0; index < RUNS; index += 1) {
+    samples.push(await measure(counter, operation));
+  }
+  return samples;
+}
+
+async function readSseEvent(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<unknown> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const boundary = buffer.indexOf("\n\n");
+    if (boundary >= 0) {
+      const event = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const data = event
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trim())
+        .join("\n");
+      if (data) {
+        return JSON.parse(data);
+      }
+      continue;
+    }
+    const chunk = await reader.read();
+    if (chunk.done) {
+      throw new Error("SSE stream ended before a history event");
+    }
+    buffer += decoder.decode(chunk.value, { stream: true });
+  }
+}
+
+async function startHistoryServer(
+  handleRequest: BenchmarkModules["handleRequest"],
+): Promise<{ baseUrl: string; server: Server }> {
+  const server = createServer((req, res) => {
+    void handleRequest(req, res, { auth: { mode: "none" } }).then((handled) => {
+      if (!handled && !res.writableEnded) {
+        res.writeHead(404).end();
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("benchmark server did not expose a TCP port");
+  }
+  return { baseUrl: `http://127.0.0.1:${String(address.port)}`, server };
+}
+
+async function fetchHistory(baseUrl: string, sessionKey: string, query: string) {
+  const response = await fetch(
+    `${baseUrl}/sessions/${encodeURIComponent(sessionKey)}/history${query}`,
+    { headers: { "x-openclaw-scopes": "operator.read" } },
+  );
+  if (!response.ok) {
+    throw new Error(`history request failed: ${String(response.status)} ${await response.text()}`);
+  }
+  return (await response.json()) as { messages?: unknown[]; nextCursor?: string };
+}
+
+async function main(): Promise<void> {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-visible-history-bench-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  fs.writeFileSync(path.join(stateDir, "openclaw.json"), '{"gateway":{"auth":{"mode":"none"}}}');
+  const sessionId = "visible-history-benchmark";
+  const sessionKey = "agent:main:visible-history-benchmark";
+  const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+  const modules = await loadBenchmarkModules();
+  const database = modules.openAgentDatabase({ agentId: "main", env: process.env });
+  let server: Server | undefined;
+  try {
+    // The first bounded tail response supplies each checkout's native cursor;
+    // all measured JSON reads request the same 50-message older page.
+    seedTranscript(database.db, { sessionId, sessionKey, storePath });
+    const started = await startHistoryServer(modules.handleRequest);
+    server = started.server;
+    const tail = await fetchHistory(started.baseUrl, sessionKey, `?limit=${String(PAGE_SIZE)}`);
+    if (!tail.nextCursor || tail.messages?.length !== PAGE_SIZE) {
+      throw new Error("tail bootstrap did not return a full cursor page");
+    }
+    const cursorQuery = `?limit=${String(PAGE_SIZE)}&cursor=${encodeURIComponent(tail.nextCursor)}`;
+    const counter = installEventParseCounter();
+    const httpSamples = await runMeasured(counter, async () => {
+      const page = await fetchHistory(started.baseUrl, sessionKey, cursorQuery);
+      if (page.messages?.length !== PAGE_SIZE) {
+        throw new Error("HTTP cursor page did not return 50 messages");
+      }
+    });
+    const measureSseRefresh = async (): Promise<OperationSample> => {
+      globalThis.gc?.();
+      const response = await fetch(
+        `${started.baseUrl}/sessions/${encodeURIComponent(sessionKey)}/history${cursorQuery}`,
+        {
+          headers: {
+            accept: "text/event-stream",
+            "x-openclaw-scopes": "operator.read",
+          },
+        },
+      );
+      const reader = response.body?.getReader();
+      if (!response.ok || !reader) {
+        throw new Error("SSE cursor page did not open");
+      }
+      await readSseEvent(reader);
+      counter.reset();
+      const before = process.memoryUsage();
+      const startedAt = performance.now();
+      modules.emitTranscriptUpdate({ target: { agentId: "main", sessionId, sessionKey } });
+      await readSseEvent(reader);
+      const after = process.memoryUsage();
+      const sample = {
+        eventParses: counter.read(),
+        heapDeltaBytes: after.heapUsed - before.heapUsed,
+        latencyMs: Number((performance.now() - startedAt).toFixed(3)),
+        rssDeltaBytes: after.rss - before.rss,
+      };
+      await reader.cancel();
+      return sample;
+    };
+    for (let index = 0; index < WARMUPS; index += 1) {
+      await measureSseRefresh();
+    }
+    // Each SSE sample measures only the production refresh after its initial
+    // cursor page has arrived, matching the long-lived stream workload.
+    const sseSamples: OperationSample[] = [];
+    for (let index = 0; index < RUNS; index += 1) {
+      sseSamples.push(await measureSseRefresh());
+    }
+    // Pin the production candidate query shape to the active-message keyset
+    // index and the transcript-event primary key, with no temporary sort.
+    const visiblePlan = database.db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT active.event_seq, active.message_position, event.event_json
+           FROM session_transcript_active_events AS active
+           JOIN transcript_events AS event
+             ON event.session_id = active.session_id AND event.seq = active.event_seq
+          WHERE active.session_id = ?
+            AND active.message_position IS NOT NULL
+            AND active.message_position < ?
+          ORDER BY active.message_position DESC
+          LIMIT ${String(RAW_WINDOW)}`,
+      )
+      .all(sessionId, EVENT_COUNT - PAGE_SIZE)
+      .map((row) => (row as { detail: string }).detail);
+    console.log(
+      JSON.stringify(
+        {
+          checkout: CHECKOUT,
+          fixture: {
+            eventCount: EVENT_COUNT,
+            eventShape: "linear active assistant messages with 64-character text payload",
+            pageSize: PAGE_SIZE,
+            rawWindow: RAW_WINDOW,
+          },
+          gitSha: execFileSync("git", ["-C", CHECKOUT, "rev-parse", "HEAD"], {
+            encoding: "utf8",
+          }).trim(),
+          machine: { hostname: os.hostname(), platform: process.platform, arch: process.arch },
+          memory: { peakRssKb: process.resourceUsage().maxRSS },
+          node: process.version,
+          runs: RUNS,
+          timings: {
+            httpJsonCursor: summarize(httpSamples),
+            sseCursorRefresh: summarize(sseSamples),
+          },
+          visibleQueryPlan: visiblePlan,
+          warmups: WARMUPS,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await new Promise<void>((resolve) => {
+      if (server) {
+        server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+    modules.closeAgentDatabases();
+    modules.closeStateDatabase();
+    fs.rmSync(stateDir, { force: true, recursive: true });
+  }
+}
+
+await main();

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -114,7 +114,7 @@ describe("SQLite active transcript event projection", () => {
       "root",
       "active",
     ]);
-    expect(page.events.map((entry) => entry.seq)).toEqual([1, 2]);
+    expect(page.events.map((entry) => entry.seq)).toEqual([2, 4]);
     expect(page.totalMessages).toBe(2);
     expect(
       database.db
@@ -396,10 +396,11 @@ describe("SQLite active transcript event projection", () => {
     expect(tail).toMatchObject({
       kind: "page",
       events: [
-        { eventSeq: 3, seq: 3 },
-        { eventSeq: 4, seq: 4 },
+        { eventSeq: 3, seq: 4 },
+        { eventSeq: 4, seq: 5 },
       ],
       hasMore: true,
+      rawTranscriptSeq: 5,
       totalMessages: 4,
     });
     if (tail.kind !== "page") {
@@ -423,11 +424,12 @@ describe("SQLite active transcript event projection", () => {
     expect(older).toMatchObject({
       kind: "page",
       events: [
-        { eventSeq: 1, seq: 1 },
-        { eventSeq: 2, seq: 2 },
+        { eventSeq: 1, seq: 2 },
+        { eventSeq: 2, seq: 3 },
       ],
       generation: tail.generation,
       hasMore: false,
+      rawTranscriptSeq: 6,
       totalMessages: 5,
     });
 
@@ -668,15 +670,15 @@ describe("SQLite active transcript event projection", () => {
     expect(page.totalMessages).toBe(100_000);
     expect(page.events).toHaveLength(25);
     expect(page.events.map((entry) => entry.seq)).toEqual(
-      Array.from({ length: 25 }, (_, index) => 99_976 + index),
+      Array.from({ length: 25 }, (_, index) => 99_977 + index),
     );
     expect(recent.totalMessages).toBe(100_000);
     expect(recent.events).toHaveLength(10);
-    expect(recent.events.at(-1)?.seq).toBe(100_000);
+    expect(recent.events.at(-1)?.seq).toBe(100_001);
     expect(lineCappedRecent.events).toHaveLength(3);
-    expect(lineCappedRecent.events.at(-1)?.seq).toBe(100_000);
+    expect(lineCappedRecent.events.at(-1)?.seq).toBe(100_001);
     expect(readSessionTranscriptMessageEventCount(scope)).toBe(100_000);
-    expect(byId?.seq).toBe(100_000);
+    expect(byId?.seq).toBe(100_001);
     expect(anchor).toMatchObject({
       found: true,
       hasOverreadContext: true,
@@ -684,7 +686,7 @@ describe("SQLite active transcript event projection", () => {
       totalMessages: 100_000,
     });
     expect(anchor.events).toHaveLength(6);
-    expect(anchor.events.at(-1)?.seq).toBe(100_000);
+    expect(anchor.events.at(-1)?.seq).toBe(100_001);
 
     database.db
       .prepare("UPDATE transcript_events SET event_json = ? WHERE session_id = ? AND seq = 1")

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -8,13 +8,18 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { appendTranscriptEvent, persistSessionTranscriptTurn } from "./session-accessor.js";
+import {
+  appendTranscriptEvent,
+  persistSessionTranscriptTurn,
+  replaceTranscriptEvents,
+} from "./session-accessor.js";
 import {
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptMessageAnchorPage,
   readSessionTranscriptMessageEventById,
   readSessionTranscriptMessageEventCount,
   readSessionTranscriptMessageEventPage,
+  readSessionTranscriptVisibleMessagePage,
   SessionTranscriptProjectionUnavailableError,
 } from "./session-accessor.sqlite-active-events.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
@@ -375,6 +380,107 @@ describe("SQLite active transcript event projection", () => {
     } finally {
       writer.close();
     }
+  });
+
+  it("pages older active messages across appends and resets after replacement", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: ["one", "two", "three", "four"].map((content, index) => ({
+        eventId: `message-${String(index + 1)}`,
+        parentId: index === 0 ? null : `message-${String(index)}`,
+        message: { role: "assistant", content },
+      })),
+      touchSessionEntry: false,
+    });
+
+    const tail = readSessionTranscriptVisibleMessagePage(scope, { maxMessages: 2 });
+    expect(tail).toMatchObject({
+      kind: "page",
+      events: [
+        { eventSeq: 3, seq: 3 },
+        { eventSeq: 4, seq: 4 },
+      ],
+      hasMore: true,
+      totalMessages: 4,
+    });
+    if (tail.kind !== "page") {
+      throw new Error("expected visible tail page");
+    }
+
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "message-5",
+          parentId: "message-4",
+          message: { role: "assistant", content: "five" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const older = readSessionTranscriptVisibleMessagePage(scope, {
+      before: { eventSeq: tail.events[0]!.eventSeq, generation: tail.generation },
+      maxMessages: 2,
+    });
+    expect(older).toMatchObject({
+      kind: "page",
+      events: [
+        { eventSeq: 1, seq: 1 },
+        { eventSeq: 2, seq: 2 },
+      ],
+      generation: tail.generation,
+      hasMore: false,
+      totalMessages: 5,
+    });
+
+    await replaceTranscriptEvents(scope, [
+      {
+        id: "replacement",
+        message: { role: "assistant", content: "replacement" },
+        type: "message",
+      },
+    ]);
+    expect(
+      readSessionTranscriptVisibleMessagePage(scope, {
+        before: { eventSeq: tail.events[0]!.eventSeq, generation: tail.generation },
+        maxMessages: 2,
+      }),
+    ).toMatchObject({ kind: "reset", reason: "generation_mismatch" });
+  });
+
+  it("resets a visible page when a branch change removes its active anchor", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "root", parentId: null, message: { role: "user", content: "root" } },
+        {
+          eventId: "old-leaf",
+          parentId: "root",
+          message: { role: "assistant", content: "old" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const page = readSessionTranscriptVisibleMessagePage(scope, { maxMessages: 1 });
+    if (page.kind !== "page") {
+      throw new Error("expected visible page");
+    }
+
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "new-leaf",
+          parentId: "root",
+          message: { role: "assistant", content: "new" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+
+    expect(
+      readSessionTranscriptVisibleMessagePage(scope, {
+        before: { eventSeq: page.events[0]!.eventSeq, generation: page.generation },
+        maxMessages: 1,
+      }),
+    ).toMatchObject({ kind: "reset", reason: "anchor_missing" });
   });
 
   it("awaits queued completion work after the preparation worker exits", async () => {

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -54,6 +54,10 @@ export type SessionTranscriptMessageEvent = {
   seq: number;
 };
 
+export type SessionTranscriptVisibleMessageEvent = SessionTranscriptMessageEvent & {
+  eventSeq: number;
+};
+
 export type SessionTranscriptMessageEventPage = {
   events: SessionTranscriptMessageEvent[];
   totalMessages: number;
@@ -64,6 +68,21 @@ export type SessionTranscriptMessageAnchorPage = SessionTranscriptMessageEventPa
   hasOverreadContext: boolean;
   offset: number;
 };
+
+export type SessionTranscriptVisibleMessagePageResult =
+  | {
+      events: SessionTranscriptVisibleMessageEvent[];
+      generation: string;
+      hasMore: boolean;
+      kind: "page";
+      totalMessages: number;
+    }
+  | {
+      generation: string;
+      kind: "reset";
+      reason: "anchor_missing" | "generation_mismatch";
+    }
+  | { kind: "missing" };
 
 export class SessionTranscriptProjectionUnavailableError extends Error {
   constructor(readonly sessionId: string) {
@@ -255,6 +274,14 @@ function parseMessageEventRow(row: {
     // Raw event seq includes headers/control rows and would make pages overlap.
     seq: row.message_position + 1,
   };
+}
+
+function parseVisibleMessageEventRow(row: {
+  event_seq: number;
+  event_json: string;
+  message_position: number | null;
+}): SessionTranscriptVisibleMessageEvent {
+  return { ...parseMessageEventRow(row), eventSeq: row.event_seq };
 }
 
 function readMessageRange(
@@ -535,6 +562,78 @@ export function readSessionTranscriptMessageEventPage(
     return {
       events: readMessageRange(projection, start, endExclusive),
       totalMessages,
+    };
+  });
+}
+
+/** Reads one append-stable older-message page with an active-projection keyset seek. */
+export function readSessionTranscriptVisibleMessagePage(
+  scope: SessionTranscriptReadScope,
+  options: { before?: { eventSeq: number; generation: string }; maxMessages: number },
+): SessionTranscriptVisibleMessagePageResult {
+  return withCurrentProjectionSnapshot(scope, (projection) => {
+    const db = getActiveTranscriptKysely(projection.database);
+    const generation = executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_generations")
+        .select("generation")
+        .where("session_id", "=", projection.resolved.sessionId),
+    )?.generation;
+    if (!generation) {
+      return { kind: "missing" };
+    }
+    if (options.before?.generation !== undefined && options.before.generation !== generation) {
+      return { generation, kind: "reset", reason: "generation_mismatch" };
+    }
+
+    let endExclusive = projection.state.activeMessageCount;
+    if (options.before) {
+      const anchor = executeSqliteQueryTakeFirstSync(
+        projection.database.db,
+        db
+          .selectFrom("session_transcript_active_events")
+          .select("message_position")
+          .where("session_id", "=", projection.resolved.sessionId)
+          .where("event_seq", "=", options.before.eventSeq)
+          .where("message_position", "is not", null),
+      );
+      if (anchor?.message_position === null || anchor?.message_position === undefined) {
+        return { generation, kind: "reset", reason: "anchor_missing" };
+      }
+      endExclusive = anchor.message_position;
+    }
+
+    const maxMessages = Math.max(
+      0,
+      Math.floor(Number.isFinite(options.maxMessages) ? options.maxMessages : 0),
+    );
+    const rows =
+      maxMessages === 0
+        ? []
+        : executeSqliteQuerySync(
+            projection.database.db,
+            db
+              .selectFrom("session_transcript_active_events as active")
+              .innerJoin("transcript_events as event", (join) =>
+                join
+                  .onRef("event.session_id", "=", "active.session_id")
+                  .onRef("event.seq", "=", "active.event_seq"),
+              )
+              .select(["active.event_seq", "active.message_position", "event.event_json"])
+              .where("active.session_id", "=", projection.resolved.sessionId)
+              .where("active.message_position", "is not", null)
+              .where("active.message_position", "<", endExclusive)
+              .orderBy("active.message_position", "desc")
+              .limit(maxMessages),
+          ).rows;
+    const events = rows.toReversed().map(parseVisibleMessageEventRow);
+    return {
+      events,
+      generation,
+      hasMore: (rows.at(-1)?.message_position ?? 0) > 0,
+      kind: "page",
+      totalMessages: projection.state.activeMessageCount,
     };
   });
 }

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -75,6 +75,7 @@ export type SessionTranscriptVisibleMessagePageResult =
       generation: string;
       hasMore: boolean;
       kind: "page";
+      rawTranscriptSeq: number;
       totalMessages: number;
     }
   | {
@@ -262,6 +263,7 @@ function withCurrentProjectionSnapshot<T>(
 }
 
 function parseMessageEventRow(row: {
+  event_seq: number;
   event_json: string;
   message_position: number | null;
 }): SessionTranscriptMessageEvent {
@@ -270,9 +272,9 @@ function parseMessageEventRow(row: {
   }
   return {
     event: JSON.parse(row.event_json) as TranscriptEvent,
-    // Gateway cursors use the visible-message ordinal, matching the JSONL index.
-    // Raw event seq includes headers/control rows and would make pages overlap.
-    seq: row.message_position + 1,
+    // Public history metadata is the one-based raw transcript row. Projection
+    // positions remain separate so paging can skip headers and control rows.
+    seq: row.event_seq + 1,
   };
 }
 
@@ -302,7 +304,7 @@ function readMessageRange(
           .onRef("event.session_id", "=", "active.session_id")
           .onRef("event.seq", "=", "active.event_seq"),
       )
-      .select(["active.message_position", "event.event_json"])
+      .select(["active.event_seq", "active.message_position", "event.event_json"])
       .where("active.session_id", "=", projection.resolved.sessionId)
       .where("active.message_position", "is not", null)
       .where("active.message_position", ">=", start)
@@ -633,6 +635,7 @@ export function readSessionTranscriptVisibleMessagePage(
       generation,
       hasMore: (rows.at(-1)?.message_position ?? 0) > 0,
       kind: "page",
+      rawTranscriptSeq: projection.state.indexedSeq + 1,
       totalMessages: projection.state.activeMessageCount,
     };
   });
@@ -664,7 +667,7 @@ export function readSessionTranscriptMessageEventById(
             .onRef("event.session_id", "=", "active.session_id")
             .onRef("event.seq", "=", "active.event_seq"),
         )
-        .select(["active.message_position", "event.event_json"])
+        .select(["active.event_seq", "active.message_position", "event.event_json"])
         .where("identity.session_id", "=", projection.resolved.sessionId)
         .where("identity.event_id", "=", messageId)
         .where("active.message_position", "is not", null),

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -199,12 +199,15 @@ export {
   readSessionTranscriptMessageEventPage,
   readSessionTranscriptMessageEvents,
   readSessionTranscriptVisibleMessageDelta,
+  readSessionTranscriptVisibleMessagePage,
   SessionTranscriptProjectionUnavailableError,
 } from "./session-accessor.sqlite-active-events.js";
 export type {
   SessionTranscriptMessageAnchorPage,
   SessionTranscriptMessageEvent,
   SessionTranscriptMessageEventPage,
+  SessionTranscriptVisibleMessageEvent,
+  SessionTranscriptVisibleMessagePageResult,
 } from "./session-accessor.sqlite-active-events.js";
 export {
   resolveSessionTranscriptReadTarget,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -1,11 +1,13 @@
 // Gateway session-history projection state.
 // Tracks transcript sequence windows for paginated chat-history SSE updates.
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
+import { normalizeAgentId } from "../routing/session-key.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   projectChatDisplayMessages,
   projectChatDisplayMessagesWithState,
 } from "./chat-display-projection.js";
+import { readVisibleSessionMessagesAsync } from "./session-history-visible-reader.js";
 import { resolveTranscriptPathForComparison } from "./session-transcript-path.js";
 import {
   attachOpenClawTranscriptMeta,
@@ -39,13 +41,18 @@ type SessionHistorySnapshot = {
   turnBoundaryPending: boolean;
 };
 
+export type SessionHistoryReadSnapshot = SessionHistorySnapshot & {
+  appliedCursor?: string;
+  transcriptPath?: string;
+};
+
 type InlineSessionHistoryAppend = {
   message?: SessionHistoryMessage;
   messageSeq?: number;
   shouldRefresh?: boolean;
 };
 
-type SessionHistoryTranscriptTarget = {
+export type SessionHistoryTranscriptTarget = {
   agentId?: string;
   sessionEntry?: { sessionFile?: string; sessionId?: string };
   sessionId: string;
@@ -59,6 +66,61 @@ type SessionHistoryRawSnapshot = {
   totalRawMessages?: number;
   transcriptPath?: string;
 };
+
+const VISIBLE_HISTORY_CURSOR_VERSION = 1;
+const MAX_VISIBLE_HISTORY_CURSOR_LENGTH = 4_096;
+
+type VisibleHistoryCursor = {
+  agentId: string;
+  anchorEventSeq: number;
+  direction: "older";
+  generation: string;
+  sessionId: string;
+  sessionKey: string;
+  version: typeof VISIBLE_HISTORY_CURSOR_VERSION;
+};
+
+function encodeVisibleHistoryCursor(cursor: VisibleHistoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function parseVisibleHistoryCursor(value: string): VisibleHistoryCursor | undefined {
+  if (value.length > MAX_VISIBLE_HISTORY_CURSOR_LENGTH) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(value, "base64url").toString("utf8"),
+    ) as Partial<VisibleHistoryCursor>;
+    if (
+      parsed.version !== VISIBLE_HISTORY_CURSOR_VERSION ||
+      parsed.direction !== "older" ||
+      typeof parsed.agentId !== "string" ||
+      typeof parsed.sessionId !== "string" ||
+      typeof parsed.sessionKey !== "string" ||
+      typeof parsed.generation !== "string" ||
+      parsed.generation.length === 0 ||
+      !Number.isSafeInteger(parsed.anchorEventSeq) ||
+      (parsed.anchorEventSeq ?? -1) < 0
+    ) {
+      return undefined;
+    }
+    return parsed as VisibleHistoryCursor;
+  } catch {
+    return undefined;
+  }
+}
+
+function cursorMatchesTarget(
+  cursor: VisibleHistoryCursor,
+  target: SessionHistoryTranscriptTarget,
+): boolean {
+  return (
+    cursor.agentId === normalizeAgentId(target.agentId) &&
+    cursor.sessionId === target.sessionId &&
+    cursor.sessionKey === target.sessionKey
+  );
+}
 
 function readMessageIdempotencyKey(message: unknown): string | undefined {
   if (!message || typeof message !== "object" || Array.isArray(message)) {
@@ -189,12 +251,131 @@ export function buildSessionHistorySnapshot(params: {
   };
 }
 
+async function readLegacySessionHistorySnapshot(params: {
+  cursor?: string;
+  limit?: number;
+  maxChars: number;
+  target: SessionHistoryTranscriptTarget;
+}): Promise<SessionHistoryReadSnapshot> {
+  const boundedSnapshot =
+    params.cursor === undefined && typeof params.limit === "number"
+      ? await readRecentSessionMessagesWithStatsAsync(params.target, {
+          ...resolveSessionHistoryTailReadOptions(params.limit),
+          allowResetArchiveFallback: true,
+        })
+      : undefined;
+  const fullSnapshot =
+    boundedSnapshot === undefined
+      ? await readSessionMessagesWithSourceAsync(params.target, {
+          mode: "full",
+          reason: "session history cursor pagination",
+          allowResetArchiveFallback: true,
+        })
+      : undefined;
+  return {
+    ...buildSessionHistorySnapshot({
+      rawMessages: boundedSnapshot?.messages ?? fullSnapshot?.messages ?? [],
+      maxChars: params.maxChars,
+      limit: params.limit,
+      cursor: params.cursor,
+      rawTranscriptSeq: boundedSnapshot?.totalMessages,
+      totalRawMessages: boundedSnapshot?.totalMessages,
+    }),
+    ...(params.cursor ? { appliedCursor: params.cursor } : {}),
+    transcriptPath: boundedSnapshot?.transcriptPath ?? fullSnapshot?.transcriptPath,
+  };
+}
+
+/** Reads the shared JSON/SSE visible-history snapshot without materializing cursor pages. */
+export async function readSessionHistorySnapshotAsync(params: {
+  cursor?: string;
+  limit?: number;
+  maxChars?: number;
+  target: SessionHistoryTranscriptTarget;
+}): Promise<SessionHistoryReadSnapshot> {
+  const maxChars = params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
+  if (typeof params.limit !== "number") {
+    return await readLegacySessionHistorySnapshot({ ...params, maxChars });
+  }
+  // Stable releases through v2026.7.1 issued numeric history cursors. Keep
+  // those requests on their shipped reader for one supported upgrade window;
+  // cursor-less SQLite pages issue only opaque v1 cursors.
+  if (params.cursor && resolveCursorSeq(params.cursor) !== undefined) {
+    return await readLegacySessionHistorySnapshot({ ...params, maxChars });
+  }
+
+  const decodedCursor = params.cursor ? parseVisibleHistoryCursor(params.cursor) : undefined;
+  const scopedCursor =
+    decodedCursor && cursorMatchesTarget(decodedCursor, params.target) ? decodedCursor : undefined;
+  let page = await readVisibleSessionMessagesAsync(params.target, {
+    ...(scopedCursor
+      ? {
+          before: {
+            eventSeq: scopedCursor.anchorEventSeq,
+            generation: scopedCursor.generation,
+          },
+        }
+      : {}),
+    maxMessages: resolveSessionHistoryTailReadOptions(params.limit).maxMessages,
+  });
+  let appliedCursor = scopedCursor ? params.cursor : undefined;
+  let fallbackCursor = params.cursor;
+  if (page.kind === "reset") {
+    page = await readVisibleSessionMessagesAsync(params.target, {
+      maxMessages: resolveSessionHistoryTailReadOptions(params.limit).maxMessages,
+    });
+    appliedCursor = undefined;
+    fallbackCursor = undefined;
+  }
+  if (page.kind !== "page") {
+    return await readLegacySessionHistorySnapshot({
+      ...params,
+      cursor: fallbackCursor,
+      maxChars,
+    });
+  }
+
+  const snapshot = buildSessionHistorySnapshot({
+    rawMessages: page.messages,
+    maxChars,
+    limit: params.limit,
+    rawTranscriptSeq: page.totalMessages,
+  });
+  const hasMore = snapshot.history.hasMore || page.hasMore;
+  const firstVisibleSeq = resolveMessageSeq(snapshot.history.messages[0]);
+  const anchor =
+    page.anchors.find((candidate) => candidate.seq === firstVisibleSeq) ?? page.anchors[0];
+  const nextCursor =
+    hasMore && anchor
+      ? encodeVisibleHistoryCursor({
+          agentId: normalizeAgentId(params.target.agentId),
+          anchorEventSeq: anchor.eventSeq,
+          direction: "older",
+          generation: page.generation,
+          sessionId: params.target.sessionId,
+          sessionKey: params.target.sessionKey,
+          version: VISIBLE_HISTORY_CURSOR_VERSION,
+        })
+      : undefined;
+  snapshot.history.hasMore = hasMore;
+  if (nextCursor) {
+    snapshot.history.nextCursor = nextCursor;
+  } else {
+    delete snapshot.history.nextCursor;
+  }
+  return {
+    ...snapshot,
+    ...(appliedCursor ? { appliedCursor } : {}),
+    transcriptPath: page.transcriptPath,
+  };
+}
+
 /** Tracks session-history SSE state and decides when inline appends are still valid. */
 export class SessionHistorySseState {
   private readonly target: SessionHistoryTranscriptTarget;
   private readonly maxChars: number;
   private readonly limit: number | undefined;
-  private readonly cursor: string | undefined;
+  private cursor: string | undefined;
   private sentHistory: PaginatedSessionHistory;
   private rawTranscriptSeq: number;
   private turnBoundaryPending: boolean;
@@ -220,6 +401,28 @@ export class SessionHistorySseState {
       totalRawMessages: params.totalRawMessages,
       transcriptPath: params.transcriptPath,
     });
+  }
+
+  /** Initializes SSE state from the shared production history read. */
+  static fromReadSnapshot(params: {
+    limit?: number;
+    maxChars?: number;
+    snapshot: SessionHistoryReadSnapshot;
+    target: SessionHistoryTranscriptTarget;
+  }): SessionHistorySseState {
+    const state = new SessionHistorySseState({
+      target: params.target,
+      maxChars: params.maxChars,
+      limit: params.limit,
+      cursor: params.snapshot.appliedCursor,
+      initialRawMessages: [],
+      transcriptPath: params.snapshot.transcriptPath,
+    });
+    state.sentHistory = params.snapshot.history;
+    state.rawTranscriptSeq = params.snapshot.rawTranscriptSeq;
+    state.turnBoundaryPending = params.snapshot.turnBoundaryPending;
+    state.cursor = params.snapshot.appliedCursor;
+    return state;
   }
 
   private constructor(params: {
@@ -364,11 +567,16 @@ export class SessionHistorySseState {
   }
 
   async refreshAsync(): Promise<PaginatedSessionHistory> {
-    const rawSnapshot = await this.readRawSnapshotAsync();
-    const snapshot = this.buildSnapshot(rawSnapshot);
+    const snapshot = await readSessionHistorySnapshotAsync({
+      target: this.target,
+      maxChars: this.maxChars,
+      limit: this.limit,
+      cursor: this.cursor,
+    });
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.turnBoundaryPending = snapshot.turnBoundaryPending;
-    this.transcriptPath = normalizeTranscriptPathForComparison(rawSnapshot.transcriptPath);
+    this.transcriptPath = normalizeTranscriptPathForComparison(snapshot.transcriptPath);
+    this.cursor = snapshot.appliedCursor;
     this.sentHistory = snapshot.history;
     return snapshot.history;
   }
@@ -386,48 +594,6 @@ export class SessionHistorySseState {
         ? { totalRawMessages: rawSnapshot.totalRawMessages }
         : {}),
     });
-  }
-
-  private async readRawSnapshotAsync(): Promise<SessionHistoryRawSnapshot> {
-    if (this.cursor === undefined && typeof this.limit === "number") {
-      const snapshot = await readRecentSessionMessagesWithStatsAsync(
-        {
-          agentId: this.target.agentId,
-          sessionEntry: this.target.sessionEntry,
-          sessionId: this.target.sessionId,
-          sessionKey: this.target.sessionKey,
-          storePath: this.target.storePath,
-        },
-        {
-          ...resolveSessionHistoryTailReadOptions(this.limit),
-          allowResetArchiveFallback: true,
-        },
-      );
-      return {
-        rawMessages: snapshot.messages,
-        rawTranscriptSeq: snapshot.totalMessages,
-        totalRawMessages: snapshot.totalMessages,
-        transcriptPath: snapshot.transcriptPath,
-      };
-    }
-    const snapshot = await readSessionMessagesWithSourceAsync(
-      {
-        agentId: this.target.agentId,
-        sessionEntry: this.target.sessionEntry,
-        sessionId: this.target.sessionId,
-        sessionKey: this.target.sessionKey,
-        storePath: this.target.storePath,
-      },
-      {
-        mode: "full",
-        reason: "session history cursor pagination",
-        allowResetArchiveFallback: true,
-      },
-    );
-    return {
-      rawMessages: snapshot.messages,
-      transcriptPath: snapshot.transcriptPath,
-    };
   }
 }
 

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -303,7 +303,8 @@ export async function readSessionHistorySnapshotAsync(params: {
   target: SessionHistoryTranscriptTarget;
 }): Promise<SessionHistoryReadSnapshot> {
   const maxChars = params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
-  if (typeof params.limit !== "number") {
+  const decodedCursor = params.cursor ? parseVisibleHistoryCursor(params.cursor) : undefined;
+  if (typeof params.limit !== "number" && !decodedCursor) {
     return await readLegacySessionHistorySnapshot({ ...params, maxChars });
   }
   // Stable releases through v2026.7.1 issued numeric history cursors. Keep
@@ -313,9 +314,12 @@ export async function readSessionHistorySnapshotAsync(params: {
     return await readLegacySessionHistorySnapshot({ ...params, maxChars });
   }
 
-  const decodedCursor = params.cursor ? parseVisibleHistoryCursor(params.cursor) : undefined;
   const scopedCursor =
     decodedCursor && cursorMatchesTarget(decodedCursor, params.target) ? decodedCursor : undefined;
+  const maxMessages =
+    typeof params.limit === "number"
+      ? resolveSessionHistoryTailReadOptions(params.limit).maxMessages
+      : Number.MAX_SAFE_INTEGER;
   let page = await readVisibleSessionMessagesAsync(params.target, {
     ...(scopedCursor
       ? {
@@ -325,13 +329,13 @@ export async function readSessionHistorySnapshotAsync(params: {
           },
         }
       : {}),
-    maxMessages: resolveSessionHistoryTailReadOptions(params.limit).maxMessages,
+    maxMessages,
   });
   let appliedCursor = scopedCursor ? params.cursor : undefined;
   let fallbackCursor = params.cursor;
   if (page.kind === "reset") {
     page = await readVisibleSessionMessagesAsync(params.target, {
-      maxMessages: resolveSessionHistoryTailReadOptions(params.limit).maxMessages,
+      maxMessages,
     });
     appliedCursor = undefined;
     fallbackCursor = undefined;

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -272,9 +272,18 @@ async function readLegacySessionHistorySnapshot(params: {
           allowResetArchiveFallback: true,
         })
       : undefined;
+  const rawMessages = boundedSnapshot?.messages ?? fullSnapshot?.messages ?? [];
+  // Shipped numeric cursors addressed the visible-message ordinal. Preserve
+  // that one-window contract even though current metadata uses raw row seq.
+  const paginatedMessages =
+    resolveCursorSeq(params.cursor) === undefined
+      ? rawMessages
+      : rawMessages.map((message, index) =>
+          attachOpenClawTranscriptMeta(message, { seq: index + 1 }),
+        );
   return {
     ...buildSessionHistorySnapshot({
-      rawMessages: boundedSnapshot?.messages ?? fullSnapshot?.messages ?? [],
+      rawMessages: paginatedMessages,
       maxChars: params.maxChars,
       limit: params.limit,
       cursor: params.cursor,
@@ -339,7 +348,7 @@ export async function readSessionHistorySnapshotAsync(params: {
     rawMessages: page.messages,
     maxChars,
     limit: params.limit,
-    rawTranscriptSeq: page.totalMessages,
+    rawTranscriptSeq: page.rawTranscriptSeq,
   });
   const hasMore = snapshot.history.hasMore || page.hasMore;
   const firstVisibleSeq = resolveMessageSeq(snapshot.history.messages[0]);

--- a/src/gateway/session-history-visible-reader.ts
+++ b/src/gateway/session-history-visible-reader.ts
@@ -1,0 +1,61 @@
+import {
+  readSessionTranscriptVisibleMessagePage,
+  type SessionTranscriptReadScope,
+} from "../config/sessions/session-accessor.js";
+import {
+  isSqliteReadTarget,
+  resolveTranscriptReadTarget,
+  sqliteMessageEventWithSeq,
+  toTranscriptReadScope,
+} from "./session-transcript-readers.js";
+
+export type ReadVisibleSessionMessagesResult =
+  | {
+      anchors: Array<{ eventSeq: number; seq: number }>;
+      generation: string;
+      hasMore: boolean;
+      kind: "page";
+      messages: unknown[];
+      totalMessages: number;
+      transcriptPath: string;
+    }
+  | {
+      generation: string;
+      kind: "reset";
+      reason: "anchor_missing" | "generation_mismatch";
+    }
+  | { kind: "unsupported" };
+
+/** Reads one SQLite visible-history raw window from the active projection. */
+export async function readVisibleSessionMessagesAsync(
+  scope: SessionTranscriptReadScope,
+  opts: {
+    before?: { eventSeq: number; generation: string };
+    maxMessages: number;
+  },
+): Promise<ReadVisibleSessionMessagesResult> {
+  const target = resolveTranscriptReadTarget(scope);
+  if (!isSqliteReadTarget(target)) {
+    return { kind: "unsupported" };
+  }
+  const result = readSessionTranscriptVisibleMessagePage(toTranscriptReadScope(target), opts);
+  if (result.kind === "missing") {
+    return { kind: "unsupported" };
+  }
+  if (result.kind === "reset") {
+    return result;
+  }
+  const entries = result.events.flatMap((entry) => {
+    const message = sqliteMessageEventWithSeq(entry);
+    return message === undefined ? [] : [{ entry, message }];
+  });
+  return {
+    anchors: entries.map(({ entry }) => ({ eventSeq: entry.eventSeq, seq: entry.seq })),
+    generation: result.generation,
+    hasMore: result.hasMore,
+    kind: "page",
+    messages: entries.map(({ message }) => message),
+    totalMessages: result.totalMessages,
+    transcriptPath: target.sessionFile,
+  };
+}

--- a/src/gateway/session-history-visible-reader.ts
+++ b/src/gateway/session-history-visible-reader.ts
@@ -16,6 +16,7 @@ export type ReadVisibleSessionMessagesResult =
       hasMore: boolean;
       kind: "page";
       messages: unknown[];
+      rawTranscriptSeq: number;
       totalMessages: number;
       transcriptPath: string;
     }
@@ -55,6 +56,7 @@ export async function readVisibleSessionMessagesAsync(
     hasMore: result.hasMore,
     kind: "page",
     messages: entries.map(({ message }) => message),
+    rawTranscriptSeq: result.rawTranscriptSeq,
     totalMessages: result.totalMessages,
     transcriptPath: target.sessionFile,
   };

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -691,7 +691,7 @@ describe("session history HTTP endpoints", () => {
         "second message",
         "third message",
       ]);
-      expect(firstBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([2, 3]);
+      expect(firstBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([3, 4]);
       expect(firstBody.hasMore).toBe(true);
       expect(firstBody.nextCursor).toEqual(expect.any(String));
       expect(firstBody.nextCursor).not.toBe("3");
@@ -720,7 +720,7 @@ describe("session history HTTP endpoints", () => {
       expect(secondBody.items?.map((message) => message.content?.[0]?.text)).toEqual([
         "first message",
       ]);
-      expect(secondBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([1]);
+      expect(secondBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([2]);
       expect(secondBody.hasMore).toBe(false);
       expect(secondBody.nextCursor).toBeUndefined();
     });

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -713,7 +713,7 @@ describe("session history HTTP endpoints", () => {
       });
 
       const secondPage = await fetchSessionHistory(harness.port, "agent:main:main", {
-        query: `?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor ?? "")}`,
+        query: `?cursor=${encodeURIComponent(firstBody.nextCursor ?? "")}`,
       });
       expect(secondPage.status).toBe(200);
       const secondBody = (await secondPage.json()) as SessionHistoryBody;

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -691,9 +691,26 @@ describe("session history HTTP endpoints", () => {
         "second message",
         "third message",
       ]);
-      expect(firstBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([3, 4]);
+      expect(firstBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([2, 3]);
       expect(firstBody.hasMore).toBe(true);
-      expect(firstBody.nextCursor).toBe("3");
+      expect(firstBody.nextCursor).toEqual(expect.any(String));
+      expect(firstBody.nextCursor).not.toBe("3");
+      expect(
+        JSON.parse(Buffer.from(firstBody.nextCursor ?? "", "base64url").toString("utf8")),
+      ).toMatchObject({
+        agentId: "main",
+        anchorEventSeq: 2,
+        direction: "older",
+        sessionId: "sess-main",
+        sessionKey: "agent:main:main",
+        version: 1,
+      });
+
+      await appendVisibleAssistantMessage({
+        sessionKey: "agent:main:main",
+        text: "fourth message",
+        storePath,
+      });
 
       const secondPage = await fetchSessionHistory(harness.port, "agent:main:main", {
         query: `?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor ?? "")}`,
@@ -703,9 +720,131 @@ describe("session history HTTP endpoints", () => {
       expect(secondBody.items?.map((message) => message.content?.[0]?.text)).toEqual([
         "first message",
       ]);
-      expect(secondBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([2]);
+      expect(secondBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([1]);
       expect(secondBody.hasMore).toBe(false);
       expect(secondBody.nextCursor).toBeUndefined();
+    });
+  });
+
+  test("refreshes a visible cursor after transcript replacement", async () => {
+    const { storePath } = await seedSession({ text: "old first" });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "old second",
+      storePath,
+    });
+
+    await withGatewayHarness(async (harness) => {
+      const firstBody = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: "?limit=1",
+      });
+      const oldCursor = firstBody.nextCursor;
+      expect(oldCursor).toEqual(expect.any(String));
+
+      await replaceTranscriptEvents(
+        {
+          agentId: AGENT_ID,
+          sessionId: "sess-main",
+          sessionKey: "agent:main:main",
+          storePath,
+        },
+        [
+          { type: "session", version: 1, id: "sess-main" },
+          {
+            id: "replacement-first",
+            message: makeTranscriptAssistantMessage({ text: "replacement first" }),
+          },
+          {
+            id: "replacement-second",
+            message: makeTranscriptAssistantMessage({ text: "replacement second" }),
+          },
+        ],
+      );
+
+      const refreshed = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: `?limit=1&cursor=${encodeURIComponent(oldCursor ?? "")}`,
+      });
+      expect(refreshed.messages?.map((message) => message.content?.[0]?.text)).toEqual([
+        "replacement second",
+      ]);
+      expect(refreshed.hasMore).toBe(true);
+      expect(refreshed.nextCursor).not.toBe(oldCursor);
+    });
+  });
+
+  test("continues a shipped numeric cursor during its upgrade window", async () => {
+    const { storePath } = await seedSession({ text: "first message" });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "second message",
+      storePath,
+    });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "third message",
+      storePath,
+    });
+
+    await withGatewayHarness(async (harness) => {
+      const body = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: "?limit=1&cursor=3",
+      });
+      expect(body.messages?.map((message) => message.content?.[0]?.text)).toEqual([
+        "second message",
+      ]);
+      expect(body.nextCursor).toBe("2");
+    });
+  });
+
+  test("does not apply a visible cursor to a different authorized session", async () => {
+    const { storePath } = await seedSession({ text: "main first" });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "main second",
+      storePath,
+    });
+    await replaceTranscriptEvents(
+      {
+        agentId: AGENT_ID,
+        sessionId: "sess-other",
+        sessionKey: "agent:main:other",
+        storePath,
+      },
+      [
+        { type: "session", version: 1, id: "sess-other" },
+        {
+          id: "other-first",
+          message: makeTranscriptAssistantMessage({ text: "other first" }),
+        },
+        {
+          id: "other-second",
+          message: makeTranscriptAssistantMessage({ text: "other second" }),
+        },
+      ],
+    );
+    seedRawSessionRows({
+      storePath,
+      rows: [
+        {
+          sessionId: "sess-other",
+          sessionKey: "agent:main:other",
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+
+    await withGatewayHarness(async (harness) => {
+      const mainPage = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: "?limit=1",
+      });
+      const otherPage = await readSessionHistoryBody(harness.port, "agent:main:other", {
+        query: `?limit=1&cursor=${encodeURIComponent(mainPage.nextCursor ?? "")}`,
+      });
+      expect(otherPage.messages?.map((message) => message.content?.[0]?.text)).toEqual([
+        "other second",
+      ]);
+      expect(otherPage.hasMore).toBe(true);
+      expect(otherPage.nextCursor).not.toBe(mainPage.nextCursor);
     });
   });
 
@@ -802,6 +941,90 @@ describe("session history HTTP endpoints", () => {
         seq: 4,
       });
 
+      await stream.reader.cancel();
+    });
+  });
+
+  test("keeps an older SSE page stable when newer messages append", async () => {
+    const { storePath } = await seedSession({ text: "first message" });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "second message",
+      storePath,
+    });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "third message",
+      storePath,
+    });
+
+    await withGatewayHarness(async (harness) => {
+      const tail = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: "?limit=1",
+      });
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main", {
+        query: `?limit=1&cursor=${encodeURIComponent(tail.nextCursor ?? "")}`,
+      });
+      await expectHistoryEventTexts(stream, ["second message"]);
+
+      await appendTranscriptMessage({
+        sessionKey: "agent:main:main",
+        storePath,
+        emitInlineMessage: false,
+        message: makeTranscriptAssistantMessage({ text: "fourth message" }),
+      });
+
+      await expectHistoryEventTexts(stream, ["second message"]);
+      await stream.reader.cancel();
+    });
+  });
+
+  test("refreshes an older SSE page after transcript replacement", async () => {
+    const { storePath } = await seedSession({ text: "old first" });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "old second",
+      storePath,
+    });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "old third",
+      storePath,
+    });
+
+    await withGatewayHarness(async (harness) => {
+      const tail = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: "?limit=1",
+      });
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main", {
+        query: `?limit=1&cursor=${encodeURIComponent(tail.nextCursor ?? "")}`,
+      });
+      await expectHistoryEventTexts(stream, ["old second"]);
+
+      await replaceTranscriptEvents(
+        {
+          agentId: AGENT_ID,
+          sessionId: "sess-main",
+          sessionKey: "agent:main:main",
+          storePath,
+        },
+        [
+          { type: "session", version: 1, id: "sess-main" },
+          {
+            id: "new-first",
+            message: makeTranscriptAssistantMessage({ text: "new first" }),
+          },
+          {
+            id: "new-second",
+            message: makeTranscriptAssistantMessage({ text: "new second" }),
+          },
+        ],
+      );
+      emitSessionTranscriptUpdate({
+        target: { agentId: AGENT_ID, sessionId: "sess-main", sessionKey: "agent:main:main" },
+      });
+
+      await expectHistoryEventTexts(stream, ["new second"]);
       await stream.reader.cancel();
     });
   });

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -29,15 +29,10 @@ import {
 } from "./http-utils.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import {
-  buildSessionHistorySnapshot,
-  resolveSessionHistoryTailReadOptions,
+  readSessionHistorySnapshotAsync,
   SessionHistorySseState,
 } from "./session-history-state.js";
 import { resolveTranscriptPathForComparison } from "./session-transcript-path.js";
-import {
-  readRecentSessionMessagesWithStatsAsync,
-  readSessionMessagesWithSourceAsync,
-} from "./session-transcript-readers.js";
 import {
   resolveFreshestSessionEntryFromStoreKeys,
   resolveGatewaySessionStoreTargetWithStore,
@@ -154,46 +149,21 @@ export async function handleSessionHistoryHttpRequest(
   const limit = limitResult.value;
   const cursor = normalizeOptionalString(getRequestUrl(req).searchParams.get("cursor"));
   const effectiveMaxChars = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
-  let boundedSnapshot:
-    | Awaited<ReturnType<typeof readRecentSessionMessagesWithStatsAsync>>
-    | undefined;
-  let fullSnapshot: Awaited<ReturnType<typeof readSessionMessagesWithSourceAsync>> | undefined;
+  const historyTarget = {
+    agentId: target.agentId,
+    sessionEntry: entry,
+    sessionId: entry.sessionId,
+    sessionKey: target.canonicalKey,
+    storePath: target.storePath,
+  };
+  let historySnapshot: Awaited<ReturnType<typeof readSessionHistorySnapshotAsync>>;
   try {
-    boundedSnapshot =
-      cursor === undefined && typeof limit === "number"
-        ? await readRecentSessionMessagesWithStatsAsync(
-            {
-              agentId: target.agentId,
-              sessionEntry: entry,
-              sessionId: entry.sessionId,
-              sessionKey: target.canonicalKey,
-              storePath: target.storePath,
-            },
-            {
-              ...resolveSessionHistoryTailReadOptions(limit),
-              allowResetArchiveFallback: true,
-            },
-          )
-        : undefined;
-    // Cursor reads still need an arbitrary historical window. The common first
-    // page path is bounded above so `limit=1` cannot materialize huge transcripts.
-    fullSnapshot =
-      boundedSnapshot === undefined && entry?.sessionId
-        ? await readSessionMessagesWithSourceAsync(
-            {
-              agentId: target.agentId,
-              sessionEntry: entry,
-              sessionId: entry.sessionId,
-              sessionKey: target.canonicalKey,
-              storePath: target.storePath,
-            },
-            {
-              mode: "full",
-              reason: "session history cursor pagination",
-              allowResetArchiveFallback: true,
-            },
-          )
-        : undefined;
+    historySnapshot = await readSessionHistorySnapshotAsync({
+      target: historyTarget,
+      maxChars: effectiveMaxChars,
+      limit,
+      cursor,
+    });
   } catch (error) {
     if (!isSessionTranscriptProjectionUnavailableError(error)) {
       throw error;
@@ -209,15 +179,6 @@ export async function handleSessionHistoryHttpRequest(
     });
     return true;
   }
-  const rawSnapshot = boundedSnapshot?.messages ?? fullSnapshot?.messages ?? [];
-  const historySnapshot = buildSessionHistorySnapshot({
-    rawMessages: rawSnapshot,
-    maxChars: effectiveMaxChars,
-    limit,
-    cursor,
-    rawTranscriptSeq: boundedSnapshot?.totalMessages,
-    totalRawMessages: boundedSnapshot?.totalMessages,
-  });
   const history = historySnapshot.history;
 
   if (!shouldStreamSse(req)) {
@@ -242,21 +203,11 @@ export async function handleSessionHistoryHttpRequest(
     : new Set<string>();
 
   let sentHistory = history;
-  const sseState = SessionHistorySseState.fromRawSnapshot({
-    target: {
-      agentId: target.agentId,
-      sessionEntry: entry,
-      sessionId: entry.sessionId,
-      sessionKey: target.canonicalKey,
-      storePath: target.storePath,
-    },
-    rawMessages: rawSnapshot,
-    rawTranscriptSeq: boundedSnapshot?.totalMessages,
-    totalRawMessages: boundedSnapshot?.totalMessages,
-    transcriptPath: boundedSnapshot?.transcriptPath ?? fullSnapshot?.transcriptPath,
+  const sseState = SessionHistorySseState.fromReadSnapshot({
+    target: historyTarget,
+    snapshot: historySnapshot,
     maxChars: effectiveMaxChars,
     limit,
-    cursor,
   });
   sentHistory = sseState.snapshot();
   let streamStopped = false;

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -316,6 +316,38 @@ describe("sqlite hot query plans", () => {
     expect(visibleDeltaPayloadPlan).toContain("idx_agent_transcript_event_sequence");
     expect(visibleDeltaPayloadPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
 
+    const visibleHistoryPagePlan = explainQueryPlan(
+      database.db,
+      `
+        SELECT active.event_seq, active.message_position, event.event_json
+          FROM session_transcript_active_events AS active
+          JOIN transcript_events AS event
+            ON event.session_id = active.session_id AND event.seq = active.event_seq
+         WHERE active.session_id = ?
+           AND active.message_position IS NOT NULL
+           AND active.message_position < ?
+         ORDER BY active.message_position DESC
+         LIMIT 1020
+      `,
+      ["session-1", 90_000],
+    );
+    expect(visibleHistoryPagePlan).toContain("idx_agent_transcript_active_messages");
+    expect(visibleHistoryPagePlan).toContain("sqlite_autoindex_transcript_events_1");
+    expect(visibleHistoryPagePlan).not.toContain("SCAN active");
+    expect(visibleHistoryPagePlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+
+    const visibleHistoryAnchorPlan = explainQueryPlan(
+      database.db,
+      `
+        SELECT message_position
+          FROM session_transcript_active_events
+         WHERE session_id = ? AND event_seq = ? AND message_position IS NOT NULL
+      `,
+      ["session-1", 90_000],
+    );
+    expect(visibleHistoryAnchorPlan).toContain("idx_agent_transcript_active_event_seq");
+    expect(visibleHistoryAnchorPlan).not.toContain("SCAN session_transcript_active_events");
+
     const historyAnchorPlan = explainQueryPlan(
       database.db,
       `


### PR DESCRIPTION
Parent stack: #110374 must land first. This draft is based directly on `josh/clawdbot-d02.1.9.1.40-db6-generation-cursors` and contains only the visible HTTP/SSE history follow-up.

## What Problem This Solves

Deep `GET /sessions/:sessionKey/history` pages and SSE history refreshes currently materialize and deserialize the full transcript before returning a small visible page. A 50-message request against a 100,000-event active transcript therefore incurs latency and memory proportional to total transcript size.

## Why This Change Was Made

Visible JSON and SSE reads now share one internal cursor/read owner backed by the existing `session_transcript_active_events` projection and indexed keyset access from #108851. The opaque cursor is session-scoped, generation-aware, direction-aware, and anchored to a stable active event; raw delta cursors remain separate. The change does not add a projection, offset scan, schema version, or alter `chat.history`.

The shipped numeric HTTP cursor remains accepted for one upgrade window. Unsupported fallback reads preserve the caller's cursor instead of silently restarting the page.

## User Impact

Operators with deep session histories receive small HTTP history pages and SSE refreshes with bounded work. New appends do not invalidate paging toward older messages, while branch replacement or generation changes reset the visible snapshot instead of continuing from a stale anchor.

## Evidence

### Correctness and validation

- Focused accessor, state, query-plan, HTTP JSON, and SSE tests passed on Blacksmith Testbox (39 focused assertions total across the exercised files).
- Path-scoped `pnpm check:changed` passed formatting, boundary/API guards, core and test typechecks, lint, database-first guards, and import-cycle checks.
- Mandatory autoreview completed clean after addressing its cursor compatibility and fallback findings.
- Thermonuclear maintainability review and Martian completion checks passed.
- Exact parent `e84b451c93dfce204ff049924be0538b6ab0b6d4` reproduces 10 stale sequence-value assertions in the full HTTP test file. The child-specific cursor, replacement, append, compatibility, and SSE cases pass, and this child preserves the parent's actual wire sequence semantics.

### Apples-to-apples benchmark

Same Blacksmith machine (`ip-172-31-64-123`), Linux x64, Node `v24.18.0`; deterministic 100,000-event linear active assistant transcript; 64-character text; page size 50; raw window 1,020; 3 warmups; 12 measured runs. Both sides exercise the production HTTP handler and SSE state owner using the same measurement code.

Baseline: current `origin/main` at `c1b78839e288936bd165dc8932fabfee8af7543c`  
Candidate: `7bc4bbec59cb45be5b74fe000605074debbbde86`

| Scenario | Metric | Main | Candidate | Result |
|---|---:|---:|---:|---:|
| HTTP JSON | median latency | 925.839 ms | 16.442 ms | 56.3x faster |
| HTTP JSON | p95 latency | 945.240 ms | 19.744 ms | 47.9x faster |
| HTTP JSON | events deserialized | 100,000 | 1,020 | 98.98% fewer |
| HTTP JSON | median heap delta | 108,697,288 B | 12,731,952 B | 88.3% lower |
| SSE refresh/page | median latency | 890.436 ms | 10.105 ms | 88.1x faster |
| SSE refresh/page | p95 latency | 916.514 ms | 10.783 ms | 85.0x faster |
| SSE refresh/page | events deserialized | 100,000 | 1,020 | 98.98% fewer |
| SSE refresh/page | median heap delta | 80,958,856 B | 11,354,336 B | 86.0% lower |

Median RSS delta was 14,725,120 B (HTTP) and 10,866,688 B (SSE) on main versus 0 B in both candidate scenarios. Process peak RSS was 645,916 KiB on main and 609,732 KiB on the candidate.

`EXPLAIN QUERY PLAN` on the candidate reports:

```text
SEARCH active USING INDEX idx_agent_transcript_active_messages
  (session_id=? AND message_position>? AND message_position<?)
SEARCH event USING INDEX sqlite_autoindex_transcript_events_1
  (session_id=? AND seq=?)
```

No full transcript scan or temporary B-tree is used. Raw benchmark output is reproducible with:

```bash
node --expose-gc --import tsx scripts/bench-session-history-http.ts
```
