### PR TITLE
fix(agents): extract Undici cause.code for ECONNRESET/ECONNREFUSED/ETIMEDOUT

### DIFF
--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -207,10 +207,12 @@ function normalizeTransportErrorBody(value: unknown): string | undefined {
 function extractTransportErrorDetails(error: unknown): TransportErrorDetails {
   const errorObject = error && typeof error === "object" ? error : undefined;
   const nestedError = readObjectProperty(errorObject, "error");
+  const cause = readObjectProperty(errorObject, "cause");
   const errorCode =
     readStringLikeProperty(errorObject, "errorCode") ??
     readStringLikeProperty(errorObject, "code") ??
-    readStringLikeProperty(nestedError, "code");
+    readStringLikeProperty(nestedError, "code") ??
+    readStringLikeProperty(cause, "code");
   const errorType =
     readStringLikeProperty(errorObject, "errorType") ??
     readStringLikeProperty(errorObject, "type") ??

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -141,6 +141,8 @@ type TransportErrorDetails = {
   errorBody?: string;
 };
 
+const MAX_TRANSPORT_ERROR_CAUSE_DEPTH = 8;
+
 function readStringLikeProperty(value: unknown, key: string): string | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
@@ -164,6 +166,24 @@ function readObjectProperty(value: unknown, key: string): Record<string, unknown
   return raw && typeof raw === "object" && !Array.isArray(raw)
     ? (raw as Record<string, unknown>)
     : undefined;
+}
+
+function readCauseChainErrorCode(value: unknown): string | undefined {
+  const seen = new Set<Record<string, unknown>>();
+  let cause = readObjectProperty(value, "cause");
+  for (
+    let depth = 0;
+    cause && depth < MAX_TRANSPORT_ERROR_CAUSE_DEPTH && !seen.has(cause);
+    depth += 1
+  ) {
+    seen.add(cause);
+    const code = readStringLikeProperty(cause, "code");
+    if (code) {
+      return code;
+    }
+    cause = readObjectProperty(cause, "cause");
+  }
+  return undefined;
 }
 
 function stringifyErrorBody(value: unknown): string | undefined {
@@ -207,12 +227,11 @@ function normalizeTransportErrorBody(value: unknown): string | undefined {
 function extractTransportErrorDetails(error: unknown): TransportErrorDetails {
   const errorObject = error && typeof error === "object" ? error : undefined;
   const nestedError = readObjectProperty(errorObject, "error");
-  const cause = readObjectProperty(errorObject, "cause");
   const errorCode =
     readStringLikeProperty(errorObject, "errorCode") ??
     readStringLikeProperty(errorObject, "code") ??
     readStringLikeProperty(nestedError, "code") ??
-    readStringLikeProperty(cause, "code");
+    readCauseChainErrorCode(errorObject);
   const errorType =
     readStringLikeProperty(errorObject, "errorType") ??
     readStringLikeProperty(errorObject, "type") ??

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -114,4 +114,26 @@ describe("transport stream shared helpers", () => {
       expect(output.errorMessage).toBeTruthy();
     }
   });
+
+  it("extracts error code from cause.code for Undici network errors", () => {
+    // Simulates a "fetch failed" error where Undici wraps a SocketError with
+    // code ECONNRESET in the cause chain. Verifies via assignTransportErrorDetails
+    // which calls extractTransportErrorDetails internally.
+    const output: { stopReason: string; errorCode?: string } = { stopReason: "stop" };
+    assignTransportErrorDetails(output, {
+      message: "fetch failed",
+      cause: { code: "ECONNRESET" },
+    });
+    expect(output.errorCode).toBe("ECONNRESET");
+  });
+
+  it("prefers top-level errorCode over cause.code", () => {
+    const output: { stopReason: string; errorCode?: string } = { stopReason: "stop" };
+    assignTransportErrorDetails(output, {
+      errorCode: "TOP_LEVEL",
+      code: "MIDDLE",
+      cause: { code: "CAUSE_CODE" },
+    });
+    expect(output.errorCode).toBe("TOP_LEVEL");
+  });
 });

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -6,9 +6,12 @@ import {
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
 } from "@openclaw/ai/transports";
+import OpenAI from "openai";
 // Transport stream shared tests cover payload sanitization, header merging, and
 // final/error stream termination helpers used by provider transports.
 import { describe, expect, it, vi } from "vitest";
+import { classifyAssistantFailoverReason } from "./embedded-agent-helpers.js";
+import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
 
 describe("transport stream shared helpers", () => {
   it("sanitizes unpaired surrogate code units", () => {
@@ -115,25 +118,36 @@ describe("transport stream shared helpers", () => {
     }
   });
 
-  it("extracts error code from cause.code for Undici network errors", () => {
-    // Simulates a "fetch failed" error where Undici wraps a SocketError with
-    // code ECONNRESET in the cause chain. Verifies via assignTransportErrorDetails
-    // which calls extractTransportErrorDetails internally.
-    const output: { stopReason: string; errorCode?: string } = { stopReason: "stop" };
-    assignTransportErrorDetails(output, {
-      message: "fetch failed",
-      cause: { code: "ECONNRESET" },
+  it("extracts Undici codes through the OpenAI SDK error wrapper", () => {
+    const socketError = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:65534"), {
+      code: "ECONNREFUSED",
     });
-    expect(output.errorCode).toBe("ECONNRESET");
+    const fetchError = new TypeError("fetch failed", { cause: socketError });
+    const sdkError = new OpenAI.APIConnectionError({ cause: fetchError });
+    const output = makeAssistantMessageFixture({ stopReason: "stop", content: [] });
+
+    assignTransportErrorDetails(output, sdkError);
+
+    expect(output.errorCode).toBe("ECONNREFUSED");
+    expect(classifyAssistantFailoverReason(output)).toBe("timeout");
   });
 
-  it("prefers top-level errorCode over cause.code", () => {
+  it("prefers top-level errorCode over nested cause codes", () => {
     const output: { stopReason: string; errorCode?: string } = { stopReason: "stop" };
     assignTransportErrorDetails(output, {
       errorCode: "TOP_LEVEL",
       code: "MIDDLE",
-      cause: { code: "CAUSE_CODE" },
+      cause: { code: "CAUSE_CODE", cause: { code: "DEEP_CAUSE_CODE" } },
     });
     expect(output.errorCode).toBe("TOP_LEVEL");
+  });
+
+  it("stops traversing cyclic cause chains", () => {
+    const error: { cause?: unknown } = {};
+    error.cause = error;
+    const output: { stopReason: string; errorCode?: string } = { stopReason: "stop" };
+
+    expect(() => assignTransportErrorDetails(output, error)).not.toThrow();
+    expect(output.errorCode).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

OpenAI's SDK wraps Undici connection failures in a cause chain:

```text
OpenAI.APIConnectionError
└─ TypeError: fetch failed
   └─ SocketError: ECONNREFUSED
```

The shared transport normalizer previously inspected top-level error fields but did not walk that chain. The resulting assistant error had no structured `errorCode`, so failover depended on generic message text instead of the network signal.

## Changed

- Preserve the existing priority: `errorCode` → `code` → nested `error.code`.
- If those fields are absent, walk object-valued `cause` links for a string/finite-number `code`.
- Bound traversal to eight causes and stop on cycles.
- Cover the actual OpenAI SDK wrapper shape, top-level precedence, and cyclic causes.

No config, schema, dependency, or user-facing API surface changes.

## Review aids

```mermaid
flowchart LR
  A["OpenAI transport request"] --> B["Undici socket failure"]
  B --> C["OpenAI.APIConnectionError cause chain"]
  C --> D["transport errorCode = ECONNREFUSED"]
  D --> E["failover reason = timeout"]
  E --> F["next configured model"]
  F --> G["successful response"]
```

The owner boundary remains the shared transport normalizer: all downstream failover classifiers already consume `AssistantMessage.errorCode`.

## Evidence

Current head: `755b4307d0bd156f67841d1833b2d9feabce31d5`

- GitHub CI: green on the current head.
- Cloudflare current-tree checks: formatter clean, type-aware oxlint clean, focused transport tests 13/13.
- Independent autoreview: no findings.

### Real OpenClaw failover

Ran the actual current-head OpenClaw CLI through Crabbox on Cloudflare Containers. The primary was an OpenAI Responses provider pointed at a freshly closed loopback port; the fallback was the real `openai/gpt-5.6-luna` provider using only a scoped `OPENAI_API_KEY` injection.

A temporary observation-only `llm_output` hook recorded only provider, model, stop reason, normalized error code, and assistant text. It had prompt injection disabled and did not replace or mock the model transport. The harness failed closed unless OpenClaw's own structured logs also recorded the timeout classification, model transition, and fallback success. It was removed after the run.

Backend: `cloudflare`  
Crabbox lease: `cbx_5d66c36dc5b4`  
Exit: `0`

```json
{
  "proof": "PASS",
  "sourceHead": "755b4307d0bd156f67841d1833b2d9feabce31d5",
  "execution": "OpenClaw CLI agent --local",
  "primary": "openai-failover-proof/gpt-5.6-luna",
  "primaryEndpoint": "http://127.0.0.1:43187/v1",
  "observedPrimaryStopReason": "error",
  "extractedErrorCode": "ECONNREFUSED",
  "failoverDecision": "fallback_model",
  "failoverReason": "timeout",
  "nextProvider": "openai",
  "nextModel": "gpt-5.6-luna",
  "fallbackOutcome": "candidate_succeeded",
  "fallbackResponse": "FAILOVER_OK"
}
```

This is an end-to-end provider request and fallback, not a direct helper invocation or simulated error object.

## Files

| File | Change |
| --- | --- |
| `packages/ai/src/transports/transport-stream-shared.ts` | Bounded, cycle-safe cause-chain code extraction |
| `src/agents/transport-stream-shared.test.ts` | OpenAI/Undici wrapper, precedence, and cycle coverage |

Net diff: 58 additions, 1 deletion.
