### PR TITLE
fix(signal): preserve reverse-proxy path prefixes

### DIFF
--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -92,6 +92,24 @@ describe("signalRpcRequest", () => {
     expect(result).toEqual({ version: "0.13.22" });
   });
 
+  it("preserves path-prefixed base URLs for RPC requests", async () => {
+    const serverUrl = await withSignalServer(async (req, res) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/signal/api/v1/rpc");
+      expect(JSON.parse(await readRequestBody(req))).toMatchObject({
+        method: "version",
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ jsonrpc: "2.0", result: { version: "0.13.22" }, id: "test-id" }));
+    });
+
+    await expect(
+      signalRpcRequest<{ version: string }>("version", undefined, {
+        baseUrl: `${serverUrl}/signal/`,
+      }),
+    ).resolves.toEqual({ version: "0.13.22" });
+  });
+
   it("throws a wrapped error when RPC response JSON is malformed", async () => {
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(502, { "Content-Type": "text/plain" });
@@ -256,6 +274,21 @@ describe("signalCheck", () => {
     await expect(signalCheck(baseUrl)).resolves.toEqual({ ok: true, status: 204, error: null });
   });
 
+  it("preserves path-prefixed base URLs for health checks", async () => {
+    const serverUrl = await withSignalServer((req, res) => {
+      expect(req.method).toBe("GET");
+      expect(req.url).toBe("/signal/api/v1/check");
+      res.writeHead(204);
+      res.end();
+    });
+
+    await expect(signalCheck(`${serverUrl}/signal`)).resolves.toEqual({
+      ok: true,
+      status: 204,
+      error: null,
+    });
+  });
+
   it("returns an HTTP status failure for unhealthy checks", async () => {
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(503);
@@ -283,6 +316,25 @@ describe("streamSignalEvents", () => {
 
     await streamSignalEvents({
       baseUrl,
+      account: "+15555550123",
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events).toEqual([{ id: "42", event: "message", data: '{"group":true}' }]);
+  });
+
+  it("preserves path-prefixed base URLs for event streams", async () => {
+    type StreamEvent = Parameters<Parameters<typeof streamSignalEvents>[0]["onEvent"]>[0];
+    const events: StreamEvent[] = [];
+    const serverUrl = await withSignalServer((req, res) => {
+      expect(req.url).toBe("/signal/api/v1/events?account=%2B15555550123");
+      expect(req.headers.accept).toBe("text/event-stream");
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end('id: 42\nevent: message\ndata: {"group":true}\n\n');
+    });
+
+    await streamSignalEvents({
+      baseUrl: `${serverUrl}/signal`,
       account: "+15555550123",
       onEvent: (event) => events.push(event),
     });

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -68,7 +68,12 @@ function parseSignalBaseUrl(url: string): URL {
 }
 
 function resolveSignalEndpointUrl(baseUrl: string, pathname: string): URL {
-  return new URL(pathname, parseSignalBaseUrl(baseUrl));
+  const parsed = parseSignalBaseUrl(baseUrl);
+  const basePath = parsed.pathname.endsWith("/") ? parsed.pathname : `${parsed.pathname}/`;
+  parsed.pathname = `${basePath}${pathname.replace(/^\/+/, "")}`;
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed;
 }
 
 function parseSignalRpcResponse<T>(text: string, status: number): SignalRpcResponse<T> {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the native Signal channel behind a reverse proxy path prefix, such as `http://127.0.0.1:8080/signal`, would still send RPC, health-check, and SSE requests to the origin root (`/api/v1/...`) instead of the configured prefix (`/signal/api/v1/...`).

That can make Signal send/check/receive flows fail with 404s even though `channels.signal.httpUrl` points at the correct mounted Signal service.

## Why This Change Was Made

`resolveSignalEndpointUrl` now keeps the parsed base URL pathname before appending the Signal native endpoint suffix. Root-mounted base URLs keep the existing `/api/v1/...` behavior, while path-prefixed base URLs now resolve beneath the configured prefix.

The change is limited to the native Signal client URL join helper. Container-mode Signal URL construction is separate and already preserves its configured path prefix, so it is intentionally unchanged.

## User Impact

Operators can run the native Signal HTTP/SSE API behind a path-prefixed reverse proxy and use the same configured `httpUrl` for sends, health checks, and event streaming.

## Evidence

### Live reverse-proxy behavior proof

I ran the current PR head against a local path-prefixed reverse-proxy setup:

```text
OpenClaw Signal native client
-> http://127.0.0.1:<proxy-port>/signal
-> path-prefixed reverse proxy
-> native-compatible signal-cli JSON-RPC/SSE service
```

This proof does not use a private Signal account or credentials. It validates the deployment behavior changed by this PR: the native OpenClaw Signal client preserves the configured `httpUrl` pathname before sending RPC, health-check, and SSE requests.

```text
[proof topology] OpenClaw Signal native client -> path-prefixed reverse proxy -> native-compatible signal-cli JSON-RPC/SSE service
[proof baseUrl] http://127.0.0.1:63713/signal
[before-current-main-shape] new URL('/api/v1/check', baseUrl).pathname=/api/v1/check -> HTTP 404
[openclaw] signalCheck(baseUrl) -> ok=true status=204
[openclaw] signalRpcRequest('version') -> {version:proof-signal-native}
[openclaw] streamSignalEvents(account=<redacted-e164>) -> [{event:message,data:{"source":"reverse-proxy-proof"},id:proof-1}]
[proxy] GET /api/v1/check rejected outside /signal mount -> 404
[proxy] GET /signal/api/v1/check -> 204
[proxy] POST /signal/api/v1/rpc -> 200
[proxy] GET /signal/api/v1/events?account=<redacted-e164> -> 200
[mock-native-signal] GET /api/v1/check -> 204
[mock-native-signal] POST /api/v1/rpc method=version -> 200
[mock-native-signal] GET /api/v1/events?account=<redacted-e164> accept=text/event-stream -> 200
```

### Focused tests

Focused behavior covered in tests:

- RPC request: `http://server/signal/` resolves to `/signal/api/v1/rpc`.
- Health check: `http://server/signal` resolves to `/signal/api/v1/check`.
- SSE receive stream: `http://server/signal` resolves to `/signal/api/v1/events?account=...`.

Local validation:

```text
D:\ZXY\Dev\nodejs\node.exe scripts/run-vitest.mjs extensions/signal/src/client.test.ts
# Test Files 1 passed (1)
# Tests 22 passed (22)

D:\ZXY\Dev\nodejs\node.exe scripts/run-vitest.mjs extensions/signal/src/client.test.ts extensions/signal/src/client-adapter.test.ts extensions/signal/src/client-container.test.ts
# Test Files 3 passed (3)
# Tests 120 passed (120)

git diff --check
# passed

pnpm exec oxfmt --check extensions/signal/src/client.ts extensions/signal/src/client.test.ts
# All matched files use the correct format.

pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/signal/src/client.ts extensions/signal/src/client.test.ts
# passed
```

`pnpm check:changed` was also attempted locally, but it did not reach repository checks because the local `crabbox` binary failed its basic `--version` / `--help` sanity check before dispatching Blacksmith Testbox.

Remote CI note: the PR's own `extensions/signal/src/client.test.ts` shard passed on GitHub. The current red `checks-node-changed-*` jobs fail in existing Signal monitor harness tests that do not execute this URL helper; those failures are tracked separately from this path-prefix proof.

Open PR overlap checked with `gh search prs` for `signal baseUrl path prefix`, `resolveSignalEndpointUrl`, and `signal reverse proxy path`; no matching open PR was found.

Prepared with AI assistance; the commit includes the verified Codex bot co-author trailer.