### PR TITLE
fix: show background commands after agent turns

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/BackgroundTaskTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/BackgroundTaskTest.kt
@@ -32,6 +32,21 @@ class BackgroundTaskTest {
   }
 
   @Test
+  fun parsesRunningBackgroundExecTask() {
+    val tasks =
+      parseBackgroundTasks(
+        json,
+        """{"tasks":[{"id":"task-exec","taskId":"task-exec","kind":"exec","status":"running","runtime":"cli","title":"CLI command","progressSummary":"Command running"}]}""",
+      )
+
+    assertEquals(1, tasks.size)
+    assertEquals("CLI command", tasks.single().displayTitle)
+    assertEquals("Command running", tasks.single().output)
+    assertTrue(tasks.single().isActive)
+    assertEquals(BackgroundTaskDisplayStatus.Running, tasks.single().displayStatus)
+  }
+
+  @Test
   fun listsActiveAndRecentTasksWithoutRequestingPrompts() =
     runTest {
       val calls = mutableListOf<Pair<String, String?>>()

--- a/apps/ios/Tests/BackgroundTasksScreenTests.swift
+++ b/apps/ios/Tests/BackgroundTasksScreenTests.swift
@@ -46,13 +46,16 @@ struct BackgroundTasksScreenTests {
           "id":"ledger-1",
           "taskId":"runtime-1",
           "status":"running",
-          "runtime":"cli"
+          "runtime":"cli",
+          "kind":"exec"
         }
         """#.utf8)
 
         let task = try JSONDecoder().decode(MobileBackgroundTask.self, from: data)
 
         #expect(task.displayTitle == "ledger-1")
+        #expect(task.isActive)
+        #expect(task.runtimeLabel == "CLI")
     }
 
     @Test func `terminal snapshot wins a timestamp tie`() throws {

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -17,7 +17,7 @@ Background tasks track work that runs **outside your main conversation session**
 Tasks do **not** replace sessions, cron jobs, or heartbeats - they are the **activity ledger** that records what detached work happened, when, and whether it succeeded.
 
 <Note>
-Not every agent run creates a task. Heartbeat turns and normal interactive chat do not. All cron executions, ACP spawns, subagent spawns, and gateway-dispatched CLI agent commands do.
+Not every agent run creates a task. Heartbeat turns and normal interactive chat do not. All cron executions, ACP spawns, subagent spawns, gateway-dispatched CLI agent commands, and agent-started background `exec` commands do.
 </Note>
 
 ## TL;DR

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -79,6 +79,7 @@ Notes:
 - Important: sandboxing is **off by default**. If sandboxing is off, implicit `host=auto` resolves to `gateway`. Explicit `host=sandbox` still fails closed instead of silently running on the gateway host. Enable sandboxing or use `host=gateway` with approvals.
 - Script preflight checks (for common Python/Node shell-syntax mistakes) only inspect files inside the effective `workdir` boundary. If a script path resolves outside `workdir`, preflight is skipped for that file. Preflight also skips entirely when `host=gateway` and the effective policy is `security=full` with `ask=off`.
 - For long-running work that starts now, start it once and rely on automatic completion wake when it is enabled and the command emits output or fails. Use `process` for logs, status, input, or intervention; do not emulate scheduling with sleep loops, timeout loops, or repeated polling.
+- Agent-started background commands appear in the Web, iOS, and Android background-task views until they finish. The task ledger is finalized before the completion heartbeat wakes the agent again.
 - For work that should happen later or on a schedule, use cron instead of `exec` sleep/delay patterns.
 
 ## Config

--- a/src/agents/bash-process-control.ts
+++ b/src/agents/bash-process-control.ts
@@ -1,0 +1,22 @@
+// Shared control seam for task-ledger and process-tool cancellation.
+import { getProcessSupervisor } from "../process/supervisor/index.js";
+import { getSession } from "./bash-process-registry.js";
+
+export function isBackgroundExecSessionActive(sessionId: string): boolean {
+  const session = getSession(sessionId);
+  return Boolean(session?.backgrounded && !session.exited);
+}
+
+export function cancelBackgroundExecSession(sessionId: string): boolean {
+  const session = getSession(sessionId);
+  if (!session?.backgrounded || session.exited || session.finalizing) {
+    return false;
+  }
+  const supervisor = getProcessSupervisor();
+  const record = supervisor.getRecord(sessionId);
+  if (!record || record.state === "exited") {
+    return false;
+  }
+  supervisor.cancel(sessionId, "manual-cancel");
+  return true;
+}

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -600,6 +600,8 @@ export async function runExecProcess(opts: {
   notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
+  /** Runs after process finalization and before the exit wake is queued. */
+  onSettledBeforeNotify?: (outcome: ExecProcessOutcome) => void;
 }): Promise<ExecProcessHandle> {
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
@@ -751,7 +753,8 @@ export async function runExecProcess(opts: {
       // Finalization can release remote process/session resources. Keep the
       // background-work blocker until that owner transition has settled.
       session.finalizing = false;
-      if (!session.exited) {
+      const shouldNotify = !session.exited;
+      if (shouldNotify) {
         markExited(
           session,
           finalOutcome.exitCode,
@@ -760,6 +763,9 @@ export async function runExecProcess(opts: {
           finalOutcome.exitReason,
           finalOutcome.noOutputTimedOut,
         );
+      }
+      opts.onSettledBeforeNotify?.(finalOutcome);
+      if (shouldNotify) {
         maybeNotifyOnExit(session, finalOutcome.status);
       }
     }

--- a/src/agents/bash-tools.exec-task-tracking.test.ts
+++ b/src/agents/bash-tools.exec-task-tracking.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecProcessOutcome } from "./bash-tools.exec-runtime.js";
+
+const taskRuntime = vi.hoisted(() => ({
+  createRunningTaskRun: vi.fn(),
+  finalizeTaskRunByRunId: vi.fn(),
+}));
+
+vi.mock("../tasks/detached-task-runtime.js", () => taskRuntime);
+
+import {
+  createBackgroundExecTask,
+  finalizeBackgroundExecTask,
+} from "./bash-tools.exec-task-tracking.js";
+
+describe("background exec task tracking", () => {
+  beforeEach(() => {
+    taskRuntime.createRunningTaskRun.mockReset();
+    taskRuntime.finalizeTaskRunByRunId.mockReset();
+  });
+
+  it("creates a silent CLI ledger row without persisting command text", () => {
+    taskRuntime.createRunningTaskRun.mockReturnValue({ taskId: "task-1" });
+
+    const handle = createBackgroundExecTask({
+      processSessionId: "amber-reef",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      startedAt: 100,
+    });
+
+    expect(handle).toEqual({
+      taskId: "task-1",
+      runId: "exec:amber-reef",
+      sessionKey: "agent:main:main",
+    });
+    expect(taskRuntime.createRunningTaskRun).toHaveBeenCalledWith({
+      runtime: "cli",
+      taskKind: "exec",
+      sourceId: "amber-reef",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      agentId: "main",
+      requesterAgentId: "main",
+      runId: "exec:amber-reef",
+      label: "CLI command",
+      task: "Background CLI command",
+      notifyPolicy: "silent",
+      deliveryStatus: "not_applicable",
+      startedAt: 100,
+      lastEventAt: 100,
+      progressSummary: "Command running",
+      detail: { processSessionId: "amber-reef" },
+    });
+  });
+
+  it.each([
+    {
+      label: "success",
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 25,
+        aggregated: "secret output",
+        timedOut: false,
+      } satisfies ExecProcessOutcome,
+      status: "succeeded",
+      error: undefined,
+    },
+    {
+      label: "timeout",
+      outcome: {
+        status: "failed",
+        exitCode: null,
+        exitSignal: "SIGTERM",
+        exitReason: "overall-timeout",
+        durationMs: 25,
+        aggregated: "secret output",
+        timedOut: true,
+        failureKind: "overall-timeout",
+        reason: "secret output\nCommand timed out",
+      } satisfies ExecProcessOutcome,
+      status: "timed_out",
+      error: "Command timed out",
+    },
+    {
+      label: "nonzero exit",
+      outcome: {
+        status: "completed",
+        exitCode: 17,
+        exitSignal: null,
+        durationMs: 25,
+        aggregated: "secret output",
+        timedOut: false,
+      } satisfies ExecProcessOutcome,
+      status: "failed",
+      error: "Command failed (exit code 17)",
+    },
+    {
+      label: "operator cancellation",
+      outcome: {
+        status: "failed",
+        exitCode: null,
+        exitSignal: "SIGTERM",
+        exitReason: "manual-cancel",
+        durationMs: 25,
+        aggregated: "secret output",
+        timedOut: false,
+        failureKind: "signal",
+        reason: "secret output\nCommand aborted",
+      } satisfies ExecProcessOutcome,
+      status: "cancelled",
+      error: "Cancelled by operator",
+    },
+  ])(
+    "finalizes $label before wake without persisting process output",
+    ({ outcome, status, error }) => {
+      finalizeBackgroundExecTask({
+        handle: {
+          taskId: "task-1",
+          runId: "exec:amber-reef",
+          sessionKey: "agent:main:main",
+        },
+        outcome,
+      });
+
+      expect(taskRuntime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "exec:amber-reef",
+          runtime: "cli",
+          sessionKey: "agent:main:main",
+          status,
+          ...(error ? { error } : { clearError: true }),
+        }),
+      );
+      expect(JSON.stringify(taskRuntime.finalizeTaskRunByRunId.mock.calls)).not.toContain(
+        "secret output",
+      );
+    },
+  );
+});

--- a/src/agents/bash-tools.exec-task-tracking.ts
+++ b/src/agents/bash-tools.exec-task-tracking.ts
@@ -1,0 +1,121 @@
+// Projects detached exec processes into the durable task ledger used by clients.
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { BACKGROUND_EXEC_TASK_KIND } from "../tasks/background-exec-task-contract.js";
+import { createRunningTaskRun, finalizeTaskRunByRunId } from "../tasks/detached-task-runtime.js";
+import type { ExecProcessOutcome } from "./bash-tools.exec-runtime.js";
+
+const log = createSubsystemLogger("agents/bash-exec-task-tracking");
+
+export type BackgroundExecTaskHandle = {
+  taskId: string;
+  runId: string;
+  sessionKey: string;
+};
+
+export function createBackgroundExecTask(params: {
+  processSessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+  startedAt: number;
+}): BackgroundExecTaskHandle | null {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return null;
+  }
+  const runId = `exec:${params.processSessionId}`;
+  try {
+    const task = createRunningTaskRun({
+      runtime: "cli",
+      taskKind: BACKGROUND_EXEC_TASK_KIND,
+      sourceId: params.processSessionId,
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      agentId: params.agentId,
+      requesterAgentId: params.agentId,
+      runId,
+      label: "CLI command",
+      task: "Background CLI command",
+      notifyPolicy: "silent",
+      deliveryStatus: "not_applicable",
+      startedAt: params.startedAt,
+      lastEventAt: params.startedAt,
+      progressSummary: "Command running",
+      detail: { processSessionId: params.processSessionId },
+    });
+    if (!task) {
+      return null;
+    }
+    return { taskId: task.taskId, runId, sessionKey };
+  } catch (error) {
+    log.warn("Failed to register background exec task", {
+      processSessionId: params.processSessionId,
+      error,
+    });
+    return null;
+  }
+}
+
+export function finalizeBackgroundExecTask(params: {
+  handle: BackgroundExecTaskHandle | null;
+  outcome: ExecProcessOutcome;
+}): void {
+  if (!params.handle) {
+    return;
+  }
+  const endedAt = Date.now();
+  const status =
+    params.outcome.status === "completed"
+      ? params.outcome.exitCode === 0
+        ? "succeeded"
+        : "failed"
+      : params.outcome.timedOut
+        ? "timed_out"
+        : params.outcome.exitReason === "manual-cancel"
+          ? "cancelled"
+          : "failed";
+  try {
+    finalizeTaskRunByRunId({
+      runId: params.handle.runId,
+      runtime: "cli",
+      sessionKey: params.handle.sessionKey,
+      status,
+      endedAt,
+      lastEventAt: endedAt,
+      terminalSummary:
+        status === "succeeded"
+          ? "Command completed"
+          : status === "failed"
+            ? "Command failed"
+            : "Command stopped",
+      ...(status === "succeeded" ? { clearError: true } : { error: execTaskError(params.outcome) }),
+      detail: {
+        processSessionId: params.handle.runId.slice("exec:".length),
+        exitCode: params.outcome.exitCode,
+        ...(params.outcome.exitSignal != null
+          ? { exitSignal: String(params.outcome.exitSignal) }
+          : {}),
+        ...(params.outcome.status === "failed" ? { failureKind: params.outcome.failureKind } : {}),
+      },
+    });
+  } catch (error) {
+    log.warn("Failed to finalize background exec task", {
+      taskId: params.handle.taskId,
+      runId: params.handle.runId,
+      error,
+    });
+  }
+}
+
+function execTaskError(outcome: ExecProcessOutcome): string {
+  if (outcome.status === "completed") {
+    return `Command failed (exit code ${outcome.exitCode ?? "unknown"})`;
+  }
+  if (outcome.timedOut) {
+    return "Command timed out";
+  }
+  if (outcome.exitReason === "manual-cancel") {
+    return "Cancelled by operator";
+  }
+  return `Command failed (${outcome.failureKind})`;
+}

--- a/src/agents/bash-tools.exec-task-wiring.test.ts
+++ b/src/agents/bash-tools.exec-task-wiring.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const taskTracking = vi.hoisted(() => ({
+  createBackgroundExecTask: vi.fn(),
+  finalizeBackgroundExecTask: vi.fn(),
+}));
+
+vi.mock("./bash-tools.exec-task-tracking.js", () => taskTracking);
+
+import { createExecTool } from "./bash-tools.exec.js";
+
+describe("exec background task wiring", () => {
+  beforeEach(() => {
+    taskTracking.createBackgroundExecTask.mockReset();
+    taskTracking.finalizeBackgroundExecTask.mockReset();
+  });
+
+  it("does not register a foreground command that settles before the yield timer", async () => {
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      allowBackground: true,
+      backgroundMs: 10_000,
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("foreground-before-yield", {
+      command: process.platform === "win32" ? "Write-Output done" : "echo done",
+    });
+
+    expect(result.details).toMatchObject({ status: "completed" });
+    expect(taskTracking.createBackgroundExecTask).not.toHaveBeenCalled();
+    expect(taskTracking.finalizeBackgroundExecTask).toHaveBeenCalledWith({
+      handle: null,
+      outcome: expect.objectContaining({ status: "completed" }),
+    });
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -71,6 +71,11 @@ import {
   runExecProcess,
   execSchema,
 } from "./bash-tools.exec-runtime.js";
+import {
+  type BackgroundExecTaskHandle,
+  createBackgroundExecTask,
+  finalizeBackgroundExecTask,
+} from "./bash-tools.exec-task-tracking.js";
 import type { ExecToolDefaults, ExecToolDetails } from "./bash-tools.exec-types.js";
 import {
   type ExecWorkdirResolution,
@@ -1782,6 +1787,8 @@ export function createExecTool(
         workdir = workdirResolution.remoteCwd;
       }
       let run: ExecProcessHandle;
+      let backgroundTask: BackgroundExecTaskHandle | null = null;
+      let settledOutcome: ExecProcessOutcome | null = null;
       let effectiveTimeout: number;
       try {
         if (elevatedRequested) {
@@ -2010,6 +2017,10 @@ export function createExecTool(
           notifyDeliveryContext,
           timeoutSec: effectiveTimeout,
           onUpdate,
+          onSettledBeforeNotify: (outcome) => {
+            settledOutcome = outcome;
+            finalizeBackgroundExecTask({ handle: backgroundTask, outcome });
+          },
         });
         discardPreparedSandboxWorkdir = null;
       } catch (error) {
@@ -2082,8 +2093,27 @@ export function createExecTool(
           if (yielded) {
             return;
           }
+          if (settledOutcome) {
+            cleanupToolRunListeners();
+            resolve(
+              buildExecForegroundResult({
+                outcome: settledOutcome,
+                cwd: run.session.cwd,
+                warningText: getWarningText(),
+              }),
+            );
+            return;
+          }
           yielded = true;
           markBackgrounded(run.session);
+          // Only the guarded yield transition owns task registration. A process
+          // that settles before this timer fires must stay out of the task ledger.
+          backgroundTask = createBackgroundExecTask({
+            processSessionId: run.session.id,
+            sessionKey: notifySessionKey,
+            agentId,
+            startedAt: run.startedAt,
+          });
           resolveRunning();
         };
 
@@ -2092,12 +2122,7 @@ export function createExecTool(
             onYieldNow();
           } else {
             yieldTimer = setTimeout(() => {
-              if (yielded) {
-                return;
-              }
-              yielded = true;
-              markBackgrounded(run.session);
-              resolveRunning();
+              onYieldNow();
             }, yieldWindow);
           }
         }

--- a/src/tasks/background-exec-task-contract.ts
+++ b/src/tasks/background-exec-task-contract.ts
@@ -1,0 +1,6 @@
+// Shared identity for background exec rows in the durable task ledger.
+export const BACKGROUND_EXEC_TASK_KIND = "exec";
+
+export function isBackgroundExecTask(task: { runtime: string; taskKind?: string }): boolean {
+  return task.runtime === "cli" && task.taskKind === BACKGROUND_EXEC_TASK_KIND;
+}

--- a/src/tasks/task-registry-control.runtime.ts
+++ b/src/tasks/task-registry-control.runtime.ts
@@ -1,4 +1,5 @@
 // Runtime control seam for cancelling runtime-owned work from task APIs.
 export { getAcpSessionManager } from "../acp/control-plane/manager.js";
+export { cancelBackgroundExecSession } from "../agents/bash-process-control.js";
 export { killSubagentRunAdmin } from "../agents/subagent-control.js";
 export { cancelActiveCronTaskRun } from "../cron/service/active-run-cancellation.js";

--- a/src/tasks/task-registry-control.types.ts
+++ b/src/tasks/task-registry-control.types.ts
@@ -31,6 +31,7 @@ type KillSubagentRunAdmin = (params: {
 }) => Promise<KillSubagentRunAdminResult>;
 
 export type TaskRegistryControlRuntime = {
+  cancelBackgroundExecSession?: (sessionId: string) => boolean;
   cancelActiveCronTaskRun: (params: { runId: string | undefined; reason?: string }) => boolean;
   getAcpSessionManager: () => {
     cancelSession: CancelAcpSessionAdmin;

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -7,6 +7,7 @@ import {
   readAcpSessionEntry,
   type AcpSessionStoreEntry,
 } from "../acp/runtime/session-meta.js";
+import { isBackgroundExecSessionActive } from "../agents/bash-process-control.js";
 import {
   formatSubagentRecoveryWedgedReason,
   isSubagentRecoveryWedgedEntry,
@@ -33,6 +34,7 @@ import {
   deriveSessionChatTypeFromKey,
   type SessionKeyChatType,
 } from "../sessions/session-chat-type-shared.js";
+import { isBackgroundExecTask } from "./background-exec-task-contract.js";
 import { CODEX_NATIVE_SUBAGENT_STALE_ERROR } from "./codex-native-subagent-task.js";
 import {
   collectCronHistoryOverflowTaskIds,
@@ -103,6 +105,7 @@ type TaskRegistryMaintenanceRuntime = {
   deriveSessionChatTypeFromKey?: typeof deriveSessionChatTypeFromKey;
   isCronJobActive: typeof isCronJobActive;
   getAgentRunContext: typeof getAgentRunContext;
+  isBackgroundExecSessionActive?: typeof isBackgroundExecSessionActive;
   hasActiveAcpTurn: (sessionKey: string) => boolean;
   parseAgentSessionKey: typeof parseAgentSessionKey;
   hasActiveTaskForChildSessionKey: typeof hasActiveTaskForChildSessionKey;
@@ -141,6 +144,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   deriveSessionChatTypeFromKey,
   isCronJobActive,
   getAgentRunContext,
+  isBackgroundExecSessionActive,
   hasActiveAcpTurn: isAcpTurnActive,
   parseAgentSessionKey,
   hasActiveTaskForChildSessionKey,
@@ -175,6 +179,7 @@ export type TaskRegistryMaintenanceTaskDiagnostic = {
   reason:
     | "acp_runtime_not_authoritative"
     | "active_cli_run"
+    | "active_background_exec"
     | "backing_session_missing"
     | "backing_session_present"
     | "cron_runtime_not_authoritative"
@@ -400,6 +405,13 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     return jobId ? taskRegistryMaintenanceRuntime.isCronJobActive(jobId) : false;
   }
 
+  if (isBackgroundExecTask(task)) {
+    const processSessionId = task.sourceId?.trim();
+    return Boolean(
+      processSessionId &&
+      taskRegistryMaintenanceRuntime.isBackgroundExecSessionActive?.(processSessionId),
+    );
+  }
   if (task.runtime === "cli" && hasActiveCliRun(task)) {
     return true;
   }
@@ -934,6 +946,9 @@ function explainActiveTaskRetention(params: {
   }
   if (params.task.runtime === "cli" && hasActiveCliRun(params.task)) {
     return { decision: "retained", reason: "active_cli_run" };
+  }
+  if (isBackgroundExecTask(params.task)) {
+    return { decision: "retained", reason: "active_background_exec" };
   }
   return { decision: "retained", reason: "backing_session_present" };
 }

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -124,11 +124,13 @@ function createTaskFlowForTask(
 const hoisted = vi.hoisted(() => {
   const sendMessageMock = vi.fn();
   const cancelSessionMock = vi.fn();
+  const cancelBackgroundExecSessionMock = vi.fn();
   const cancelActiveCronTaskRunMock = vi.fn();
   const killSubagentRunAdminMock = vi.fn();
   return {
     sendMessageMock,
     cancelSessionMock,
+    cancelBackgroundExecSessionMock,
     cancelActiveCronTaskRunMock,
     killSubagentRunAdminMock,
   };
@@ -167,6 +169,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
   acpEntries?: AcpSessionStoreEntry[];
   listAcpSessionEntries?: () => Promise<AcpSessionStoreEntry[]>;
   hasActiveAcpTurn?: (sessionKey: string) => boolean;
+  isBackgroundExecSessionActive?: (sessionId: string) => boolean;
   sessionBindings?: SessionBindingRecord[];
   closeAcpSession?: (params: {
     cfg: AcpSessionStoreEntry["cfg"];
@@ -198,6 +201,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
     parseAgentSessionKey: () => null as ParsedAgentSessionKey | null,
     isCronJobActive: () => false,
     getAgentRunContext: () => undefined,
+    isBackgroundExecSessionActive: params.isBackgroundExecSessionActive,
     hasActiveAcpTurn: params.hasActiveAcpTurn ?? (() => false),
     hasActiveTaskForChildSessionKey: ({ sessionKey, excludeTaskId }) => {
       const normalized = sessionKey.trim().toLowerCase();
@@ -516,6 +520,8 @@ describe("task-registry", () => {
       sendMessage: hoisted.sendMessageMock,
     });
     setTaskRegistryControlRuntimeForTests({
+      cancelBackgroundExecSession: (sessionId) =>
+        hoisted.cancelBackgroundExecSessionMock(sessionId),
       cancelActiveCronTaskRun: (params) => hoisted.cancelActiveCronTaskRunMock(params),
       getAcpSessionManager: () => ({
         cancelSession: hoisted.cancelSessionMock,
@@ -540,6 +546,7 @@ describe("task-registry", () => {
     resetTaskFlowRegistryForTests({ persist: false });
     hoisted.sendMessageMock.mockReset();
     hoisted.cancelSessionMock.mockReset();
+    hoisted.cancelBackgroundExecSessionMock.mockReset();
     hoisted.cancelActiveCronTaskRunMock.mockReset();
     hoisted.killSubagentRunAdminMock.mockReset();
   });
@@ -2831,6 +2838,54 @@ describe("task-registry", () => {
     });
   });
 
+  it("retains live background exec tasks and marks missing process sessions lost", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      const task = createTaskRecord({
+        runtime: "cli",
+        taskKind: "exec",
+        sourceId: "amber-reef",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "exec:amber-reef",
+        task: "Background CLI command",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        lastEventAt: Date.now() - 10 * 60_000,
+      });
+      const currentTasks = new Map([[task.taskId, task]]);
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks,
+        snapshotTasks: [task],
+        isBackgroundExecSessionActive: () => true,
+      });
+
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expectRecordFields(currentTasks.get(task.taskId), { status: "running" });
+
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks,
+        snapshotTasks: [task],
+        isBackgroundExecSessionActive: () => false,
+      });
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expectRecordFields(currentTasks.get(task.taskId), {
+        status: "lost",
+        error: "backing session missing",
+      });
+    });
+  });
+
   it("projects inspection-time orphaned tasks as lost without mutating the registry", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
@@ -4303,6 +4358,33 @@ describe("task-registry", () => {
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
       relay.dispose();
       vi.useRealTimers();
+    });
+  });
+
+  it("cancels background exec tasks through process control", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelBackgroundExecSessionMock.mockReturnValue(true);
+      const task = createTaskRecord({
+        runtime: "cli",
+        taskKind: "exec",
+        sourceId: "amber-reef",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "exec:amber-reef",
+        task: "Background CLI command",
+        status: "running",
+        deliveryStatus: "not_applicable",
+      });
+
+      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+
+      expect(hoisted.cancelBackgroundExecSessionMock).toHaveBeenCalledWith("amber-reef");
+      expectRecordFields(result, { found: true, cancelled: true });
+      expectRecordFields(result.task, {
+        taskId: task.taskId,
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      });
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -22,6 +22,7 @@ import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.j
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import { isBackgroundExecTask } from "./background-exec-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import { isChildlessNativeSubagentTask } from "./native-subagent-task.js";
 import {
@@ -2337,7 +2338,18 @@ export async function cancelTaskById(params: {
     ensureTaskCancellationReady(task);
     // A direct kill is only a provisional terminal projection. Re-read the
     // owning subagent run before promotion so its canonical completion can win.
-    if (task.runtime !== "cli") {
+    if (isBackgroundExecTask(task)) {
+      const processSessionId = task.sourceId?.trim();
+      const { cancelBackgroundExecSession } = await loadTaskRegistryControlRuntime();
+      if (!processSessionId || !cancelBackgroundExecSession?.(processSessionId)) {
+        return {
+          found: true,
+          cancelled: false,
+          reason: "Background command has no active cancellation handle.",
+          task: cloneTaskRecord(task),
+        };
+      }
+    } else if (task.runtime !== "cli") {
       if (task.runtime === "cron") {
         const { cancelActiveCronTaskRun } = await loadTaskRegistryControlRuntime();
         if (

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -61,6 +61,20 @@ const finishedCli = {
   error: "Index generation failed",
 };
 
+const runningExec = {
+  id: "task-exec",
+  taskId: "task-exec",
+  kind: "exec",
+  runtime: "cli",
+  status: "running",
+  title: "CLI command",
+  agentId: "main",
+  createdAt: baseTime - 2_000,
+  updatedAt: baseTime,
+  startedAt: baseTime - 2_000,
+  progressSummary: "Command running",
+};
+
 let server: ControlUiE2eServer;
 let browser: Browser;
 
@@ -220,6 +234,51 @@ describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E",
         .toBe(true);
       await page.screenshot({
         path: path.join(artifactDir, "04-transcript-open.png"),
+        fullPage: true,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows one detached exec after the agent turn ends", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    try {
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            content: [{ type: "text", text: "I started the CLI command in the background." }],
+            role: "assistant",
+            timestamp: Date.now(),
+          },
+        ],
+        methodResponses: {
+          "tasks.list": { tasks: [runningExec] },
+        },
+      });
+
+      const response = await page.goto(`${server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      await page
+        .getByText("I started the CLI command in the background.")
+        .waitFor({ timeout: 10_000 });
+      expect(await page.locator(".chat-tasks-toggle__badge").textContent()).toBe("1");
+      expect(await page.locator(".chat-tasks-status__link").textContent()).toContain(
+        "1 running task",
+      );
+
+      await page.getByRole("button", { name: "Show background tasks" }).click();
+      const row = page.locator('[data-task-id="task-exec"]');
+      await row.waitFor({ state: "visible" });
+      expect(await row.textContent()).toContain("CLI command");
+      expect(await row.textContent()).toContain("Command running");
+      await page.screenshot({
+        path: path.join(artifactDir, "05-one-background-exec.png"),
         fullPage: true,
       });
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could ask an agent to start a CLI command in the background, end the agent turn, and then see no running task in the Web, iOS, or Android task view while the command was still active.

## Why This Change Was Made

Background exec sessions now project a privacy-safe row into the durable task ledger only after the exec actually yields. The row is finalized before the existing completion heartbeat wakes the agent, supports operator cancellation, and is reconciled after a gateway restart. Command text and command output are not persisted in task metadata.

## User Impact

Web, iOS, and Android now show one running background task for an agent-started CLI command after the initiating turn ends, then move it to finished when the command exits. Failed nonzero exits are shown as failed rather than successful.

Release note: Background CLI commands now remain visible in task views until completion.

AI-assisted: yes. I reviewed the implementation and understand the lifecycle, privacy, cancellation, and recovery behavior.

## Evidence

- Live OpenAI Responses API run with an approved OpenAI key: the agent launched a 90-second command, ended with STARTED, the Web task badge and rail showed one running CLI task, and completion triggered a second OpenAI model turn through the existing exec-event heartbeat path.
- Live Web completion state: the same row moved to Completed with a 1m 30s duration and Command completed summary.
- Blacksmith Testbox changed gate: format, core/test typecheck, full core/UI lint, import-cycle, SDK boundary, dependency, and database-first guards passed.
- Focused task/exec tests: 159 tests passed after the nonzero-exit fix; 162 tests passed in the wider lifecycle run.
- Web background-task E2E: 2 tests passed, including the one-running-task badge, rail row, and screenshot artifact.
- Android unit suite: BUILD SUCCESSFUL, including the background exec parsing/display assertion.
- Autoreview: clean on the exact branch diff after addressing nonzero exit-code projection.
- iOS parsing/display assertion added; exact-head macOS CI will provide compiler and test proof before merge.
