### PR TITLE
perf(ci): split straggler bin pairings and drop needless jsdom environments

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -38,7 +38,10 @@ const MAX_BUNDLED_NODE_TEST_PATTERNS = 64;
 // (6 large + 15 small) while the measured ~60s median job setup keeps the slowest
 // bin near the 5-minute PR wall-clock budget. 220 with honest hints adds a job to
 // each pool for no ceiling win.
-const COMPACT_NODE_TEST_JOB_SECONDS = 235;
+// 190s cap: forbids pairings like core-runtime-media-ui (124) +
+// core-unit-src-security (95) that produced a 195s real-wall straggler bin
+// while the pack sat at ~160s; ~3 extra bins buy ~30-40s of run wall.
+const COMPACT_NODE_TEST_JOB_SECONDS = 190;
 const COMPACT_NODE_TEST_JOB_GROUPS = 10;
 const COMPACT_TOOLING_NODE_TEST_GROUPS = 4;
 const COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES = 120;

--- a/ui/src/app/approval-deep-link.test.ts
+++ b/ui/src/app/approval-deep-link.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { resolveApprovalDocumentMode } from "./approval-deep-link.ts";
 

--- a/ui/src/app/control-ui-chunking.test.ts
+++ b/ui/src/app/control-ui-chunking.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   controlUiCodeSplitting,

--- a/ui/src/app/exec-approval.test.ts
+++ b/ui/src/app/exec-approval.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover exec approval behavior.
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/ui/src/app/operator-access.test.ts
+++ b/ui/src/app/operator-access.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { hasOperatorApprovalsAccess } from "./operator-access.ts";
 

--- a/ui/src/app/router-outlet-controller.test.ts
+++ b/ui/src/app/router-outlet-controller.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { createRouter, definePage, type RouteLocation } from "@openclaw/uirouter";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RouterOutletController, selectRenderedRouteMatch } from "./router-outlet-controller.ts";

--- a/ui/src/app/theme.test.ts
+++ b/ui/src/app/theme.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover theme behavior.
 import { describe, expect, it, vi } from "vitest";
 import { parseThemeSelection, resolveTheme } from "./theme.ts";

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";

--- a/ui/src/components/mascot-animator.test.ts
+++ b/ui/src/components/mascot-animator.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { MascotAnimator } from "./mascot-animator.ts";
 import { staticMascotPose, type MascotMood, type MascotPose } from "./mascot-pose.ts";

--- a/ui/src/components/terminal/terminal-connection.test.ts
+++ b/ui/src/components/terminal/terminal-connection.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import {
   TerminalConnection,

--- a/ui/src/components/terminal/terminal-task-queue.test.ts
+++ b/ui/src/components/terminal/terminal-task-queue.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
 

--- a/ui/src/lib/assistant-identity.test.ts
+++ b/ui/src/lib/assistant-identity.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover assistant identity behavior.
 import { describe, expect, it } from "vitest";
 import { AVATAR_MAX_BYTES, AVATAR_MAX_DATA_URL_CHARS } from "../../../src/shared/avatar-limits.js";

--- a/ui/src/lib/browser-redact.test.ts
+++ b/ui/src/lib/browser-redact.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover browser redact behavior.
 import { describe, expect, it } from "vitest";
 import { redactToolDetail, redactToolPayloadText } from "./browser-redact.ts";

--- a/ui/src/lib/chat/message-extract.test.ts
+++ b/ui/src/lib/chat/message-extract.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover message extract behavior.
 import { describe, expect, it } from "vitest";
 import { extractText, extractTextCached, extractThinkingCached } from "./message-extract.ts";

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover message normalizer behavior.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { normalizeMessage } from "./message-normalizer.ts";

--- a/ui/src/lib/chat/session-diff.test.ts
+++ b/ui/src/lib/chat/session-diff.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { parseSessionDiffPatch } from "./session-diff.ts";
 

--- a/ui/src/lib/chat/side-question.test.ts
+++ b/ui/src/lib/chat/side-question.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   buildMoreDetailsSideCommand,

--- a/ui/src/lib/chat/tool-call-diff.test.ts
+++ b/ui/src/lib/chat/tool-call-diff.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover inline diff parsing and computation for tool-call rows.
 import { describe, expect, it } from "vitest";
 import {

--- a/ui/src/lib/chat/tool-call-view.test.ts
+++ b/ui/src/lib/chat/tool-call-view.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover tool-call classification and view-model resolution.
 import { describe, expect, it } from "vitest";
 import {

--- a/ui/src/lib/external-link.test.ts
+++ b/ui/src/lib/external-link.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover external link behavior.
 import { describe, expect, it } from "vitest";
 import { buildExternalLinkRel } from "./external-link.ts";

--- a/ui/src/lib/media-file-extension.test.ts
+++ b/ui/src/lib/media-file-extension.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover browser-safe media extension parsing.
 import { describe, expect, it } from "vitest";
 import { getMediaFileExtension } from "./media-file-extension.ts";

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   resolveChannelSessionInfo,

--- a/ui/src/lib/sessions/custom-groups.test.ts
+++ b/ui/src/lib/sessions/custom-groups.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { readSessionCustomGroupNames, reorderSessionCustomGroups } from "./custom-groups.ts";
 

--- a/ui/src/lib/sessions/unread.test.ts
+++ b/ui/src/lib/sessions/unread.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { SessionUnreadPatchGuard } from "./unread.ts";
 

--- a/ui/src/lib/text-direction.test.ts
+++ b/ui/src/lib/text-direction.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover text direction behavior.
 import { describe, expect, it } from "vitest";
 import { detectTextDirection } from "./text-direction.ts";

--- a/ui/src/lib/uuid.test.ts
+++ b/ui/src/lib/uuid.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover uuid behavior.
 import { describe, expect, it, vi } from "vitest";
 import { generateUUID } from "./uuid.ts";

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Channel wizard controller: step/answer state machine over wizard.* RPCs.
 import { describe, expect, it, vi } from "vitest";
 import { ChannelWizardController } from "./wizard-controller.ts";

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover history merge behavior.
 import { describe, expect, it } from "vitest";
 import { preserveOptimisticTailMessages } from "./history-merge.ts";

--- a/ui/src/pages/chat/realtime-talk-conversation.test.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover realtime talk conversation behavior.
 import { describe, expect, it } from "vitest";
 import {

--- a/ui/src/pages/chat/session-message-cache.test.ts
+++ b/ui/src/pages/chat/session-message-cache.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import {
   appendChatMessageToCache,

--- a/ui/src/pages/custodian/structured-question.test.ts
+++ b/ui/src/pages/custodian/structured-question.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import type { SystemAgentChatQuestion } from "@openclaw/gateway-protocol";
 import { describe, expect, it } from "vitest";
 import { parseCustodianQuestion } from "./structured-question.ts";

--- a/ui/src/pages/logs/data.test.ts
+++ b/ui/src/pages/logs/data.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover logs behavior.
 import { describe, expect, it } from "vitest";
 import { parseLogLine } from "./log-lines.ts";

--- a/ui/src/pages/model-providers/mutations.test.ts
+++ b/ui/src/pages/model-providers/mutations.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   buildDefaultModelsPatch,

--- a/ui/src/pages/new-session/create-params.test.ts
+++ b/ui/src/pages/new-session/create-params.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { buildDraftSessionCreateParams } from "./create-params.ts";
 

--- a/ui/src/pages/new-session/discovery.test.ts
+++ b/ui/src/pages/new-session/discovery.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { readDraftCloudProfiles } from "./discovery.ts";
 

--- a/ui/src/pages/usage/refresh-policy.test.ts
+++ b/ui/src/pages/usage/refresh-policy.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { decideUsageRefresh, USAGE_PAYLOAD_TTL_MS } from "./refresh-policy.ts";
 


### PR DESCRIPTION
## What Problem This Solves

Main push CI wall (~4.5min) is bounded by one straggler bin and needless per-file DOM environment construction. Census of green run 29633628994 (wall 267s): fan-out jobs queue 65s, the bin pack sits at ~160s, but `checks-node-compact-large-2/3` runs 195s because (a) the 235s hint cap let `core-runtime-media-ui` (124) + `core-unit-src-security` (95) share a bin, and (b) inside media-ui's `ui` config, jsdom construction costs 95.2s across 309 files while tests take 59.4s.

## Why This Change Was Made

1. `COMPACT_NODE_TEST_JOB_SECONDS` 235 → 190: forbids the pairing; the plan repacks 21 → 25 bins with the two heavy groups separated (verified by local plan simulation). ~4 extra runners per run; wall is the optimization target.
2. 35 `ui/src` test files whose transitive import closure never touches DOM APIs or the lit runtime now carry the repo-standard `// @vitest-environment node` docblock (29 files in ui/ already use the convention), skipping jsdom construction for them.

Expected wall: ~3.8–4.0min.

## User Impact

Faster main-push and PR compact CI feedback; no change to coverage, shard contents, or gate semantics (the gate consumes the manifest dynamically).

## Evidence

- Plan simulation with the new cap: 25 compact bins; `core-runtime-media-ui` and `core-unit-src-security` in different bins.
- `test/scripts/ci-node-test-plan.test.ts` 20/20 passed; `test/scripts/ci-workflow-guards.test.ts` passed.
- Full `vitest.ui.config.ts` run with the annotations: all 35 annotated files pass; the only failures are three storage tests that fail identically on a clean checkout under local Node 26 (untouched here; green on CI's Node 24).
- Classification method: transitive relative-import closure scan for DOM/lit/browser tokens (conservative; misclassification fails loudly as "document is not defined").
- Codex autoreview (branch mode): clean, "patch is correct (0.91)".
- Wall decomposition source: run 29633628994 job/step timings (preflight 39s, 65s queue-to-fan-out, max bin 195s = 26s setup + 157s vitest, gate 3s).