### PR TITLE
fix(slack): repeated external menus grow gateway memory

### DIFF
--- a/extensions/slack/src/monitor/external-arg-menu-store.test.ts
+++ b/extensions/slack/src/monitor/external-arg-menu-store.test.ts
@@ -34,6 +34,23 @@ describe("createSlackExternalArgMenuStore", () => {
     expect(store.get(token, 1_700_000_001_000)).toBeUndefined();
   });
 
+  it("bounds unexpired external menus with least-recently-used eviction", () => {
+    const store = createSlackExternalArgMenuStore();
+    const now = 1_700_000_000_000;
+    const oldestToken = store.create({ choices, userId: "U0" }, now);
+    const secondToken = store.create({ choices, userId: "U1" }, now);
+
+    for (let index = 2; index < 256; index += 1) {
+      store.create({ choices, userId: `U${index}` }, now);
+    }
+    expect(store.get(oldestToken, now + 1)).toMatchObject({ userId: "U0" });
+    const newestToken = store.create({ choices, userId: "U256" }, now);
+
+    expect(store.get(secondToken, now + 1)).toBeUndefined();
+    expect(store.get(oldestToken, now + 1)).toMatchObject({ userId: "U0" });
+    expect(store.get(newestToken, now + 1)).toMatchObject({ userId: "U256" });
+  });
+
   it("reads only prefixed valid menu tokens", () => {
     const store = createSlackExternalArgMenuStore();
     const token = store.create({ choices, userId: "U1" }, 1_700_000_000_000);

--- a/extensions/slack/src/monitor/external-arg-menu-store.ts
+++ b/extensions/slack/src/monitor/external-arg-menu-store.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements external arg menu store behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -13,6 +14,7 @@ const SLACK_EXTERNAL_ARG_MENU_TOKEN_PATTERN = new RegExp(
   `^[A-Za-z0-9_-]{${SLACK_EXTERNAL_ARG_MENU_TOKEN_LENGTH}}$`,
 );
 const SLACK_EXTERNAL_ARG_MENU_TTL_MS = 10 * 60 * 1000;
+const SLACK_EXTERNAL_ARG_MENU_MAX_ENTRIES = 256;
 
 export const SLACK_EXTERNAL_ARG_MENU_PREFIX = "openclaw_cmdarg_ext:";
 
@@ -66,6 +68,9 @@ export function createSlackExternalArgMenuStore() {
           userId: params.userId,
           expiresAt,
         });
+        // Each live entry retains the full choice list for its ten-minute lifetime.
+        // Keep recent menus usable without allowing command bursts to grow memory unchecked.
+        pruneMapToMaxSize(store, SLACK_EXTERNAL_ARG_MENU_MAX_ENTRIES);
       }
       return token;
     },
@@ -78,7 +83,12 @@ export function createSlackExternalArgMenuStore() {
     },
     get(token: string, now = Date.now()): SlackExternalArgMenuEntry | undefined {
       pruneSlackExternalArgMenuStore(store, now);
-      return store.get(token);
+      const entry = store.get(token);
+      if (entry) {
+        store.delete(token);
+        store.set(token, entry);
+      }
+      return entry;
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated Slack command menus could steadily increase Gateway memory during a long-running process. Every external-select menu retained its complete choice list for ten minutes, and the store had no limit on how many unexpired menus it could hold at once.

## Why This Change Was Made

The Slack-owned menu store now retains at most 256 unexpired menus using the shared plugin SDK map-pruning helper. Successful Slack option lookups refresh recency, so overflow evicts the least-recently-used menu instead of an actively queried one. TTL behavior and token validation remain unchanged.

## User Impact

Slack workspaces can repeatedly open large command menus without letting the Gateway retain an unlimited number of choice arrays. Normal menus remain available for their existing ten-minute lifetime; only when more than 256 menus are simultaneously live does the least-recently-used menu behave like an expired menu and return no options.

## Evidence

Exact head: `71d601bbc2b075ca363b1014d716476f8e5dcb85`.

Red proof on parent `99046179a8f` with only the regression test applied:

```text
$ node scripts/run-vitest.mjs extensions/slack/src/monitor/external-arg-menu-store.test.ts
[test] starting test/vitest/vitest.extension-slack.config.ts

 RUN  v4.1.10 /tmp/openclaw-110499-red

 ❯ |extension-slack| extensions/slack/src/monitor/external-arg-menu-store.test.ts (5 tests | 1 failed) 53ms
     × bounds unexpired external menus with least-recently-used eviction 40ms

 FAIL  |extension-slack| extensions/slack/src/monitor/external-arg-menu-store.test.ts > createSlackExternalArgMenuStore > bounds unexpired external menus with least-recently-used eviction
AssertionError: expected { choices: [ { …(2) } ], …(2) } to be undefined

- Expected:
undefined

+ Received:
{
  "choices": [
    {
      "label": "Daily",
      "value": "day",
    },
  ],
  "expiresAt": 1700000600000,
  "userId": "U1",
}

 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
[test] failed 1 Vitest shard
```

Green proof on the exact PR head, including the store test and its Slack slash-command caller tests:

```text
$ node scripts/run-vitest.mjs extensions/slack/src/monitor/external-arg-menu-store.test.ts extensions/slack/src/monitor/slash.test.ts
[test] starting test/vitest/vitest.extension-slack.config.ts

 RUN  v4.1.10 /media/vdc/code/ai/github/openclaw

 Test Files  2 passed (2)
      Tests  56 passed (56)
   Duration  25.75s (transform 14.53s, setup 117ms, import 24.26s, tests 971ms, environment 0ms)

[test] passed 1 Vitest shard in 33.49s
```

Production and test TypeScript surfaces:

```text
$ pnpm tsgo:extensions
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
[exit 0]

$ pnpm tsgo:extensions:test
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
[exit 0]
```

Targeted lint and whitespace validation:

```text
$ node scripts/run-oxlint.mjs extensions/slack/src/monitor/external-arg-menu-store.ts extensions/slack/src/monitor/external-arg-menu-store.test.ts
[plugin-sdk boundary dts] fresh; skipping
[plugin-sdk package boundary dts] fresh; skipping
[qa-channel boundary dts] fresh; skipping
[matrix boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
[whatsapp boundary dts] fresh; skipping
[telegram boundary dts] fresh; skipping
[plugin-sdk boundary root shims] fresh; skipping
[exit 0]

$ git diff --check HEAD^ HEAD
[no output; exit 0]
```

- No screenshot is included because the change only bounds in-process retention; Slack menu layout and copy are unchanged.

AI-assisted: yes. I inspected the store, its slash-command caller, the shared pruning helper, and the validation results.
