### PR TITLE
fix(qa): avoid retaining credentials after successful live runs

### DIFF
--- a/extensions/qa-lab/src/live-transports/discord/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/adapter.runtime.ts
@@ -4,6 +4,10 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import {
+  createLiveTransportQuiesce,
+  runLiveTransportCleanupSteps,
+} from "../shared/live-transport-lifecycle.runtime.js";
 import { discordQaScenarioSupport } from "./discord-live.runtime.js";
 import { createDiscordQaScenarioEnvironment } from "./scenario-environment.js";
 
@@ -99,6 +103,14 @@ export async function createDiscordQaTransportAdapter(
       pollingError = error instanceof Error ? error : new Error(String(error));
     }
   });
+  const quiesce = createLiveTransportQuiesce({
+    stopPolling: () => {
+      stopped = true;
+    },
+    waitForPolling: async () => {
+      await polling.catch(() => undefined);
+    },
+  });
   const scenarioEnvironment = createDiscordQaScenarioEnvironment({
     accountId,
     driverIdentity,
@@ -156,15 +168,13 @@ export async function createDiscordQaTransportAdapter(
       throw new Error("Discord live QA adapter does not implement transport actions");
     },
     createReportNotes: () => ["Uses the Discord live adapter."],
+    quiesce,
     async cleanup() {
-      stopped = true;
-      await polling.catch(() => undefined);
-      // Lease release must still run when heartbeat shutdown reports an error.
-      try {
-        await heartbeat.stop();
-      } finally {
-        await lease.release();
-      }
+      await runLiveTransportCleanupSteps([
+        quiesce,
+        async () => await heartbeat.stop(),
+        async () => await lease.release(),
+      ]);
     },
   };
 }

--- a/extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
@@ -5,6 +5,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { buildQaTarget } from "openclaw/plugin-sdk/qa-channel";
 import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import { readQaScenarioExecutionConfig } from "../../scenario-catalog.js";
+import {
+  createLiveTransportQuiesce,
+  runLiveTransportCleanupSteps,
+} from "../shared/live-transport-lifecycle.runtime.js";
 import { createMatrixQaScenarioEnvironment } from "./scenarios/scenario-environment.js";
 import { createMatrixQaClient, provisionMatrixQaRoom } from "./substrate/client.js";
 import { buildMatrixQaConfig } from "./substrate/config.js";
@@ -274,6 +278,14 @@ export async function createMatrixQaTransportAdapter(
       pollingError = error instanceof Error ? error : new Error(String(error));
     }
   });
+  const quiesce = createLiveTransportQuiesce({
+    stopPolling: () => {
+      stopped = true;
+    },
+    waitForPolling: async () => {
+      await polling.catch(() => undefined);
+    },
+  });
 
   return {
     id: "matrix",
@@ -413,10 +425,9 @@ export async function createMatrixQaTransportAdapter(
       );
     },
     createReportNotes: () => ["Uses the Matrix live adapter."],
+    quiesce,
     async cleanup() {
-      stopped = true;
-      await polling.catch(() => undefined);
-      await harness.stop();
+      await runLiveTransportCleanupSteps([quiesce, async () => await harness.stop()]);
     },
   };
 }

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-lifecycle.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-lifecycle.runtime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createLiveTransportQuiesce,
+  runLiveTransportCleanupSteps,
+} from "./live-transport-lifecycle.runtime.js";
+
+describe("live transport lifecycle", () => {
+  it("stops, drains, and closes once across both cleanup phases", async () => {
+    const stopPolling = vi.fn();
+    const waitForPolling = vi.fn(async () => undefined);
+    const close = vi.fn(async () => undefined);
+    const quiesce = createLiveTransportQuiesce({ close, stopPolling, waitForPolling });
+
+    const first = quiesce();
+    const second = quiesce();
+
+    expect(second).toBe(first);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(stopPolling).toHaveBeenCalledOnce();
+    expect(waitForPolling).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("runs every cleanup step and preserves all failures", async () => {
+    const calls: string[] = [];
+    const firstFailure = new Error("first cleanup failed");
+    const secondFailure = new Error("second cleanup failed");
+
+    const cleanup = runLiveTransportCleanupSteps([
+      async () => {
+        calls.push("first");
+        throw firstFailure;
+      },
+      async () => {
+        calls.push("second");
+        throw secondFailure;
+      },
+      async () => {
+        calls.push("third");
+      },
+    ]);
+
+    await expect(cleanup).rejects.toEqual(
+      new AggregateError([firstFailure, secondFailure], "live transport cleanup failed"),
+    );
+    expect(calls).toEqual(["first", "second", "third"]);
+  });
+});

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-lifecycle.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-lifecycle.runtime.ts
@@ -1,0 +1,35 @@
+export function createLiveTransportQuiesce(params: {
+  close?: () => Promise<void>;
+  stopPolling: () => void;
+  waitForPolling: () => Promise<void>;
+}): () => Promise<void> {
+  let quiescePromise: Promise<void> | undefined;
+  return () => {
+    // Cleanup calls this again after gateway shutdown. Reuse the first drain so drivers close once.
+    quiescePromise ??= (async () => {
+      params.stopPolling();
+      await params.waitForPolling();
+      await params.close?.();
+    })();
+    return quiescePromise;
+  };
+}
+
+export async function runLiveTransportCleanupSteps(
+  steps: ReadonlyArray<() => Promise<void>>,
+): Promise<void> {
+  const errors: unknown[] = [];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "live transport cleanup failed");
+  }
+}

--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -6,6 +6,10 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import {
+  createLiveTransportQuiesce,
+  runLiveTransportCleanupSteps,
+} from "../shared/live-transport-lifecycle.runtime.js";
 import { createSlackQaScenarioEnvironment } from "./scenario-environment.js";
 import {
   buildSlackQaConfig,
@@ -160,6 +164,14 @@ export async function createSlackQaTransportAdapter(
       pollingError = error instanceof Error ? error : new Error(String(error));
     }
   });
+  const quiesce = createLiveTransportQuiesce({
+    stopPolling: () => {
+      stopped = true;
+    },
+    waitForPolling: async () => {
+      await polling.catch(() => undefined);
+    },
+  });
 
   return {
     id: "slack",
@@ -231,15 +243,13 @@ export async function createSlackQaTransportAdapter(
       throw new Error("Slack live QA adapter does not implement transport actions");
     },
     createReportNotes: () => ["Runs through the Slack live adapter and shared QA suite host."],
+    quiesce,
     async cleanup() {
-      stopped = true;
-      await polling.catch(() => undefined);
-      // Lease release must still run when heartbeat shutdown reports an error.
-      try {
-        await heartbeat.stop();
-      } finally {
-        await lease.release();
-      }
+      await runLiveTransportCleanupSteps([
+        quiesce,
+        async () => await heartbeat.stop(),
+        async () => await lease.release(),
+      ]);
     },
   };
 }

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -172,9 +172,14 @@ describe("Telegram QA transport adapter", () => {
     );
 
     await vi.waitFor(() => expect(pollResolvers).toHaveLength(3));
+    const quiesce = adapter.quiesce?.();
+    pollResolvers[2]?.([]);
+    await expect(quiesce).resolves.toBeUndefined();
+    expect(mocks.heartbeatStop).not.toHaveBeenCalled();
+    expect(mocks.leaseRelease).not.toHaveBeenCalled();
+
     mocks.heartbeatStop.mockRejectedValueOnce(new Error("heartbeat stop failed"));
     const cleanup = adapter.cleanup?.();
-    pollResolvers[2]?.([]);
     await expect(cleanup).rejects.toThrow("heartbeat stop failed");
     expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
     expect(mocks.leaseRelease).toHaveBeenCalledOnce();

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -10,6 +10,10 @@ import {
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
 import {
+  createLiveTransportQuiesce,
+  runLiveTransportCleanupSteps,
+} from "../shared/live-transport-lifecycle.runtime.js";
+import {
   buildTelegramQaConfig,
   callTelegramApi,
   flushTelegramUpdates,
@@ -45,14 +49,11 @@ export async function createTelegramQaTransportAdapter(
     throw error;
   }
   const heartbeat = startQaCredentialLeaseHeartbeat(credentialLease);
-  const releaseCredentialLease = async () => {
-    // Lease release must still run when heartbeat shutdown reports an error.
-    try {
-      await heartbeat.stop();
-    } finally {
-      await credentialLease.release();
-    }
-  };
+  const releaseCredentialLease = async () =>
+    await runLiveTransportCleanupSteps([
+      async () => await heartbeat.stop(),
+      async () => await credentialLease.release(),
+    ]);
   const runtimeEnv = credentialLease.payload;
   let driverIdentity: TelegramBotIdentity;
   let sutIdentity: TelegramBotIdentity;
@@ -149,6 +150,14 @@ export async function createTelegramQaTransportAdapter(
       pollingError = error instanceof Error ? error : new Error(String(error));
     }
   });
+  const quiesce = createLiveTransportQuiesce({
+    stopPolling: () => {
+      stopped = true;
+    },
+    waitForPolling: async () => {
+      await polling.catch(() => undefined);
+    },
+  });
   return {
     id: "telegram",
     label: "Telegram live",
@@ -224,27 +233,33 @@ export async function createTelegramQaTransportAdapter(
       throw new Error("Telegram live QA adapter does not implement transport actions");
     },
     createReportNotes: () => ["Runs through the Telegram live adapter and shared QA suite host."],
+    quiesce,
     async cleanup() {
-      stopped = true;
-      await polling.catch(() => undefined);
-      if (await shouldRetainQaGatewayCredentialLease()) {
-        const quarantineErrors: unknown[] = [];
-        try {
-          await credentialLease.heartbeat();
-        } catch (error) {
-          quarantineErrors.push(error);
-        }
-        try {
-          await heartbeat.stop();
-        } catch (error) {
-          quarantineErrors.push(error);
-        }
-        throw new Error(
-          "retained Telegram credential lease for two hours because isolated SUT quiescence was not proven",
-          quarantineErrors.length > 0 ? { cause: new AggregateError(quarantineErrors) } : undefined,
-        );
-      }
-      await releaseCredentialLease();
+      await runLiveTransportCleanupSteps([
+        quiesce,
+        async () => {
+          if (await shouldRetainQaGatewayCredentialLease()) {
+            const quarantineErrors: unknown[] = [];
+            try {
+              await credentialLease.heartbeat();
+            } catch (error) {
+              quarantineErrors.push(error);
+            }
+            try {
+              await heartbeat.stop();
+            } catch (error) {
+              quarantineErrors.push(error);
+            }
+            throw new Error(
+              "retained Telegram credential lease for two hours because isolated SUT quiescence was not proven",
+              quarantineErrors.length > 0
+                ? { cause: new AggregateError(quarantineErrors) }
+                : undefined,
+            );
+          }
+          await releaseCredentialLease();
+        },
+      ]);
     },
   };
 }

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
@@ -10,6 +10,10 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import {
+  createLiveTransportQuiesce,
+  runLiveTransportCleanupSteps,
+} from "../shared/live-transport-lifecycle.runtime.js";
 import { createWhatsAppQaScenarioEnvironment } from "./scenario-environment.js";
 import {
   buildWhatsAppQaConfig,
@@ -133,6 +137,15 @@ export async function createWhatsAppQaTransportAdapter(
       pollingError = error instanceof Error ? error : new Error(String(error));
     }
   });
+  const quiesce = createLiveTransportQuiesce({
+    close: async () => await getDriver().close(),
+    stopPolling: () => {
+      stopped = true;
+    },
+    waitForPolling: async () => {
+      await polling.catch(() => undefined);
+    },
+  });
 
   return {
     id: "whatsapp",
@@ -220,23 +233,14 @@ export async function createWhatsAppQaTransportAdapter(
       throw new Error("WhatsApp live QA adapter does not implement transport actions");
     },
     createReportNotes: () => ["Uses the WhatsApp live adapter."],
+    quiesce,
     async cleanup() {
-      stopped = true;
-      await polling.catch(() => undefined);
-      // Credential and auth cleanup must run even when the live driver cannot close cleanly.
-      try {
-        await getDriver().close();
-      } finally {
-        try {
-          await heartbeat.stop();
-        } finally {
-          try {
-            await lease.release();
-          } finally {
-            await fs.rm(authRoot, { force: true, recursive: true });
-          }
-        }
-      }
+      await runLiveTransportCleanupSteps([
+        quiesce,
+        async () => await heartbeat.stop(),
+        async () => await lease.release(),
+        async () => await fs.rm(authRoot, { force: true, recursive: true }),
+      ]);
     },
   };
 }

--- a/extensions/qa-lab/src/qa-transport-registry.test.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 
-function createAdapterDefinition(cleanup?: () => Promise<void>) {
+function createAdapterDefinition(cleanup?: () => Promise<void>, quiesce?: () => Promise<void>) {
   const state = createQaBusState();
   return {
     id: "selected",
@@ -30,6 +30,7 @@ function createAdapterDefinition(cleanup?: () => Promise<void>) {
     }),
     async handleAction() {},
     createReportNotes: () => [],
+    ...(quiesce ? { quiesce } : {}),
     ...(cleanup ? { cleanup } : {}),
   };
 }
@@ -83,9 +84,10 @@ describe("qa transport registry", () => {
     expect(selectedCreate).toHaveBeenCalledOnce();
   });
 
-  it("returns cleanup owned by the selected adapter", async () => {
+  it("returns lifecycle hooks owned by the selected adapter", async () => {
     const cleanup = vi.fn(async () => undefined);
-    const definition = createAdapterDefinition(cleanup);
+    const quiesce = vi.fn(async () => undefined);
+    const definition = createAdapterDefinition(cleanup, quiesce);
     const factory: QaTransportAdapterFactory = {
       id: "cleanup",
       matches: () => true,
@@ -98,8 +100,10 @@ describe("qa transport registry", () => {
       [factory],
     );
 
+    await created.quiesce?.();
     await created.cleanup();
 
+    expect(quiesce).toHaveBeenCalledOnce();
     expect(cleanup).toHaveBeenCalledOnce();
   });
 

--- a/extensions/qa-lab/src/qa-transport-registry.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.ts
@@ -25,6 +25,7 @@ export type QaTransportAdapterFactoryResult<
   TAdapter extends QaTransportAdapter = QaTransportAdapter,
 > = {
   adapter: TAdapter;
+  quiesce?: () => Promise<void>;
   cleanup: () => Promise<void>;
 };
 
@@ -103,6 +104,13 @@ function createQaTransportAdapterFactoryRegistry(
       }
       return {
         adapter,
+        ...(adapter.quiesce
+          ? {
+              quiesce: async () => {
+                await adapter.quiesce?.();
+              },
+            }
+          : {}),
         cleanup: async () => {
           await adapter.cleanup?.();
         },

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -359,6 +359,7 @@ export function createQaStateBackedTransportAdapter(
       ? { createRuntimeEnvPatch: params.createRuntimeEnvPatch }
       : {}),
     ...(params.prepareFlow ? { prepareFlow: params.prepareFlow } : {}),
+    ...(params.quiesce ? { quiesce: params.quiesce } : {}),
     ...(params.cleanup ? { cleanup: params.cleanup } : {}),
   });
   return adapter;

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -67,6 +67,38 @@ describe("qa suite", () => {
     expect(errors).toEqual([failure]);
   });
 
+  it("quiesces two-phase transports before gateway stop and releases them after", async () => {
+    const calls: string[] = [];
+    const failure = new Error("transport quiesce failed");
+    const step = (name: string, error?: Error) => async () => {
+      calls.push(name);
+      if (error) {
+        throw error;
+      }
+    };
+
+    const errors = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+      closeWebSessions: step("web sessions"),
+      quiesceTransport: step("transport quiesce", failure),
+      stopGateway: step("gateway"),
+      cleanupTransport: step("transport cleanup"),
+      disposeAgentHarnesses: step("agent harnesses"),
+      stopProvider: step("provider"),
+      finishLab: step("lab"),
+    });
+
+    expect(calls).toEqual([
+      "web sessions",
+      "transport quiesce",
+      "gateway",
+      "transport cleanup",
+      "agent harnesses",
+      "provider",
+      "lab",
+    ]);
+    expect(errors).toEqual([failure]);
+  });
+
   it("keeps the primary suite error as the cause of aggregated cleanup failures", () => {
     const runError = new Error("gateway infrastructure failed");
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -320,18 +320,21 @@ async function runQaSuiteCleanupSteps(steps: ReadonlyArray<() => Promise<void>>)
 
 async function runQaFlowSuiteCleanupPlan(params: {
   closeWebSessions?: () => Promise<void>;
+  quiesceTransport?: () => Promise<void>;
   cleanupTransport: () => Promise<void>;
   stopGateway?: () => Promise<void>;
   disposeAgentHarnesses: () => Promise<void>;
   stopProvider?: () => Promise<void>;
   finishLab: () => Promise<void>;
 }) {
+  const usesTwoPhaseTransportCleanup = params.quiesceTransport !== undefined;
   return await runQaSuiteCleanupSteps([
     ...(params.closeWebSessions ? [params.closeWebSessions] : []),
-    // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
-    // emit an unhandled response-close rejection during delivery.
-    params.cleanupTransport,
+    // Drain transport work before gateway shutdown, but keep credential resources alive until
+    // the gateway proves SUT quiescence. Legacy one-phase adapters still clean up here.
+    params.quiesceTransport ?? params.cleanupTransport,
     ...(params.stopGateway ? [params.stopGateway] : []),
+    ...(usesTwoPhaseTransportCleanup ? [params.cleanupTransport] : []),
     params.disposeAgentHarnesses,
     ...(params.stopProvider ? [params.stopProvider] : []),
     params.finishLab,
@@ -2026,6 +2029,7 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
     const activeMock = mock;
     const cleanupErrors = await runQaFlowSuiteCleanupPlan({
       closeWebSessions: activeEnv ? () => closeQaWebSessions(activeEnv.webSessionIds) : undefined,
+      quiesceTransport: transportFactoryResult.quiesce,
       cleanupTransport: () => transportFactoryResult.cleanup(),
       stopGateway: activeGateway
         ? () =>

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -130,6 +130,9 @@ type QaRunnerTransportAdapterDefinition = {
     concurrency: number;
     isolatedWorkers?: boolean;
   }) => string[];
+  // Drain transport I/O while the gateway remains available. Final cleanup runs
+  // after gateway shutdown so credential-backed adapters release only after SUT quiescence.
+  quiesce?: () => Promise<void>;
   cleanup?: () => Promise<void>;
 };
 


### PR DESCRIPTION
Related: #106027

## What Problem This Solves

Fixes an issue where successful credential-backed QA runs could fail during shutdown and retain their live credential lease when verified Gateway process isolation was enabled. Telegram release QA hit this deterministically because transport cleanup checked the still-live SUT marker before Gateway shutdown could prove quiescence and clear it.

## Why This Change Was Made

Adds an optional two-phase transport lifecycle. Live adapters first quiesce polling and active I/O while the Gateway is available, then release credentials and final resources only after Gateway shutdown; legacy one-phase adapters keep their existing order. Shared lifecycle helpers make quiescence idempotent and run every final cleanup step while preserving all failures.

## User Impact

No product-runtime behavior changes. QA and release operators can complete isolated live transport runs without false shutdown failures or unnecessary two-hour credential retention.

## Evidence

- Focused QA tests: 4 files, 38 tests passed.
- Blacksmith Testbox `tbx_01kxsz7f8wcrqm0avc1xa7w7jh`: `pnpm check:changed` passed after 13m29s, including core/extension typechecks, lint, SDK, architecture, and guard lanes. Hydration run: https://github.com/openclaw/openclaw/actions/runs/29634369669
- Autoreview: clean, no accepted/actionable findings; correctness score 0.94.
- A live Telegram canary reached the QA runtime on Testbox, then stopped at the expected credential boundary because that generic Testbox workflow does not hydrate the Convex broker secret. The isolated Telegram workflow is the exact credentialed proof lane for this head.

AI-assisted. I reviewed the lifecycle, failure handling, tests, and resulting diff.
