### PR TITLE
docs: explain that downgrades stop working after updating to 2026.7.2

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8649,6 +8649,10 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Agent schema history
   - H2: State schema history
   - H2: Integrity checks
+  - H2: Troubleshooting
+  - H3: Why you cannot go back after updating to 2026.7.2
+  - H3: The Gateway refuses to start with a newer schema version error
+  - H3: A database is quarantined after integrity verification failed
   - H2: Downgrades are unsupported
   - H3: Example: agent schema 11 to 9
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -66,6 +66,28 @@ Version 3 was an unshipped development step folded into version 4.
 The Gateway preflight reads schema headers only. The background verifier owns the slower full scan for databases that do not need migration.
 Quarantine decisions live in a dedicated `openclaw-quarantine.sqlite` store, so they survive damage to the databases being quarantined. The global `database_verifications` table remains verification history.
 
+## Troubleshooting
+
+### Why you cannot go back after updating to 2026.7.2
+
+Every release through `v2026.7.1` used agent schema 1 and state schema 1. The 2026.7.2 release train (starting with `v2026.7.2-beta.1`) migrates your databases forward on first start. That migration is one-way: the data is rewritten into the newer schema, and installing an older OpenClaw afterwards does not undo it. The older build refuses to start with a `newer schema version` error that names the build that owns the database.
+
+Downgrading the binary never downgrades the data. If you must run a release older than 2026.7.2 after updating, you have three options:
+
+1. Restore a backup taken before the update. [Create and verify backups](/cli/backup) before major updates.
+2. Run the older build against a separate state directory (`OPENCLAW_STATE_DIR`). It starts fresh; your migrated data stays untouched for when you return to the newer build.
+3. Follow the manual downgrade procedure below. It is unsupported and risks data loss without a verified backup.
+
+Since 2026.7.2, `openclaw update` refuses to install a release that cannot open your current databases, so the updater will not put you in this situation. Installing an older version manually through npm bypasses that guard; the databases still refuse the old binary, but only after it is installed.
+
+### The Gateway refuses to start with a newer schema version error
+
+A newer OpenClaw build wrote your databases, and the running build is older. The error and the Gateway startup log name the build that owns the database (`app_version`). Install that version or newer, or use one of the options above. Do not edit the database to silence the error.
+
+### A database is quarantined after integrity verification failed
+
+The background verifier proved the file is corrupt, and every open now fails fast instead of rescanning. Restore the database from a backup or repair it, then run `openclaw doctor --fix` to clear the quarantine record. Doctor reports an explicit error if the quarantine record itself cannot be cleared; rerun it until it reports clean.
+
 ## Downgrades are unsupported
 
 Manual schema downgrades are for agents and operators who accept the risk. [Create and verify a backup](/cli/backup) before editing any database. Stop the Gateway and every process that can open the database.


### PR DESCRIPTION
## What Problem This Solves

Users updating to the 2026.7.2 release train get one-way database migrations (agent schema 1 -> 9+, state 1 -> 3), and the existing docs explain the mechanics but not the practical consequence: you cannot go back to 2026.7.1 or earlier once migrated. Support threads (Discord, Dave Morin's downgrade incident behind #110271) show this is the first question people hit.

## Why This Change Was Made

Adds a Troubleshooting section to /reference/database-schemas covering: why downgrades stop working after updating to 2026.7.2 (with the three real options: restore a pre-update backup, separate state directory, or the unsupported manual recipe), what the "newer schema version" startup refusal means and that the error names the owning build, and how to recover from a quarantined database via doctor. Also notes that `openclaw update` refuses incompatible installs since 2026.7.2 while manual npm installs bypass that guard.

## User Impact

Docs-only. Clear, linkable answer for the most common post-2026.7.2 support question; the runtime error messages already point at this page.

## Evidence

- Docs-only change: `node scripts/docs-link-audit.mjs` 6070 links, 0 broken; `node scripts/generate-docs-map.mjs --check` clean after regen; i18n glossary guard exit 0; `git diff --check` clean.
