### PR TITLE
fix(ui): center session title on the native macOS titlebar centerline

### DIFF
--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -278,6 +278,17 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   padding-left: 52px;
 }
 
+/* Native macOS desktop shells: the pane header is the window's top surface,
+   so it adopts the app titlebar height (52px injected by
+   DashboardWindowController; the 50px fallback mirrors
+   .macos-titlebar-controls for older app builds). The web 48px default would
+   center the session title/actions 2px above the traffic-light/hosted-button
+   centerline. Drawer layouts instead fold titlebar clearance into their 58px
+   topbar row (layout.mobile.css). */
+html.openclaw-native-macos .shell:not(.shell--mobile-nav) .chat-pane__header {
+  min-height: var(--openclaw-native-titlebar-height, 50px);
+}
+
 /* Native macOS: with the nav column collapsed the top-left pane header is the
    window's top surface, so its content shifts right of the floating window
    chrome (Safari-style) instead of hiding under it. Traffic lights end at


### PR DESCRIPTION
## What Problem This Solves

In the macOS app the session title (and workspace chip / header actions) sits ~2px too high relative to the traffic lights and the hosted titlebar buttons. The Mac app injects a 52px transparent titlebar (`--openclaw-native-titlebar-height: 52px`, `apps/macos/Sources/OpenClaw/DashboardWindowController.swift`), so native chrome centers at y=26, while `.chat-pane__header` keeps the web default `min-height: 48px` and centers its content at y=24.

## Why This Change Was Made

The pane header is the window's top surface in native macOS desktop shells, so it should share the titlebar centerline. In native macOS desktop shells (`html.openclaw-native-macos`, not `.shell--mobile-nav`), `.chat-pane__header` now adopts `min-height: var(--openclaw-native-titlebar-height, 50px)` — the same var+fallback the sibling `.macos-titlebar-controls` strip uses, so the title, workspace chip, header actions, and hosted buttons center on one line whether or not the app injects the var. Drawer layouts are unaffected: they fold titlebar clearance into their own 58px topbar row (`ui/src/styles/layout.mobile.css`) and the header is not the window-top surface there. Plain web keeps the 48px shared chrome centerline.

## User Impact

Session title, workspace chip, and header actions in the Mac app line up vertically with the traffic lights and the titlebar back/forward/search/new-session buttons instead of floating 2px high.

## Evidence

Static harness loading the real `layout.css` + `chat/split-view.css` with `openclaw-native-macos`/`openclaw-native-web-chrome` classes and the app-injected `--openclaw-native-titlebar-height: 52px`, measured via `getBoundingClientRect`:

- Before: session title center y=24, titlebar button center y=26 (2px misalignment, matching the report)
- After: title / workspace chip / titlebar buttons all center at y=26

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/session-title-titlebar-centering/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/session-title-titlebar-centering/after.png) |

`git diff --check` clean; CSS-only change, UI lanes on CI. Codex autoreview clean after addressing a comment-wording finding.
