### PR TITLE
fix: stop mock Control UI QA from hanging in live suites

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -945,7 +945,9 @@ describe("qa scenario catalog", () => {
   });
 
   it("keeps the Control UI transcript role boundary in the mock lane", () => {
-    const scenario = readQaScenarioById("control-ui-assistant-transcript-role-boundary");
+    const scenario = requireFlowScenario(
+      readQaScenarioById("control-ui-assistant-transcript-role-boundary"),
+    );
 
     expect(scenario.execution.providerMode).toBe("mock-openai");
   });

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -944,6 +944,12 @@ describe("qa scenario catalog", () => {
     expect(scenario.execution.channel).toBe("matrix");
   });
 
+  it("keeps the Control UI transcript role boundary in the mock lane", () => {
+    const scenario = readQaScenarioById("control-ui-assistant-transcript-role-boundary");
+
+    expect(scenario.execution.providerMode).toBe("mock-openai");
+  });
+
   it("routes native command session targeting through Crabline Telegram", () => {
     const scenario = readQaScenarioById("native-command-session-target");
     const config = readQaScenarioExecutionConfig("native-command-session-target") as

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -803,6 +803,32 @@ describe("qa suite planning helpers", () => {
     ).toEqual(["generic", "live-only"]);
   });
 
+  it("filters scenario-selected providers from implicit suite selections", () => {
+    const scenarios = [
+      makeMatrixFlowQaSuiteTestScenario("mock-selected", "mock-openai"),
+      makeMatrixFlowQaSuiteTestScenario("live-selected", "live-frontier"),
+    ];
+
+    expect(
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
+      }).map((scenario) => scenario.id),
+    ).toEqual(["mock-selected"]);
+    expect(
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
+      }).map((scenario) => scenario.id),
+    ).toEqual(["live-selected"]);
+  });
+
   it("keeps implicit scenario membership identical across channel drivers", () => {
     const scenarios = [
       makeQaSuiteTestScenario("generic"),

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -80,6 +80,10 @@ function selectQaFlowSuiteScenarios(params: {
   return params.scenarios.filter(
     (scenario) =>
       scenario.execution.kind === "flow" &&
+      // Explicit single-scenario runs adopt this provider later. Implicit suites must
+      // filter it here so a scenario-pinned provider cannot leak into another lane.
+      (scenario.execution.providerMode === undefined ||
+        scenario.execution.providerMode === params.providerMode) &&
       scenarioMatchesQaProviderLane({
         scenario,
         providerMode: params.providerMode,

--- a/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
+++ b/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
@@ -27,6 +27,7 @@ scenario:
     - ui/src/pages/chat/components/chat-message.ts
   execution:
     kind: flow
+    providerMode: mock-openai
     suiteIsolation: isolated
     isolationReason: The flow appends assistant fixtures to one dedicated session before opening a fresh Control UI transcript.
     summary: Drive one assistant reply through Gateway and qa-channel, append parser anti-cheat fixtures, then verify role-aware rendering in a real Control UI browser.


### PR DESCRIPTION
Closes #110473

## What Problem This Solves

Fixes an issue where the mock-specific Control UI assistant transcript role-boundary scenario entered live-frontier suites, replaced its deterministic fixture reply with a real model turn, and then waited up to six minutes inside browser assertions.

## Why This Change Was Made

The scenario now declares the mock OpenAI provider lane that its objective and fixtures require. Implicit suite selection now honors scenario-level provider pins at the shared selector boundary, while explicit single-scenario runs retain their existing automatic provider selection. Catalog and selector tests pin both contracts.

## User Impact

No product runtime behavior changes. QA operators get deterministic Control UI role-boundary coverage without a misleading live-provider hang.

## Evidence

- Before, live-frontier run 29633607793 passed setup, stalled in the fresh Control UI assertion, then hit the outer timeout.
- Before, the same scenario under mock-openai completed all three steps in run 29633786503.
- After, focused catalog and suite-planning proof passes: 84 tests.
- Autoreview: clean, 0.96 confidence after the selector fix.
