### PR TITLE
improve(ui): plugins hub hierarchy, settings section spacing, and grid-aligned secret inputs

### DIFF
--- a/ui/src/components/plugins-hub-tabs.ts
+++ b/ui/src/components/plugins-hub-tabs.ts
@@ -72,13 +72,13 @@ function reclaimFocus(tab: PluginsHubTab, element: Element | undefined) {
 /**
  * Every hub page marks its main content container with
  * id="plugins-hub-panel" so aria-controls stays valid on each route.
- * Styled through the settings design language's segmented control
- * (ui/src/styles/settings.css) while keeping tablist semantics.
+ * Styled as page-level navigation (.hub-tabs in ui/src/styles/plugins.css),
+ * deliberately distinct from segmented filter pills, keeping tablist semantics.
  */
 export function renderPluginsHubTabs(props: PluginsHubTabsProps) {
   return html`
     <wa-tab-group
-      class="settings-segmented plugins-hub-tabs plugins-tabs"
+      class="hub-tabs plugins-hub-tabs plugins-tabs"
       aria-label=${t("pluginsPage.hubTablistLabel")}
       .active=${props.active}
       activation="manual"
@@ -94,7 +94,7 @@ export function renderPluginsHubTabs(props: PluginsHubTabsProps) {
             id=${`plugins-tab-${tab}`}
             panel=${tab}
             aria-controls="plugins-hub-panel"
-            class="settings-segmented__btn ${selected ? "settings-segmented__btn--active" : ""}"
+            class="hub-tab"
             ?active=${selected}
             @click=${(event: MouseEvent) => {
               // Trusted pointer clicks carry a click count. Keyboard and AT

--- a/ui/src/components/sessions-hub-tabs.ts
+++ b/ui/src/components/sessions-hub-tabs.ts
@@ -29,12 +29,12 @@ function hubTabLabel(tab: SessionsHubTab): string {
 /**
  * Every hub page marks its main content container with
  * id="sessions-hub-panel" so aria-controls stays valid on each route.
- * Styled through the settings design language's segmented control.
+ * Styled as page-level navigation (.hub-tabs in ui/src/styles/plugins.css).
  */
 export function renderSessionsHubTabs(props: SessionsHubTabsProps) {
   return html`
     <wa-tab-group
-      class="settings-segmented plugins-hub-tabs sessions-hub-tabs"
+      class="hub-tabs plugins-hub-tabs sessions-hub-tabs"
       aria-label=${t("sessionsPage.hubTablistLabel")}
       .active=${props.active}
       activation="manual"
@@ -49,7 +49,7 @@ export function renderSessionsHubTabs(props: SessionsHubTabsProps) {
             id=${`sessions-tab-${tab}`}
             panel=${tab}
             aria-controls="sessions-hub-panel"
-            class="settings-segmented__btn ${selected ? "settings-segmented__btn--active" : ""}"
+            class="hub-tab"
             ?active=${selected}
           >
             ${hubTabLabel(tab)}

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -7,6 +7,7 @@ import "@awesome.me/webawesome/dist/components/radio-group/radio-group.js";
 import "@awesome.me/webawesome/dist/components/switch/switch.js";
 import { html, nothing, type TemplateResult } from "lit";
 import { icons } from "./icons.ts";
+import "./tooltip.ts";
 
 type SettingsStatusKind = "ok" | "warn" | "danger" | "accent" | "muted";
 
@@ -258,4 +259,42 @@ export function renderSettingsValue(value: unknown, options: { mono?: boolean } 
 
 export function renderSettingsEmpty(message: unknown): TemplateResult {
   return html`<div class="settings-empty">${message}</div>`;
+}
+
+/** Secret text input with an inset reveal toggle — one field, no trailing
+ * button, so secret rows line up with plain input rows in the same group. */
+export function renderSettingsSecretInput(props: {
+  value: string;
+  placeholder?: string;
+  visible: boolean;
+  showLabel: string;
+  hideLabel: string;
+  toggleLabel: string;
+  onInput: (next: string) => void;
+  onToggle: () => void;
+}): TemplateResult {
+  return html`
+    <span class="settings-secret">
+      <input
+        class="settings-input"
+        type=${props.visible ? "text" : "password"}
+        autocomplete="off"
+        spellcheck="false"
+        .value=${props.value}
+        placeholder=${props.placeholder ?? ""}
+        @input=${(e: Event) => props.onInput((e.target as HTMLInputElement).value)}
+      />
+      <openclaw-tooltip .content=${props.visible ? props.hideLabel : props.showLabel}>
+        <button
+          type="button"
+          class="settings-secret__toggle"
+          aria-label=${props.toggleLabel}
+          aria-pressed=${props.visible}
+          @click=${props.onToggle}
+        >
+          ${props.visible ? icons.eye : icons.eyeOff}
+        </button>
+      </openclaw-tooltip>
+    </span>
+  `;
 }

--- a/ui/src/pages/connection/view.ts
+++ b/ui/src/pages/connection/view.ts
@@ -2,11 +2,10 @@
 import { html } from "lit";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import { resolveGatewayTokenForUrlEdit, type UiSettings } from "../../app/settings.ts";
-import "../../components/tooltip.ts";
-import { icons } from "../../components/icons.ts";
 import {
   renderSettingsPage,
   renderSettingsRow,
+  renderSettingsSecretInput,
   renderSettingsSection,
   renderSettingsStatus,
   renderSettingsValue,
@@ -43,31 +42,8 @@ function renderSecretRow(params: {
   onInput: (next: string) => void;
   onToggle: () => void;
 }) {
-  return renderSettingsRow({
-    title: params.label,
-    control: html`
-      <input
-        class="settings-input"
-        type=${params.visible ? "text" : "password"}
-        autocomplete="off"
-        spellcheck="false"
-        .value=${params.value}
-        @input=${(e: Event) => params.onInput((e.target as HTMLInputElement).value)}
-        placeholder=${params.placeholder}
-      />
-      <openclaw-tooltip .content=${params.visible ? params.hideLabel : params.showLabel}>
-        <button
-          type="button"
-          class="btn btn--icon ${params.visible ? "active" : ""}"
-          aria-label=${params.toggleLabel}
-          aria-pressed=${params.visible}
-          @click=${params.onToggle}
-        >
-          ${params.visible ? icons.eye : icons.eyeOff}
-        </button>
-      </openclaw-tooltip>
-    `,
-  });
+  const { label, ...secret } = params;
+  return renderSettingsRow({ title: label, control: renderSettingsSecretInput(secret) });
 }
 
 export function renderConnection(props: ConnectionProps) {

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -768,7 +768,6 @@ function renderInstalled(props: PluginsViewProps) {
   const groups = groupInstalledByCategory(plugins);
   const filtered = Boolean(props.query || props.installedFilter !== "all");
   return html`
-    ${renderInstalledFilter(props)}
     ${groups.length === 0
       ? renderEmpty(
           filtered ? t("pluginsPage.noInstalledMatchTitle") : t("pluginsPage.noInstalledTitle"),
@@ -1260,6 +1259,14 @@ function renderActivePanel(props: PluginsViewProps) {
 
 export function renderPlugins(props: PluginsViewProps) {
   const canShowCatalog = Boolean(props.result);
+  const panelState =
+    props.loading && !canShowCatalog
+      ? "loading"
+      : props.error && !canShowCatalog
+        ? "error"
+        : !props.connected && !canShowCatalog
+          ? "offline"
+          : "content";
   return renderSettingsPage(
     html`
       <div class="plugins-toolbar">
@@ -1275,6 +1282,9 @@ export function renderPlugins(props: PluginsViewProps) {
           @input=${(event: Event) =>
             props.onQueryChange((event.currentTarget as HTMLInputElement).value)}
         />
+        ${props.activeTab === "installed" && panelState === "content"
+          ? renderInstalledFilter(props)
+          : nothing}
         <button
           type="button"
           class="btn btn--sm btn--icon plugins-refresh"
@@ -1318,11 +1328,11 @@ export function renderPlugins(props: PluginsViewProps) {
         active
         aria-labelledby=${`plugins-tab-${props.activeTab}`}
       >
-        ${props.loading && !canShowCatalog
+        ${panelState === "loading"
           ? html`<div class="plugins-search-state" role="status">${t("pluginsPage.loading")}</div>`
-          : props.error && !canShowCatalog
+          : panelState === "error"
             ? nothing
-            : !props.connected && !canShowCatalog
+            : panelState === "offline"
               ? renderEmpty(t("pluginsPage.offlineTitle"), t("pluginsPage.offlineBody"))
               : renderActivePanel(props)}
       </wa-tab-panel>

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -341,6 +341,12 @@ function stateStatus(plugin: PluginCatalogItem) {
   return renderSettingsStatus({ kind, label: stateLabel(plugin) });
 }
 
+/** Rows pair the status with an Enable/Disable button that already implies the
+ * healthy states, so only the error status earns a pill next to the actions. */
+function rowStateStatus(plugin: PluginCatalogItem) {
+  return plugin.state === "error" ? stateStatus(plugin) : nothing;
+}
+
 function originLabel(origin: string): string {
   switch (origin) {
     case "bundled":
@@ -614,7 +620,7 @@ function renderInstalledRow(plugin: PluginCatalogItem, props: PluginsViewProps):
         ])}
       </div>
       <div class="settings-row__control">
-        ${stateStatus(plugin)} ${renderCatalogActions(plugin, props, busy, key)}
+        ${rowStateStatus(plugin)} ${renderCatalogActions(plugin, props, busy, key)}
       </div>
       ${plugin.error
         ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
@@ -697,10 +703,6 @@ function renderMcpRow(server: McpServerSummary, props: PluginsViewProps): Templa
         ])}
       </div>
       <div class="settings-row__control">
-        ${renderSettingsStatus({
-          kind: server.enabled ? "ok" : "muted",
-          label: server.enabled ? t("pluginsPage.enabled") : t("pluginsPage.disabled"),
-        })}
         ${renderToggleButton(props, props.mcpBusy, {
           enabled: server.enabled,
           onToggle: (enabled) => props.onMcpToggle(server.name, enabled),
@@ -821,7 +823,7 @@ function renderCatalogRow(plugin: PluginCatalogItem, props: PluginsViewProps): T
         ${renderMetaLine([plugin.origin ? originLabel(plugin.origin) : nothing])}
       </div>
       <div class="settings-row__control">
-        ${plugin.installed ? stateStatus(plugin) : nothing}
+        ${plugin.installed ? rowStateStatus(plugin) : nothing}
         ${renderCatalogActions(plugin, props, busy, key)}
       </div>
       ${plugin.error
@@ -966,7 +968,7 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
       </div>
       <div class="settings-row__control">
         ${installed
-          ? html`${stateStatus(installed)}${renderCatalogActions(installed, props, busy, key)}`
+          ? html`${rowStateStatus(installed)}${renderCatalogActions(installed, props, busy, key)}`
           : renderInstallButton(props, busy, key, pkg.displayName, {
               source: "clawhub",
               packageName: pkg.name,

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -15,6 +15,60 @@
   padding: var(--space-3) var(--space-4) 0;
 }
 
+/* ---------- hub tabs ---------- */
+
+/* Hub tab strips (plugins + sessions hubs) are page-level navigation, not
+   filters: quiet text tabs on a hairline track with an accent indicator, so
+   they read differently from the segmented filter pills inside the pages.
+   Track/indicator come from wa-tab-group's shadow machinery. */
+wa-tab-group.hub-tabs {
+  --track-color: color-mix(in srgb, var(--border) 60%, transparent);
+  --indicator-color: var(--accent);
+}
+
+wa-tab-group.hub-tabs::part(body) {
+  display: none;
+}
+
+wa-tab-group.hub-tabs::part(tabs) {
+  gap: var(--space-2);
+}
+
+wa-tab.hub-tab {
+  font-size: var(--control-ui-text-sm);
+  font-weight: 550;
+  color: var(--muted);
+  transition: color var(--duration-normal) var(--ease-out);
+}
+
+/* Neutralize wa-tab's stock 1em padding; keep a slim nav-tab hit area. */
+wa-tab.hub-tab::part(base) {
+  padding: var(--space-1) var(--space-2) var(--space-2);
+  gap: 6px;
+  font: inherit;
+  color: inherit;
+}
+
+wa-tab.hub-tab:hover {
+  color: var(--text);
+}
+
+wa-tab.hub-tab[active] {
+  color: var(--text-strong);
+}
+
+wa-tab.hub-tab:focus-visible {
+  outline: none;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+/* Web Awesome also draws its stock focus ring on the inner base part;
+   without this reset both rings render at once. */
+wa-tab.hub-tab:focus-visible::part(base) {
+  outline: none;
+}
+
 /* ---------- toolbar ---------- */
 
 .plugins-toolbar {
@@ -113,17 +167,18 @@
 
 /* ---------- panel + notices ---------- */
 
-/* Sections inside the tabpanel keep the settings-page rhythm. */
+/* Sections inside the tabpanel keep the settings-page rhythm. wa-tab-panel's
+   shadow slot (part=base) owns the slotted children's layout, so the column
+   flex + gap must live on the part — host-level gap never reaches them. */
 .plugins-panel {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-7);
   min-width: 0;
 }
 
-/* Keep the installed-state filter shrink-to-fit inside the panel column. */
-.plugins-panel > .settings-segmented {
-  align-self: flex-start;
+.plugins-panel::part(base) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  min-width: 0;
 }
 
 .plugins-readonly {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -96,26 +96,28 @@
   min-width: 0;
 }
 
+/* Header and description indent to var(--space-4) so the eyebrow label lines
+   up with the row content inside the group surface below it. */
 .settings-section__header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: 0 var(--space-1);
+  padding: 0 var(--space-4);
 }
 
 .settings-section__heading {
   margin: 0;
-  font-size: var(--control-ui-text-sm);
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.06em;
   color: var(--muted-strong);
   text-transform: uppercase;
 }
 
 .settings-section__desc {
   margin: calc(-1 * var(--space-2)) 0 0;
-  padding: 0 var(--space-1);
+  padding: 0 var(--space-4);
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
@@ -408,6 +410,35 @@ wa-radio-group.settings-segmented::part(radios) {
 .settings-segmented__btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ── Web Awesome tab strips reusing the segmented look (hub tabs) ──
+   wa-tab-group ships an underline track/indicator and 1em tab padding in its
+   shadow DOM; both would stack on top of the pill styling above, so they are
+   neutralized and the pill metrics come from the host classes instead. */
+
+wa-tab-group.settings-segmented {
+  --track-color: transparent;
+  --indicator-color: transparent;
+}
+
+wa-tab-group.settings-segmented::part(body) {
+  display: none;
+}
+
+wa-tab-group.settings-segmented::part(tabs) {
+  gap: 2px;
+}
+
+wa-tab.settings-segmented__btn::part(base) {
+  padding: 0;
+  gap: 6px;
+  font: inherit;
+  color: inherit;
+}
+
+wa-tab.settings-segmented__btn:focus-visible::part(base) {
+  outline: none;
 }
 
 .settings-input,

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -66,6 +66,9 @@
 
 /* ── Page ── */
 
+/* Section separation stays generous (--space-8) so group surfaces read as
+   distinct blocks; headings bind to their own group via the tighter
+   .settings-section gap. */
 .settings-page {
   width: 100%;
   max-width: 760px;
@@ -73,7 +76,7 @@
   padding: var(--space-3) var(--space-4) var(--space-8);
   display: flex;
   flex-direction: column;
-  gap: var(--space-7);
+  gap: var(--space-8);
 }
 
 /* Table/list-heavy pages (sessions, automations, plugins) need more width. */
@@ -100,7 +103,7 @@
    up with the row content inside the group surface below it. */
 .settings-section__header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
   padding: 0 var(--space-4);
@@ -412,35 +415,6 @@ wa-radio-group.settings-segmented::part(radios) {
   cursor: not-allowed;
 }
 
-/* ── Web Awesome tab strips reusing the segmented look (hub tabs) ──
-   wa-tab-group ships an underline track/indicator and 1em tab padding in its
-   shadow DOM; both would stack on top of the pill styling above, so they are
-   neutralized and the pill metrics come from the host classes instead. */
-
-wa-tab-group.settings-segmented {
-  --track-color: transparent;
-  --indicator-color: transparent;
-}
-
-wa-tab-group.settings-segmented::part(body) {
-  display: none;
-}
-
-wa-tab-group.settings-segmented::part(tabs) {
-  gap: 2px;
-}
-
-wa-tab.settings-segmented__btn::part(base) {
-  padding: 0;
-  gap: 6px;
-  font: inherit;
-  color: inherit;
-}
-
-wa-tab.settings-segmented__btn:focus-visible::part(base) {
-  outline: none;
-}
-
 .settings-input,
 .settings-select {
   width: 100%;
@@ -455,10 +429,68 @@ wa-tab.settings-segmented__btn:focus-visible::part(base) {
   transition: border-color var(--duration-fast) var(--ease-out);
 }
 
-.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-select,
-.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-input {
+.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-select {
   width: auto;
   min-width: min(220px, 100%);
+}
+
+/* Lone value inputs share one width so stacked rows in a group read as a
+   grid instead of ragged right-aligned fields. A percentage guard cannot work
+   here (the shrink-to-fit control resolves 100% circularly); the fixed width
+   shrinks via flex because .settings-input/.settings-secret set min-width: 0. */
+.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-input,
+.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-secret {
+  width: 340px;
+}
+
+/* ── Secret input (inset reveal toggle; no trailing button) ── */
+
+.settings-secret {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.settings-secret > .settings-input {
+  width: 100%;
+  padding-right: 36px;
+}
+
+.settings-secret__toggle {
+  position: absolute;
+  right: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+.settings-secret__toggle:hover {
+  color: var(--text);
+}
+
+.settings-secret__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.settings-secret__toggle svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .settings-input::placeholder {


### PR DESCRIPTION
## What Problem This Solves

The Plugins hub and Connection settings read messy:

- The hub tab strip (Installed / Discover / Skills / Workshop) rendered as a broken hybrid — a segmented-pill container with Web Awesome's stock tab underline/track and oversized 1em tab padding stacked on top — and it looked identical to the status filter below it, so page navigation and list filtering were indistinguishable.
- The Plugins page stacked two look-alike selectors plus a search field vertically, wasting space and confusing hierarchy.
- Section headers (CHANNELS, MODEL PROVIDERS, …) sat nearly flush against the page edge, misaligned with row content, and sections had almost no air above them — the intended panel gap silently never applied because `wa-tab-panel`'s shadow slot owns the slotted children's layout, so a host-level flex `gap` does nothing.
- Installed plugin rows and MCP rows showed a status pill ("Enabled"/"Disabled") right next to an Enable/Disable button that already says the same thing.
- On the Connection page, secret fields bolted a separate eye button next to the input and every field had a different width, so the group read as ragged chaos instead of a grid.

## Why This Change Was Made

Requested cleanup of padding, hierarchy, and control styling. The fixes live at the owning boundaries so both hubs and every settings surface benefit:

- Hub tab strips (plugins + sessions hubs) are now real page navigation: quiet text tabs on a hairline track with an accent indicator (`.hub-tabs`), visually distinct from segmented filter pills.
- The installed-state filter (All / Enabled / Disabled / Issues) moved onto the search row — one toolbar: search, filter, refresh. Its visibility is tied to the same state that renders the installed list, so a hidden control can never leave a stale filter applied.
- `.settings-section__header`/`__desc` indent to `var(--space-4)` to align with row content; headings use an xs eyebrow style; header rows center-align so action buttons no longer sag below the text baseline.
- Section separation is an honest `--space-8`: `.plugins-panel::part(base)` carries the column flex + gap (the host-level gap never reached slotted sections), and `.settings-page` steps up to the same rhythm.
- Plugin and MCP rows only show a status pill for the error state ("Needs attention"); healthy state stays implicit in the toggle button label. The detail overlay keeps the full status.
- New `renderSettingsSecretInput` design-language primitive: a secret input with an inset reveal toggle (no trailing button), used by the Connection page. Lone value inputs in settings rows now share one width (340px, flex-shrinking on narrow layouts) so grouped fields align as a grid.

## User Impact

The Plugins hub gets a clear visual hierarchy — page tabs, one toolbar, generously spaced sections with aligned headers, uncluttered rows. The Connection page's Gateway Access group aligns as a grid with the reveal eye inside each secret field. The sessions hub and all settings pages inherit the same header/spacing polish.

Before (plugins hub):

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/plugins-hub-padding/before.png)

After (plugins hub):

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/plugins-hub-padding/after-redesign.png)

After (connection page):

![connection](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/plugins-hub-padding/connection-after.png)

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/connection/view.render.test.ts ui/src/pages/plugins/view.test.ts ui/src/pages/plugins/plugins-page.test.ts ui/src/components/plugins-hub-tabs.test.ts` — 49 tests pass; earlier full pass also covered skills/worktrees suites (74 tests).
- `node scripts/check-changed.mjs` — delegated Blacksmith Testbox, green.
- Live-verified against `pnpm dev:ui:mock` (dark, desktop + 375px mobile): plugins Installed/Discover, Skills, Sessions hub, Connection, General; spacing measured via `getBoundingClientRect` (40px section separation, 12px heading-to-card); keyboard focus on hub tabs shows a single accent ring (stock Web Awesome inner outline reset verified).
- Codex autoreview (gpt-5.6-sol): two accepted findings across cycles — stale-filter-while-hidden and duplicated focus ring — both fixed and re-reviewed; final pass clean apart from an untracked local screenshot helper, which was deleted, not landed.
