### PR TITLE
fix(scripts): bound sync-labels GitHub CLI operations

### DIFF
--- a/scripts/sync-labels.ts
+++ b/scripts/sync-labels.ts
@@ -1,11 +1,11 @@
 // Sync Labels script supports OpenClaw repository automation.
 import { execFileSync } from "node:child_process";
-
-const SYNC_LABELS_TIMEOUT_MS = 120_000;
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse } from "yaml";
 import { resolveGitHubRepoFromOrigin } from "./lib/github-repo.ts";
+
+const SYNC_LABELS_TIMEOUT_MS = 120_000;
 
 type RepoLabel = {
   name: string;
@@ -79,7 +79,7 @@ for (const label of missing) {
   if (metadata.description) {
     args.push("-f", `description=${metadata.description}`);
   }
-  execFileSync("gh", args, { stdio: "inherit" }, timeout: SYNC_LABELS_TIMEOUT_MS, killSignal: "SIGKILL" });
+  execFileSync("gh", args, { stdio: "inherit", timeout: SYNC_LABELS_TIMEOUT_MS, killSignal: "SIGKILL" });
   console.log(`Created label: ${label}`);
 }
 
@@ -95,8 +95,6 @@ function resolveLabelMetadata(label: string): { color: string; description?: str
 function fetchExistingLabels(repoLocal: string): Map<string, RepoLabel> {
   const raw = execFileSync("gh", ["api", `repos/${repoLocal}/labels?per_page=100`, "--paginate"], {
     encoding: "utf8",
-    timeout: SYNC_LABELS_TIMEOUT_MS,
-    killSignal: "SIGKILL",
   });
   const labels = JSON.parse(raw) as RepoLabel[];
   return new Map(labels.map((label) => [label.name, label]));

--- a/scripts/sync-labels.ts
+++ b/scripts/sync-labels.ts
@@ -79,7 +79,11 @@ for (const label of missing) {
   if (metadata.description) {
     args.push("-f", `description=${metadata.description}`);
   }
-  execFileSync("gh", args, { stdio: "inherit", timeout: SYNC_LABELS_TIMEOUT_MS, killSignal: "SIGKILL" });
+  execFileSync("gh", args, {
+    stdio: "inherit",
+    timeout: SYNC_LABELS_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+  });
   console.log(`Created label: ${label}`);
 }
 
@@ -95,6 +99,8 @@ function resolveLabelMetadata(label: string): { color: string; description?: str
 function fetchExistingLabels(repoLocal: string): Map<string, RepoLabel> {
   const raw = execFileSync("gh", ["api", `repos/${repoLocal}/labels?per_page=100`, "--paginate"], {
     encoding: "utf8",
+    timeout: SYNC_LABELS_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
   const labels = JSON.parse(raw) as RepoLabel[];
   return new Map(labels.map((label) => [label.name, label]));

--- a/scripts/sync-labels.ts
+++ b/scripts/sync-labels.ts
@@ -1,5 +1,7 @@
 // Sync Labels script supports OpenClaw repository automation.
 import { execFileSync } from "node:child_process";
+
+const SYNC_LABELS_TIMEOUT_MS = 120_000;
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse } from "yaml";
@@ -77,7 +79,7 @@ for (const label of missing) {
   if (metadata.description) {
     args.push("-f", `description=${metadata.description}`);
   }
-  execFileSync("gh", args, { stdio: "inherit" });
+  execFileSync("gh", args, { stdio: "inherit" }, timeout: SYNC_LABELS_TIMEOUT_MS, killSignal: "SIGKILL" });
   console.log(`Created label: ${label}`);
 }
 
@@ -93,6 +95,8 @@ function resolveLabelMetadata(label: string): { color: string; description?: str
 function fetchExistingLabels(repoLocal: string): Map<string, RepoLabel> {
   const raw = execFileSync("gh", ["api", `repos/${repoLocal}/labels?per_page=100`, "--paginate"], {
     encoding: "utf8",
+    timeout: SYNC_LABELS_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
   const labels = JSON.parse(raw) as RepoLabel[];
   return new Map(labels.map((label) => [label.name, label]));

--- a/test/scripts/sync-labels.test.ts
+++ b/test/scripts/sync-labels.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
+describe("sync-labels", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockImplementation((command: string, args?: readonly string[]) => {
+      if (command === "git") {
+        return "https://github.com/openclaw/openclaw.git\n";
+      }
+      if (command === "gh" && args?.some((arg) => arg.includes("/labels?"))) {
+        return "[]";
+      }
+      return "";
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("bounds every GitHub CLI operation", async () => {
+    await import("../../scripts/sync-labels.ts");
+
+    const ghCalls = execFileSyncMock.mock.calls.filter(([command]) => command === "gh");
+    expect(ghCalls.length).toBeGreaterThan(1);
+    for (const [, , options] of ghCalls) {
+      expect(options).toMatchObject({
+        timeout: 120_000,
+        killSignal: "SIGKILL",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `gh` CLI operations in the sync-labels script could hang indefinitely during GitHub API calls. When the GitHub API is unreachable or rate-limited, `execFileSync` calls to `gh api` and `gh label` would block without any timeout, stalling CI label synchronization workflows.

## Why This Change Was Made

All `execFileSync` calls to external commands that touch the network must include a timeout and kill signal. Without these, transient API outages cause resource leaks and indefinite stalls. This follows the same bounding pattern applied in #109325 (docker attestation).

## User Impact

Label synchronization can complete or fail-fast within a bounded deadline instead of blocking indefinitely when GitHub API endpoints are unresponsive.

## Evidence

- The change adds a `SYNC_LABELS_TIMEOUT_MS = 120_000` constant and applies `timeout` + `killSignal: "SIGKILL"` to both `execFileSync("gh", ??` call sites.
- Pattern consistency: matches the bounding approach in `scripts/verify-docker-attestations.mjs` (#109325).