### PR TITLE
fix(plugin-sdk): guard provider isConfigured probe against malformed config throws

### DIFF
--- a/src/plugin-sdk/provider-selection-runtime.ts
+++ b/src/plugin-sdk/provider-selection-runtime.ts
@@ -237,9 +237,19 @@ function resolveProviderCandidate<
     rawConfig: rawProviderConfig,
   });
 
-  if (
-    !params.isProviderConfigured({ provider: params.provider, cfg: params.cfg, providerConfig })
-  ) {
+  let isConfigured: boolean;
+  try {
+    isConfigured = params.isProviderConfigured({
+      provider: params.provider,
+      cfg: params.cfg,
+      providerConfig,
+    });
+  } catch {
+    // A malformed provider config must not hide other usable providers
+    // (e.g. a provider whose isConfigured throws on an invalid baseUrl).
+    isConfigured = false;
+  }
+  if (!isConfigured) {
     return {
       ok: false,
       code: "provider-not-configured",


### PR DESCRIPTION
## What Problem This Solves

`resolveConfiguredCapabilityProvider` calls the `isProviderConfigured` callback without try/catch. The callback is a direct passthrough to the provider's own `isConfigured` — if that throws (e.g. Gradium on a malformed `baseUrl`), the exception crashes capability resolution. This affects realtime transcription provider selection in voice-call and TTS talk routing.

Third sibling of #108569 and #110506 — all three fix the same throw-in-isConfigured pattern at different call sites.

## Fix

Wrap the callback invocation in try/catch. A thrown exception returns `{ ok: false, code: "provider-not-configured" }` — same result as an unconfigured provider — so other providers remain selectable.

## Evidence

### Function probe (real production function)

```
$ node --import tsx -e "import { resolveConfiguredCapabilityProvider } from ./src/plugin-sdk/provider-selection-runtime.js; ..."

=== After fix: guarded isConfigured callback ===
Result: {
  "ok": false,
  "code": "provider-not-configured",
  "configuredProviderId": "broken-provider",
  "provider": { "id": "broken-provider", "label": "Broken" }
}

Provider with broken isConfigured → { ok: false, code: "provider-not-configured" }
The exception is caught. Resolution continues to next provider.
```

### Vitest output (4/4 tests pass)

```
$ npx vitest run src/plugin-sdk/provider-selection-runtime.test.ts --reporter=verbose

 Test Files  1 passed (1)
      Tests  4 passed (4)
```