### PR TITLE
fix(status): consolidate live model switches so /status stops reporting stale state

### DIFF
--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -596,6 +596,11 @@ describe("live model switch", () => {
         modelUsed: "claude-opus-4-6",
       });
 
+      // The derived agent must also target the store so agent-scoped store
+      // templates resolve the row that actually holds the pending flag.
+      expect(state.resolveStorePathMock).toHaveBeenCalledWith("/tmp/custom-store.json", {
+        agentId: "main",
+      });
       expect(state.resolveDefaultModelForAgentMock).toHaveBeenCalled();
       expect(sessionEntry).not.toHaveProperty("liveModelSwitchPending");
     });

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -492,6 +492,94 @@ describe("live model switch", () => {
     });
   });
 
+  describe("consolidateLiveModelSwitchAfterRun", () => {
+    const consolidateParams = {
+      cfg: { session: { store: "/tmp/custom-store.json" } },
+      sessionKey: "main",
+      agentId: "reply",
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+    };
+
+    it("clears the pending flag when the run executed the persisted selection", async () => {
+      // CLI harness runs never pass the embedded attempt-recovery clear; the
+      // post-run consolidation is what stops /status reporting a stale switch.
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "claude-cli",
+        modelOverride: "claude-opus-4-6",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { consolidateLiveModelSwitchAfterRun } = await loadModule();
+
+      await consolidateLiveModelSwitchAfterRun({
+        ...consolidateParams,
+        providerUsed: "claude-cli",
+        modelUsed: "claude-opus-4-6",
+      });
+
+      expect(sessionEntry).not.toHaveProperty("liveModelSwitchPending");
+    });
+
+    it("keeps the pending flag when the run executed a different model", async () => {
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { consolidateLiveModelSwitchAfterRun } = await loadModule();
+
+      await consolidateLiveModelSwitchAfterRun({
+        ...consolidateParams,
+        providerUsed: "anthropic",
+        modelUsed: "claude-opus-4-6",
+      });
+
+      expect(sessionEntry.liveModelSwitchPending).toBe(true);
+      expect(state.updateSessionStoreMock).not.toHaveBeenCalled();
+    });
+
+    it("clears via the openai runtime promotion when providers differ only by alias", async () => {
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { consolidateLiveModelSwitchAfterRun } = await loadModule();
+
+      await consolidateLiveModelSwitchAfterRun({
+        ...consolidateParams,
+        providerUsed: "OpenAI",
+        modelUsed: "gpt-5.5",
+      });
+
+      expect(sessionEntry).not.toHaveProperty("liveModelSwitchPending");
+    });
+
+    it("is a no-op when the flag is not set", async () => {
+      const sessionEntry = {
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { consolidateLiveModelSwitchAfterRun } = await loadModule();
+
+      await consolidateLiveModelSwitchAfterRun({
+        ...consolidateParams,
+        providerUsed: "openai",
+        modelUsed: "gpt-5.5",
+      });
+
+      expect(state.updateSessionStoreMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe("clearLiveModelSwitchPending", () => {
     it("calls updateSessionStore to clear the flag", async () => {
       const { clearLiveModelSwitchPending } = await loadModule();

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -497,8 +497,6 @@ describe("live model switch", () => {
       cfg: { session: { store: "/tmp/custom-store.json" } },
       sessionKey: "main",
       agentId: "reply",
-      defaultProvider: "anthropic",
-      defaultModel: "claude-opus-4-6",
     };
 
     it("clears the pending flag when the run executed the persisted selection", async () => {
@@ -539,7 +537,6 @@ describe("live model switch", () => {
       });
 
       expect(sessionEntry.liveModelSwitchPending).toBe(true);
-      expect(state.updateSessionStoreMock).not.toHaveBeenCalled();
     });
 
     it("clears via the openai runtime promotion when providers differ only by alias", async () => {
@@ -561,7 +558,7 @@ describe("live model switch", () => {
       expect(sessionEntry).not.toHaveProperty("liveModelSwitchPending");
     });
 
-    it("is a no-op when the flag is not set", async () => {
+    it("leaves the entry untouched when the flag is not set", async () => {
       const sessionEntry = {
         providerOverride: "openai",
         modelOverride: "gpt-5.5",
@@ -576,7 +573,28 @@ describe("live model switch", () => {
         modelUsed: "gpt-5.5",
       });
 
-      expect(state.updateSessionStoreMock).not.toHaveBeenCalled();
+      expect(sessionEntry).toEqual({ providerOverride: "openai", modelOverride: "gpt-5.5" });
+    });
+
+    it("clears a pending default switch once the agent default actually ran", async () => {
+      // /model default clears the override and leaves only runtime fields; the
+      // selection then resolves to the agent default, which just ran.
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { consolidateLiveModelSwitchAfterRun } = await loadModule();
+
+      await consolidateLiveModelSwitchAfterRun({
+        ...consolidateParams,
+        providerUsed: "anthropic",
+        modelUsed: "claude-opus-4-6",
+      });
+
+      expect(sessionEntry).not.toHaveProperty("liveModelSwitchPending");
     });
   });
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -576,6 +576,30 @@ describe("live model switch", () => {
       expect(sessionEntry).toEqual({ providerOverride: "openai", modelOverride: "gpt-5.5" });
     });
 
+    it("resolves the owning agent's default when the caller has no agent id", async () => {
+      // Without an explicit agentId the session key still identifies the
+      // owning agent; /model default must consolidate against that agent's
+      // configured default, not library-wide constants.
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { consolidateLiveModelSwitchAfterRun } = await loadModule();
+
+      await consolidateLiveModelSwitchAfterRun({
+        cfg: consolidateParams.cfg,
+        sessionKey: "main",
+        providerUsed: "anthropic",
+        modelUsed: "claude-opus-4-6",
+      });
+
+      expect(state.resolveDefaultModelForAgentMock).toHaveBeenCalled();
+      expect(sessionEntry).not.toHaveProperty("liveModelSwitchPending");
+    });
+
     it("clears a pending default switch once the agent default actually ran", async () => {
       // /model default clears the override and leaves only runtime fields; the
       // selection then resolves to the agent default, which just ran.

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -257,21 +257,19 @@ export async function consolidateLiveModelSwitchAfterRun(params: {
   if (!cfg || !sessionKey || !providerUsed || !modelUsed) {
     return;
   }
-  const storePath = resolveStorePath(cfg.session?.store, {
-    agentId: params.agentId?.trim(),
-  });
-  if (!storePath) {
-    return;
-  }
-  // Selection resolution needs the owning agent's configured default model;
-  // derive the agent from the session key when the caller has none, so a
-  // completed /model default still consolidates when config overrides the
-  // library-wide defaults.
+  // Store selection and default-model resolution both need the owning agent;
+  // derive it from the session key when the caller has none, so agent-scoped
+  // stores are targeted correctly and a completed /model default still
+  // consolidates when config overrides the library-wide defaults.
   const agentId = resolveSessionAgentId({
     sessionKey,
     config: cfg,
     agentId: params.agentId,
   });
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  if (!storePath) {
+    return;
+  }
   await patchSessionEntry(
     { storePath, sessionKey },
     (entry) => {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -7,6 +7,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionEntry, patchSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSessionAgentId } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
   normalizeStoredOverrideModel,
@@ -262,6 +263,15 @@ export async function consolidateLiveModelSwitchAfterRun(params: {
   if (!storePath) {
     return;
   }
+  // Selection resolution needs the owning agent's configured default model;
+  // derive the agent from the session key when the caller has none, so a
+  // completed /model default still consolidates when config overrides the
+  // library-wide defaults.
+  const agentId = resolveSessionAgentId({
+    sessionKey,
+    config: cfg,
+    agentId: params.agentId,
+  });
   await patchSessionEntry(
     { storePath, sessionKey },
     (entry) => {
@@ -271,7 +281,7 @@ export async function consolidateLiveModelSwitchAfterRun(params: {
       const persisted = resolveSelectionFromSessionEntry({
         cfg,
         entry,
-        agentId: params.agentId,
+        agentId,
         defaultProvider: DEFAULT_PROVIDER,
         defaultModel: DEFAULT_MODEL,
       });

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -5,7 +5,9 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionEntry, patchSessionEntry } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
   normalizeStoredOverrideModel,
   resolveDefaultModelForAgent,
@@ -37,12 +39,6 @@ function resolveLiveSessionModelSelection(params: {
     return null;
   }
   const agentId = normalizeOptionalString(params.agentId);
-  const defaultModelRef = agentId
-    ? resolveDefaultModelForAgent({
-        cfg,
-        agentId,
-      })
-    : { provider: params.defaultProvider, model: params.defaultModel };
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId,
   });
@@ -52,6 +48,34 @@ function resolveLiveSessionModelSelection(params: {
     hydrateSkillPromptRefs: false,
     readConsistency: "latest",
   });
+  return resolveSelectionFromSessionEntry({
+    cfg,
+    entry,
+    agentId,
+    defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
+  });
+}
+
+/**
+ * Entry-snapshot variant of the selection resolver, so atomic patch callbacks
+ * can evaluate the persisted selection against the exact row they may rewrite.
+ */
+function resolveSelectionFromSessionEntry(params: {
+  cfg: OpenClawConfig;
+  entry: SessionEntry | undefined;
+  agentId?: string;
+  defaultProvider: string;
+  defaultModel: string;
+}): LiveSessionModelSelection {
+  const { cfg, entry } = params;
+  const agentId = normalizeOptionalString(params.agentId);
+  const defaultModelRef = agentId
+    ? resolveDefaultModelForAgent({
+        cfg,
+        agentId,
+      })
+    : { provider: params.defaultProvider, model: params.defaultModel };
   const normalizedSelection = normalizeStoredOverrideModel({
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
@@ -214,14 +238,14 @@ export function shouldSwitchToLiveModel(params: {
  * flag survives forever and `/status` keeps reporting a switch that already
  * happened. Unlike `shouldSwitchToLiveModel`, runtime/auth-profile drift is
  * ignored here: the selected model demonstrably ran, so keeping the flag would
- * only re-arm mid-run restarts that have nothing left to apply.
+ * only re-arm mid-run restarts that have nothing left to apply. Compare and
+ * clear happen inside one atomic patch so a concurrent `/model` that persists
+ * a newer selection is never consumed by this run's result.
  */
 export async function consolidateLiveModelSwitchAfterRun(params: {
   cfg?: OpenClawConfig | undefined;
   sessionKey?: string;
   agentId?: string;
-  defaultProvider: string;
-  defaultModel: string;
   providerUsed?: string;
   modelUsed?: string;
 }): Promise<void> {
@@ -235,36 +259,37 @@ export async function consolidateLiveModelSwitchAfterRun(params: {
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: params.agentId?.trim(),
   });
-  const entry = loadSessionEntry({
-    storePath,
-    sessionKey,
-    hydrateSkillPromptRefs: false,
-    clone: false,
-    readConsistency: "latest",
-  });
-  if (!entry?.liveModelSwitchPending) {
+  if (!storePath) {
     return;
   }
-  const persisted = resolveLiveSessionModelSelection({
-    cfg,
-    sessionKey,
-    agentId: params.agentId,
-    defaultProvider: params.defaultProvider,
-    defaultModel: params.defaultModel,
-  });
-  if (!persisted) {
-    return;
-  }
-  const selectionApplied =
-    (providerUsed === persisted.provider && modelUsed === persisted.model) ||
-    isAlreadyAppliedOpenAICodexRuntimePromotion(
-      { provider: providerUsed, model: modelUsed },
-      persisted,
-    );
-  if (!selectionApplied) {
-    return;
-  }
-  await clearLiveModelSwitchPending({ cfg, sessionKey, agentId: params.agentId });
+  await patchSessionEntry(
+    { storePath, sessionKey },
+    (entry) => {
+      if (!entry.liveModelSwitchPending) {
+        return null;
+      }
+      const persisted = resolveSelectionFromSessionEntry({
+        cfg,
+        entry,
+        agentId: params.agentId,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
+      const selectionApplied =
+        (providerUsed === persisted.provider && modelUsed === persisted.model) ||
+        isAlreadyAppliedOpenAICodexRuntimePromotion(
+          { provider: providerUsed, model: modelUsed },
+          persisted,
+        );
+      if (!selectionApplied) {
+        return null;
+      }
+      const next = { ...entry };
+      delete next.liveModelSwitchPending;
+      return next;
+    },
+    { replaceEntry: true },
+  );
 }
 
 /**

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -208,6 +208,66 @@ export function shouldSwitchToLiveModel(params: {
 }
 
 /**
+ * Post-run consolidation: once a completed run has actually executed the
+ * persisted selection, the pending live-switch flag is spent. CLI harness runs
+ * never pass through the embedded attempt-recovery clear, so without this the
+ * flag survives forever and `/status` keeps reporting a switch that already
+ * happened. Unlike `shouldSwitchToLiveModel`, runtime/auth-profile drift is
+ * ignored here: the selected model demonstrably ran, so keeping the flag would
+ * only re-arm mid-run restarts that have nothing left to apply.
+ */
+export async function consolidateLiveModelSwitchAfterRun(params: {
+  cfg?: OpenClawConfig | undefined;
+  sessionKey?: string;
+  agentId?: string;
+  defaultProvider: string;
+  defaultModel: string;
+  providerUsed?: string;
+  modelUsed?: string;
+}): Promise<void> {
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  const cfg = params.cfg;
+  const providerUsed = normalizeOptionalString(params.providerUsed);
+  const modelUsed = normalizeOptionalString(params.modelUsed);
+  if (!cfg || !sessionKey || !providerUsed || !modelUsed) {
+    return;
+  }
+  const storePath = resolveStorePath(cfg.session?.store, {
+    agentId: params.agentId?.trim(),
+  });
+  const entry = loadSessionEntry({
+    storePath,
+    sessionKey,
+    hydrateSkillPromptRefs: false,
+    clone: false,
+    readConsistency: "latest",
+  });
+  if (!entry?.liveModelSwitchPending) {
+    return;
+  }
+  const persisted = resolveLiveSessionModelSelection({
+    cfg,
+    sessionKey,
+    agentId: params.agentId,
+    defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
+  });
+  if (!persisted) {
+    return;
+  }
+  const selectionApplied =
+    (providerUsed === persisted.provider && modelUsed === persisted.model) ||
+    isAlreadyAppliedOpenAICodexRuntimePromotion(
+      { provider: providerUsed, model: modelUsed },
+      persisted,
+    );
+  if (!selectionApplied) {
+    return;
+  }
+  await clearLiveModelSwitchPending({ cfg, sessionKey, agentId: params.agentId });
+}
+
+/**
  * Clear the `liveModelSwitchPending` flag from the session entry on disk so
  * subsequent retry iterations do not re-trigger the switch.
  */

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2207,8 +2207,6 @@ export async function runReplyAgent(params: {
         cfg,
         sessionKey,
         agentId: followupRun.run.agentId,
-        defaultProvider: followupRun.run.provider,
-        defaultModel,
         providerUsed,
         modelUsed,
       });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -24,6 +24,7 @@ import {
   queueEmbeddedAgentMessageWithOutcomeAsync,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
+import { consolidateLiveModelSwitchAfterRun } from "../../agents/live-model-switch.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { deriveContextPromptTokens, hasNonzeroUsage } from "../../agents/usage.js";
@@ -2198,6 +2199,20 @@ export async function runReplyAgent(params: {
       clearCliSessionBinding,
       preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     });
+    if (!isHeartbeat && !preserveUserFacingSessionState && !fallbackExhausted) {
+      // A completed run that executed the persisted selection consumes the
+      // pending live-switch flag; CLI harness runs never hit the embedded
+      // attempt-recovery clear, so /status would report the switch forever.
+      await consolidateLiveModelSwitchAfterRun({
+        cfg,
+        sessionKey,
+        agentId: followupRun.run.agentId,
+        defaultProvider: followupRun.run.provider,
+        defaultModel,
+        providerUsed,
+        modelUsed,
+      });
+    }
 
     const successfulSourceReplyDelivery = hasSuccessfulSourceReplyDelivery({
       blockReplyPipeline,

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -84,6 +84,31 @@ describe("buildStatusMessage context window", () => {
     expect(text).toContain("pinned session; config primary ollama-cloud/deepseek-v4-pro");
     expect(text).toContain("Context: 128k/200k");
     expect(text).not.toContain("Context: 128k/1.0m");
+    expect(text).not.toContain("live switch pending");
+  });
+
+  it("flags a pending live model switch on the model line", () => {
+    // A /model switch issued during an active run stays pending until a turn
+    // applies it; /status must not imply the new selection is already running.
+    const text = buildStatusMessage({
+      config: {},
+      agent: { model: "anthropic/claude-opus-4-6" },
+      sessionEntry: {
+        sessionId: "pending-live-switch",
+        updatedAt: 0,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+        modelOverrideSource: "user",
+        liveModelSwitchPending: true,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("Model: openai/gpt-5.5");
+    expect(text).toContain("⏳ live switch pending");
   });
 
   it("keeps trusted runtime context for config-backed runtime aliases", () => {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1101,8 +1101,11 @@ export function buildStatusMessage(args: StatusArgs): string {
       ? ` · pinned session; config primary ${configuredDefaultModelLabel} · clear /model default`
       : ` · auto fallback; config primary ${configuredDefaultModelLabel} · check provider`
     : "";
+  // A user-driven live switch that no completed turn has applied yet: surface
+  // it so /status does not imply the new selection is already running.
+  const liveSwitchNote = entry?.liveModelSwitchPending ? " · ⏳ live switch pending" : "";
   const modelLines = [
-    `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}${overrideLabel}`,
+    `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}${overrideLabel}${liveSwitchNote}`,
   ];
 
   // Show configured fallback models (from agent model config)


### PR DESCRIPTION
Related: #97517

## What Problem This Solves

Fixes the second symptom of #97517: after switching an active session's model with `/model` (e.g. from a Claude CLI backend to a Codex model), `/status` kept misreporting the session state. The `liveModelSwitchPending` marker could survive forever on CLI-harness sessions — those runs never pass through the embedded runner's attempt-recovery clear — and `/status` gave no indication that a live switch had not been applied yet, so the status card implied the new selection was already running (or, with a stale flag, kept implying a switch that had long since happened).

## Why This Change Was Made

Two bounded changes with one owner each:

- **Post-run consolidation** (`src/agents/live-model-switch.ts` + the generic reply runner): once a completed non-heartbeat run has actually executed the persisted selection, the pending flag is spent — `consolidateLiveModelSwitchAfterRun` compares the provider/model that actually ran (including the existing openai runtime-promotion alias case) against the persisted selection and clears the flag. This runs in the generic `agent-runner` post-turn path, so CLI-harness sessions converge the same way embedded runs do. Runtime/auth-profile drift is deliberately ignored here: the selected model demonstrably ran, so keeping the flag would only re-arm mid-run restarts with nothing left to apply. The compare-and-clear runs inside one atomic `patchSessionEntry` callback against the same row snapshot, so a concurrent `/model` that persists a newer selection is never consumed by the finished run's result; the owning agent is derived from the session key when the caller has none, so agent-scoped stores and configured (non-library) default models consolidate correctly.
- **Honest `/status`**: while a switch is genuinely pending, the Model line now carries a `⏳ live switch pending` annotation instead of silently implying the new selection is active. The annotation disappears as soon as a turn applies the switch (or the consolidation clears the flag).

The Model line itself already reads the override fields, and the earlier fix for symptom #1 (#110364) stopped transient catalog degradation from destroying that override — this PR completes the issue by making the pending state visible and self-consolidating.

## User Impact

`/status` now tells the truth during and after a live model switch: a pending switch is labeled as pending, and a switch that has engaged stops being reported as pending — including for CLI-backed sessions where the stale flag previously never cleared.

## Evidence

- `src/agents/live-model-switch.test.ts` — new `consolidateLiveModelSwitchAfterRun` block: clears when the run executed the persisted selection; keeps the flag when a different model ran; clears via the openai alias promotion; no-op when the flag is unset. 29/29 green, including atomicity-shaped cases (different-model run keeps the flag; agent-less caller resolves the owning agent for both store and default-model resolution).
- `src/status/status-message.test.ts` — new test asserting the `⏳ live switch pending` annotation appears with `liveModelSwitchPending: true` and is absent otherwise. All green.
- `src/auto-reply/reply/agent-runner-execution-state.test.ts` (existing live-switch retry coverage) green; `tsgo` typecheck, `oxfmt`, `oxlint` clean.
