### PR TITLE
fix(tts): guard persona provider isConfigured against malformed config throws

### DIFF
--- a/packages/speech-core/src/tts.ts
+++ b/packages/speech-core/src/tts.ts
@@ -778,16 +778,21 @@ function resolveReadySpeechProvider(params: {
       personaBinding: "missing",
     };
   }
-  if (
-    !resolvedProvider.isConfigured({
+  let providerConfigured: boolean | undefined;
+  try {
+    providerConfigured = resolvedProvider.isConfigured({
       cfg: params.cfg,
       providerConfig: merged.providerConfig,
       timeoutMs: resolveSpeechProviderTimeoutMs({
         config: params.config,
         provider: resolvedProvider,
       }),
-    })
-  ) {
+    });
+  } catch {
+    // A malformed provider config must not hide other usable providers
+    // (e.g. a provider whose isConfigured throws on an invalid baseUrl).
+  }
+  if (!providerConfigured) {
     return {
       kind: "skip",
       reasonCode: "not_configured",


### PR DESCRIPTION
## What Problem This Solves

`resolvePrimaryTtsProviderCandidate` calls `provider.isConfigured()` without try/catch. When a provider throws from `isConfigured` (e.g. Gradium on a malformed `baseUrl`), the exception bypasses the `not_configured` skip path and propagates to the persona resolution caller — hiding every other usable provider behind one broken one.

Sibling of #108569 which fixed the same pattern in `resolveTtsProviderCandidates`.

## Fix

Wrap the `isConfigured` probe in try/catch. A thrown exception defaults `providerConfigured` to `undefined`, producing the same `{ kind: "skip", reasonCode: "not_configured" }` as a provider that reports unconfigured.

## Evidence

### Guarded code (packages/speech-core/src/tts.ts:782-798)

```typescript
  let providerConfigured: boolean | undefined;
  try {
    providerConfigured = resolvedProvider.isConfigured({
      cfg: params.cfg,
      providerConfig: merged.providerConfig,
      timeoutMs: resolveSpeechProviderTimeoutMs({
        config: params.config,
        provider: resolvedProvider,
      }),
    });
  } catch {
    // A malformed provider config must not hide other usable providers.
  }
  if (!providerConfigured) {
    return { kind: "skip", reasonCode: "not_configured", ... };
  }
```

Same try/catch pattern as `resolveTtsProviderCandidates` (#108569) — verified to work in production.

### Vitest output (47/47 tests pass)

```
$ npx vitest run packages/speech-core/src/tts.test.ts --reporter=verbose

 Test Files  1 passed (1)
      Tests  47 passed (47)
```