### PR TITLE
feat(onboard): extend browser handoff and refresh recommendations

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -122,13 +122,13 @@ the same plan the conversational `openclaw setup` chat would apply on "yes" —
 then offers plugin and skill recommendations from installed apps; app names
 are matched through your configured model and ClawHub search, and the step can
 be disabled with [`wizard.appRecommendations`](/gateway/configuration-reference#wizard).
-On a macOS console, it then opens the authenticated Control UI dashboard and
-waits up to 60 seconds for the browser client to connect. Over SSH, it prints a
-prominent copy-pasteable dashboard URL, including an SSH port-forward command
-for a loopback Gateway, and waits up to five minutes. A successful connection
-continues in the browser; an unreachable Gateway or a timeout falls back to the
-same terminal hatch as before. Pass `--tui` to skip the browser handoff and
-force that terminal hatch. Other platforms currently keep the terminal hatch.
+In a macOS, Linux, or Windows desktop session, it then opens the authenticated
+Control UI dashboard and waits up to 60 seconds for the browser client to
+connect. On headless Linux or over SSH, it prints a prominent copy-pasteable
+dashboard URL, including an SSH port-forward command for a loopback Gateway,
+and waits up to five minutes. A successful connection continues in the browser;
+an unreachable Gateway or a timeout falls back to the same terminal hatch as
+before. Pass `--tui` to skip the browser handoff and force that terminal hatch.
 If applying setup fails, onboarding falls back to the conversational OpenClaw
 chat to finish interactively. Channels, agents,
 plugins, and other optional features remain OpenClaw chat territory: run

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -46,6 +46,7 @@ openclaw onboard --import-from hermes --import-source ~/.hermes
 openclaw onboard --skip-bootstrap
 openclaw onboard recommendations --json
 openclaw onboard recommendations acknowledge
+openclaw onboard recommendations refresh
 openclaw onboard --mode remote --remote-url wss://gateway-host:18789
 ```
 
@@ -55,8 +56,9 @@ the first-run bootstrap. The command does not rescan installed apps or call a
 model. Its output contains only validated install IDs, source, and tier; it
 intentionally omits untrusted marketplace prose, model reasons, and local app
 labels. After the recommendation offer has been answered, the command returns
-an empty list and future onboarding runs skip the step entirely. A future
-explicit refresh command can clear that accepted state and run discovery again.
+an empty list and future onboarding runs skip the step entirely.
+`openclaw onboard recommendations refresh` clears the stored offer so the next
+onboarding run rescans installed apps and creates a new offer.
 
 Fresh workspaces defer the recommendation choice to the bootstrap conversation.
 After that conversation handles the user's choices,

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -403,6 +403,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { bypassConfigGuard: true, loadPlugins: "never", networkProxy: "bypass" },
   },
   {
+    commandPath: ["onboard", "recommendations", "refresh"],
+    exact: true,
+    policy: { bypassConfigGuard: true, loadPlugins: "never", networkProxy: "bypass" },
+  },
+  {
     commandPath: ["channels", "add"],
     exact: true,
     policy: { loadPlugins: "never", networkProxy: "bypass" },

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -6,6 +6,7 @@ import { registerOnboardCommand } from "./register.onboard.js";
 const mocks = vi.hoisted(() => ({
   acknowledgeOnboardRecommendationsCommand: vi.fn(),
   onboardRecommendationsCommand: vi.fn(),
+  refreshOnboardRecommendationsCommand: vi.fn(),
   runSystemAgentWithInference: vi.fn(),
   setupWizardCommandMock: vi.fn(),
   runtime: {
@@ -54,6 +55,7 @@ vi.mock("../../commands/onboard.js", () => ({
 vi.mock("../../commands/onboard-recommendations.js", () => ({
   acknowledgeOnboardRecommendationsCommand: mocks.acknowledgeOnboardRecommendationsCommand,
   onboardRecommendationsCommand: mocks.onboardRecommendationsCommand,
+  refreshOnboardRecommendationsCommand: mocks.refreshOnboardRecommendationsCommand,
 }));
 
 vi.mock("../../commands/system-agent-with-inference.js", () => ({
@@ -97,6 +99,13 @@ describe("registerOnboardCommand", () => {
     await runCli(["onboard", "recommendations", "acknowledge"]);
 
     expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(runtime);
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("routes the recommendations refresh subcommand", async () => {
+    await runCli(["onboard", "recommendations", "refresh"]);
+
+    expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledWith(runtime);
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -266,6 +266,18 @@ export function registerOnboardCommand(program: Command): void {
       });
     });
 
+  recommendations
+    .command("refresh")
+    .description("Clear stored app recommendations so the next onboarding run rescans")
+    .action(async () => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { refreshOnboardRecommendationsCommand } =
+          await import("../../commands/onboard-recommendations.js");
+        refreshOnboardRecommendationsCommand(defaultRuntime);
+      });
+    });
+
   command.action(async (opts, commandRuntime: Command) => {
     const { defaultRuntime } = await import("../../runtime.js");
     await runCommandWithRuntime(defaultRuntime, async () => {

--- a/src/commands/onboard-browser-handoff.test.ts
+++ b/src/commands/onboard-browser-handoff.test.ts
@@ -48,7 +48,11 @@ describe("detectGraphicalSession", () => {
 });
 
 describe("runBrowserHatchHandoff", () => {
-  it("opens once in a GUI session and returns after the Control UI connects", async () => {
+  it.each([
+    { platform: "darwin" as const, env: {} },
+    { platform: "linux" as const, env: { DISPLAY: ":0" } },
+    { platform: "win32" as const, env: {} },
+  ])("opens once in a $platform GUI session", async ({ platform, env }) => {
     const prompter = createWizardPrompter();
     const openBrowser = vi.fn(async () => true);
     const probePresence = vi
@@ -59,8 +63,8 @@ describe("runBrowserHatchHandoff", () => {
     const result = await runBrowserHatchHandoff(
       { config: {}, prompter },
       {
-        env: {},
-        platform: "darwin",
+        env,
+        platform,
         openBrowser,
         resolveTarget: async () => target,
         probePresence,
@@ -77,7 +81,10 @@ describe("runBrowserHatchHandoff", () => {
     );
   });
 
-  it("prints the authenticated URL and waits longer in a headless session", async () => {
+  it.each([
+    { name: "headless Linux", env: {} },
+    { name: "Linux SSH", env: { DISPLAY: ":0", SSH_CONNECTION: "client server" } },
+  ])("prints the authenticated URL and waits longer in $name", async ({ env }) => {
     const prompter = createWizardPrompter();
     const openBrowser = vi.fn(async () => true);
     const probePresence = vi.fn(async () => ({ reachable: true as const, clientKeys: [] }));
@@ -89,8 +96,8 @@ describe("runBrowserHatchHandoff", () => {
     const result = await runBrowserHatchHandoff(
       { config: {}, prompter },
       {
-        env: { SSH_CONNECTION: "client server" },
-        platform: "darwin",
+        env,
+        platform: "linux",
         openBrowser,
         resolveTarget: async () => target,
         probePresence,

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -273,43 +273,40 @@ describe("runGuidedOnboarding", () => {
     );
   });
 
-  it.each(["darwin", "linux", "win32"] satisfies NodeJS.Platform[])(
-    "hands the custodian hatch to the browser on %s after apply and recommendations",
-    async (platform) => {
-      const prompter = createWizardPrompter();
-      const applySetup = vi.fn(async () => ({
-        configPath: "/tmp/openclaw.json",
-        configHashBefore: null,
-        configHashAfter: null,
-        lines: [],
-      }));
-      const runAppRecommendations = vi.fn<
-        NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>
-      >(async ({ config }) => config);
-      const probeBrowserHandoffGateway = vi.fn(async () => ({ ok: true }));
-      const runBrowserHandoff = vi.fn(async () => ({ handedOff: true as const }));
-      const deps = setupDeps({
-        prompter,
-        applySetup,
-        runAppRecommendations,
-        probeBrowserHandoffGateway,
-        runBrowserHandoff,
-        platform,
-      });
+  it("hands the custodian hatch to the browser on Linux after apply and recommendations", async () => {
+    const prompter = createWizardPrompter();
+    const applySetup = vi.fn(async () => ({
+      configPath: "/tmp/openclaw.json",
+      configHashBefore: null,
+      configHashAfter: null,
+      lines: [],
+    }));
+    const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
+      async ({ config }) => config,
+    );
+    const probeBrowserHandoffGateway = vi.fn(async () => ({ ok: true }));
+    const runBrowserHandoff = vi.fn(async () => ({ handedOff: true as const }));
+    const deps = setupDeps({
+      prompter,
+      applySetup,
+      runAppRecommendations,
+      probeBrowserHandoffGateway,
+      runBrowserHandoff,
+      platform: "linux",
+    });
 
-      await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
+    await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
 
-      expect(runBrowserHandoff).toHaveBeenCalledWith({ config: {}, prompter });
-      expect(applySetup.mock.invocationCallOrder[0]).toBeLessThan(
-        runAppRecommendations.mock.invocationCallOrder[0]!,
-      );
-      expect(runAppRecommendations.mock.invocationCallOrder[0]).toBeLessThan(
-        runBrowserHandoff.mock.invocationCallOrder[0]!,
-      );
-      expect(deps.launchHatchTui).not.toHaveBeenCalled();
-      expect(prompter.outro).toHaveBeenCalledWith("Your browser is ready — I'll be in Settings.");
-    },
-  );
+    expect(runBrowserHandoff).toHaveBeenCalledWith({ config: {}, prompter });
+    expect(applySetup.mock.invocationCallOrder[0]).toBeLessThan(
+      runAppRecommendations.mock.invocationCallOrder[0]!,
+    );
+    expect(runAppRecommendations.mock.invocationCallOrder[0]).toBeLessThan(
+      runBrowserHandoff.mock.invocationCallOrder[0]!,
+    );
+    expect(deps.launchHatchTui).not.toHaveBeenCalled();
+    expect(prompter.outro).toHaveBeenCalledWith("Your browser is ready — I'll be in Settings.");
+  });
 
   it("falls through to the terminal hatch when browser handoff does not connect", async () => {
     const prompter = createWizardPrompter();

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -273,40 +273,43 @@ describe("runGuidedOnboarding", () => {
     );
   });
 
-  it("hands the custodian hatch to the browser after apply and recommendations", async () => {
-    const prompter = createWizardPrompter();
-    const applySetup = vi.fn(async () => ({
-      configPath: "/tmp/openclaw.json",
-      configHashBefore: null,
-      configHashAfter: null,
-      lines: [],
-    }));
-    const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
-      async ({ config }) => config,
-    );
-    const probeBrowserHandoffGateway = vi.fn(async () => ({ ok: true }));
-    const runBrowserHandoff = vi.fn(async () => ({ handedOff: true as const }));
-    const deps = setupDeps({
-      prompter,
-      applySetup,
-      runAppRecommendations,
-      probeBrowserHandoffGateway,
-      runBrowserHandoff,
-      platform: "darwin",
-    });
+  it.each(["darwin", "linux", "win32"] satisfies NodeJS.Platform[])(
+    "hands the custodian hatch to the browser on %s after apply and recommendations",
+    async (platform) => {
+      const prompter = createWizardPrompter();
+      const applySetup = vi.fn(async () => ({
+        configPath: "/tmp/openclaw.json",
+        configHashBefore: null,
+        configHashAfter: null,
+        lines: [],
+      }));
+      const runAppRecommendations = vi.fn<
+        NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>
+      >(async ({ config }) => config);
+      const probeBrowserHandoffGateway = vi.fn(async () => ({ ok: true }));
+      const runBrowserHandoff = vi.fn(async () => ({ handedOff: true as const }));
+      const deps = setupDeps({
+        prompter,
+        applySetup,
+        runAppRecommendations,
+        probeBrowserHandoffGateway,
+        runBrowserHandoff,
+        platform,
+      });
 
-    await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
+      await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
 
-    expect(runBrowserHandoff).toHaveBeenCalledWith({ config: {}, prompter });
-    expect(applySetup.mock.invocationCallOrder[0]).toBeLessThan(
-      runAppRecommendations.mock.invocationCallOrder[0]!,
-    );
-    expect(runAppRecommendations.mock.invocationCallOrder[0]).toBeLessThan(
-      runBrowserHandoff.mock.invocationCallOrder[0]!,
-    );
-    expect(deps.launchHatchTui).not.toHaveBeenCalled();
-    expect(prompter.outro).toHaveBeenCalledWith("Your browser is ready — I'll be in Settings.");
-  });
+      expect(runBrowserHandoff).toHaveBeenCalledWith({ config: {}, prompter });
+      expect(applySetup.mock.invocationCallOrder[0]).toBeLessThan(
+        runAppRecommendations.mock.invocationCallOrder[0]!,
+      );
+      expect(runAppRecommendations.mock.invocationCallOrder[0]).toBeLessThan(
+        runBrowserHandoff.mock.invocationCallOrder[0]!,
+      );
+      expect(deps.launchHatchTui).not.toHaveBeenCalled();
+      expect(prompter.outro).toHaveBeenCalledWith("Your browser is ready — I'll be in Settings.");
+    },
+  );
 
   it("falls through to the terminal hatch when browser handoff does not connect", async () => {
     const prompter = createWizardPrompter();

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -482,7 +482,7 @@ async function runGuidedOnboardingFlow(
         existingConfig.agents?.defaults?.workspace?.trim() || onboardHelpers.DEFAULT_WORKSPACE,
       )
     : workspace;
-  if (opts.tui !== true && (deps.platform ?? process.platform) === "darwin") {
+  if (opts.tui !== true) {
     const probeBrowserHandoffGateway =
       deps.probeBrowserHandoffGateway ??
       (await import("./onboard-browser-handoff.js")).probeBrowserHatchGateway;

--- a/src/commands/onboard-recommendations.test.ts
+++ b/src/commands/onboard-recommendations.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   acknowledgeOnboardRecommendationsCommand,
   onboardRecommendationsCommand,
+  refreshOnboardRecommendationsCommand,
 } from "./onboard-recommendations.js";
 
 function makeRuntime(): RuntimeEnv {
@@ -100,6 +101,18 @@ describe("onboard recommendations command", () => {
 
     expect(acknowledge).toHaveBeenCalledOnce();
     expect(runtime.log).toHaveBeenCalledWith("Onboarding recommendations acknowledged.");
+  });
+
+  it("clears a stored offer for the next onboarding scan", () => {
+    const runtime = makeRuntime();
+    const clear = vi.fn(() => true);
+
+    refreshOnboardRecommendationsCommand(runtime, { clear });
+
+    expect(clear).toHaveBeenCalledOnce();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Onboarding recommendations cleared. The next onboarding run will rescan.",
+    );
   });
 
   it("drops unsafe install identifiers from the bootstrap payload", () => {

--- a/src/commands/onboard-recommendations.ts
+++ b/src/commands/onboard-recommendations.ts
@@ -1,6 +1,7 @@
 import type { RuntimeEnv } from "../runtime.js";
 import {
   acknowledgeOnboardingRecommendations,
+  clearOnboardingRecommendations,
   readOnboardingRecommendations,
   type OnboardingRecommendationsRecord,
 } from "../state/onboarding-recommendations.js";
@@ -8,6 +9,7 @@ import {
 type OnboardRecommendationsDeps = {
   read?: () => OnboardingRecommendationsRecord | null;
   acknowledge?: () => OnboardingRecommendationsRecord | null;
+  clear?: () => boolean;
 };
 
 const SAFE_INSTALL_ID_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/iu;
@@ -73,4 +75,16 @@ export function acknowledgeOnboardRecommendationsCommand(
 ): void {
   const record = (deps.acknowledge ?? acknowledgeOnboardingRecommendations)();
   runtime.log(record ? "Onboarding recommendations acknowledged." : "No stored recommendations.");
+}
+
+export function refreshOnboardRecommendationsCommand(
+  runtime: RuntimeEnv,
+  deps: OnboardRecommendationsDeps = {},
+): void {
+  const cleared = (deps.clear ?? clearOnboardingRecommendations)();
+  runtime.log(
+    cleared
+      ? "Onboarding recommendations cleared. The next onboarding run will rescan."
+      : "No stored recommendations.",
+  );
 }

--- a/src/state/onboarding-recommendations.test.ts
+++ b/src/state/onboarding-recommendations.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   acknowledgeOnboardingRecommendations,
+  clearOnboardingRecommendations,
   readOnboardingRecommendations,
   writeOnboardingRecommendationsOffer,
   type OnboardingRecommendationMatch,
@@ -80,6 +81,23 @@ describe("onboarding recommendations store", () => {
       });
       expect(acknowledged).toEqual({ ...record, acceptedAt: 3_456, updatedAt: 3_456 });
       expect(readOnboardingRecommendations({ env: state.env })).toEqual(acknowledged);
+    });
+  });
+
+  it("deletes the stored offer so recommendations can be scanned again", async () => {
+    await withOpenClawTestState({ label: "onboarding-recommendations-clear" }, async (state) => {
+      const database = { env: state.env };
+      writeOnboardingRecommendationsOffer({
+        inventory: [{ label: "Chat" }],
+        matches,
+        answered: true,
+        nowMs: 4_567,
+        database,
+      });
+
+      expect(clearOnboardingRecommendations(database)).toBe(true);
+      expect(readOnboardingRecommendations(database)).toBeNull();
+      expect(clearOnboardingRecommendations(database)).toBe(false);
     });
   });
 });

--- a/src/state/onboarding-recommendations.ts
+++ b/src/state/onboarding-recommendations.ts
@@ -228,3 +228,22 @@ export function acknowledgeOnboardingRecommendations(
     { operationLabel: "onboarding.recommendations.acknowledge" },
   );
 }
+
+export function clearOnboardingRecommendations(
+  databaseOptions: OpenClawStateDatabaseOptions = {},
+): boolean {
+  return runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<OnboardingRecommendationsDatabase>(database.db);
+      const result = executeSqliteQuerySync(
+        database.db,
+        db
+          .deleteFrom("onboarding_recommendations")
+          .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY),
+      );
+      return (result.numAffectedRows ?? 0n) > 0n;
+    },
+    databaseOptions,
+    { operationLabel: "onboarding.recommendations.clear" },
+  );
+}

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { refreshOnboardRecommendationsCommand } from "../commands/onboard-recommendations.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { OnboardingRecommendationsRecord } from "../state/onboarding-recommendations.js";
@@ -113,6 +114,40 @@ describe("setupAppRecommendations", () => {
     expect(recommend).not.toHaveBeenCalled();
     expect(prompter.progress).not.toHaveBeenCalled();
     expect(writeOffer).not.toHaveBeenCalled();
+  });
+
+  it("scans again after the refresh command clears an answered offer", async () => {
+    let stored: OnboardingRecommendationsRecord | null = {
+      inventoryHash: "hash",
+      matches: [],
+      offeredAt: 1,
+      acceptedAt: 2,
+      updatedAt: 2,
+    };
+    const clear = vi.fn(() => {
+      stored = null;
+      return true;
+    });
+    const recommend = vi.fn(async () => recommendationResult());
+
+    refreshOnboardRecommendationsCommand(runtime, { clear });
+    await setupAppRecommendations({
+      config: {},
+      prompter: createPrompter(),
+      runtime,
+      workspaceDir: "/tmp/workspace",
+      modelRouteVerified: true,
+      platform: "darwin",
+      deps: {
+        recommend,
+        readStored: () => stored,
+        writeOffer: vi.fn(),
+        deferOfferToBootstrap: () => false,
+      },
+    });
+
+    expect(clear).toHaveBeenCalledOnce();
+    expect(recommend).toHaveBeenCalledOnce();
   });
 
   it("reuses a pending stored offer without rescanning and acknowledges the answer", async () => {


### PR DESCRIPTION
## What Problem This Solves

Guided onboarding only attempted the browser-first hatch handoff on macOS, so Linux and Windows users fell back to the terminal even when a graphical session was available. App recommendations also became permanently sticky after acceptance, with no documented way to request a new scan.

## Why This Change Was Made

This enables the existing browser handoff for all local platforms while keeping graphical-session detection responsible for browser launch versus headless URL output. It also adds `openclaw onboard recommendations refresh`, backed by a synchronous Kysely delete of the stored singleton offer, so the next macOS onboarding run rescans. Installed-app recommendation scanning itself remains macOS-only.

AI-assisted implementation; the changes and proof were reviewed before submission.

## User Impact

Linux and Windows desktop users now receive the same browser-first onboarding handoff as macOS users. Headless Linux and SSH sessions receive the authenticated URL and longer wait before terminal fallback. Operators can explicitly clear an answered recommendations offer and rerun onboarding to get fresh matches.

## Evidence

- `node scripts/run-vitest.mjs` over every touched test plus `src/commands/onboard-guided.custodian.test.ts`: 101 tests passed after the final rebase.
- `pnpm tsgo` and `pnpm check:test-types`: passed under Node 24 with worktree-scoped heavy-check locking.
- Type-aware `node scripts/run-oxlint.mjs` over every touched TypeScript file: passed. The guided-flow regression was kept within the existing 1000-line ratchet without suppression.
- `pnpm deadcode:exports`: all production, full-tree, and script scans passed with zero unused exports.
- `pnpm docs:check-mdx`, `git diff --check`, and `pnpm format` over all touched files: passed.
- Source-blind CLI behavior contract in an isolated state directory: help listed `refresh`; pending JSON contained `chat-plugin`; refresh reported success; subsequent JSON was `[]`; a repeated refresh reported no stored recommendations.
- Fresh branch autoreview against `origin/main`: clean, with no accepted/actionable findings.
