### PR TITLE
fix(qqbot): send quoted media paths with spaces

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -337,6 +337,34 @@ describe("dispatchOutbound", () => {
     }
   });
 
+  it("uploads quoted self-closing qqmedia file tags with spaces", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qqbot-scoped-media-space-"));
+    try {
+      const filePath = path.join(tmpRoot, "tagged report.docx");
+      await fs.writeFile(filePath, Buffer.from("report"));
+      const realFilePath = await fs.realpath(filePath);
+
+      const result = await sendText({
+        to: "qqbot:c2c:user-openid",
+        text: `<qqmedia file="${filePath}" />`,
+        accountId: "qq-main",
+        account,
+        mediaAccess: { localRoots: [tmpRoot] },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(sendMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "file",
+          source: { localPath: realFilePath },
+          target: { id: "user-openid", type: "c2c" },
+        }),
+      );
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("loads scoped media through host read callbacks", async () => {
     // realpath: macOS tmpdir is a /var -> /private/var symlink and root
     // containment checks compare against canonicalized roots.

--- a/extensions/qqbot/src/engine/utils/media-tags.test.ts
+++ b/extensions/qqbot/src/engine/utils/media-tags.test.ts
@@ -18,6 +18,26 @@ describe("media-tags with HTML entities", () => {
     expect(normalizeMediaTags(input)).toBe("<qqmedia>https://example.com/c.zip</qqmedia>");
   });
 
+  it("extracts quoted file paths with spaces from self-closing tags", () => {
+    const input = '<qqmedia file="C:/tmp/foo bar.png" />';
+    expect(normalizeMediaTags(input)).toBe("<qqmedia>C:/tmp/foo bar.png</qqmedia>");
+  });
+
+  it("extracts single-quoted file paths with spaces from self-closing tags", () => {
+    const input = "<qqmedia file='C:/tmp/foo bar.png' />";
+    expect(normalizeMediaTags(input)).toBe("<qqmedia>C:/tmp/foo bar.png</qqmedia>");
+  });
+
+  it("keeps unquoted file attributes bounded by whitespace", () => {
+    const input = "<qqmedia file=C:/tmp/foo bar.png />";
+    expect(normalizeMediaTags(input)).toBe(input);
+  });
+
+  it("extracts quoted file paths with spaces after another quoted attribute", () => {
+    const input = '<qqmedia alt="upload proof" file="C:/tmp/foo bar.png" />';
+    expect(normalizeMediaTags(input)).toBe("<qqmedia>C:/tmp/foo bar.png</qqmedia>");
+  });
+
   it("does not match invalid input", () => {
     const input = "no tag here";
     expect(normalizeMediaTags(input)).toBe(input);

--- a/extensions/qqbot/src/engine/utils/media-tags.ts
+++ b/extensions/qqbot/src/engine/utils/media-tags.ts
@@ -81,6 +81,10 @@ const TAG_NAME_PATTERN = ALL_TAG_NAMES.join("|");
 
 const LEFT_BRACKET = "(?:[<\uff1c\u003c]|&lt;)";
 const RIGHT_BRACKET = "(?:[>\uff1e\u003e]|&gt;)";
+const ATTR_VALUE_PATTERN =
+  "(?:\"[^\"\\uff1c<>\uff1e>]*\"|'[^'\\uff1c<>\uff1e>]*'|[^\"'\\s\\uff1c<>\uff1e>]+)";
+const MEDIA_ATTR_VALUE_PATTERN =
+  "(?:\"([^\"\\uff1c<>\uff1e>]*)\"|'([^'\\uff1c<>\uff1e>]*)'|([^\"'\\s\\uff1c<>\uff1e>]+))";
 
 /** Match self-closing media-tag syntax with file/src/path/url attributes. */
 const SELF_CLOSING_TAG_REGEX = new RegExp(
@@ -89,12 +93,14 @@ const SELF_CLOSING_TAG_REGEX = new RegExp(
     "\\s*(" +
     TAG_NAME_PATTERN +
     ")" +
-    "(?:\\s+(?!file|src|path|url)[a-z_-]+\\s*=\\s*[\"']?[^\"'\\s\uff1c<>\uff1e>]*?[\"']?)*" +
+    "(?:\\s+(?!(?:file|src|path|url)\\b)[a-z_-]+\\s*=\\s*" +
+    ATTR_VALUE_PATTERN +
+    ")*" +
     "\\s+(?:file|src|path|url)\\s*=\\s*" +
-    "[\"']?" +
-    "([^\"'\\s>\uff1e]+?)" +
-    "[\"']?" +
-    "(?:\\s+[a-z_-]+\\s*=\\s*[\"']?[^\"'\\s\uff1c<>\uff1e>]*?[\"']?)*" +
+    MEDIA_ATTR_VALUE_PATTERN +
+    "(?:\\s+[a-z_-]+\\s*=\\s*" +
+    ATTR_VALUE_PATTERN +
+    ")*" +
     "\\s*/?" +
     "\\s*" +
     RIGHT_BRACKET +
@@ -163,7 +169,16 @@ export function normalizeMediaTags(text: string): string {
     return `<${tag}>${expanded}</${tag}>`;
   };
 
-  let cleaned = text.replace(SELF_CLOSING_TAG_REGEX, normalizeWrappedTag);
+  let cleaned = text.replace(
+    SELF_CLOSING_TAG_REGEX,
+    (
+      _match: string,
+      rawTag: string,
+      doubleQuoted: string,
+      singleQuoted: string,
+      unquoted: string,
+    ) => normalizeWrappedTag(_match, rawTag, doubleQuoted ?? singleQuoted ?? unquoted ?? ""),
+  );
 
   cleaned = cleaned.replace(
     MULTILINE_TAG_CLEANUP,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where QQBot outbound media tags did not recognize quoted self-closing media paths containing spaces, such as `<qqmedia file="C:/tmp/foo bar.png" />`.

`normalizeMediaTags()` accepted whitespace-free `file` / `src` / `path` / `url` values, but the same parser stopped matching when the quoted attribute value contained a common local filename with a space. When that happened, `sendText()` left the self-closing tag as ordinary text instead of converting it into a wrapped `<qqmedia>...</qqmedia>` block for the media sender.

The narrow pre-fix trigger was:

```text
<qqmedia file="C:/tmp/foo bar.png" />
```

Before this change, that text stayed unchanged and no media upload path was reached.

## Why This Change Was Made

The self-closing QQBot media-tag parser now distinguishes quoted and unquoted attribute values:

- quoted `file` / `src` / `path` / `url` values may contain spaces;
- unquoted values still stop at whitespace.

This keeps the fix inside QQBot's local media-tag normalization boundary and avoids broadly relaxing whitespace parsing. Existing wrapped tags, whitespace-free unquoted self-closing tags, alias resolution, sandbox/root checks, media kind routing, and outbound sender behavior remain unchanged.

## User Impact

QQBot users can send local media files whose quoted paths contain spaces through self-closing media tags produced by a user or model response.

For example, a reply containing `<qqmedia file="C:/tmp/foo bar.png" />` now enters the existing QQBot media upload path instead of being delivered as literal text.

## Evidence

Focused parser proof:

```text
input:  <qqmedia file="C:/tmp/foo.png" />
output: <qqmedia>C:/tmp/foo.png</qqmedia>

input:  <qqmedia file="C:/tmp/foo bar.png" />
output: <qqmedia>C:/tmp/foo bar.png</qqmedia>

input:  <qqmedia file='C:/tmp/foo bar.png' />
output: <qqmedia>C:/tmp/foo bar.png</qqmedia>

input:  <qqmedia alt="upload proof" file="C:/tmp/foo bar.png" />
output: <qqmedia>C:/tmp/foo bar.png</qqmedia>

input:  <qqmedia file=C:/tmp/foo bar.png />
output: <qqmedia file=C:/tmp/foo bar.png />
```

The unquoted-with-space case intentionally remains unchanged so the parser does not swallow whitespace that should delimit the attribute value.

User-realistic outbound path covered by test:

```text
user/model QQBot reply text
  -> <qqmedia file=".../tagged report.docx" />
  -> sendText()
  -> normalizeMediaTags()
  -> <qqmedia>.../tagged report.docx</qqmedia>
  -> media tag dispatch
  -> sendMedia()
```

The outbound regression creates a temporary file named `tagged report.docx`, sends it through `sendText()` as a quoted self-closing `<qqmedia file="..." />` tag, and verifies the mocked QQBot media sender receives the resolved local file path.

Live QQBot behavior proof:

```text
OpenClaw 2026.7.2 (PR head)
  -> real QQBot AppID/AppSecret configured locally
  -> QQBot access token obtained
  -> QQBot WebSocket connected
  -> real C2C user sent "proof"
  -> OpenClaw recorded target: default:c2c:<redacted-openid>
```

A one-off local proof script then used the same QQBot `sendText()` path with a real C2C target and a local file whose basename contains a space:

```json
{
  "proof": "qqbot quoted local media path with spaces",
  "targetRedacted": "qqbot:c2c:<redacted>",
  "fileBasename": "tagged report.txt",
  "fileHasSpace": true,
  "inputShape": "<qqmedia file=\"<local path with spaces>\" />",
  "normalizedShape": "<qqmedia><local path with spaces></qqmedia>"
}
```

The real QQBot send returned a platform message id with no error:

```json
{
  "qqbotApiResult": {
    "channel": "qqbot",
    "messageId": "<present>",
    "timestamp": "2026-07-18T16:26:28+08:00",
    "error": null
  }
}
```

Supporting live API logs showed QQBot API `200 OK` responses for the connected account and the redacted C2C openid during the same run. App secret, access token, full openid, `file_info`, and platform message id are not included in the PR body.

Validation:

- `node scripts/run-vitest.mjs run extensions/qqbot/src/engine/utils/media-tags.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts` - passed, 56 tests
- `pnpm exec oxfmt --check extensions/qqbot/src/engine/utils/media-tags.ts extensions/qqbot/src/engine/utils/media-tags.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts` - passed
- `pnpm tsgo:extensions` - passed
- `pnpm tsgo:extensions:test` - passed
- `git diff --check` - passed