### PR TITLE
fix(apns): keep diagnostics valid when response capture reaches its byte limit

### DIFF
--- a/src/infra/push-apns-http2.test.ts
+++ b/src/infra/push-apns-http2.test.ts
@@ -64,8 +64,13 @@ const {
     setEncoding: vi.fn(),
     end: vi.fn(() => {
       queueMicrotask(() => {
+        const responseBody = Buffer.from(
+          '{"reason":"InvalidProviderToken","detail":"split 🚀 response"}',
+        );
+        const emojiOffset = responseBody.indexOf(Buffer.from("🚀"));
         fakeRequestLocal.emit("response", { ":status": 403 });
-        fakeRequestLocal.emit("data", '{"reason":"InvalidProviderToken"}');
+        fakeRequestLocal.emit("data", responseBody.subarray(0, emojiOffset + 2));
+        fakeRequestLocal.emit("data", responseBody.subarray(emojiOffset + 2));
         fakeRequestLocal.emit("end");
       });
     }),
@@ -373,9 +378,10 @@ describe("connectApnsHttp2Session", () => {
 
     expect(result).toEqual({
       status: 403,
-      body: '{"reason":"InvalidProviderToken"}',
+      body: '{"reason":"InvalidProviderToken","detail":"split 🚀 response"}',
       responseHeaders: {},
     });
+    expect(fakeRequest.setEncoding).not.toHaveBeenCalled();
     const tunnelCall = lastTunnelCall();
     const proxyUrl = tunnelCall.proxyUrl;
     expect(proxyUrl).toBeInstanceOf(URL);

--- a/src/infra/push-apns-http2.ts
+++ b/src/infra/push-apns-http2.ts
@@ -1,8 +1,8 @@
 // Opens APNs HTTP/2 sessions with optional managed proxy tunneling.
 import { once } from "node:events";
 import http2 from "node:http2";
-import { StringDecoder } from "node:string_decoder";
 import tls from "node:tls";
+import { decodeTextPrefix } from "@openclaw/normalization-core";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { openProxyConnectTunnel } from "@openclaw/proxyline";
 import { toErrorObject } from "./errors.js";
@@ -223,7 +223,7 @@ export function appendApnsResponseBodyCapture(
     return;
   }
   const slice = buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer;
-  capture.chunks.push(slice);
+  capture.chunks.push(Buffer.from(slice));
   capture.capturedBytes += slice.byteLength;
   if (slice.byteLength < buffer.byteLength) {
     capture.truncated = true;
@@ -231,7 +231,9 @@ export function appendApnsResponseBodyCapture(
 }
 
 export function getApnsResponseBodyCaptureText(capture: ApnsResponseBodyCapture): string {
-  return new StringDecoder("utf8").write(Buffer.concat(capture.chunks));
+  return decodeTextPrefix(Buffer.concat(capture.chunks, capture.capturedBytes), {
+    truncated: capture.truncated,
+  });
 }
 
 /** Sends an intentionally invalid APNs push through a proxy to prove HTTP/2 reachability. */

--- a/src/infra/push-apns-http2.ts
+++ b/src/infra/push-apns-http2.ts
@@ -1,6 +1,7 @@
 // Opens APNs HTTP/2 sessions with optional managed proxy tunneling.
 import { once } from "node:events";
 import http2 from "node:http2";
+import { StringDecoder } from "node:string_decoder";
 import tls from "node:tls";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { openProxyConnectTunnel } from "@openclaw/proxyline";
@@ -26,7 +27,8 @@ const APNS_RESPONSE_BODY_MAX_BYTES = 8192;
 const APNS_HTTP2_MIN_TIMEOUT_MS = 1000;
 
 type ApnsResponseBodyCapture = {
-  text: string;
+  chunks: Buffer[];
+  capturedBytes: number;
   bytes: number;
   truncated: boolean;
 };
@@ -205,7 +207,7 @@ function resolveApnsHttp2TimeoutMs(timeoutMs: number): number {
 }
 
 export function createApnsResponseBodyCapture(): ApnsResponseBodyCapture {
-  return { text: "", bytes: 0, truncated: false };
+  return { chunks: [], capturedBytes: 0, bytes: 0, truncated: false };
 }
 
 export function appendApnsResponseBodyCapture(
@@ -213,18 +215,23 @@ export function appendApnsResponseBodyCapture(
   chunk: unknown,
   maxBytes = APNS_RESPONSE_BODY_MAX_BYTES,
 ): void {
-  const buffer = Buffer.from(String(chunk));
+  const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
   capture.bytes += buffer.byteLength;
-  const remaining = maxBytes - Buffer.byteLength(capture.text);
+  const remaining = maxBytes - capture.capturedBytes;
   if (remaining <= 0) {
     capture.truncated = capture.truncated || buffer.byteLength > 0;
     return;
   }
   const slice = buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer;
-  capture.text += slice.toString("utf8");
+  capture.chunks.push(slice);
+  capture.capturedBytes += slice.byteLength;
   if (slice.byteLength < buffer.byteLength) {
     capture.truncated = true;
   }
+}
+
+export function getApnsResponseBodyCaptureText(capture: ApnsResponseBodyCapture): string {
+  return new StringDecoder("utf8").write(Buffer.concat(capture.chunks));
 }
 
 /** Sends an intentionally invalid APNs push through a proxy to prove HTTP/2 reachability. */
@@ -278,7 +285,6 @@ export async function probeApnsHttp2ReachabilityViaProxy(
       });
 
       session.once("error", fail);
-      request.setEncoding("utf8");
       request.on("response", (headers) => {
         const rawStatus = headers[":status"];
         status = typeof rawStatus === "number" ? rawStatus : Number(rawStatus);
@@ -302,7 +308,7 @@ export async function probeApnsHttp2ReachabilityViaProxy(
           reject(new Error("APNs reachability probe ended without an HTTP/2 status"));
           return;
         }
-        resolve({ status, body: body.text, responseHeaders });
+        resolve({ status, body: getApnsResponseBodyCaptureText(body), responseHeaders });
       });
       request.end(JSON.stringify({ aps: { alert: "OpenClaw APNs proxy validation" } }));
     });

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -297,8 +297,7 @@ describe("push APNs send semantics", () => {
     appendApnsResponseBodyCapture(capture, "def", 5);
 
     expect(getApnsResponseBodyCaptureText(capture)).toBe("abcde");
-    expect(capture.bytes).toBe(6);
-    expect(capture.truncated).toBe(true);
+    expect(capture).toMatchObject({ capturedBytes: 5, bytes: 6, truncated: true });
   });
 
   it("preserves UTF-8 across HTTP/2 chunks and drops an incomplete capped suffix", () => {
@@ -314,7 +313,15 @@ describe("push APNs send semantics", () => {
     const cappedPrefix = "a".repeat(8191);
     appendApnsResponseBodyCapture(cappedCapture, Buffer.from(`${cappedPrefix}🚀`));
     expect(getApnsResponseBodyCaptureText(cappedCapture)).toBe(cappedPrefix);
-    expect(cappedCapture).toMatchObject({ bytes: 8195, truncated: true });
+    expect(cappedCapture).toMatchObject({ capturedBytes: 8192, bytes: 8195, truncated: true });
+  });
+
+  it("preserves replacement decoding for a complete malformed APNs response", () => {
+    const capture = createApnsResponseBodyCapture();
+    appendApnsResponseBodyCapture(capture, Buffer.from([0x61, 0xf0, 0x9f]));
+
+    expect(getApnsResponseBodyCaptureText(capture)).toBe("a�");
+    expect(capture).toMatchObject({ capturedBytes: 3, bytes: 3, truncated: false });
   });
 
   it("sends alert pushes with alert headers and payload", async () => {

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -311,9 +311,10 @@ describe("push APNs send semantics", () => {
     expect(getApnsResponseBodyCaptureText(splitCapture)).toBe("before 🚀 after");
 
     const cappedCapture = createApnsResponseBodyCapture();
-    appendApnsResponseBodyCapture(cappedCapture, Buffer.from("abc🚀"), 5);
-    expect(getApnsResponseBodyCaptureText(cappedCapture)).toBe("abc");
-    expect(cappedCapture).toMatchObject({ bytes: 7, truncated: true });
+    const cappedPrefix = "a".repeat(8191);
+    appendApnsResponseBodyCapture(cappedCapture, Buffer.from(`${cappedPrefix}🚀`));
+    expect(getApnsResponseBodyCaptureText(cappedCapture)).toBe(cappedPrefix);
+    expect(cappedCapture).toMatchObject({ bytes: 8195, truncated: true });
   });
 
   it("sends alert pushes with alert headers and payload", async () => {

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -6,7 +6,11 @@ import net from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startProxy, stopProxy, type ProxyHandle } from "./net/proxy/proxy-lifecycle.js";
-import { appendApnsResponseBodyCapture, createApnsResponseBodyCapture } from "./push-apns-http2.js";
+import {
+  appendApnsResponseBodyCapture,
+  createApnsResponseBodyCapture,
+  getApnsResponseBodyCaptureText,
+} from "./push-apns-http2.js";
 import {
   sendApnsAlert,
   sendApnsBackgroundWake,
@@ -292,11 +296,24 @@ describe("push APNs send semantics", () => {
     appendApnsResponseBodyCapture(capture, "abc", 5);
     appendApnsResponseBodyCapture(capture, "def", 5);
 
-    expect(capture).toEqual({
-      text: "abcde",
-      bytes: 6,
-      truncated: true,
-    });
+    expect(getApnsResponseBodyCaptureText(capture)).toBe("abcde");
+    expect(capture.bytes).toBe(6);
+    expect(capture.truncated).toBe(true);
+  });
+
+  it("preserves UTF-8 across HTTP/2 chunks and drops an incomplete capped suffix", () => {
+    const splitCapture = createApnsResponseBodyCapture();
+    const emoji = Buffer.from("🚀");
+    appendApnsResponseBodyCapture(splitCapture, Buffer.from("before "));
+    appendApnsResponseBodyCapture(splitCapture, emoji.subarray(0, 2));
+    appendApnsResponseBodyCapture(splitCapture, emoji.subarray(2));
+    appendApnsResponseBodyCapture(splitCapture, Buffer.from(" after"));
+    expect(getApnsResponseBodyCaptureText(splitCapture)).toBe("before 🚀 after");
+
+    const cappedCapture = createApnsResponseBodyCapture();
+    appendApnsResponseBodyCapture(cappedCapture, Buffer.from("abc🚀"), 5);
+    expect(getApnsResponseBodyCaptureText(cappedCapture)).toBe("abc");
+    expect(cappedCapture).toMatchObject({ bytes: 7, truncated: true });
   });
 
   it("sends alert pushes with alert headers and payload", async () => {

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -11,6 +11,7 @@ import {
   appendApnsResponseBodyCapture,
   connectApnsHttp2Session,
   createApnsResponseBodyCapture,
+  getApnsResponseBodyCaptureText,
 } from "./push-apns-http2.js";
 import {
   createApnsAlertPayload,
@@ -304,7 +305,6 @@ async function sendApnsRequest(params: {
     let apnsId: string | undefined;
     const responseBody = createApnsResponseBodyCapture();
 
-    req.setEncoding("utf8");
     req.setTimeout(params.timeoutMs, () => {
       req.close(APNS_HTTP2_CANCEL_CODE);
       fail(new Error(`APNs request timed out after ${params.timeoutMs}ms`));
@@ -318,12 +318,10 @@ async function sendApnsRequest(params: {
       }
     });
     req.on("data", (chunk) => {
-      if (typeof chunk === "string") {
-        appendApnsResponseBodyCapture(responseBody, chunk);
-      }
+      appendApnsResponseBodyCapture(responseBody, chunk);
     });
     req.on("end", () => {
-      finish({ status: statusCode, apnsId, body: responseBody.text });
+      finish({ status: statusCode, apnsId, body: getApnsResponseBodyCaptureText(responseBody) });
     });
     req.on("error", (err) => fail(err));
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where APNs push and proxy-reachability diagnostics could contain a replacement character when an oversized HTTP/2 response reached the 8192-byte capture limit in the middle of a UTF-8 character.

## Why This Change Was Made

The shared APNs response capture now retains bounded raw bytes and decodes them once when the stream ends. Both direct pushes and proxy reachability use that owner, so complete characters are preserved and only an incomplete capped suffix is omitted.

## User Impact

APNs failure reasons and proxy diagnostics remain valid UTF-8 at the response capture boundary instead of showing corrupted text.

## Evidence

Focused APNs suites:

```text
$ node scripts/test-projects.mjs src/infra/push-apns.test.ts src/infra/push-apns-http2.test.ts
Test Files  2 passed (2)
Tests       31 passed (31)
```

After-fix boundary diagnostic through the production direct-send path, using real TLS, HTTP/2, and CONNECT with a protocol-compatible endpoint:

```text
transport: direct
status: 400
response body bytes: 8195
capture limit bytes: 8192
four-byte UTF-8 suffix starts at byte: 8191
observed reason: 边界保留
incomplete suffix dropped: true
replacement character present: false
```

Separate live Apple sandbox proof through the production reachability probe:

```text
status: 403
reason: InvalidProviderToken
apns-id header present: true
provider/device credentials used: false
```

Apple controls APNs error response bodies, so a live Apple request cannot be instructed to return an oversized non-ASCII payload at this exact boundary. The boundary diagnostic therefore supplies the controllable trigger over the production transport path, while the separate live request confirms that the same capture code reaches and decodes a real Apple APNs response.
