### PR TITLE
fix(ai): keep OpenAI tool call id truncation UTF-16 safe

### DIFF
--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -49,4 +49,52 @@ describe("convertMessages assistant text replay", () => {
     const replayed = converted.find((message) => message.role === "assistant");
     expect(replayed?.content).toBe("Let me check the file.\nThe file contains X.");
   });
+
+  it("keeps paired OpenAI tool call ids UTF-16 safe when truncating", () => {
+    const prefix = "a".repeat(39);
+    const oversizedId = `${prefix}🐱`;
+    const targetModel: Model<"openai-completions"> = {
+      ...model,
+      id: "target-model",
+      provider: "openai",
+    };
+    const assistant: AssistantMessage = {
+      role: "assistant",
+      api: targetModel.api,
+      provider: targetModel.provider,
+      model: "source-model",
+      content: [{ type: "toolCall", id: oversizedId, name: "lookup", arguments: {} }],
+      usage: emptyUsage,
+      stopReason: "toolUse",
+      timestamp: 1,
+    };
+    const context: Context = {
+      messages: [
+        assistant,
+        {
+          role: "toolResult",
+          toolCallId: oversizedId,
+          toolName: "lookup",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+          timestamp: 2,
+        },
+      ],
+    };
+
+    const converted = convertMessages(
+      targetModel,
+      context,
+      resolveOpenAICompletionsCompat(targetModel),
+    );
+    const assistantParam = converted.find((message) => message.role === "assistant");
+    const toolParam = converted.find((message) => message.role === "tool");
+    const normalizedAssistantId =
+      assistantParam?.role === "assistant" ? assistantParam.tool_calls?.[0]?.id : undefined;
+    const normalizedToolResultId = toolParam?.role === "tool" ? toolParam.tool_call_id : undefined;
+
+    expect(oversizedId.slice(0, 40).charCodeAt(39)).toBe(0xd83d);
+    expect(normalizedAssistantId).toBe(prefix);
+    expect(normalizedToolResultId).toBe(prefix);
+  });
 });

--- a/packages/ai/src/openai-completions-messages.ts
+++ b/packages/ai/src/openai-completions-messages.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   ChatCompletionAssistantMessageParam,
   ChatCompletionContentPart,
@@ -57,7 +58,7 @@ export function convertMessages(
     }
 
     if (model.provider === "openai") {
-      return id.length > 40 ? id.slice(0, 40) : id;
+      return id.length > 40 ? truncateUtf16Safe(id, 40) : id;
     }
     return id;
   };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

OpenAI-compatible tool-call IDs are limited to OpenClaw's existing 40 UTF-16
code-unit policy. A raw `slice(0, 40)` could split a valid surrogate pair,
leaving a lone high surrogate in both the assistant tool-call ID and its paired
tool-result ID.

## Fix

Use the existing `truncateUtf16Safe` normalization helper at the current
`@openclaw/ai` owner boundary. The pipe-separated ID branch already sanitizes
to ASCII before slicing and is unchanged.

This is a maintainer rewrite of the contributor's original fix after the owner
moved from `src/agents` into `packages/ai`. Contributor authorship is preserved
on the commit.

## User Impact

- OpenAI-compatible tool calls keep well-formed UTF-16 IDs at the truncation boundary.
- Assistant `tool_calls[].id` and matching tool-result `tool_call_id` remain identical.
- IDs without a surrogate pair at the boundary behave as before.
- Non-OpenAI provider paths are unchanged.

## Evidence

Exact head: `49d715bfafa2545abfa367fb74a7495eb766a45a`

```text
node scripts/run-vitest.mjs \
  packages/ai/src/openai-completions-messages.test.ts \
  packages/ai/src/providers/openai-completions.test.ts \
  packages/ai/src/providers/openai-completions-structured-content-parity.test.ts

Test Files  3 passed (3)
Tests      115 passed (115)
```

The owner-local regression was also repeated three times and passed each run.
After the final rebase, the exact-head owner suite passed again: 1 file, 2 tests.

Autoreview reported no findings with 0.99 confidence. Formatting and
`git diff --check` are clean.

The local changed gate passed formatting, lint, dependency, dead-code, and
other classified lanes. Its typecheck stopped on an unrelated unchanged
`packages/terminal-core/src/ansi.ts` shared-install mismatch; exact-head CI is
the dependency-resolved typecheck proof.

### Exact-head OpenAI SDK loopback proof

A temporary untracked proof called production `streamOpenAICompletions` through
OpenAI SDK 6.49.0 and captured the actual JSON posted to a local loopback
`/v1/chat/completions` endpoint. It used cross-model replay so the production
transcript normalization path processed a 41-code-unit tool-call ID whose
40th code unit was a lone high surrogate under the old raw slice.

The proof passed three bounded repeats; a maintainer independently reran it once:

```text
UTF16_LOOPBACK_PROOF {
  "requestPath": "/v1/chat/completions",
  "assistantId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "toolResultId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "idsMatch": true,
  "orphanSurrogate": false,
  "expectedSafePrefix": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
}

Test Files  1 passed (1)
Tests       1 passed (1)
```

The proof exercised the real SDK request path without a paid provider call,
credential, private endpoint, or tracked proof-only file. The temporary file was
deleted after verification and the exact PR head remains unchanged.

## Real Behavior Proof

The regression test drives the production message converter with an assistant
tool call and paired tool result whose valid surrogate pair crosses the
40-code-unit boundary. The SDK loopback proof additionally captures the actual
outbound request JSON and proves the repaired assistant ID and paired
tool-result ID are identical, equal the expected 39-character safe prefix, and
contain no orphan surrogate.
