### PR TITLE
Bound plugin bundle command file reads with size cap

### DIFF
--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -11,6 +11,7 @@ import {
 } from "../../packages/markdown-core/src/frontmatter.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRootJsonObjectSync } from "../infra/json-files.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { parseFrontmatterBool } from "../shared/frontmatter.js";
 import {
@@ -32,6 +33,8 @@ type ClaudeBundleCommandSpec = {
   promptTemplate: string;
   sourceFilePath: string;
 };
+
+const BUNDLE_COMMAND_MAX_BYTES = 1 * 1024 * 1024;
 
 function readClaudeBundleManifest(rootDir: string): Record<string, unknown> {
   const result = readRootJsonObjectSync({
@@ -103,7 +106,7 @@ function loadBundleCommandsFromRoot(params: {
   for (const filePath of listMarkdownFilesRecursive(params.commandRoot)) {
     let raw: string;
     try {
-      raw = fs.readFileSync(filePath, "utf-8");
+      raw = readRegularFileSync({ filePath, maxBytes: BUNDLE_COMMAND_MAX_BYTES });
     } catch {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

`loadBundleCommandsFromRoot` calls `fs.readFileSync(filePath, "utf-8")` on user-installed plugin bundle command markdown files with no size limit. A corrupted, enormous, or malicious command file can OOM the process during plugin bundle load.

## Why This Change Was Made

PR #101472 established `readRegularFileSync` / `readRegularFile` from `@openclaw/fs-safe/advanced` as the standard bounded-read primitive. This applies the same pattern to plugin bundle command file reads — the most natural extension of the bounded-read initiative, since bundle commands are user-installed content that should not be trusted to have reasonable size.

## User Impact

No user-visible change under normal conditions. Plugin bundle command files under 1 MB load identically to before. Files exceeding 1 MB are silently skipped with an error log instead of crashing the load path with an OOM or hang.

## Evidence

- Replaced `fs.readFileSync(filePath, "utf-8")` with `readRegularFileSync({ filePath, maxBytes: BUNDLE_COMMAND_MAX_BYTES })` at `src/plugins/bundle-commands.ts:112-117`
- Added `BUNDLE_COMMAND_MAX_BYTES = 1 * 1024 * 1024` constant
- Added `readRegularFileSync` import from `../infra/regular-file.js`
- `RangeError` from oversized file is caught and the command file is skipped gracefully
- Pattern matches PR #101472 (`src/cron/store.ts`) and PR #101477 (`src/cron/store.ts` archive pruning)