### PR TITLE
fix(skills): warn when a skill is dropped for unterminated frontmatter

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -201,6 +201,16 @@ metadata:
     expect(parseFrontmatterBlock(content)).toStrictEqual({});
   });
 
+  it("reports an unterminated frontmatter block", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: broken
+description: Missing the closing delimiter
+`);
+
+    expect(result.frontmatter).toEqual({});
+    expect(result.issues).toEqual([expect.objectContaining({ code: "UNTERMINATED_FRONTMATTER" })]);
+  });
+
   it("ignores non-delimiter opening prefixes", () => {
     for (const prefix of ["---not", "----", "--- name"]) {
       const content = `${prefix}

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -200,11 +200,12 @@ function normalizeFrontmatterContent(content: string): string {
 }
 
 const FRONTMATTER_CLOSING_DELIMITER = /(?:^|\n)---[^\S\n]*(?:\n|(?![\s\S]))/;
+const FRONTMATTER_OPENING_DELIMITER = /^---[^\S\n]*\n/;
 
 function extractFrontmatterBlockFromNormalized(
   normalized: string,
 ): ExtractedFrontmatterBlock | undefined {
-  const opening = /^---[^\S\n]*\n/.exec(normalized);
+  const opening = FRONTMATTER_OPENING_DELIMITER.exec(normalized);
   if (!opening) {
     return undefined;
   }
@@ -239,6 +240,20 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
 
 /** Parses frontmatter once while retaining recoverable YAML parser issues for owning loaders. */
 export function parseFrontmatterBlockResult(content: string): ParsedFrontmatterBlockResult {
-  const block = extractFrontmatterBlock(content)?.block;
-  return block ? parseYamlFrontmatter(block) : { frontmatter: {}, issues: [] };
+  const normalized = normalizeFrontmatterContent(content);
+  const block = extractFrontmatterBlockFromNormalized(normalized)?.block;
+  if (block !== undefined) {
+    return block ? parseYamlFrontmatter(block) : { frontmatter: {}, issues: [] };
+  }
+  return FRONTMATTER_OPENING_DELIMITER.test(normalized)
+    ? {
+        frontmatter: {},
+        issues: [
+          {
+            code: "UNTERMINATED_FRONTMATTER",
+            message: "missing closing --- delimiter",
+          },
+        ],
+      }
+    : { frontmatter: {}, issues: [] };
 }

--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -423,11 +423,14 @@ metadata:
     expect(entry?.metadata?.requires?.env).toEqual(["EXAMPLE_VAR"]);
   });
 
-  it("warns with the malformed file and keeps loading sibling workspace skills", async () => {
+  it("warns for malformed files and keeps loading sibling workspace skills", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     const brokenDir = path.join(workspaceDir, "skills", "broken");
     const brokenFile = path.join(brokenDir, "SKILL.md");
+    const unterminatedDir = path.join(workspaceDir, "skills", "unterminated");
+    const unterminatedFile = path.join(unterminatedDir, "SKILL.md");
     await fs.mkdir(brokenDir, { recursive: true });
+    await fs.mkdir(unterminatedDir, { recursive: true });
     await fs.writeFile(
       brokenFile,
       `---
@@ -435,6 +438,11 @@ name: [broken
 description: Broken skill
 ---
 `,
+      "utf8",
+    );
+    await fs.writeFile(
+      unterminatedFile,
+      "---\nname: unterminated\ndescription: Missing closing delimiter\n",
       "utf8",
     );
     await writeSkill({
@@ -451,6 +459,11 @@ description: Broken skill
     expect(entries.map((entry) => entry.skill.name)).not.toContain("broken");
     expect(warningText).toContain(brokenFile);
     expect(warningText).toContain("invalid frontmatter: BAD_INDENT");
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("unterminated");
+    expect(warningText).toContain(unterminatedFile);
+    expect(warningText).toContain(
+      "invalid frontmatter: UNTERMINATED_FRONTMATTER: missing closing --- delimiter",
+    );
   });
 
   it("applies agent skill filters and replacement semantics", async () => {


### PR DESCRIPTION
## What Problem This Solves

A workspace skill whose SKILL.md has an unterminated/broken YAML frontmatter block silently vanished: absent from `skills list`, `skills info` reports not-found, and no log line at any level. A user with a frontmatter typo got zero signal anywhere (contrast: the oversized-SKILL.md case logs "Skipping skill due to oversized SKILL.md" with size + limit).

## Why This Change Was Made

Found by the R5 QA campaign (skills/MCP lane). The frontmatter parser treated an unterminated block the same as "no frontmatter", so the loader dropped the skill without a diagnosable reason.

## User Impact

The parser now distinguishes an unterminated frontmatter block from content without an opening delimiter, and the workspace loader emits a warn-level diagnostic naming the skill file and the parse problem — consistent with the existing oversized-skill warning. Valid and frontmatter-less files parse exactly as before.

## Evidence

- Parser tests 24/24, workspace loader 40/40 (`packages/markdown-core/src/frontmatter.test.ts`, `src/skills/loading/workspace-load.test.ts`).
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.95)".
- +42 LOC total across parser + loader + tests; no behavior change for well-formed skills.
