### PR TITLE
Bound trajectory pointer file read with size cap

### DIFF
--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -6,11 +6,14 @@ import { resolveSessionFilePath } from "../config/sessions/paths.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import { readFileWindowFullySync } from "../infra/file-read.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
   safeTrajectorySessionFileName,
 } from "./paths.js";
+
+const TRAJECTORY_POINTER_MAX_BYTES = 1 * 1024 * 1024;
 
 type RemovedTrajectoryArtifact = {
   kind: "pointer" | "runtime";
@@ -56,7 +59,7 @@ function readTrajectoryPointerFile(
     return null;
   }
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(pointerPath, "utf8"));
+    const parsed: unknown = JSON.parse(readRegularFileSync({ filePath: pointerPath, maxBytes: TRAJECTORY_POINTER_MAX_BYTES }));
     if (!isRecord(parsed)) {
       return null;
     }


### PR DESCRIPTION
## What Problem This Solves

`readTrajectoryPointerFile` calls `fs.readFileSync(pointerPath, "utf8")` on session trajectory pointer files with no size limit. A corrupted pointer file can OOM the trajectory cleanup path.

## Why This Change Was Made

PR #101472 established the bounded-read pattern for file reads. Trajectory pointer files are small JSON metadata files, but the unbounded `readFileSync` call was a latent vulnerability. Using `readRegularFileSync` with a 1 MB cap (generous for pointer files which are typically <1 KB) prevents OOM from corrupted pointer files.

## User Impact

No user-visible change. Trajectory pointer files are small JSON objects (<1 KB typically); a 1 MB cap is more than sufficient. Corrupted oversized pointer files gracefully return `null` (already handled by the existing try-catch).

## Evidence

- Replaced `fs.readFileSync(pointerPath, "utf8")` with `readRegularFileSync({ filePath: pointerPath, maxBytes: TRAJECTORY_POINTER_MAX_BYTES })` at `src/trajectory/cleanup.ts:65-69`
- Added `TRAJECTORY_POINTER_MAX_BYTES = 1 * 1024 * 1024` constant
- Added `readRegularFileSync` import from `../infra/regular-file.js`