### PR TITLE
feat(ui): logo-scare lobster visits; drop the model-auth-expiring chip

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -46,7 +46,9 @@ class AppSidebar extends AppSidebarSessionListElement {
 
   private readonly handleLogoVisit = (event: Event) => {
     const detail = (event as CustomEvent<LobsterLogoVisitDetail>).detail;
-    this.logoVisit = detail.phase === "out" || !detail.look ? null : detail;
+    // A lookless visit is a logo scare: the brand mark hides (the img gets
+    // the --vacated class) but no stand-in crab renders in its place.
+    this.logoVisit = detail.phase === "out" ? null : detail;
   };
 
   private renderLogoStandIn() {

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -749,15 +749,15 @@ describe("lobster pet element", () => {
   });
 });
 
-describe("lobster pet logo stand-in", () => {
-  function trackLogoPhases(element: LobsterPetElement): LobsterLogoVisitDetail[] {
-    const phases: LobsterLogoVisitDetail[] = [];
-    element.addEventListener(LOBSTER_LOGO_VISIT_EVENT, (event) => {
-      phases.push((event as CustomEvent<LobsterLogoVisitDetail>).detail);
-    });
-    return phases;
-  }
+function trackLogoPhases(element: LobsterPetElement): LobsterLogoVisitDetail[] {
+  const phases: LobsterLogoVisitDetail[] = [];
+  element.addEventListener(LOBSTER_LOGO_VISIT_EVENT, (event) => {
+    phases.push((event as CustomEvent<LobsterLogoVisitDetail>).detail);
+  });
+  return phases;
+}
 
+describe("lobster pet logo stand-in", () => {
   // Seed 70 is a planned logo load, not shy, first arrival ~25s.
   const LOGO_SEED = 70;
 
@@ -830,12 +830,57 @@ describe("lobster pet logo stand-in", () => {
   it("keeps unplanned loads on the ledge without logo events", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    // Seed 42 also rolls no logo scare on its first arrival, so a full visit
+    // passes with the brand mark untouched.
     const element = createPet(42);
     const phases = trackLogoPhases(element);
 
     await arrive(element);
 
     expect(spritePresent(element)).toBe(true);
+    expect(phases).toEqual([]);
+  });
+});
+
+describe("lobster pet logo scare", () => {
+  // Seed 91: a normal ledge load (not a logo load), not shy, first arrival
+  // ~19s, and the first arrival's scare roll hits (~0.07 < 0.3).
+  const SCARE_SEED = 91;
+
+  it("hides the logo without a stand-in mid-visit, restoring after the exit", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(SCARE_SEED);
+    const phases = trackLogoPhases(element);
+
+    const scared = await advanceUntil(element, () => phases.length > 0, 200_000);
+    expect(scared).toBe(true);
+    // Unlike a perch, the crab stays on the ledge while the logo hides.
+    expect(spritePresent(element)).toBe(true);
+    const first = expectDefined(phases[0], "first scare phase");
+    expect(first.phase).toBe("in");
+    expect(first.look).toBeNull();
+    expect(first.name).toBeNull();
+
+    const left = await advanceUntil(element, () => phases.some((p) => p.phase === "out"), 400_000);
+    expect(left).toBe(true);
+    expect(phases.map((p) => p.phase)).toEqual(["in", "leaving", "out"]);
+  });
+
+  it("never scares the logo under reduced motion", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true }) as MediaQueryList),
+    );
+    const element = createPet(SCARE_SEED);
+    const phases = trackLogoPhases(element);
+
+    const arrived = await advanceUntil(element, () => spritePresent(element), 200_000);
+    expect(arrived).toBe(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await element.updateComplete;
     expect(phases).toEqual([]);
   });
 });

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -315,6 +315,12 @@ const VISIT_FIRST_DELAY_MS = [15_000, 180_000] as const;
 const VISIT_STAY_MS = [90_000, 300_000] as const;
 const VISIT_GAP_MS = [360_000, 1_080_000] as const;
 
+// Some ledge visits spook the logo: a beat after the crab settles in, the
+// brand mark ducks away, and it pops back once the visit ends. Rolled from a
+// dedicated seeded stream so tests can probe arrivals purely.
+const LOGO_SCARE_CHANCE = 0.3;
+const LOGO_SCARE_DELAY_MS = 900;
+
 // Seeded pet names; rare palettes carry signature names. Shown via the
 // sprite's native title tooltip, so no i18n surface.
 const PET_NAMES = [
@@ -383,6 +389,8 @@ type LobsterLogoVisitPhase = "in" | "leaving" | "out";
 
 export type LobsterLogoVisitDetail = {
   phase: LobsterLogoVisitPhase;
+  // A null look on a non-"out" phase means "hide the logo, render no
+  // stand-in": a ledge visit scared the brand mark away.
   look: LobsterPetLook | null;
   name: string | null;
 };
@@ -917,6 +925,10 @@ class LobsterPet extends LitElement {
   @state() private anchor: LobsterPetAnchor = "ledge";
   @state() private scheduledVisiting = false;
   @state() private logoPerched = false;
+  @state() private logoScared = false;
+  private logoScarePending = false;
+  private logoScareTimer: number | null = null;
+  private scareRng: () => number = mulberry32(0);
   private logoPlanned = false;
   private logoDone = false;
   private lastLogoPhase: LobsterLogoVisitPhase = "out";
@@ -983,6 +995,7 @@ class LobsterPet extends LitElement {
       this.passerTimer,
       this.passerEndTimer,
       this.passerWatchTimer,
+      this.logoScareTimer,
     ]) {
       if (timer !== null) {
         window.clearTimeout(timer);
@@ -993,6 +1006,7 @@ class LobsterPet extends LitElement {
     this.passerTimer = null;
     this.passerEndTimer = null;
     this.passerWatchTimer = null;
+    this.logoScareTimer = null;
     if (this.audioCtx) {
       this.audioCtx.close().catch(() => {});
       this.audioCtx = null;
@@ -1018,6 +1032,7 @@ class LobsterPet extends LitElement {
       this.look = createLobsterPetLook(this.seed);
       this.rng = mulberry32(this.seed ^ 0x9e3779b9);
       this.visitRng = mulberry32(this.seed ^ 0x5eaf00d);
+      this.scareRng = mulberry32((this.seed ^ 0x5ca2e) >>> 0);
       this.spotPct = this.look.spotPct;
       this.facing = this.look.facing;
       // Reset the act loop inside the update pass; deferring state flips to
@@ -1038,6 +1053,12 @@ class LobsterPet extends LitElement {
       this.logoPlanned = isLobsterLogoLoad(this.seed);
       this.logoDone = false;
       this.logoPerched = false;
+      this.logoScared = false;
+      this.logoScarePending = false;
+      if (this.logoScareTimer !== null) {
+        window.clearTimeout(this.logoScareTimer);
+        this.logoScareTimer = null;
+      }
       this.familiarity = getLobsterFamiliarity();
       this.sailorDay = isLobsterDay(new Date());
       this.greetedThisLoad = false;
@@ -1103,6 +1124,16 @@ class LobsterPet extends LitElement {
         if (this.logoPerched) {
           this.logoDone = true;
         }
+        // One scare roll per arrival keeps the stream aligned across visit
+        // kinds; only an idle ledge visit may spook the logo (a perch owns
+        // the slot outright, offline summons are on status duty).
+        const scareRolled = this.scareRng() < LOGO_SCARE_CHANCE;
+        this.logoScarePending =
+          scareRolled &&
+          !this.logoPerched &&
+          this.scheduledVisiting &&
+          this.mode === "idle" &&
+          !prefersReducedMotion();
         if (this.look) {
           // Anniversary check reads the dex before this arrival records into
           // it: a first-ever visit today must not celebrate itself.
@@ -1128,11 +1159,19 @@ class LobsterPet extends LitElement {
       this.clearActTimers();
       this.act = null;
       this.entering = false;
+      this.logoScarePending = false;
+      if (this.logoScareTimer !== null) {
+        window.clearTimeout(this.logoScareTimer);
+        this.logoScareTimer = null;
+      }
       this.presence = "leaving";
       this.leaveTimer = window.setTimeout(() => {
         this.leaveTimer = null;
         this.presence = "out";
         this.logoPerched = false;
+        // The "out" edge is the single restore point: the logo fades back
+        // in the same update that ends the visit, scare or perch alike.
+        this.logoScared = false;
       }, LEAVE_MS);
     }
   }
@@ -1159,11 +1198,23 @@ class LobsterPet extends LitElement {
         this.performAct("wave");
       }
     }, ENTER_MS);
+    if (this.logoScarePending) {
+      this.logoScarePending = false;
+      // The beat between arrival and the duck is what sells "the crab scared
+      // the logo" instead of reading as a render glitch.
+      this.logoScareTimer = window.setTimeout(() => {
+        this.logoScareTimer = null;
+        if (this.presence === "in" && !this.logoPerched) {
+          this.logoScared = true;
+        }
+      }, LOGO_SCARE_DELAY_MS);
+    }
     this.scheduleNextAct();
   }
 
   private logoVisitPhase(): LobsterLogoVisitPhase {
-    if (!this.logoPerched || !this.visitsEnabled || this.dismissed) {
+    const occupied = this.logoPerched || this.logoScared;
+    if (!occupied || !this.visitsEnabled || this.dismissed) {
       return "out";
     }
     return this.presence === "in" ? "in" : this.presence === "leaving" ? "leaving" : "out";
@@ -1177,7 +1228,8 @@ class LobsterPet extends LitElement {
       return;
     }
     this.lastLogoPhase = phase;
-    const look = phase === "out" || !this.look ? null : this.look;
+    // Scare phases send no look: the logo just hides, nobody fills in.
+    const look = phase === "out" || !this.logoPerched || !this.look ? null : this.look;
     // The ledge sprite dresses up for palette anniversaries; the stand-in
     // celebrates the same way.
     const dressed =

--- a/ui/src/components/sidebar-attention-dismissals.ts
+++ b/ui/src/components/sidebar-attention-dismissals.ts
@@ -8,7 +8,6 @@ const SIDEBAR_ATTENTION_KINDS = [
   "cronFailed",
   "cronOverdue",
   "modelAuthExpired",
-  "modelAuthExpiring",
   "pendingApproval",
 ] as const;
 export type SidebarAttentionKind = (typeof SIDEBAR_ATTENTION_KINDS)[number];

--- a/ui/src/components/sidebar-attention-items.ts
+++ b/ui/src/components/sidebar-attention-items.ts
@@ -106,20 +106,5 @@ export function buildSidebarAttentionItems(params: {
       signature: signatureOf(expired.map((provider) => provider.provider)),
     });
   }
-  const expiring = monitored.filter((provider) => provider.status === "expiring");
-  if (expiring.length > 0) {
-    items.push({
-      kind: "modelAuthExpiring",
-      severity: "warning",
-      icon: "plug",
-      label: t("attention.modelAuthExpiring", {
-        providers: expiring
-          .map((provider) => `${provider.displayName} (${provider.expiry?.label ?? "soon"})`)
-          .join(", "),
-      }),
-      action: { kind: "navigate", routeId: "model-providers" },
-      signature: signatureOf(expiring.map((provider) => provider.provider)),
-    });
-  }
   return items;
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2762,7 +2762,6 @@ export const en: TranslationMap = {
     cronFailed: "{count} cron job(s) failed",
     cronOverdue: "{count} cron job(s) overdue",
     modelAuthExpired: "Model auth expired: {providers}",
-    modelAuthExpiring: "Model auth expiring: {providers}",
     pendingApproval: "{count} pending approval",
     pendingApprovals: "{count} pending approvals",
   },

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -254,6 +254,17 @@ describe("AppSidebar logo stand-in wiring", () => {
     await sidebar.updateComplete;
     expect(standIn()).toBeNull();
     expect(logo()?.classList.contains("sidebar-brand__logo--vacated")).toBe(false);
+
+    // A lookless scare phase hides the logo with no stand-in crab, and the
+    // "out" edge restores it.
+    dispatch({ phase: "in", look: null, name: null });
+    await sidebar.updateComplete;
+    expect(logo()?.classList.contains("sidebar-brand__logo--vacated")).toBe(true);
+    expect(standIn()).toBeNull();
+
+    dispatch({ phase: "out", look: null, name: null });
+    await sidebar.updateComplete;
+    expect(logo()?.classList.contains("sidebar-brand__logo--vacated")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Two sidebar-footer nits:

1. The warning-severity "Model auth expiring: <provider> (...)" attention chip nags for OAuth tokens that roll expiry continuously (e.g. short-lived tokens), creating recurring noise for auth that still works.
2. The lobster pet and the brand logo coexist without interacting: ledge visits never touch the logo, so the only playful logo moment is the rare perch load.

## Why This Change Was Made

- The expiring chip is removed; the error-severity "Model auth expired" chip stays, so genuinely broken auth still surfaces with a route to Model Providers.
- Ledge visits now sometimes scare the logo away: a seeded 30% roll per arrival, a ~900ms beat after the crab settles in, the logo fades out via the existing `sidebar-brand__logo--vacated` transition (no stand-in renders), and the existing `presence -> out` edge restores it when the visit ends. Perch visits, offline summons, and `prefers-reduced-motion` users are exempt. The existing `LOBSTER_LOGO_VISIT_EVENT` channel is reused with a lookless detail variant, so the sidebar needs no new event surface.

## User Impact

- No more recurring "auth expiring" warnings; expired/missing auth still alerts.
- Roughly a third of idle lobster visits now play a small "crab scared the logo" gag; the logo always returns when the visit ends. Reduced-motion users see no change.

## Evidence

Before (crab visiting, logo present bottom-left) / after (logo scared away, crab stays):

| Before | Scare |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/logo-scare-2026-07/logo-before.png) | ![scare](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/logo-scare-2026-07/logo-scare.png) |

(The "Model auth expired" chip in the shots is the mock harness's expired fixture — that chip intentionally stays.)

Validation (Blacksmith Testbox `tbx_01kxsw4ew9g3z35cjdg1yxnzxx`):
- `pnpm test ui/src/components/lobster-pet.test.ts ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-attention.test.ts` — 159/159 passed, including new scare tests (seeded scare visit hides the logo lookless and restores on exit; reduced motion never scares; existing seed-42 no-event and seed-70 perch tests unchanged).
- `pnpm check:changed` — exit 0 (coreTests + ui lanes, incl. `ui:i18n` verify with the removed `attention.modelAuthExpiring` key).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, no actionable findings.

Foreign locale bundles keep the stale `modelAuthExpiring` key until the post-merge locale-refresh workflow prunes them (generated output; per `ui/CLAUDE.md` not hand-edited in source PRs).

### Startup JS budget note

The first CI round tripped the Control UI startup-JS budget (370.8 KiB vs the then-370.0 limit): main had grown to 369.3 KiB organically and this branch adds ~0.3 KiB plus one `control-ui-core` chunk. Meanwhile main landed the approval-page lazy-load (#110528), which cut startup weight and ratcheted the budget down to 340 KiB / 20 requests. After rebasing onto that, this branch measures **13 requests / 322.9 KiB gzip** (Testbox `tbx_01kxt6wxq19zwcs4m9mrt5rc4n`) — comfortably inside the new budget, with no budget changes in this PR. Post-rebase, the relocated sidebar wiring test (now in `ui/src/test-helpers/app-sidebar-cases/sessions.ts`) and the full focused set pass 159/159 on the same lease.
