### PR TITLE
fix(agents): greedily pack the code mode quick index so one oversized entry cannot blank it

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -507,6 +507,72 @@ describe("Code Mode", () => {
     expect(index).toContain("-> { ok: boolean }");
   });
 
+  it("skips a single oversized entry instead of blanking the whole index", () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    // One declared tool whose line alone blows the 8000-char budget; it sorts
+    // first among declared tools, so a prefix cut would zero the entire index.
+    const oversized = pluginTool(`a_${"z".repeat(9_000)}`, "Deferred");
+    (oversized as { outputSchema?: unknown }).outputSchema = Type.Object(
+      { ok: Type.Boolean() },
+      { additionalProperties: false },
+    );
+    const shortContracted = Array.from({ length: 4 }, (_, index) => {
+      const tool = pluginTool(`b_short_${index}`, "Deferred");
+      (tool as { outputSchema?: unknown }).outputSchema = Type.Object(
+        { ok: Type.Boolean() },
+        { additionalProperties: false },
+      );
+      return tool;
+    });
+    const compacted = applyCodeModeCatalog({
+      tools: [...tools, oversized, ...shortContracted],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const description = compacted.tools[0]?.description ?? "";
+    const indexStart = description.indexOf("OpenClaw/plugin tool quick index");
+    const index = indexStart >= 0 ? description.slice(indexStart) : "";
+    expect(index.length).toBeLessThanOrEqual(8_000);
+    // The oversized line is skipped, but every short declared contract survives.
+    expect(index).not.toContain("z".repeat(9_000));
+    for (let i = 0; i < 4; i += 1) {
+      expect(index).toContain(`b_short_${i}`);
+    }
+  });
+
+  it("renders a deterministic truncated index across rebuilds", () => {
+    const build = () => {
+      const { config, catalogRef, tools } = createCodeModeHarness();
+      const catalogTools = Array.from({ length: 100 }, (_, index) =>
+        pluginTool(
+          `fake_${index.toString().padStart(3, "0")}`,
+          "Deferred",
+          `fake-${"x".repeat(120)}`,
+        ),
+      );
+      const compacted = applyCodeModeCatalog({
+        tools: [...tools, ...catalogTools],
+        config,
+        sessionId: "session-code-mode",
+        sessionKey: "agent:main:main",
+        runId: "run-code-mode",
+        catalogRef,
+      });
+      const description = compacted.tools[0]?.description ?? "";
+      const start = description.indexOf("OpenClaw/plugin tool quick index");
+      return start >= 0 ? description.slice(start) : "";
+    };
+    const first = build();
+    for (let i = 0; i < 5; i += 1) {
+      expect(build()).toBe(first);
+    }
+    expect(first).toContain("additional OpenClaw/plugin tools omitted");
+  });
+
   it("bounds the model-visible native tool index", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
     const pluginId = `fake-${"x".repeat(120)}`;

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -1308,22 +1308,23 @@ function formatCodeModeCatalogIndex(catalog: readonly ToolSearchCatalogEntry[]):
     return fullIndex;
   }
 
-  // Prompt bytes and ordering must stay stable for provider prompt caches.
-  // Truncated entries remain discoverable inside the guest through ALL_TOOLS.
-  let low = 0;
-  let high = lines.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
+  // Greedily pack lines in the deterministic sorted order, skipping any single
+  // line too large to fit rather than dropping the whole tail after it. A prefix
+  // cut let one oversized entry — a pathological plugin id or input hint — blank
+  // the entire index; skipping it keeps every other declared contract visible
+  // and fits more of them when the declared tier alone overflows. Skipped
+  // entries stay discoverable through ALL_TOOLS, and the stable input order
+  // keeps prompt bytes deterministic for provider caches.
+  const included: string[] = [];
+  for (const line of lines) {
     if (
-      renderCodeModeCatalogIndex(lines.slice(0, middle), lines.length).length <=
+      renderCodeModeCatalogIndex([...included, line], lines.length).length <=
       MAX_CODE_MODE_CATALOG_INDEX_CHARS
     ) {
-      low = middle;
-    } else {
-      high = middle - 1;
+      included.push(line);
     }
   }
-  return renderCodeModeCatalogIndex(lines.slice(0, low), lines.length);
+  return renderCodeModeCatalogIndex(included, lines.length);
 }
 
 function createCodeModeExecDescription(


### PR DESCRIPTION
## What Problem This Solves

The Code Mode quick index sorts declared-output tools first (#110317) and truncates to 8000 chars by keeping the longest contiguous **prefix** of lines that fits (binary search). If a single line alone exceeds the budget — a tool with a multi-KB id (`${source}:${owner}:${tool.name}`, where owner/name come from installed plugins and aren't length-capped) or a pathological input hint — the fitting prefix is 0 lines, so the **entire** quick index is blanked for that agent. A single buggy or hostile plugin thereby removes every declared-output contract hint, including core tools. Found via adversarial fuzzing during the stress pass that landed #110417; deferred from there.

## Why This Change Was Made

`formatCodeModeCatalogIndex` (`src/agents/code-mode.ts`) now greedily packs lines in the existing deterministic sorted order: it includes each line that keeps the rendered index within budget and **skips** any single line too large to fit, rather than dropping the whole tail after it. This:

- prevents one oversized entry from blanking the index (the reported failure mode);
- fits strictly more declared contracts when the declared tier alone overflows 8000 chars;
- is a simplification (removes the binary search).

Skipped entries stay fully discoverable through `ALL_TOOLS`, and packing over a deterministically sorted input keeps prompt bytes stable for provider prompt caches.

## User Impact

Code Mode agents on plugin-heavy or pathological catalogs keep their declared-output contract hints instead of losing the whole index to one bad entry. For existing catalogs whose index already exceeded 8000 chars, the packed content can differ slightly (a one-time prompt-cache miss); normal-sized catalogs render the full index unchanged.

## Evidence

- New regression: a declared tool with a ~9000-char id sorted first no longer blanks the index; all four short declared contracts survive and the oversized line is skipped (`src/agents/code-mode.test.ts`).
- New determinism test: same catalog produces a byte-identical truncated index across rebuilds.
- Full `src/agents/code-mode.test.ts`: 78 tests green.
- Autoreview (Codex gpt-5.6-sol): clean, "patch is correct (0.91)". Lint clean; +12/−11 LOC.
