### PR TITLE
fix(ui): use arrow cursor on dropdown menu items

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -615,6 +615,17 @@ a:hover {
   text-decoration-thickness: 2px;
 }
 
+/* Web Awesome dropdown items ship `cursor: pointer` on their shadow host.
+   Document rules beat `:host`, so restore the chrome arrow here — and re-add
+   the disabled cue this override would otherwise clobber. */
+wa-dropdown-item {
+  cursor: default;
+}
+
+wa-dropdown-item[disabled] {
+  cursor: not-allowed;
+}
+
 button,
 input,
 textarea,


### PR DESCRIPTION
## What Problem This Solves

Every context/dropdown menu in the Control UI shows the hyperlink hand cursor over its items. The repo's cursor convention (`ui/src/styles/base.css`) reserves the pointer hand for real hyperlinks; app chrome — buttons, menus, tabs, controls — uses the default arrow. Menus violated this because the cursor came from inside the component library, not from our CSS.

## Why This Change Was Made

Web Awesome's `wa-dropdown-item` sets `cursor: pointer` on its shadow `:host` (`@awesome.me/webawesome` 3.10.0, `dropdown-item` host styles). No repo stylesheet ever set it, so the fix is a single document-level override next to the existing cursor-convention comment in `base.css`. Document rules beat shadow `:host` rules in the cascade, so one rule covers all ~30 menu surfaces (session menus, sidebar nav/agent menus, chat pane/controls/attachments, cron, usage, workspace widgets, native-link menu). Because the override also beats the shadow `:host([disabled]) { cursor: not-allowed }`, the disabled cue is re-added explicitly.

## User Impact

Menu items now show the standard arrow cursor like native context menus; disabled items keep the not-allowed cursor. No layout or behavior change.

## Evidence

- Cascade mechanism verified in a live browser harness: a custom element with `:host { cursor: pointer }` + `:host([disabled]) { cursor: not-allowed }` and the same document-level overrides computes `cursor: default` when enabled and `not-allowed` when disabled.
- `wa-dropdown-item` is the only menu-item element used (`rg wa-menu-item` → no prod hits); all call sites set disabled via `?disabled`, so the `[disabled]` attribute selector applies.
- Autoreview (Codex gpt-5.6-sol): clean, "patch is correct (0.96)".
- `git diff --check` clean; CSS-only change, no cursor renders in screenshots so no before/after images.
