### PR TITLE
fix(gateway): audit managed service starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Gateway start audit:** record successful managed-service starts across launchd, systemd, and Windows Scheduled Tasks in `gateway-restart.log` while keeping already-running starts silent.
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Gateway start audit:** record successful managed-service starts across launchd, systemd, and Windows Scheduled Tasks in `gateway-restart.log` while keeping already-running starts silent.
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.

--- a/src/cli/daemon-cli.coverage.test.ts
+++ b/src/cli/daemon-cli.coverage.test.ts
@@ -14,6 +14,7 @@ const resolveGatewayProgramArguments = vi.fn(async (_opts?: unknown) => ({
 const serviceInstall = vi.fn().mockResolvedValue(undefined);
 const serviceStage = vi.fn().mockResolvedValue(undefined);
 const serviceUninstall = vi.fn().mockResolvedValue(undefined);
+const serviceStart = vi.fn().mockResolvedValue({ outcome: "completed" });
 const serviceStop = vi.fn().mockResolvedValue(undefined);
 const serviceRestart = vi.fn().mockResolvedValue({ outcome: "completed" });
 const serviceIsLoaded = vi.fn().mockResolvedValue(false);
@@ -100,6 +101,7 @@ vi.mock("../daemon/service.js", async () => {
       stage: serviceStage,
       install: serviceInstall,
       uninstall: serviceUninstall,
+      start: serviceStart,
       stop: serviceStop,
       restart: serviceRestart,
       isLoaded: serviceIsLoaded,
@@ -347,7 +349,7 @@ describe("daemon-cli coverage", () => {
 
   it("starts and stops daemon (json output)", async () => {
     runtimeLogs.length = 0;
-    serviceRestart.mockClear();
+    serviceStart.mockClear();
     serviceStop.mockClear();
     serviceIsLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValueOnce({ status: "stopped" });
@@ -355,7 +357,7 @@ describe("daemon-cli coverage", () => {
     await runDaemonCommand(["daemon", "start", "--json"]);
     await runDaemonCommand(["daemon", "stop", "--json", "--force"]);
 
-    expect(serviceRestart).toHaveBeenCalledTimes(1);
+    expect(serviceStart).toHaveBeenCalledTimes(1);
     expect(serviceStop).toHaveBeenCalledTimes(1);
     const jsonLines = runtimeLogs.filter((line) => line.trim().startsWith("{"));
     const parsed = jsonLines.map((line) => JSON.parse(line) as { action?: string; ok?: boolean });

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -223,7 +223,7 @@ describe("runServiceStart config pre-flight (#35862)", () => {
 
     await expect(runServiceStart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
 
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
     expectLatestRuntimeJson({
       action: "start",
       ok: false,
@@ -239,7 +239,7 @@ describe("runServiceStart config pre-flight (#35862)", () => {
 
     await expect(runServiceStart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
 
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
     expectLatestRuntimeJson({
       action: "start",
       ok: false,
@@ -269,7 +269,7 @@ describe("runServiceStart config pre-flight (#35862)", () => {
     ).rejects.toThrow("__exit__:1");
 
     expect(onNotLoaded).not.toHaveBeenCalled();
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
   it("proceeds with start when config is valid", async () => {
@@ -277,7 +277,7 @@ describe("runServiceStart config pre-flight (#35862)", () => {
 
     await runServiceStart(createServiceRunArgs());
 
-    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(service.start).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -436,7 +436,7 @@ describe("runServiceRestart token drift", () => {
     expect(payload.result).toBe("started");
     expect(payload.message).toContain("re-bootstrapped");
     expect(payload.service?.loaded).toBe(true);
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
   it("runs restart health checks after an unmanaged restart signal", async () => {
@@ -580,8 +580,8 @@ describe("runServiceRestart token drift", () => {
     expect(clearGatewayRestartIntentSync).toHaveBeenCalledOnce();
   });
 
-  it("emits scheduled when service start routes through a scheduled restart", async () => {
-    service.restart.mockResolvedValue({ outcome: "scheduled" });
+  it("emits scheduled when service start is deferred", async () => {
+    service.start.mockResolvedValue({ outcome: "scheduled" });
 
     await runServiceStart({
       serviceNoun: "Gateway",
@@ -596,7 +596,7 @@ describe("runServiceRestart token drift", () => {
     expect(payload.message).toBe("restart scheduled, gateway will restart momentarily");
   });
 
-  it("reports an already-running gateway without restarting it", async () => {
+  it("reports an already-running gateway without starting it", async () => {
     service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
 
     await runServiceStart({
@@ -612,12 +612,12 @@ describe("runServiceRestart token drift", () => {
       result: "already-running",
       message: "Gateway service already running (pid 4242).",
     });
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
     expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
   });
 
   it("audits a service start that actually mutates the gateway", async () => {
-    service.restart.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
+    service.start.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
       args?.onMutation?.({ mode: "kickstart" });
       return { outcome: "completed" };
     });
@@ -667,7 +667,7 @@ describe("runServiceRestart token drift", () => {
   });
 
   it("captures service start warnings in json start output", async () => {
-    service.restart.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
+    service.start.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
       args?.warn?.(
         "Existing generated LaunchAgent env wrapper contains custom behavior and will be overwritten.",
       );
@@ -685,7 +685,7 @@ describe("runServiceRestart token drift", () => {
     expect(payload.warnings).toContain(
       "Existing generated LaunchAgent env wrapper contains custom behavior and will be overwritten.",
     );
-    expect(service.restart).toHaveBeenCalledWith(
+    expect(service.start).toHaveBeenCalledWith(
       expect.objectContaining({ warn: expect.any(Function) }),
     );
   });
@@ -719,7 +719,7 @@ describe("runServiceRestart token drift", () => {
     });
 
     expect(repairLoadedService).toHaveBeenCalledTimes(1);
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
     const payload = readJsonLog<{
       result?: string;
       message?: string;
@@ -749,12 +749,12 @@ describe("runServiceRestart token drift", () => {
     expect(payload.ok).toBe(false);
     expect(payload.error).toContain("service needs repair");
     expect(payload.hints).toEqual(["openclaw gateway install --force"]);
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
-  it("fails start when restarting a stopped installed service errors", async () => {
+  it("fails start when starting a stopped installed service errors", async () => {
     service.isLoaded.mockResolvedValue(false);
-    service.restart.mockRejectedValue(new Error("launchctl kickstart failed: permission denied"));
+    service.start.mockRejectedValue(new Error("launchctl kickstart failed: permission denied"));
 
     await expect(runServiceStart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
 
@@ -788,6 +788,6 @@ describe("runServiceRestart token drift", () => {
         (item) => item.kind === "install" && item.text === "openclaw gateway install",
       ),
     ).toBe(true);
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon-cli/test-helpers/lifecycle-core-harness.ts
+++ b/src/cli/daemon-cli/test-helpers/lifecycle-core-harness.ts
@@ -12,6 +12,7 @@ type LifecycleServiceHarness = GatewayService & {
   stage: MockFn<GatewayService["stage"]>;
   install: MockFn<GatewayService["install"]>;
   uninstall: MockFn<GatewayService["uninstall"]>;
+  start: MockFn<GatewayService["start"]>;
   stop: MockFn<GatewayService["stop"]>;
   isLoaded: MockFn<GatewayService["isLoaded"]>;
   readCommand: MockFn<GatewayService["readCommand"]>;
@@ -28,6 +29,7 @@ export const service: LifecycleServiceHarness = {
   stage: vi.fn(),
   install: vi.fn(),
   uninstall: vi.fn(),
+  start: vi.fn(),
   stop: vi.fn(),
   isLoaded: vi.fn(),
   readCommand: vi.fn(),
@@ -43,6 +45,7 @@ export function resetLifecycleServiceMocks() {
   service.stage.mockReset();
   service.install.mockReset();
   service.uninstall.mockReset();
+  service.start.mockReset();
   service.stop.mockReset();
   service.isLoaded.mockReset();
   service.readCommand.mockReset();
@@ -53,6 +56,7 @@ export function resetLifecycleServiceMocks() {
   service.readRuntime.mockResolvedValue({ status: "stopped" });
   service.stop.mockResolvedValue(undefined);
   service.uninstall.mockResolvedValue(undefined);
+  service.start.mockResolvedValue({ outcome: "completed" });
   service.restart.mockResolvedValue({ outcome: "completed" });
 }
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,5 +1,6 @@
 // Launchd tests cover macOS service plist generation and command handling.
 import { PassThrough } from "node:stream";
+import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
@@ -19,6 +20,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  startLaunchAgent,
   stopLaunchAgent,
 } from "./launchd.js";
 
@@ -1995,6 +1997,66 @@ describe("launchd install", () => {
     expect(launchctlCommandNames()).not.toContain("bootout");
     expect(launchctlCommandNames()).not.toContain("bootstrap");
     expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }], [{ mode: "kickstart" }]]);
+  });
+
+  it("starts a loaded LaunchAgent and audits before output", async () => {
+    const env = createDefaultLaunchdEnv();
+    const write = vi.fn();
+    const onMutation = vi.fn(({ mode }: { mode: string }) => {
+      if (mode === "kickstart") {
+        throw new Error("audit failed");
+      }
+    });
+
+    await expect(
+      startLaunchAgent({
+        env,
+        stdout: { write } as unknown as NodeJS.WritableStream,
+        onMutation,
+      }),
+    ).resolves.toEqual({ outcome: "completed" });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    expect(state.launchctlCalls).toEqual([
+      ["enable", serviceId],
+      ["kickstart", serviceId],
+    ]);
+    expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }], [{ mode: "kickstart" }]]);
+    expect(
+      expectDefined(onMutation.mock.invocationCallOrder[1], "kickstart audit call order"),
+    ).toBeLessThan(expectDefined(write.mock.invocationCallOrder[0], "start output call order"));
+  });
+
+  it("bootstraps an unloaded LaunchAgent and audits the successful mutation", async () => {
+    const env = createDefaultLaunchdEnv();
+    const onMutation = vi.fn();
+    state.kickstartError = "Could not find service";
+    state.kickstartFailuresRemaining = 1;
+
+    await startLaunchAgent({ env, stdout: new PassThrough(), onMutation });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    expect(state.launchctlCalls).toEqual([
+      ["enable", serviceId],
+      ["kickstart", serviceId],
+      ["bootstrap", domain, resolveLaunchAgentPlistPath(env)],
+    ]);
+    expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }], [{ mode: "bootstrap" }]]);
+  });
+
+  it("audits enable but not kickstart when the later launch fails", async () => {
+    const env = createDefaultLaunchdEnv();
+    const onMutation = vi.fn();
+    state.kickstartError = "Input/output error";
+    state.kickstartFailuresRemaining = 1;
+
+    await expect(startLaunchAgent({ env, stdout: new PassThrough(), onMutation })).rejects.toThrow(
+      "launchctl kickstart failed: Input/output error",
+    );
+
+    expect(onMutation.mock.calls).toEqual([[{ mode: "enable" }]]);
   });
 
   it("audits kickstart before a later output failure", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -608,12 +608,15 @@ async function bootstrapLaunchAgentOrThrow(params: {
   plistPath: string;
   actionHint: string;
   onMutation?: (mode: "enable" | "bootstrap") => void;
+  skipEnable?: boolean;
 }) {
   // `disable` state survives bootout and plist rewrites; explicit start/repair
   // paths must clear it before asking launchd to load the job again.
-  const enable = await execLaunchctl(["enable", params.serviceTarget]);
-  if (enable.code === 0) {
-    params.onMutation?.("enable");
+  if (!params.skipEnable) {
+    const enable = await execLaunchctl(["enable", params.serviceTarget]);
+    if (enable.code === 0) {
+      params.onMutation?.("enable");
+    }
   }
   const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
   if (boot.code === 0) {
@@ -1252,6 +1255,57 @@ async function ensureLaunchAgentLoadedAfterFailure(params: {
   }
 }
 
+function createLaunchAgentMutationReporter(
+  onMutation: GatewayServiceControlArgs["onMutation"],
+): (mode: string) => void {
+  return (mode) => {
+    try {
+      onMutation?.({ mode });
+    } catch {
+      // Audit observers are diagnostic; never interrupt service control.
+    }
+  };
+}
+
+export async function startLaunchAgent({
+  stdout,
+  env,
+  onMutation,
+}: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
+  const serviceEnv = env ?? (process.env as GatewayServiceEnv);
+  const domain = resolveGuiDomain();
+  const label = resolveLaunchAgentLabel({ env: serviceEnv });
+  const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const serviceTarget = `${domain}/${label}`;
+  const reportMutation = createLaunchAgentMutationReporter(onMutation);
+
+  // Enable is an independent mutation; audit it even if the later launch fails.
+  const enable = await execLaunchctl(["enable", serviceTarget]);
+  const enabled = enable.code === 0;
+  if (enabled) {
+    reportMutation("enable");
+  }
+
+  const start = await execLaunchctl(["kickstart", serviceTarget]);
+  if (start.code === 0) {
+    reportMutation("kickstart");
+  } else if (isLaunchctlNotLoaded(start)) {
+    await bootstrapLaunchAgentOrThrow({
+      domain,
+      serviceTarget,
+      plistPath,
+      actionHint: "openclaw gateway start",
+      onMutation: reportMutation,
+      skipEnable: enabled,
+    });
+  } else {
+    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+  }
+
+  writeLaunchAgentActionLine(stdout, "Started LaunchAgent", serviceTarget);
+  return { outcome: "completed" };
+}
+
 export async function restartLaunchAgent({
   stdout,
   env,
@@ -1263,13 +1317,7 @@ export async function restartLaunchAgent({
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
   const serviceTarget = `${domain}/${label}`;
-  const reportMutation = (mode: string) => {
-    try {
-      onMutation?.({ mode });
-    } catch {
-      // Audit observers are diagnostic; never interrupt a multi-step restart.
-    }
-  };
+  const reportMutation = createLaunchAgentMutationReporter(onMutation);
 
   // Restart requests issued from inside the managed gateway process tree need a
   // detached handoff. A direct `kickstart -k` would terminate the caller before

--- a/src/daemon/node-service.ts
+++ b/src/daemon/node-service.ts
@@ -61,6 +61,9 @@ export function resolveNodeService(): GatewayService {
     uninstall: async (args) => {
       return base.uninstall({ ...args, env: withNodeServiceEnv(args.env) });
     },
+    start: async (args) => {
+      return base.start({ ...args, env: withNodeServiceEnv(args.env ?? {}) });
+    },
     stop: async (args) => {
       return base.stop({ ...args, env: withNodeServiceEnv(args.env ?? {}) });
     },

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -54,6 +54,7 @@ vi.mock("../utils.js", async () => {
 const {
   restartScheduledTask,
   resumeScheduledTaskAutoStartAfterUpdate,
+  startScheduledTask,
   stopScheduledTask,
   suspendScheduledTaskAutoStartForUpdate,
 } = await import("./schtasks.js");
@@ -350,6 +351,39 @@ describe("Scheduled Task stop/restart cleanup", () => {
       expectGatewayTermination(4242);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
       expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-stop" });
+    });
+  });
+
+  it("starts a registered task and ignores audit observer failures", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        {
+          ...SUCCESS_RESPONSE,
+          stdout: "Status: Running\r\nLast Run Result: 0x41301\r\n",
+        },
+      );
+      const write = vi.fn();
+      const onMutation = vi.fn(() => {
+        throw new Error("audit failed");
+      });
+
+      await expect(
+        startScheduledTask({
+          env,
+          stdout: { write } as unknown as NodeJS.WritableStream,
+          onMutation,
+        }),
+      ).resolves.toEqual({ outcome: "completed" });
+
+      expect(schtasksCalls).toContainEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-start" });
+      expect(
+        expectDefined(onMutation.mock.invocationCallOrder[0], "start audit call order"),
+      ).toBeLessThan(expectDefined(write.mock.invocationCallOrder[0], "start output call order"));
     });
   });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1203,6 +1203,17 @@ async function restartStartupEntry(
   return { outcome: "completed" };
 }
 
+async function startStartupEntry(
+  env: GatewayServiceEnv,
+  stdout: NodeJS.WritableStream,
+  onMutation?: () => void,
+): Promise<GatewayServiceRestartResult> {
+  await launchFallbackTaskScript(env);
+  onMutation?.();
+  stdout.write(`${formatLine("Started Windows login item", resolveTaskName(env))}\n`);
+  return { outcome: "completed" };
+}
+
 const CALLER_OWNED_SERVICE_IDENTITY_KEYS = [
   "OPENCLAW_LAUNCHD_LABEL",
   "OPENCLAW_SYSTEMD_UNIT",
@@ -1912,6 +1923,47 @@ export async function stopScheduledTask({
     }
   }
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
+}
+
+export async function startScheduledTask({
+  stdout,
+  env,
+  onMutation,
+}: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
+  const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
+  const reportMutation = (mode: string) => {
+    try {
+      onMutation?.({ mode });
+    } catch {
+      // Audit observers are diagnostic; never interrupt service control.
+    }
+  };
+  try {
+    await assertSchtasksAvailable();
+  } catch (err) {
+    if (await isStartupEntryInstalled(effectiveEnv)) {
+      return await startStartupEntry(effectiveEnv, stdout, () =>
+        reportMutation("startup-entry-start"),
+      );
+    }
+    throw err;
+  }
+  if (!(await isRegisteredScheduledTask(effectiveEnv))) {
+    if (await isStartupEntryInstalled(effectiveEnv)) {
+      return await startStartupEntry(effectiveEnv, stdout, () =>
+        reportMutation("startup-entry-start"),
+      );
+    }
+  }
+  const taskName = resolveTaskName(effectiveEnv);
+  await runScheduledTaskOrThrow({
+    taskName,
+    env: effectiveEnv,
+    scriptPath: resolveTaskScriptPath(effectiveEnv),
+    onMutation: () => reportMutation("schtasks-start"),
+  });
+  stdout.write(`${formatLine("Started Scheduled Task", taskName)}\n`);
+  return { outcome: "completed" };
 }
 
 async function restartRegisteredScheduledTask(params: {

--- a/src/daemon/service.test-helpers.ts
+++ b/src/daemon/service.test-helpers.ts
@@ -11,6 +11,7 @@ export function createMockGatewayService(overrides: Partial<GatewayService> = {}
     stage: vi.fn(async () => {}),
     install: vi.fn(async () => {}),
     uninstall: vi.fn(async () => {}),
+    start: vi.fn(async () => ({ outcome: "completed" as const })),
     stop: vi.fn(async () => {}),
     restart: vi.fn(async () => ({ outcome: "completed" as const })),
     isLoaded: vi.fn(async () => false),

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -52,6 +52,9 @@ describe("resolveGatewayService", () => {
       status: "unknown",
       detail: "Gateway service install not supported on aix",
     });
+    await expect(service.start({ env: process.env, stdout: process.stdout })).rejects.toThrow(
+      "Gateway service install not supported on aix",
+    );
     await expect(service.restart({ env: process.env, stdout: process.stdout })).rejects.toThrow(
       "Gateway service install not supported on aix",
     );
@@ -108,6 +111,7 @@ describe("resolveGatewayService", () => {
       () => service.stage(installArgs),
       () => service.install(installArgs),
       () => service.uninstall({ env, stdout: process.stdout }),
+      () => service.start({ env, stdout: process.stdout }),
       () => service.stop({ env, stdout: process.stdout }),
       () => service.restart({ env, stdout: process.stdout }),
     ];
@@ -179,7 +183,7 @@ describe("readGatewayServiceState", () => {
 });
 
 describe("startGatewayService", () => {
-  it("returns missing-install without attempting restart", async () => {
+  it("returns missing-install without attempting start", async () => {
     const service = createService();
 
     const result = await startGatewayService(service, {
@@ -188,10 +192,10 @@ describe("startGatewayService", () => {
     });
 
     expect(result.outcome).toBe("missing-install");
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
-  it("restarts stopped installed services and returns post-start state", async () => {
+  it("starts stopped installed services and returns post-start state", async () => {
     const readCommand = vi.fn(async () => ({
       programArguments: ["openclaw", "gateway", "run"],
       environment: { OPENCLAW_GATEWAY_PORT: "18789" },
@@ -216,13 +220,14 @@ describe("startGatewayService", () => {
     });
 
     expect(result.outcome).toBe("started");
-    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(service.start).toHaveBeenCalledTimes(1);
+    expect(service.restart).not.toHaveBeenCalled();
     expect(result.state.installed).toBe(true);
     expect(result.state.loaded).toBe(true);
     expect(result.state.running).toBe(true);
   });
 
-  it("returns already-running without restarting a loaded running service", async () => {
+  it("returns already-running without starting a loaded running service", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({
         programArguments: ["openclaw", "gateway", "run"],
@@ -240,7 +245,7 @@ describe("startGatewayService", () => {
     if (result.outcome === "already-running") {
       expect(result.state.runtime?.pid).toBe(4242);
     }
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
   it("requests repair before start when the loaded service version is stale", async () => {
@@ -264,7 +269,7 @@ describe("startGatewayService", () => {
         "service was installed by OpenClaw 2026.4.24",
       );
     }
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
   it("requests repair before start when the managed port differs from config", async () => {
@@ -293,7 +298,7 @@ describe("startGatewayService", () => {
         message: "service port 18789 does not match current gateway config port 19001",
       });
     }
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
   it("uses the command-line port before a stale managed environment port", async () => {
@@ -316,7 +321,7 @@ describe("startGatewayService", () => {
     );
 
     expect(result.outcome).toBe("started");
-    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(service.start).toHaveBeenCalledTimes(1);
   });
 
   it("requests repair before start when the loaded service points at temporary install paths", async () => {
@@ -341,10 +346,10 @@ describe("startGatewayService", () => {
     if (result.outcome === "repair-required") {
       expect(result.issues.map((issue) => issue.code)).toContain("temporary-program");
     }
-    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.start).not.toHaveBeenCalled();
   });
 
-  it("falls back to missing-install when restart fails and install artifacts are gone", async () => {
+  it("falls back to missing-install when start fails and install artifacts are gone", async () => {
     const readCommand = vi
       .fn<GatewayService["readCommand"]>()
       .mockResolvedValueOnce({
@@ -353,7 +358,7 @@ describe("startGatewayService", () => {
       .mockResolvedValueOnce(null);
     const service = createService({
       readCommand,
-      restart: vi.fn(async () => {
+      start: vi.fn(async () => {
         throw new Error("launchctl bootstrap failed");
       }),
     });

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -13,6 +13,7 @@ import {
   readLaunchAgentProgramArguments,
   readLaunchAgentRuntime,
   restartLaunchAgent,
+  startLaunchAgent,
   stageLaunchAgent,
   stopLaunchAgent,
   uninstallLaunchAgent,
@@ -23,6 +24,7 @@ import {
   readScheduledTaskCommand,
   readScheduledTaskRuntime,
   restartScheduledTask,
+  startScheduledTask,
   stageScheduledTask,
   stopScheduledTask,
   uninstallScheduledTask,
@@ -49,6 +51,7 @@ import {
   readSystemdServiceExecStart,
   readSystemdServiceRuntime,
   restartSystemdService,
+  startSystemdService,
   stageSystemdService,
   stopSystemdService,
   uninstallSystemdService,
@@ -76,6 +79,7 @@ export type GatewayService = {
   stage: (args: GatewayServiceStageArgs) => Promise<void>;
   install: (args: GatewayServiceInstallArgs) => Promise<void>;
   uninstall: (args: GatewayServiceManageArgs) => Promise<void>;
+  start: (args: GatewayServiceControlArgs) => Promise<GatewayServiceRestartResult>;
   stop: (args: GatewayServiceControlArgs) => Promise<void>;
   restart: (args: GatewayServiceControlArgs) => Promise<GatewayServiceRestartResult>;
   isLoaded: (args: GatewayServiceEnvArgs) => Promise<boolean>;
@@ -230,10 +234,10 @@ export async function startGatewayService(
   }
 
   try {
-    const restartResult = await service.restart({ ...args, env: state.env });
+    const startResult = await service.start({ ...args, env: state.env });
     const nextState = await readGatewayServiceState(service, { env: state.env });
     return {
-      outcome: restartResult.outcome === "scheduled" ? "scheduled" : "started",
+      outcome: startResult.outcome === "scheduled" ? "scheduled" : "started",
       state: nextState,
     };
   } catch (err) {
@@ -291,6 +295,7 @@ function createUnsupportedGatewayService(): GatewayService {
     stage: rejectUnsupportedGatewayService,
     install: rejectUnsupportedGatewayService,
     uninstall: rejectUnsupportedGatewayService,
+    start: rejectUnsupportedGatewayService,
     stop: rejectUnsupportedGatewayService,
     restart: rejectUnsupportedGatewayService,
     isLoaded: rejectUnsupportedGatewayService,
@@ -310,6 +315,7 @@ const GATEWAY_SERVICE_REGISTRY: Record<SupportedGatewayServicePlatform, GatewayS
     stage: ignoreServiceWriteResult(stageLaunchAgent),
     install: ignoreServiceWriteResult(installLaunchAgent),
     uninstall: uninstallLaunchAgent,
+    start: startLaunchAgent,
     stop: stopLaunchAgent,
     restart: restartLaunchAgent,
     isLoaded: isLaunchAgentLoaded,
@@ -323,6 +329,7 @@ const GATEWAY_SERVICE_REGISTRY: Record<SupportedGatewayServicePlatform, GatewayS
     stage: ignoreServiceWriteResult(stageSystemdService),
     install: ignoreServiceWriteResult(installSystemdService),
     uninstall: uninstallSystemdService,
+    start: startSystemdService,
     stop: stopSystemdService,
     restart: restartSystemdService,
     isLoaded: isSystemdServiceEnabled,
@@ -336,6 +343,7 @@ const GATEWAY_SERVICE_REGISTRY: Record<SupportedGatewayServicePlatform, GatewayS
     stage: ignoreServiceWriteResult(stageScheduledTask),
     install: ignoreServiceWriteResult(installScheduledTask),
     uninstall: uninstallScheduledTask,
+    start: startScheduledTask,
     stop: stopScheduledTask,
     restart: restartScheduledTask,
     isLoaded: isScheduledTaskInstalled,
@@ -376,6 +384,11 @@ function withGatewayServiceMutationGuards(service: GatewayService): GatewayServi
       assertGatewayServiceMutationOwnedByOpenClaw("uninstall the gateway service", args.env);
       await assertFutureConfigActionAllowed("uninstall the gateway service");
       return await service.uninstall(args);
+    },
+    start: async (args) => {
+      assertGatewayServiceMutationOwnedByOpenClaw("start the gateway service", args.env);
+      await assertFutureConfigActionAllowed("start the gateway service");
+      return await service.start(args);
     },
     stop: async (args) => {
       assertGatewayServiceMutationOwnedByOpenClaw("stop the gateway service", args.env);

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -88,6 +88,7 @@ import {
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
+  startSystemdService,
   stageSystemdService,
   stopSystemdService,
   uninstallSystemdService,
@@ -2170,6 +2171,33 @@ describe("systemd service control", () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+  });
+
+  it("starts the resolved user unit and ignores audit observer failures", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+    const write = vi.fn();
+    const onMutation = vi.fn(() => {
+      throw new Error("audit failed");
+    });
+
+    await expect(
+      startSystemdService({
+        stdout: { write } as unknown as NodeJS.WritableStream,
+        env: {},
+        onMutation,
+      }),
+    ).resolves.toEqual({ outcome: "completed" });
+
+    expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-start" });
+    expect(
+      expectDefined(onMutation.mock.invocationCallOrder[0], "start audit call order"),
+    ).toBeLessThan(expectDefined(write.mock.invocationCallOrder[0], "start output call order"));
+    expect(requireFirstWrite(write)).toContain("Started systemd service");
   });
 
   it("stops the resolved user unit", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1340,7 +1340,7 @@ function isRunningAsRoot(): boolean {
 async function runSystemdServiceAction(params: {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
-  action: "stop" | "restart";
+  action: "start" | "stop" | "restart";
   label: string;
   onMutation?: () => void;
 }) {
@@ -1380,6 +1380,27 @@ async function runSystemdServiceAction(params: {
   }
   params.onMutation?.();
   params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+}
+
+export async function startSystemdService({
+  stdout,
+  env,
+  onMutation,
+}: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
+  await runSystemdServiceAction({
+    stdout,
+    env,
+    action: "start",
+    label: "Started systemd service",
+    onMutation: () => {
+      try {
+        onMutation?.({ mode: "systemctl-start" });
+      } catch {
+        // Audit observers are diagnostic; never interrupt service control.
+      }
+    },
+  });
+  return { outcome: "completed" };
 }
 
 export async function stopSystemdService({


### PR DESCRIPTION
## Summary

Follow-up to #110323. Live verification showed a plain successful `gateway start` (bootstrap of an installed-but-not-running service) wrote no line to `gateway-restart.log` — only stop/restart and the darwin recovery branch audited. Managed starts are now first-class: `GatewayService` gains a real `start()` (launchd enable+kickstart/bootstrap, `systemctl start`, schtasks `/Run` + login-item), so start no longer routes through `restart()`, and each successful mutation is audited immediately, before fallible validation — same ordering as the stop/restart hardening. The already-running no-op stays silent.

## Proof

- Focused suites green (service, launchd, systemd, schtasks, lifecycle-core): 275 tests.
- Targeted oxlint clean, max-lines ratchet OK, `git diff --check` clean.
- Structured review (Codex gpt-5.6-sol): clean, no actionable findings.

Release-note context: managed gateway starts recorded in the lifecycle audit log across platforms.
