### PR TITLE
fix(config): model compat schema rejects eight fields present in the TypeScript type and consumed at runtime

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -248,13 +248,18 @@ const ModelCompatSchema = z
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
     supportsLongCacheRetention: z.boolean().optional(),
+    // Opaque interface types (OpenRouterRouting / VercelGatewayRouting) must use
+    // z.any() to satisfy the bidirectional TS AssertAssignable contract at the
+    // bottom of this block. Using z.object({}).passthrough() or z.record() would
+    // fail direction 1: a structural object type is not assignable to the nominal
+    // interface. The TS type check is the narrowest guard available for these fields.
     openRouterRouting: z.any().optional(),
     vercelGatewayRouting: z.any().optional(),
     cacheControlFormat: z.literal("anthropic").optional(),
     sendSessionIdHeader: z.boolean().optional(),
     supportsEagerToolInputStreaming: z.boolean().optional(),
     sendSessionAffinityHeaders: z.boolean().optional(),
-    zaiToolStream: z.any().optional(),
+    zaiToolStream: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -248,13 +248,13 @@ const ModelCompatSchema = z
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
     supportsLongCacheRetention: z.boolean().optional(),
-    openRouterRouting: z.record(z.string(), z.unknown()).optional(),
-    vercelGatewayRouting: z.record(z.string(), z.unknown()).optional(),
+    openRouterRouting: z.any().optional(),
+    vercelGatewayRouting: z.any().optional(),
     cacheControlFormat: z.literal("anthropic").optional(),
     sendSessionIdHeader: z.boolean().optional(),
     supportsEagerToolInputStreaming: z.boolean().optional(),
     sendSessionAffinityHeaders: z.boolean().optional(),
-    zaiToolStream: z.record(z.string(), z.unknown()).optional(),
+    zaiToolStream: z.any().optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -247,6 +247,14 @@ const ModelCompatSchema = z
     toolCallArgumentsEncoding: z.string().optional(),
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
+    supportsLongCacheRetention: z.boolean().optional(),
+    openRouterRouting: z.record(z.string(), z.unknown()).optional(),
+    vercelGatewayRouting: z.record(z.string(), z.unknown()).optional(),
+    cacheControlFormat: z.literal("anthropic").optional(),
+    sendSessionIdHeader: z.boolean().optional(),
+    supportsEagerToolInputStreaming: z.boolean().optional(),
+    sendSessionAffinityHeaders: z.boolean().optional(),
+    zaiToolStream: z.record(z.string(), z.unknown()).optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -202,6 +202,27 @@ describe("ModelsConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  // zaiToolStream is a boolean per the TS type (packages/llm-core/src/types.ts:465:
+  // `zaiToolStream?: boolean`). Non-boolean values must fail schema validation.
+  it("rejects a non-boolean zaiToolStream value", () => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "m1",
+              name: "M1",
+              compat: { zaiToolStream: "not-a-boolean" },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("accepts catalog-declared temperature compatibility", () => {
     const result = ModelsConfigSchema.safeParse({
       providers: {

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -114,6 +114,94 @@ describe("ModelsConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  // Regression: the .strict() ModelCompatSchema was missing eight fields that
+  // are present in ModelCompatConfig (TS type) and consumed at runtime. Setting
+  // any of them caused the entire model definition to be rejected as invalid.
+  // This is the same defect family as #89660 / #110065.
+  it("accepts compat.supportsLongCacheRetention (issue #81281)", () => {
+    // openai-completions-transport.ts:1726 reads this field to gate the
+    // prompt_cache_retention header on API requests.
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "gpt-5.6-luna",
+              name: "GPT-5.6 Luna",
+              compat: { supportsLongCacheRetention: false },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts compat.openRouterRouting for routing header injection", () => {
+    // openai-transport-params.ts:299 reads this to inject OpenRouter headers.
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "gemini-2.0-flash",
+              name: "Gemini 2.0 Flash",
+              compat: {
+                openRouterRouting: { model: "google/gemini-2.0-flash" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts compat.vercelGatewayRouting for Vercel AI Gateway routing", () => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "claude-opus-4-8",
+              name: "Claude Opus 4.8",
+              compat: {
+                vercelGatewayRouting: { model: "anthropic/claude-opus-4-8" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("still rejects unknown compat fields to maintain strictness", () => {
+    // .strict() must still fire for truly unknown keys.
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "m1",
+              name: "M1",
+              compat: { nonexistentField: true },
+            },
+          ],
+        },
+      },
+    } as unknown as Record<string, unknown>);
+
+    expect(result.success).toBe(false);
+  });
+
   it("accepts catalog-declared temperature compatibility", () => {
     const result = ModelsConfigSchema.safeParse({
       providers: {


### PR DESCRIPTION
See also: #81281, #89660 (same defect family — fields added to TS type but missed in the Zod schema)

## What Problem This Solves

Fixes an issue where users setting model compatibility fields — `supportsLongCacheRetention`, `openRouterRouting`, `vercelGatewayRouting`, `cacheControlFormat`, `sendSessionIdHeader`, `supportsEagerToolInputStreaming`, `sendSessionAffinityHeaders`, or `zaiToolStream` — on custom model providers would have their entire model configuration rejected as invalid, even though:

- Every one of these fields is present in the `ModelCompatConfig` TypeScript type (`types.models.ts:29-113`)
- Several are consumed by runtime code at request time (e.g. `openai-completions-transport.ts:1726` reads `supportsLongCacheRetention` to gate the `prompt_cache_retention` header; `openai-transport-params.ts:299` reads `openRouterRouting` to inject OpenRouter headers; the internal model registry round-trips these fields through config for persistence)
- The Zod `ModelCompatSchema` uses `.strict()` but was missing all eight fields, so any config containing them was rejected

This is the same defect family as #89660 (`requiresReasoningContentOnAssistantMessages`) and #110065 (`compaction.enabled`) — TS types and runtime code were updated but the `.strict()` Zod schema was not kept in sync.

## Why This Change Was Made

Added the eight missing fields to `ModelCompatSchema` with their runtime-correct Zod types: `supportsLongCacheRetention`, `sendSessionIdHeader`, `supportsEagerToolInputStreaming`, `sendSessionAffinityHeaders`, and `zaiToolStream` as `z.boolean().optional()`; `cacheControlFormat` as `z.literal("anthropic").optional()` (the only supported value per the TS type); `openRouterRouting` and `vercelGatewayRouting` as `z.any().optional()`. These last two are opaque interface types (`OpenRouterRouting` / `VercelGatewayRouting`) with dozens of optional fields; `z.any()` is the narrowest Zod type that satisfies the bidirectional TS `AssertAssignable` contract at the bottom of the schema block — using `z.object({}).passthrough()` or `z.record()` would fail direction 1 (a structural object type is not assignable to the nominal TS interface). Their transport-layer validation is the practical guard. The schema remains `.strict()` so unknown compat keys are still rejected.

## User Impact

Users can now configure custom model providers with OpenRouter routing, Vercel AI Gateway routing, cache retention behavior, session ID headers, eager tool input streaming, session affinity headers, Z.AI tool streaming, and Anthropic cache control format — without the config being rejected.

## Evidence

### Real Zod schema proof

Running the production `ModelsConfigSchema.safeParse` with `supportsLongCacheRetention: false` — before: schema rejects it as unrecognized key; after: schema accepts it:

```
[before] supportsLongCacheRetention accepted: false
[after]  supportsLongCacheRetention accepted: true
```

### Regression coverage

- `zod-schema.models.test.ts`: 28 tests pass (5 new).
  - 3 positive: `supportsLongCacheRetention`, `openRouterRouting`, `vercelGatewayRouting` — all fail against unfixed `main` (`.strict()` rejects them as unrecognized keys).
  - 1 negative: `zaiToolStream: "not-a-boolean"` is rejected by `z.boolean()` validation — confirms the Zod type for this field is actually enforced.
  - 1 strictness-preservation: `nonexistentField` on a compat object is still rejected — the `.strict()` guard stays intact.
  - 23 pre-existing tests pass in both states (no regressions).
- `config.schema-regressions.test.ts`: 36 tests pass (no regressions).
- `pnpm tsgo:core:test` — passed (no type errors).
- Scoped `oxfmt`, `oxlint`, and `git diff --check` pass on the two changed files.

AI-assisted.
