### PR TITLE
fix(ui): move child-session toggle after the session title

### DIFF
--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -128,6 +128,24 @@ export abstract class AppSidebarSessionListElement extends AppSidebarMenusElemen
         @mouseenter=${(event: MouseEvent) => startHoverMarquee(event.currentTarget as HTMLElement)}
         @mouseleave=${(event: MouseEvent) => stopHoverMarquee(event.currentTarget as HTMLElement)}
       >
+        <a
+          href=${session.href}
+          class="sidebar-recent-session__link"
+          draggable="false"
+          title=${title}
+          aria-current=${session.visuallyActive ? "page" : nothing}
+          aria-describedby=${metaId ?? nothing}
+          @click=${(event: MouseEvent) => this.handleSessionRowClick(event, session)}
+        >
+          <span class="sidebar-recent-session__text">
+            <span class="sidebar-recent-session__name hover-marquee">${label}</span>
+            ${subtitle
+              ? html`<span class="sidebar-recent-session__subtitle">${subtitle}</span>`
+              : nothing}
+          </span>
+          ${this.renderSessionState(session)}
+          ${session.isChild ? nothing : renderSessionRowBadges(session)}
+        </a>
         ${session.childSessionKeys.length > 0
           ? html`<button
               class="sidebar-child-session-toggle ${session.runningChildCount > 0
@@ -156,24 +174,6 @@ export abstract class AppSidebarSessionListElement extends AppSidebarMenusElemen
               >
             </button>`
           : nothing}
-        <a
-          href=${session.href}
-          class="sidebar-recent-session__link"
-          draggable="false"
-          title=${title}
-          aria-current=${session.visuallyActive ? "page" : nothing}
-          aria-describedby=${metaId ?? nothing}
-          @click=${(event: MouseEvent) => this.handleSessionRowClick(event, session)}
-        >
-          <span class="sidebar-recent-session__text">
-            <span class="sidebar-recent-session__name hover-marquee">${label}</span>
-            ${subtitle
-              ? html`<span class="sidebar-recent-session__subtitle">${subtitle}</span>`
-              : nothing}
-          </span>
-          ${this.renderSessionState(session)}
-          ${session.isChild ? nothing : renderSessionRowBadges(session)}
-        </a>
         <span class="sidebar-recent-session__aside session-row-aside">
           <span class="session-row-trail" id=${metaId ?? nothing}
             >${session.isChild && session.runtimeMs != null

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1712,7 +1712,7 @@ html.openclaw-native-macos
   width: 31px;
   height: 30px;
   flex: 0 0 31px;
-  padding: 0 1px 0 5px;
+  padding: 0 3px;
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -1750,10 +1750,6 @@ html.openclaw-native-macos
   font-size: 9px;
   font-variant-numeric: tabular-nums;
   line-height: 1;
-}
-
-.sidebar-child-session-toggle + .sidebar-recent-session__link {
-  padding-left: 0;
 }
 
 .sidebar-recent-session__link:hover {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110448. Sidebar session rows that have child sessions rendered the expand toggle (chevron + child count) before the title, so those rows sat ~31px right of the shared left edge that section labels and plain session rows now align to.

## Why This Change Was Made

Maintainer request: parent rows should align to the same sidebar grid. This applies the same "text first, chevron after" pattern used for section headers in #110448.

## User Impact

- Rows with child sessions now start at the same left edge as every other row; the child toggle (`⌄ 1` / `› 1`) sits after the title, before the row meta.
- Toggle behavior, running/failed accent colors, and child-row indentation are unchanged.

After (collapsed children / expanded children):

| Collapsed | Expanded |
| --- | --- |
| ![collapsed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after2-childtoggle.png) | ![expanded](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after2-children-expanded.png) |

Before is visible in #110448's "after" shot, where "Tax filing research" is indented by the leading toggle.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 107 tests pass (toggle assertions are selector-based, order-agnostic).
- Live-verified in the Control UI mock harness: toggle click still expands/collapses children; screenshots above.
- Codex autoreview (gpt-5.6-sol) clean: no accepted/actionable findings.
