### PR TITLE
fix(ui): quiet expanded child-session toggles

### DIFF
--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -169,9 +169,11 @@ export abstract class AppSidebarSessionListElement extends AppSidebarMenusElemen
                   ? icons.chevronDown
                   : icons.chevronRight}</span
               >
-              <span class="sidebar-child-session-toggle__count"
-                >${session.childSessionKeys.length}</span
-              >
+              ${this.isSessionChildrenExpanded(session)
+                ? nothing
+                : html`<span class="sidebar-child-session-toggle__count"
+                    >${session.childSessionKeys.length}</span
+                  >`}
             </button>`
           : nothing}
         <span class="sidebar-recent-session__aside session-row-aside">

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1719,6 +1719,30 @@ html.openclaw-native-macos
   color: var(--muted);
 }
 
+/* Expanded parents already show their children below, so the collapse control
+   is quiet until row hover; collapsed toggles stay visible because the count
+   and status tint are the only signal that hidden children exist. */
+.sidebar-child-session-toggle[aria-expanded="true"] {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-fast) ease;
+}
+
+.session-row-host:hover .sidebar-child-session-toggle[aria-expanded="true"],
+.session-row-host:focus-within .sidebar-child-session-toggle[aria-expanded="true"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Touch has no hover: keep the collapse control usable, matching the
+   session-action touch override in components.css. */
+@media (hover: none), (pointer: coarse) {
+  .sidebar-child-session-toggle[aria-expanded="true"] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .sidebar-child-session-toggle:hover,
 .sidebar-child-session-toggle:focus-visible {
   background: color-mix(in srgb, var(--bg-hover) 88%, transparent);


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110448/#110459. Parent session rows with children still showed a chevron + child count in every state. When a parent is expanded its children are visible directly below, so both the count and the always-on chevron are redundant chrome that makes the sidebar busier than it needs to be.

## Why This Change Was Made

Maintainer request after discussing how to quiet the sidebar: counts should only appear when they carry information (children hidden), and the expanded parent's collapse control should use the same hover-revealed treatment as the existing pin/menu row actions.

## User Impact

- Collapsed parent: unchanged — `› N` stays always visible (plus running/failed tint), since it is the only signal that hidden children exist.
- Expanded parent at rest: no chevron, no count — just the title with children listed below.
- Expanded parent on row hover or keyboard focus: the `⌄` collapse control fades in alongside the pin/menu actions.
- Touch / coarse-pointer devices keep the collapse control always visible (no hover exists), matching the existing `session-action` touch override.

| Collapsed | Expanded (rest) | Expanded (hover) |
| --- | --- | --- |
| ![collapsed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after3-collapsed.png) | ![expanded rest](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after3-expanded-nohover.png) | ![expanded hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-section-chevrons/after3-expanded-hover.png) |

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 107 tests pass.
- Live-verified in the Control UI mock harness (screenshots above): collapsed shows `› 1`; expanded resting row shows nothing; hovering the row reveals the `⌄` control; clicking it still collapses (`:focus-within` keeps it visible after click, so it remains clickable).
- Codex autoreview (gpt-5.6-sol) clean: no accepted/actionable findings.
