### PR TITLE
fix(ui): render pinned sessions headerless like sidebar nav entries

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -984,9 +984,12 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
       hasActiveRun: true,
       status: "running",
       childSessions: ["agent:main:subagent:tax-receipts"],
+      pinned: true,
     }),
     mainChildRow,
-    sessionRow("agent:main:home-server", "Home server migration", baseTime - 240_000),
+    sessionRow("agent:main:home-server", "Home server migration", baseTime - 240_000, {
+      pinned: true,
+    }),
     sessionRow("agent:main:whatsapp:group:family", "Family", baseTime - 90_000, {
       kind: "group",
       channel: "whatsapp",

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -410,15 +410,17 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
 
-      // Sidebar: pinned rows form their own group ahead of the Sessions group.
+      // Sidebar: pinned rows form their own headerless group ahead of the
+      // Sessions group, styled like the nav entries above them.
       const sidebarRows = page.locator(".sidebar-recent-sessions__list .sidebar-recent-session");
       await sidebarRows.first().waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => sidebarRows.first().textContent()).toContain("Release planning");
       const groups = page.locator(".sidebar-recent-sessions__group");
       await expect.poll(() => groups.count()).toBe(2);
+      await expect.poll(() => groups.first().getAttribute("data-session-section")).toBe("pinned");
       await expect
-        .poll(() => groups.first().locator(".sidebar-recent-sessions__label-text").textContent())
-        .toContain("Pinned");
+        .poll(() => groups.first().locator(".sidebar-recent-sessions__head").count())
+        .toBe(0);
 
       // Chats keep recency order with the open session highlighted in place —
       // selecting a row must not reshuffle the list.

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -35,16 +35,17 @@ export type SidebarSessionSection<Row> = {
 };
 
 /**
- * Sections that render a header (and therefore can collapse). Every zone
- * shows one — Threads hosts the sort and new-session actions on its header.
+ * Sections that render a header (and therefore can collapse). Pinned rows
+ * render headerless like the nav entries above them; every other zone shows
+ * one — Threads hosts the sort and new-session actions on its header.
  * Shared by the renderer and keyboard-order walker so collapse behavior
  * cannot drift between them.
  */
 export function sidebarSectionHasHeader(
-  _sectionId: string,
+  sectionId: string,
   _grouping: SidebarSessionsGrouping,
 ): boolean {
-  return true;
+  return sectionId !== "pinned";
 }
 
 export function normalizeSessionsGroupBy(raw: unknown): SessionsGroupBy {


### PR DESCRIPTION
## What Problem This Solves

The sidebar renders pinned sessions under a collapsible "PINNED" zone header. That header adds chrome the zone does not need: pinned sessions are the user's hand-picked shortcuts and should read like the nav pages directly above them (Home, Automations, Plugins), not like another collapsible session bucket.

## Why This Change Was Made

`sidebarSectionHasHeader` now returns `false` for the `pinned` section, so pinned rows render headerless directly under the nav pages. The helper is shared by the renderer and the keyboard-order/collapse walker, so collapse behavior stays consistent (a headerless zone can no longer be collapsed, and any persisted collapsed state for it is ignored). Threads, Groups, Coding, and category zones keep their headers; drag-to-pin onto the pinned zone and the per-row pin action are unchanged. The mock dev harness now marks two sessions pinned so the pinned zone is exercised there.

## User Impact

Pinned sessions look like first-class sidebar entries, matching the nav pages above them. No "PINNED" label, chevron, or count.

Before | After
--- | ---
![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-pinned-headerless/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-pinned-headerless/after.png)

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/sessions/grouping.test.ts` — 12 passed
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 107 passed
- `ui/src/e2e/session-management.e2e.test.ts` updated to assert the pinned group is headerless; the file has 7 pre-existing local failures identical with and without this change (verified by stash/rerun), all at assertions unrelated to the pinned header.
- Visual proof above captured against `pnpm dev:ui:mock`.
