### PR TITLE
fix(vydra): preserve HTTP errors when response body breaks

### DIFF
--- a/extensions/vydra/shared.test.ts
+++ b/extensions/vydra/shared.test.ts
@@ -142,6 +142,34 @@ describe("downloadVydraAsset", () => {
     expect(result).toMatchObject({ name: "ProviderHttpError", status: 304, statusCode: 304 });
   });
 
+  it("preserves HTTP metadata when the error body stream fails", async () => {
+    const result = await downloadVydraAsset({
+      url: "https://cdn.vydra.example/generated/test.png",
+      kind: "image",
+      timeoutMs: 250,
+      fetchFn: async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error("broken error body"));
+            },
+          }),
+          {
+            status: 502,
+            headers: { "x-request-id": "req-vydra-broken-body" },
+          },
+        ),
+      maxBytes: 1024 * 1024,
+    }).catch((error: unknown) => error);
+
+    expect(result).toMatchObject({
+      name: "ProviderHttpError",
+      status: 502,
+      statusCode: 502,
+      requestId: "req-vydra-broken-body",
+    });
+  });
+
   it("does not bound a dripping body when only chunk idle timeout is used", async () => {
     // Negative control: chunkTimeoutMs resets on every drip, so idle alone never fires.
     server = http.createServer((_req, res) => {

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -38,6 +38,8 @@ type VydraAuthStore = Parameters<typeof resolveApiKeyForProvider>[0]["store"];
 
 type VydraMediaKind = "audio" | "image" | "video";
 
+class VydraDownloadBodyTimeoutError extends Error {}
+
 type VydraJobPayload = {
   id?: string;
   jobId?: string;
@@ -246,9 +248,13 @@ function resolveVydraDownloadBodyTimeout(params: {
     chunkTimeoutMs: params.timeoutMs,
     timeoutMs: Math.max(1, params.deadlineMs - Date.now()),
     onIdleTimeout: ({ chunkTimeoutMs }: { chunkTimeoutMs: number }) =>
-      new Error(`Vydra ${params.kind} download stalled after ${chunkTimeoutMs}ms`),
+      new VydraDownloadBodyTimeoutError(
+        `Vydra ${params.kind} download stalled after ${chunkTimeoutMs}ms`,
+      ),
     onTimeout: () =>
-      new Error(`Vydra ${params.kind} download timed out after ${params.timeoutMs}ms`),
+      new VydraDownloadBodyTimeoutError(
+        `Vydra ${params.kind} download timed out after ${params.timeoutMs}ms`,
+      ),
   };
 }
 
@@ -267,15 +273,27 @@ export async function downloadVydraAsset(params: {
   if (!response.ok) {
     // Shared assertOkOrThrowHttpError reads error detail without a wall-clock bound; a dripping
     // non-2xx body would hang before the success-path reader runs.
-    const prefix = await readResponseTextPrefix(
-      response,
-      16 * 1024,
-      resolveVydraDownloadBodyTimeout({ kind: params.kind, timeoutMs, deadlineMs }),
-    );
+    let errorBody: string | null = null;
+    try {
+      errorBody =
+        (
+          await readResponseTextPrefix(
+            response,
+            16 * 1024,
+            resolveVydraDownloadBodyTimeout({ kind: params.kind, timeoutMs, deadlineMs }),
+          )
+        ).text || null;
+    } catch (error) {
+      if (error instanceof VydraDownloadBodyTimeoutError) {
+        throw error;
+      }
+      // The shared formatter historically ignored unreadable error bodies. Preserve the known
+      // HTTP status and request id even when the provider closes a failed response mid-stream.
+    }
     // Re-run the bounded body through the shared formatter so provider error metadata and
     // sensitive-text redaction remain identical to the previous assertOkOrThrowHttpError path.
     throw await createProviderHttpError(
-      new Response(prefix.text || null, {
+      new Response(errorBody, {
         headers: response.headers,
         status: response.status,
         statusText: response.statusText,


### PR DESCRIPTION
Related: #109210

## What Problem This Solves

Fixes an issue where Vydra users could lose the HTTP status and request ID from a failed generated-media download when the provider closed or errored the non-2xx response body after sending headers.

## Why This Change Was Made

The wall-clock deadline fix in #109210 intentionally pre-reads failed response bodies under the same overall budget. This follow-up preserves the prior normalized `ProviderHttpError` fallback for body-stream failures while continuing to propagate the explicit idle and wall-clock timeout errors.

The commit preserves contributor credit for @Pick-cat, whose original PR supplied the deadline fix and loopback coverage.

## User Impact

Vydra download failures retain stable status-based handling and request IDs even when an error response body breaks mid-stream. Slow-drip bodies still terminate at the configured operation deadline.

## Evidence

- `node scripts/run-vitest.mjs extensions/vydra/shared.test.ts` on current `main`: 6/6 passed.
- Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29633703354 on the patch-identical prep tree: 6/6 passed.
- New regression test makes a non-2xx `ReadableStream` fail and asserts normalized status plus request ID.
- Fresh autoreview run before publication; all accepted findings addressed.

AI-assisted: yes. Maintainer-reviewed, source-verified, and tested.
