### PR TITLE
fix(ios): prevent black edge bands in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **iOS chat edge treatment:** restore the layered chat canvas and use a soft native scroll-edge blur so message content no longer meets opaque black bands at the navigation bar or composer.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **iOS chat edge treatment:** restore the layered chat canvas and use a soft native scroll-edge blur so message content no longer meets opaque black bands at the navigation bar or composer.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -16635,7 +16635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 147,
+      "line": 159,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -16643,7 +16643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 151,
+      "line": 163,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -16651,7 +16651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 155,
+      "line": 167,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -16659,7 +16659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 177,
+      "line": 189,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -16667,7 +16667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 190,
+      "line": 202,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -16675,7 +16675,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 318,
+      "line": 330,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -16683,7 +16683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 343,
+      "line": 355,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -16691,7 +16691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 356,
+      "line": 368,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -16699,7 +16699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 369,
+      "line": 381,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Sessions…",
       "surface": "apple",
@@ -16707,7 +16707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 382,
+      "line": 394,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -16715,7 +16715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 394,
+      "line": 406,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -16723,7 +16723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 404,
+      "line": 416,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show reasoning & tool activity",
       "surface": "apple",
@@ -16731,7 +16731,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 413,
+      "line": 425,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -16739,7 +16739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 482,
+      "line": 494,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -16747,7 +16747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 482,
+      "line": 494,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -16755,7 +16755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 495,
+      "line": 507,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -16763,7 +16763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 500,
+      "line": 512,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -16771,7 +16771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 503,
+      "line": 515,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -16779,7 +16779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 601,
+      "line": 613,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -16787,7 +16787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 602,
+      "line": 614,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -16795,7 +16795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 605,
+      "line": 617,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -16803,7 +16803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 606,
+      "line": 618,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -16811,7 +16811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 609,
+      "line": 621,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -16819,7 +16819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 610,
+      "line": 622,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -2,6 +2,18 @@ import OpenClawChatUI
 import OpenClawProtocol
 import SwiftUI
 
+private struct ChatScrollEdgeTreatment: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            // The shared canvas supplies color for the native blur. Automatic
+            // edge effects harden to black when the host inserts an opaque fill.
+            content.scrollEdgeEffectStyle(.soft, for: .vertical)
+        } else {
+            content
+        }
+    }
+}
+
 struct ChatProTab: View {
     private struct TranscriptShareItem: Identifiable {
         let id = UUID()
@@ -108,7 +120,7 @@ struct ChatProTab: View {
 
     private var content: some View {
         self.chatSurface
-            .background(Color(uiColor: .systemBackground))
+            .modifier(ChatScrollEdgeTreatment())
             .navigationTitle(self.headerDisplayTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -162,7 +174,7 @@ struct ChatProTab: View {
         if let viewModel {
             OpenClawChatView(
                 viewModel: viewModel,
-                drawsBackground: false,
+                drawsBackground: true,
                 showsSessionSwitcher: false,
                 userAccent: self.chatUserAccent,
                 showsAssistantTrace: self.showsAssistantTrace,

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -381,6 +381,14 @@ struct RootTabsSourceGuardTests {
         #expect(settingsSource.contains("ToolbarItem(placement: .topBarLeading)"))
     }
 
+    @Test func `chat keeps layered canvas behind soft native scroll edges`() throws {
+        let source = try String(contentsOf: Self.chatProTabSourceURL(), encoding: .utf8)
+
+        #expect(source.contains("drawsBackground: true"))
+        #expect(source.contains("content.scrollEdgeEffectStyle(.soft, for: .vertical)"))
+        #expect(!source.contains(".background(Color(uiColor: .systemBackground))"))
+    }
+
     @Test func `phone hub keeps docs as destination only`() throws {
         let source = try String(contentsOf: Self.phoneHubSourceURL(), encoding: .utf8)
 

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -372,6 +372,21 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.attachScreenshot(named: "chat-light")
     }
 
+    func testChatKeepsLayeredCanvasInDarkAppearance() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone chat proof only")
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "chat",
+            initialDestination: "chat",
+            name: "chat-dark-layered-canvas"))
+
+        XCTAssertTrue(self.app?.otherElements["chat-composer-surface"].waitForExistence(timeout: 8) == true)
+        self.assertChatCanvasIsNotSolidBlack()
+        self.attachScreenshot(named: "chat-dark-layered-canvas")
+
+        self.sendFixtureChatMessage("Check the release status and prepare the next steps.")
+        self.attachScreenshot(named: "chat-dark-soft-bottom-edge")
+    }
+
     func testEmptyChatStarterPromptSendsMessage() throws {
         self.launchApp(
             for: ScreenshotTarget(
@@ -995,6 +1010,81 @@ final class OpenClawSnapshotUITests: XCTestCase {
             "Dark appearance must keep the settings labels visibly light",
             file: file,
             line: line)
+    }
+
+    private func assertChatCanvasIsNotSolidBlack(
+        file: StaticString = #filePath,
+        line: UInt = #line)
+    {
+        guard let app, let image = app.screenshot().image.cgImage else {
+            XCTFail("App screenshot has no CGImage", file: file, line: line)
+            return
+        }
+        let width = image.width
+        let height = image.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        let rendered = pixels.withUnsafeMutableBytes { buffer in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+            else {
+                return false
+            }
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard rendered else {
+            XCTFail("Could not render the chat screenshot", file: file, line: line)
+            return
+        }
+
+        // The fixture leaves this canvas region empty. A pure-black host makes
+        // both system scroll-edge effects collapse into hard black clipping.
+        let sampleX = (width / 8)..<(width * 7 / 8)
+        let sampleY = (height * 2 / 5)..<(height * 7 / 10)
+        var layeredPixels = 0
+        for y in sampleY {
+            for x in sampleX {
+                let offset = (y * width + x) * 4
+                if pixels[offset] > 3 || pixels[offset + 1] > 3 || pixels[offset + 2] > 3 {
+                    layeredPixels += 1
+                }
+            }
+        }
+        let sampledPixels = max(1, sampleX.count * sampleY.count)
+        XCTAssertGreaterThan(
+            Double(layeredPixels) / Double(sampledPixels),
+            0.95,
+            "Dark Chat must retain a layered canvas behind its translucent edge chrome",
+            file: file,
+            line: line)
+    }
+
+    private func sendFixtureChatMessage(_ text: String) {
+        guard let app else {
+            XCTFail("Fixture app is unavailable")
+            return
+        }
+        let input = app.textFields["chat-message-input"]
+        XCTAssertTrue(input.waitForExistence(timeout: 8))
+        input.tap()
+        input.typeText(text)
+
+        let send = app.buttons["chat-send-message"]
+        XCTAssertTrue(send.waitForExistence(timeout: 3))
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 3))
+        send.tap()
+
+        XCTAssertTrue(app.staticTexts[text].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "I can help with"))
+                .firstMatch.waitForExistence(timeout: 5))
     }
 
     private func attachScreenshot(named name: String) {


### PR DESCRIPTION
Closes #110503

## What Problem This Solves

Fixes an issue where iOS users in dark appearance saw message content meet opaque black bands at the top navigation bar and bottom composer after the native navigation redesign.

## Why This Change Was Made

The iOS host now lets the shared layered chat canvas extend behind its chrome instead of covering it with `systemBackground`. On iOS 26, descendant vertical scroll views use the native soft edge effect; earlier iOS versions retain their existing edge behavior.

## User Impact

Chat once again reads as one continuous translucent surface. Messages transition softly beneath the navigation and composer chrome without changing composer behavior, routing, or conversation state.

## Evidence

- Before: the dark fixture's empty canvas measured `0.0` layered pixels and rendered as a solid-black surface.
- After: the same fixture passes a pixel-level layered-canvas assertion, sends a message, receives the fixture response, and captures the bottom-edge state.
- `OpenClawSnapshotUITests.testChatKeepsLayeredCanvasInDarkAppearance` passes on iPhone 17 Pro / iOS 26.5.
- `OpenClawSnapshotUITests.testChatComposerStartsCompactAndGrowsWithDraft` and `testChatPresentationInLightAppearance` pass on the same simulator.
- The new `RootTabsSourceGuardTests` edge-treatment guard passed; the full source-guard run on the earlier base exposed three unrelated stale expectations.
- Changed-gate proof passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29634870411
- Source-blind behavior contract passed for dark canvas continuity, message send/reply, and light-appearance preservation.

AI-assisted with Codex. I reviewed the implementation and ran the repository autoreview gate; no actionable findings remained.
