### PR TITLE
Bound diagnostic config file read with size cap

### DIFF
--- a/src/logging/diagnostic-support-export.ts
+++ b/src/logging/diagnostic-support-export.ts
@@ -8,6 +8,7 @@ import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
 import { buildConfigSchema } from "../config/schema.js";
 import { resolveHomeRelativePath } from "../infra/home-dir.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import { VERSION } from "../version.js";
 import {
   readDiagnosticStabilityBundleFileSync,
@@ -38,6 +39,7 @@ const DIAGNOSTIC_SUPPORT_EXPORT_VERSION = 1;
 
 const DEFAULT_LOG_LIMIT = 5000;
 const DEFAULT_LOG_MAX_BYTES = 1_000_000;
+const DIAGNOSTIC_CONFIG_MAX_BYTES = 8 * 1024 * 1024;
 const SUPPORT_EXPORT_PREFIX = "openclaw-diagnostics-";
 const SUPPORT_EXPORT_SUFFIX = ".zip";
 type Awaitable<T> = T | Promise<T>;
@@ -343,7 +345,7 @@ function readConfigExport(options: {
   let stat: fs.Stats | undefined;
   try {
     stat = fs.statSync(options.configPath);
-    const parsed = parseConfigJson5(fs.readFileSync(options.configPath, "utf8"));
+    const parsed = parseConfigJson5(readRegularFileSync({ filePath: options.configPath, maxBytes: DIAGNOSTIC_CONFIG_MAX_BYTES }));
     if (!parsed.ok) {
       return {
         shape: configShapeReadFailure({


### PR DESCRIPTION
## What Problem This Solves

`readConfigExport` in the diagnostic support export path calls `fs.readFileSync(options.configPath, "utf8")` on the user's config file with no size limit. A corrupted or enormous config file can OOM the diagnostic export path, preventing support bundle generation.

## Why This Change Was Made

PR #101472 established the bounded-read pattern. The diagnostic export path reads the user's config file to include sanitized config in support bundles. Config files are user-controlled content and should not be trusted to have reasonable size. Using `readRegularFileSync` with an 8 MB cap (config files are typically <100 KB) prevents OOM from corrupted config files while maintaining diagnostic value.

## User Impact

No user-visible change under normal conditions. Config files under 8 MB export identically to before. An oversized config file results in a graceful config-shape-read-failure entry in the diagnostic report instead of crashing the export.

## Evidence

- Replaced `fs.readFileSync(options.configPath, "utf8")` with `readRegularFileSync({ filePath: options.configPath, maxBytes: DIAGNOSTIC_CONFIG_MAX_BYTES })` at `src/logging/diagnostic-support-export.ts:353-356`
- Added `DIAGNOSTIC_CONFIG_MAX_BYTES = 8 * 1024 * 1024` constant
- Added `readRegularFileSync` import from `../infra/regular-file.js`
- Existing error handling already catches and reports read failures gracefully