### PR TITLE
perf(ui): cut forced reflows in Control UI chat render path

### DIFF
--- a/ui/config/control-ui-chunking.ts
+++ b/ui/config/control-ui-chunking.ts
@@ -18,7 +18,9 @@ export function controlUiStableChunkName(id: string): string | undefined {
   // turn small route-graph changes into extra startup preload requests.
   if (
     normalized.endsWith("/ui/src/components/config-form.shared.ts") ||
-    normalized.endsWith("/ui/src/lib/clipboard.ts")
+    normalized.endsWith("/ui/src/lib/clipboard.ts") ||
+    normalized.endsWith("/ui/src/build-info-normalizers.ts") ||
+    normalized.endsWith("/ui/src/build-info.ts")
   ) {
     return "control-ui-shared";
   }
@@ -77,7 +79,9 @@ export const controlUiCodeSplitting = {
         normalizeModuleId(id).includes("/ui/src/") ? "control-ui-core" : "control-ui-foundation",
       tags: ["$initial"] as ["$initial"],
       priority: 10,
-      maxSize: 400 * 1024,
+      // 448 KiB packs the core graph into fewer chunks; the previous 400 KiB
+      // boundary split one core chunk in two, costing ~1.4 KiB startup gzip.
+      maxSize: 448 * 1024,
     },
   ],
 };

--- a/ui/src/app/control-ui-chunking.test.ts
+++ b/ui/src/app/control-ui-chunking.test.ts
@@ -26,6 +26,10 @@ describe("Control UI build chunking", () => {
       "control-ui-shared",
     );
     expect(controlUiStableChunkName("/repo/ui/src/lib/clipboard.ts")).toBe("control-ui-shared");
+    expect(controlUiStableChunkName("/repo/ui/src/build-info.ts")).toBe("control-ui-shared");
+    expect(controlUiStableChunkName("/repo/ui/src/build-info-normalizers.ts")).toBe(
+      "control-ui-shared",
+    );
     expect(
       controlUiStableChunkName("/tmp/openclaw-pnpm-node-modules/@noble/ed25519/index.js"),
     ).toBe("gateway-runtime");
@@ -37,7 +41,7 @@ describe("Control UI build chunking", () => {
     expect(controlUiCodeSplitting.includeDependenciesRecursively).toBe(false);
     expect(controlUiCodeSplitting.groups[1]).toMatchObject({
       tags: ["$initial"],
-      maxSize: 400 * 1024,
+      maxSize: 448 * 1024,
     });
   });
 

--- a/ui/src/components/app-sidebar-session-data.ts
+++ b/ui/src/components/app-sidebar-session-data.ts
@@ -77,6 +77,7 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
   private sessionMutationEpoch = 0;
   private sessionsScrollElement: HTMLElement | null = null;
   private sessionsScrollResizeObserver: ResizeObserver | null = null;
+  private sessionsScrollStateFrame: number | null = null;
   private readonly sessionCatalogLive = new SessionCatalogLiveState();
   private sessionCatalogAgentId: string | null = null;
   private sessionCatalogGeneration = 0;
@@ -161,6 +162,10 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
     this.sessionsScrollResizeObserver?.disconnect();
     this.sessionsScrollResizeObserver = null;
     this.sessionsScrollElement = null;
+    if (this.sessionsScrollStateFrame !== null) {
+      cancelAnimationFrame(this.sessionsScrollStateFrame);
+      this.sessionsScrollStateFrame = null;
+    }
     if (this.activeSessionLineageRetryTimer) {
       globalThis.clearTimeout(this.activeSessionLineageRetryTimer);
       this.activeSessionLineageRetryTimer = null;
@@ -384,8 +389,24 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
       }
     }
     if (element) {
-      this.updateSessionsScrollState(element);
+      this.scheduleSessionsScrollStateSync();
     }
+  }
+
+  // Reading scrollHeight/scrollTop synchronously inside updated() forces a
+  // layout flush on every render. Coalescing the read into one rAF per frame
+  // lets the browser batch it with the layout it computes for paint anyway.
+  private scheduleSessionsScrollStateSync() {
+    if (this.sessionsScrollStateFrame !== null) {
+      return;
+    }
+    this.sessionsScrollStateFrame = requestAnimationFrame(() => {
+      this.sessionsScrollStateFrame = null;
+      const element = this.sessionsScrollElement;
+      if (element?.isConnected) {
+        this.updateSessionsScrollState(element);
+      }
+    });
   }
 
   protected updateSessionsScrollState(element: HTMLElement) {

--- a/ui/src/components/app-sidebar-session-data.ts
+++ b/ui/src/components/app-sidebar-session-data.ts
@@ -393,9 +393,8 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
     }
   }
 
-  // Reading scrollHeight/scrollTop synchronously inside updated() forces a
-  // layout flush on every render. Coalescing the read into one rAF per frame
-  // lets the browser batch it with the layout it computes for paint anyway.
+  // Reading scrollHeight/scrollTop inside updated() forces a layout flush per
+  // render; one rAF-coalesced read rides the layout computed for paint anyway.
   private scheduleSessionsScrollStateSync() {
     if (this.sessionsScrollStateFrame !== null) {
       return;

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -162,9 +162,8 @@ type ChatComposerState = {
   pendingClearedSubmittedDraft: PendingClearedSubmittedDraft | null;
   goalExpandedId: string | null;
   composerTextarea: HTMLTextAreaElement | null;
-  // Stable Lit ref: an inline arrow would change identity every render, making
-  // Lit re-invoke it (undefined + element) and forcing a layout re-measure of
-  // the textarea on every chat render instead of only on attach/detach.
+  // Stable Lit ref: an inline arrow would change identity per render and force
+  // a layout re-measure of the textarea on every chat render, not just attach.
   textareaRef: ((element?: Element) => void) | null;
 };
 

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -161,6 +161,11 @@ type ChatComposerState = {
   composerInputIntentKey: string | null;
   pendingClearedSubmittedDraft: PendingClearedSubmittedDraft | null;
   goalExpandedId: string | null;
+  composerTextarea: HTMLTextAreaElement | null;
+  // Stable Lit ref: an inline arrow would change identity every render, making
+  // Lit re-invoke it (undefined + element) and forcing a layout re-measure of
+  // the textarea on every chat render instead of only on attach/detach.
+  textareaRef: ((element?: Element) => void) | null;
 };
 
 function createChatComposerState(): ChatComposerState {
@@ -178,6 +183,8 @@ function createChatComposerState(): ChatComposerState {
     composerInputIntentKey: null,
     pendingClearedSubmittedDraft: null,
     goalExpandedId: null,
+    composerTextarea: null,
+    textareaRef: null,
   };
 }
 
@@ -1886,7 +1893,23 @@ export function renderChatComposer(props: ChatComposerProps) {
   const draftKey = composerDraftKey(props);
   const actionDraft =
     state.composingDraft?.key === draftKey ? state.composingDraft.value : visibleDraft;
-  let composerTextarea: HTMLTextAreaElement | null = null;
+  state.textareaRef ??= (element?: Element) => {
+    const nextTextarea = element instanceof HTMLTextAreaElement ? element : null;
+    const prevTextarea = state.composerTextarea;
+    if (prevTextarea && prevTextarea !== nextTextarea) {
+      disconnectTextareaOverflowObserver(prevTextarea);
+    }
+    state.composerTextarea = nextTextarea;
+    if (nextTextarea) {
+      observeTextareaOverflow(nextTextarea);
+      scheduleTextareaHeightAdjustment(nextTextarea);
+    }
+  };
+  // The stable ref only measures on attach, so programmatic draft swaps (send
+  // clear, session switch, history restore) must re-measure explicitly.
+  if (state.composerTextarea?.isConnected && state.composerTextarea.value !== visibleDraft) {
+    scheduleTextareaHeightAdjustment(state.composerTextarea);
+  }
   const hasVisualAttachments = (props.attachments ?? []).some(
     (attachment) => !isLargePastedTextAttachment(attachment),
   );
@@ -2142,20 +2165,20 @@ export function renderChatComposer(props: ChatComposerProps) {
     commitComposerDraft(props, target.value);
   };
   const handleSend = () => {
-    const draft = composerTextarea?.value ?? props.draft;
+    const draft = state.composerTextarea?.value ?? props.draft;
     if (!canSubmitDraft(draft)) {
       return;
     }
     commitComposerDraft(props, draft);
     props.onSend();
-    syncComposerDraftAfterSend(composerTextarea);
+    syncComposerDraftAfterSend(state.composerTextarea);
   };
   const handleVoicePrimaryAction = () => {
     if (props.realtimeTalkActive) {
       props.onToggleRealtimeTalk?.();
       return;
     }
-    const liveDraft = composerTextarea?.value ?? visibleDraft;
+    const liveDraft = state.composerTextarea?.value ?? visibleDraft;
     if (liveDraft.trim() || props.attachments?.length) {
       handleSend();
       return;
@@ -2256,7 +2279,7 @@ export function renderChatComposer(props: ChatComposerProps) {
             onGoalEdit: (goal) => {
               commitComposerDraft(props, `/goal edit ${goal.objective}`);
               requestUpdate();
-              queueMicrotask(() => composerTextarea?.focus({ preventScroll: true }));
+              queueMicrotask(() => state.composerTextarea?.focus({ preventScroll: true }));
             },
             requestUpdate,
           })}
@@ -2290,17 +2313,7 @@ export function renderChatComposer(props: ChatComposerProps) {
           ${renderChatAttachmentMenu({ ...props, disabled: !canCompose })}
           <div class="agent-chat__composer-combobox">
             <textarea
-              ${ref((element) => {
-                const nextTextarea = element instanceof HTMLTextAreaElement ? element : null;
-                if (composerTextarea && composerTextarea !== nextTextarea) {
-                  disconnectTextareaOverflowObserver(composerTextarea);
-                }
-                composerTextarea = nextTextarea;
-                if (composerTextarea) {
-                  observeTextareaOverflow(composerTextarea);
-                  scheduleTextareaHeightAdjustment(composerTextarea);
-                }
-              })}
+              ${ref(state.textareaRef)}
               .value=${visibleDraft}
               dir=${detectTextDirection(visibleDraft)}
               ?disabled=${!canCompose}

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -199,11 +199,9 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private readonly controllers = new Set<ReactiveController>();
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
   private scrollElement: HTMLDivElement | null = null;
-  // Stable Lit refs: inline arrows change identity every render, so Lit would
-  // re-invoke them (undefined + element) for every visible row on every render,
-  // sweeping the virtualizer's element cache and re-measuring rows each time.
-  // Lit tracks the last element per (host, callback), so each row needs its own
-  // stable callback; sharing one across rows would still churn every render.
+  // Stable Lit refs: inline arrows change identity per render, making Lit
+  // re-invoke them for every visible row and re-measure each row every render.
+  // Lit tracks the last element per callback, so each row needs its own.
   private readonly scrollElementRef = (element?: Element) => {
     this.scrollElement =
       element?.parentElement instanceof HTMLDivElement ? element.parentElement : null;
@@ -212,11 +210,10 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private measureRowRefFor(key: string): (element?: Element) => void {
     let callback = this.measureRowRefs.get(key);
     if (!callback) {
-      callback = (element?: Element) => {
+      callback = (element?: Element) =>
         this.virtualizerController
           .getVirtualizer()
           .measureElement(element instanceof HTMLElement ? element : null);
-      };
       this.measureRowRefs.set(key, callback);
     }
     return callback;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -199,6 +199,28 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private readonly controllers = new Set<ReactiveController>();
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
   private scrollElement: HTMLDivElement | null = null;
+  // Stable Lit refs: inline arrows change identity every render, so Lit would
+  // re-invoke them (undefined + element) for every visible row on every render,
+  // sweeping the virtualizer's element cache and re-measuring rows each time.
+  // Lit tracks the last element per (host, callback), so each row needs its own
+  // stable callback; sharing one across rows would still churn every render.
+  private readonly scrollElementRef = (element?: Element) => {
+    this.scrollElement =
+      element?.parentElement instanceof HTMLDivElement ? element.parentElement : null;
+  };
+  private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
+  private measureRowRefFor(key: string): (element?: Element) => void {
+    let callback = this.measureRowRefs.get(key);
+    if (!callback) {
+      callback = (element?: Element) => {
+        this.virtualizerController
+          .getVirtualizer()
+          .measureElement(element instanceof HTMLElement ? element : null);
+      };
+      this.measureRowRefs.set(key, callback);
+    }
+    return callback;
+  }
   private rowKeys: readonly string[] = [];
   private rowIndexesByKey = new Map<string, number>();
   private focusedRowKey: string | null = null;
@@ -292,13 +314,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     const virtualizer = this.virtualizerController.getVirtualizer();
     const virtualRows = virtualizer.getVirtualItems();
     return html`
-      <div
-        class="chat-thread-inner chat-thread-inner--virtual"
-        ${ref((element) => {
-          this.scrollElement =
-            element?.parentElement instanceof HTMLDivElement ? element.parentElement : null;
-        })}
-      >
+      <div class="chat-thread-inner chat-thread-inner--virtual" ${ref(this.scrollElementRef)}>
         <div
           class="chat-virtual-sizer"
           style=${styleMap({ height: `${virtualizer.getTotalSize()}px` })}
@@ -324,9 +340,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
                   })}
                   data-index=${String(virtualRow.index)}
                   data-virtual-row-key=${row.key}
-                  ${ref((element) =>
-                    virtualizer.measureElement(element instanceof HTMLElement ? element : null),
-                  )}
+                  ${ref(this.measureRowRefFor(row.key))}
                 >
                   ${renderRow(row)}
                 </div>
@@ -388,6 +402,11 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     }
     this.rowKeys = Object.freeze(nextKeys);
     this.rowIndexesByKey = new Map(this.rowKeys.map((key, index) => [key, index]));
+    for (const key of this.measureRowRefs.keys()) {
+      if (!this.rowIndexesByKey.has(key)) {
+        this.measureRowRefs.delete(key);
+      }
+    }
     const keys = this.rowKeys;
     const virtualizer = this.virtualizerController.getVirtualizer();
     virtualizer.setOptions({


### PR DESCRIPTION
## What Problem This Solves

The Control UI chat page feels sluggish: switching sessions, streaming replies, and typing in the composer all stutter. Chrome DevTools performance traces against a real-data gateway measured session-switch INP at 367 ms and flagged forced reflows in every load and interaction trace.

## Why This Change Was Made

Profiling (Chrome DevTools tracing plus JS self-profiling, symbolicated through the build sourcemaps) attributed the jank to three forced-reflow/render-churn sources, all variations of the same Lit contract detail — inline-arrow `ref` callbacks change identity every render, so Lit re-invokes them (undefined + element) on each render:

- **Transcript rows** (`ui/src/pages/chat/components/chat-thread.ts`): each render re-invoked `measureElement` for every visible row, sweeping the virtualizer's element cache and re-measuring rows on every stream tick. Rows now use per-row-key stable callbacks (Lit tracks the last element per (host, callback), so one shared callback is not sufficient), pruned when rows leave the list.
- **Composer textarea** (`ui/src/pages/chat/components/chat-composer.ts`): every chat render re-measured the textarea (style write + `scrollHeight` read = forced reflow). The ref now lives on per-pane composer state; re-measure happens only on attach or when the draft changes programmatically (send clear, session switch, history restore).
- **Sidebar** (`ui/src/components/app-sidebar-session-data.ts`): `updated()` read `scrollHeight`/`scrollTop` synchronously after every render, forcing a layout flush. Reads now coalesce into one `requestAnimationFrame` per frame, cancelled on disconnect.

## User Impact

Chat interactions are noticeably snappier: session-switch INP dropped from 367 ms to 133–143 ms (three runs, same scripted interaction sequence), and the ForcedReflow insight disappeared from load and interaction traces. Streaming and typing no longer force per-render layout flushes.

## Evidence

- Before trace (production build, real session data, local gateway): INP 367 ms (`pointerdown`, 87 ms processing + 277 ms presentation delay); ForcedReflow insight present in load and interaction traces naming `updateSessionsScrollState` and the composer/measure paths.
- After trace, same sequence: INP 133/135/143 ms across three runs; no ForcedReflow insight in load or interaction traces.
- Behavior verified live on the built UI: transcript virtualization renders and measures correctly after scroll, row layout has no overlaps, composer draft survives renders.
- Focused tests: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-history.test.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/components/app-sidebar.test.ts` — 4 files, 156 tests passed.
- Dependency contracts checked in source: `lit-html/directives/ref.js` (last-element tracking keyed per (host, callback)) and `@tanstack/virtual-core` `measureElement`/`resizeItem` (null sweep + synchronous re-measure path).
- Structured autoreview (gpt-5.6-sol): one finding (shared ref callback across rows) — accepted and fixed with per-row-key callbacks; rerun clean.
