### PR TITLE
fix(ui): prevent appended chat rows from overlapping

### DIFF
--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -179,7 +179,7 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
     await server?.close();
   });
 
-  it("pastes and sends a roughly 2 MB PNG through the chat composer", async () => {
+  it("sends a roughly 2 MB PNG without overlapping transcript rows", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });
     const pngBytes = createLargePngBytes(1_901_669);

--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -194,7 +194,20 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
       const gateway = await installMockGateway(recorded.page, {
         historyMessages: [
           {
-            content: [{ text: "Ready for #99213 large screenshot paste proof.", type: "text" }],
+            content: [
+              {
+                text: [
+                  "The existing assistant reply is taller than the virtualizer estimate.",
+                  "",
+                  "- First line of the existing answer.",
+                  "- Second line of the existing answer.",
+                  "- Third line of the existing answer.",
+                  "- Fourth line of the existing answer.",
+                  "- Fifth line of the existing answer.",
+                ].join("\n"),
+                type: "text",
+              },
+            ],
             role: "assistant",
             timestamp: Date.now(),
           },
@@ -203,7 +216,7 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
 
       await recorded.page.goto(`${server.baseUrl}chat`);
       await recorded.page
-        .getByText("Ready for #99213 large screenshot paste proof.")
+        .getByText("The existing assistant reply is taller than the virtualizer estimate.")
         .waitFor({ timeout: 10_000 });
 
       const composer = recorded.page.locator(".agent-chat__composer-combobox textarea");
@@ -230,6 +243,25 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
       expect(attachment.mimeType).toBe("image/png");
       expect(attachment.fileName).toBe("pasted-image.png");
       expect(requireString(attachment.content, "attachment content")).toBe(imageBase64);
+
+      const assistantRow = recorded.page
+        .getByText("The existing assistant reply is taller than the virtualizer estimate.")
+        .locator("xpath=ancestor::div[contains(@class, 'chat-virtual-row')]");
+      const userRow = recorded.page
+        .getByText(prompt)
+        .locator("xpath=ancestor::div[contains(@class, 'chat-virtual-row')]");
+      await expect
+        .poll(async () => {
+          const [assistantBounds, userBounds] = await Promise.all([
+            assistantRow.boundingBox(),
+            userRow.boundingBox(),
+          ]);
+          if (!assistantBounds || !userBounds) {
+            return Number.NEGATIVE_INFINITY;
+          }
+          return Math.round(userBounds.y - (assistantBounds.y + assistantBounds.height));
+        })
+        .toBeGreaterThanOrEqual(0);
 
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
       await gateway.emitChatFinal({ runId, text: "Large screenshot paste proof received." });

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -198,13 +198,18 @@ function initialTranscriptScrollMargin(host: ReactiveControllerHost): number {
 class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private readonly controllers = new Set<ReactiveController>();
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
-  private scrollElement: HTMLDivElement | null = null;
+  private threadInnerElement: HTMLDivElement | null = null;
+  // Lit calls refs before newly rendered nodes are connected. Resolve the
+  // scroll parent lazily or a stable ref can permanently capture null.
+  private get scrollElement(): HTMLDivElement | null {
+    const parent = this.threadInnerElement?.parentElement;
+    return parent instanceof HTMLDivElement ? parent : null;
+  }
   // Stable Lit refs: inline arrows change identity per render, making Lit
   // re-invoke them for every visible row and re-measure each row every render.
   // Lit tracks the last element per callback, so each row needs its own.
   private readonly scrollElementRef = (element?: Element) => {
-    this.scrollElement =
-      element?.parentElement instanceof HTMLDivElement ? element.parentElement : null;
+    this.threadInnerElement = element instanceof HTMLDivElement ? element : null;
   };
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
   private measureRowRefFor(key: string): (element?: Element) => void {
@@ -296,7 +301,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     for (const controller of this.controllers) {
       controller.hostDisconnected?.();
     }
-    this.scrollElement = null;
+    this.threadInnerElement = null;
   }
 
   render(


### PR DESCRIPTION
## What Problem This Solves

Fixes Control UI transcript rows stacking on top of each other when a new message is appended after a tall reply, including image-paste turns.

## Why This Change Was Made

#110472 made the thread and row Lit refs stable to reduce forced reflows. Lit invokes the thread ref before the newly rendered inner element is connected, so reading `parentElement` in the callback permanently captured `null`. The virtualizer then had no scroll owner and left appended rows at the same transform.

This change stores the inner thread element and resolves its scroll parent lazily after the render commit, retaining the stable-ref performance improvement while restoring virtual row positioning.

## User Impact

Newly appended Control UI messages now appear below existing transcript rows without requiring a reload.

## Verification

- Regression reproduced on merged `main`: the focused browser test measured a persistent `-184px` row gap.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-large-paste-99213.e2e.test.ts`
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-history.test.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/chat-view.test.ts` (207 passed)
- Relevant virtualizer E2E cases in `ui/src/e2e/claude-sessions.e2e.test.ts` (2 passed)
- `pnpm format:check ui/src/pages/chat/components/chat-thread.ts ui/src/e2e/chat-large-paste-99213.e2e.test.ts`
- Blacksmith Testbox changed gate: `tbx_01kxt1fbjj2zt2eeq48cwrp6sc` ([run](https://github.com/openclaw/openclaw/actions/runs/29635524592))
- Blacksmith Testbox build: `tbx_01kxt1qn1qbc2x7r1fs0mfabg3` ([run](https://github.com/openclaw/openclaw/actions/runs/29635654203))
- Fresh autoreview: no findings

Related: #110472
