### PR TITLE
fix(googlechat): journal webhook events before ack

### DIFF
--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -81,6 +81,7 @@ function createTarget(): WebhookTarget {
     core: {} as never,
     path: "/googlechat",
     mediaMaxMb: 20,
+    ingress: { enqueue: vi.fn(async () => ({ kind: "accepted", duplicate: false })) },
   };
 }
 

--- a/extensions/googlechat/src/monitor-ingress.test.ts
+++ b/extensions/googlechat/src/monitor-ingress.test.ts
@@ -1,0 +1,196 @@
+// Googlechat tests cover durable webhook admission and replay.
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGoogleChatIngressSpool, type GoogleChatIngressPayload } from "./monitor-ingress.js";
+import type { GoogleChatRuntimeEnv } from "./monitor-types.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const runtime: GoogleChatRuntimeEnv = { log: vi.fn(), error: vi.fn() };
+
+const stateDirs: string[] = [];
+const disposers: Array<() => void> = [];
+type GoogleChatIngressDeliver = Parameters<typeof createGoogleChatIngressSpool>[0]["deliver"];
+type GoogleChatIngressSpool = ReturnType<typeof createGoogleChatIngressSpool>;
+
+async function createStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-googlechat-ingress-"));
+  const resolved = await realpath(created);
+  stateDirs.push(resolved);
+  return resolved;
+}
+
+function createQueue(stateDir: string) {
+  return createChannelIngressQueueForTests<GoogleChatIngressPayload>({
+    channelId: "googlechat",
+    accountId: "default",
+    stateDir,
+  });
+}
+
+function messageEvent(messageName: string): GoogleChatEvent {
+  return {
+    type: "MESSAGE",
+    space: { name: "spaces/AAA" },
+    message: { name: messageName, text: "hello", sender: { name: "users/123" } },
+    user: { name: "users/123" },
+    eventTime: "2026-03-22T00:00:00.000Z",
+  } as GoogleChatEvent;
+}
+
+function track(spool: GoogleChatIngressSpool): GoogleChatIngressSpool {
+  disposers.push(spool.dispose);
+  return spool;
+}
+
+async function drainSpool(spool: GoogleChatIngressSpool): Promise<void> {
+  await spool.drainOnce();
+  await spool.waitForIdle();
+}
+
+afterEach(async () => {
+  for (const dispose of disposers.splice(0).toReversed()) {
+    dispose();
+  }
+  for (const stateDir of stateDirs.splice(0).toReversed()) {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+describe("createGoogleChatIngressSpool", () => {
+  it("recovers an acknowledged-but-undispatched message with a fresh drain instance", async () => {
+    const stateDir = await createStateDir();
+    const first = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue: createQueue(stateDir),
+        deliver: vi.fn<GoogleChatIngressDeliver>(async () => undefined),
+      }),
+    );
+    await first.enqueue(messageEvent("spaces/AAA/messages/restart"));
+    // Simulate a crash after the webhook ack but before any dispatch ran.
+    first.dispose();
+
+    const deliver = vi.fn<GoogleChatIngressDeliver>(async (_event, lifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const recovered = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue: createQueue(stateDir),
+        deliver,
+      }),
+    );
+    await drainSpool(recovered);
+
+    expect(deliver).toHaveBeenCalledOnce();
+    expect(deliver.mock.calls[0]?.[0]).toMatchObject({
+      type: "MESSAGE",
+      message: { name: "spaces/AAA/messages/restart", text: "hello" },
+    });
+  });
+
+  it("reclaims a message whose dispatch was claimed when the gateway died", async () => {
+    const stateDir = await createStateDir();
+    const blockedDeliver = vi.fn<GoogleChatIngressDeliver>(() => new Promise<void>(() => {}));
+    const first = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue: createQueue(stateDir),
+        deliver: blockedDeliver,
+      }),
+    );
+    await first.enqueue(messageEvent("spaces/AAA/messages/claimed"));
+    await first.drainOnce();
+    expect(blockedDeliver).toHaveBeenCalledOnce();
+    // Crash mid-dispatch: the claim is still held by the disposed owner.
+    first.dispose();
+
+    const deliver = vi.fn<GoogleChatIngressDeliver>(async (_event, lifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const recovered = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue: createQueue(stateDir),
+        deliver,
+      }),
+    );
+    await drainSpool(recovered);
+
+    expect(deliver).toHaveBeenCalledOnce();
+    expect(deliver.mock.calls[0]?.[0]).toMatchObject({
+      message: { name: "spaces/AAA/messages/claimed" },
+    });
+  });
+
+  it("keeps a completed message tombstone from dispatching twice", async () => {
+    const stateDir = await createStateDir();
+    const deliver = vi.fn<GoogleChatIngressDeliver>(async (_event, lifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const spool = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue: createQueue(stateDir),
+        deliver,
+      }),
+    );
+
+    expect(await spool.enqueue(messageEvent("spaces/AAA/messages/dup"))).toMatchObject({
+      kind: "accepted",
+      duplicate: false,
+    });
+    await drainSpool(spool);
+    expect(await spool.enqueue(messageEvent("spaces/AAA/messages/dup"))).toMatchObject({
+      kind: "completed",
+      duplicate: true,
+    });
+    await drainSpool(spool);
+
+    expect(deliver).toHaveBeenCalledOnce();
+  });
+
+  it("uses the space as the durable lane", async () => {
+    const stateDir = await createStateDir();
+    const queue = createQueue(stateDir);
+    const spool = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue,
+        deliver: vi.fn<GoogleChatIngressDeliver>(async () => undefined),
+      }),
+    );
+
+    await spool.enqueue(messageEvent("spaces/AAA/messages/lane"));
+
+    expect(await queue.listPending()).toEqual([
+      expect.objectContaining({ laneKey: "space:spaces/AAA" }),
+    ]);
+  });
+
+  it("refuses to journal a MESSAGE event without a message name", async () => {
+    const stateDir = await createStateDir();
+    const spool = track(
+      createGoogleChatIngressSpool({
+        accountId: "default",
+        runtime,
+        queue: createQueue(stateDir),
+        deliver: vi.fn<GoogleChatIngressDeliver>(async () => undefined),
+      }),
+    );
+    const event = messageEvent("");
+    delete event.message?.name;
+
+    await expect(spool.enqueue(event)).rejects.toThrow("missing message.name");
+    expect(await createQueue(stateDir).listPending()).toEqual([]);
+  });
+});

--- a/extensions/googlechat/src/monitor-ingress.test.ts
+++ b/extensions/googlechat/src/monitor-ingress.test.ts
@@ -4,9 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createGoogleChatIngressSpool, type GoogleChatIngressPayload } from "./monitor-ingress.js";
+import { createGoogleChatIngressSpool } from "./monitor-ingress.js";
 import type { GoogleChatRuntimeEnv } from "./monitor-types.js";
 import type { GoogleChatEvent } from "./types.js";
+
+type GoogleChatIngressPayload = {
+  version: 1;
+  rawEvent: string;
+};
 
 const runtime: GoogleChatRuntimeEnv = { log: vi.fn(), error: vi.fn() };
 

--- a/extensions/googlechat/src/monitor-ingress.ts
+++ b/extensions/googlechat/src/monitor-ingress.ts
@@ -16,12 +16,12 @@ const GOOGLECHAT_COMPLETED_MAX_ENTRIES = 20_000;
 const GOOGLECHAT_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const GOOGLECHAT_FAILED_MAX_ENTRIES = 1_000;
 
-export type GoogleChatIngressPayload = {
+type GoogleChatIngressPayload = {
   version: typeof GOOGLECHAT_INGRESS_PAYLOAD_VERSION;
   rawEvent: string;
 };
 
-export type GoogleChatIngressLifecycle = ReturnType<
+type GoogleChatIngressLifecycle = ReturnType<
   typeof bindIngressLifecycleToReplyOptions
 >["turnAdoptionLifecycle"];
 
@@ -133,5 +133,3 @@ export function createGoogleChatIngressSpool(params: {
     dispose: () => drain.dispose(),
   };
 }
-
-export type GoogleChatIngressSpool = ReturnType<typeof createGoogleChatIngressSpool>;

--- a/extensions/googlechat/src/monitor-ingress.ts
+++ b/extensions/googlechat/src/monitor-ingress.ts
@@ -1,0 +1,137 @@
+// Googlechat plugin module owns durable webhook admission and replay.
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import type { GoogleChatRuntimeEnv } from "./monitor-types.js";
+import { getGoogleChatRuntime } from "./runtime.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const GOOGLECHAT_INGRESS_PAYLOAD_VERSION = 1;
+// Completed tombstones only guard duplicate admission (Google Chat does not
+// retry webhooks); failed rows keep longer diagnostics. Mirrors sms #109866.
+const GOOGLECHAT_COMPLETED_TTL_MS = 24 * 60 * 60 * 1000;
+const GOOGLECHAT_COMPLETED_MAX_ENTRIES = 20_000;
+const GOOGLECHAT_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const GOOGLECHAT_FAILED_MAX_ENTRIES = 1_000;
+
+export type GoogleChatIngressPayload = {
+  version: typeof GOOGLECHAT_INGRESS_PAYLOAD_VERSION;
+  rawEvent: string;
+};
+
+export type GoogleChatIngressLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
+
+class GoogleChatIngressPermanentError extends Error {}
+
+function resolveGoogleChatIngressEventId(event: GoogleChatEvent): string {
+  // Google Chat message resource names (spaces/<space>/messages/<message>) are
+  // the platform uniqueness contract, so the raw name is the redelivery key.
+  const eventId = typeof event.message?.name === "string" ? event.message.name.trim() : "";
+  if (!eventId) {
+    throw new GoogleChatIngressPermanentError("Google Chat MESSAGE event is missing message.name.");
+  }
+  return eventId;
+}
+
+function resolveGoogleChatIngressLaneKey(event: GoogleChatEvent, eventId: string): string {
+  const spaceName = typeof event.space?.name === "string" ? event.space.name.trim() : "";
+  return spaceName ? `space:${spaceName}` : `event:${eventId}`;
+}
+
+function readGoogleChatIngressEventType(event: GoogleChatEvent): string | undefined {
+  return event.type ?? (event as { eventType?: string }).eventType;
+}
+
+function parseGoogleChatIngressPayload(
+  payload: GoogleChatIngressPayload,
+  claimedId: string,
+): GoogleChatEvent {
+  if (
+    payload.version !== GOOGLECHAT_INGRESS_PAYLOAD_VERSION ||
+    typeof payload.rawEvent !== "string"
+  ) {
+    throw new GoogleChatIngressPermanentError("Google Chat ingress payload is invalid.");
+  }
+  let event: unknown;
+  try {
+    event = JSON.parse(payload.rawEvent);
+  } catch (error) {
+    throw new GoogleChatIngressPermanentError("Google Chat ingress event JSON is invalid.", {
+      cause: error,
+    });
+  }
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    throw new GoogleChatIngressPermanentError("Google Chat ingress event must be an object.");
+  }
+  const parsed = event as GoogleChatEvent;
+  if (readGoogleChatIngressEventType(parsed) !== "MESSAGE") {
+    throw new GoogleChatIngressPermanentError("Google Chat ingress row is not a MESSAGE event.");
+  }
+  if (resolveGoogleChatIngressEventId(parsed) !== claimedId) {
+    throw new GoogleChatIngressPermanentError(
+      "Google Chat message name changed after durable admission.",
+    );
+  }
+  return parsed;
+}
+
+export function createGoogleChatIngressSpool(params: {
+  accountId: string;
+  runtime: GoogleChatRuntimeEnv;
+  deliver: (event: GoogleChatEvent, lifecycle: GoogleChatIngressLifecycle) => Promise<void>;
+  queue?: ChannelIngressQueue<GoogleChatIngressPayload>;
+  abortSignal?: AbortSignal;
+}) {
+  const queue =
+    params.queue ??
+    getGoogleChatRuntime().state.openChannelIngressQueue<GoogleChatIngressPayload>({
+      accountId: params.accountId,
+    });
+  const drain = createChannelIngressDrain<GoogleChatIngressPayload>({
+    queue,
+    orderBy: "received",
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    onLog: (message) => params.runtime.error?.(`googlechat: ${message}`),
+    resolveNonRetryableFailure: (error) =>
+      error instanceof GoogleChatIngressPermanentError
+        ? { reason: "invalid-payload", message: error.message }
+        : null,
+    dispatchClaimedEvent: async (claimed, lifecycle) => {
+      await params.deliver(
+        parseGoogleChatIngressPayload(claimed.payload, claimed.id),
+        bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
+      );
+    },
+  });
+  return {
+    enqueue: async (event: GoogleChatEvent) => {
+      const eventId = resolveGoogleChatIngressEventId(event);
+      await queue.prune({
+        completedTtlMs: GOOGLECHAT_COMPLETED_TTL_MS,
+        completedMaxEntries: GOOGLECHAT_COMPLETED_MAX_ENTRIES,
+        failedTtlMs: GOOGLECHAT_FAILED_TTL_MS,
+        failedMaxEntries: GOOGLECHAT_FAILED_MAX_ENTRIES,
+      });
+      const result = await queue.enqueue(
+        eventId,
+        { version: GOOGLECHAT_INGRESS_PAYLOAD_VERSION, rawEvent: JSON.stringify(event) },
+        {
+          receivedAt: Date.now(),
+          laneKey: resolveGoogleChatIngressLaneKey(event, eventId),
+        },
+      );
+      return { kind: result.kind, duplicate: result.duplicate };
+    },
+    drainOnce: async () => {
+      await drain.drainOnce();
+    },
+    waitForIdle: drain.waitForIdle,
+    dispose: () => drain.dispose(),
+  };
+}
+
+export type GoogleChatIngressSpool = ReturnType<typeof createGoogleChatIngressSpool>;

--- a/extensions/googlechat/src/monitor-types.ts
+++ b/extensions/googlechat/src/monitor-types.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import type { GoogleChatAudienceType } from "./auth.js";
 import type { getGoogleChatRuntime } from "./runtime.js";
+import type { GoogleChatEvent } from "./types.js";
 
 export type GoogleChatRuntimeEnv = {
   log?: (message: string) => void;
@@ -31,4 +32,11 @@ export type WebhookTarget = {
   audience?: string;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   mediaMaxMb: number;
+  /**
+   * Durable admission for MESSAGE events. The webhook journals through this
+   * seam before acking Google; the owning monitor drains and disposes it.
+   */
+  ingress: {
+    enqueue: (event: GoogleChatEvent) => Promise<{ kind: string; duplicate: boolean }>;
+  };
 };

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -243,6 +243,7 @@ describe("googlechat monitor webhook", () => {
   });
 
   it("accepts add-on payloads that carry systemIdToken in the body", async () => {
+    const enqueue = vi.fn(async () => ({ kind: "accepted", duplicate: false }));
     const target = {
       account: {
         accountId: "default",
@@ -252,6 +253,7 @@ describe("googlechat monitor webhook", () => {
       statusSink: vi.fn(),
       audienceType: "app-url",
       audience: "https://example.com/googlechat",
+      ingress: { enqueue },
     };
     installSimplePipeline([target]);
     readJsonWebhookBodyOrReject.mockResolvedValue({
@@ -286,17 +288,16 @@ describe("googlechat monitor webhook", () => {
       audience: "https://example.com/googlechat",
       expectedAddOnPrincipal: "chat-app",
     });
-    expect(processEvent).toHaveBeenCalledWith(
-      {
-        type: "MESSAGE",
-        space: { name: "spaces/AAA" },
-        message: { name: "spaces/AAA/messages/1", text: "hello" },
-        user: { name: "users/123" },
-        eventTime: "2026-03-22T00:00:00.000Z",
-      },
-      target,
-    );
-    expect(runDetachedWebhookWork).toHaveBeenCalledTimes(1);
+    // MESSAGE events are journaled before the ack; dispatch is the drain's job.
+    expect(enqueue).toHaveBeenCalledWith({
+      type: "MESSAGE",
+      space: { name: "spaces/AAA" },
+      message: { name: "spaces/AAA/messages/1", text: "hello" },
+      user: { name: "users/123" },
+      eventTime: "2026-03-22T00:00:00.000Z",
+    });
+    expect(processEvent).not.toHaveBeenCalled();
+    expect(runDetachedWebhookWork).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
     expect(res.body).toBe("{}");
@@ -484,6 +485,7 @@ describe("googlechat monitor webhook", () => {
         statusSink: vi.fn(),
         audienceType: "app-url",
         audience: "https://example.com/googlechat",
+        ingress: { enqueue: vi.fn(async () => ({ kind: "accepted", duplicate: false })) },
       },
     ]);
     readJsonWebhookBodyOrReject.mockResolvedValue({
@@ -521,6 +523,7 @@ describe("googlechat monitor webhook", () => {
   it("does not log failed candidate targets when another target verifies", async () => {
     const logA = vi.fn();
     const logB = vi.fn();
+    const enqueueB = vi.fn(async () => ({ kind: "accepted", duplicate: false }));
     const targetA = {
       account: {
         accountId: "acct-a",
@@ -539,6 +542,7 @@ describe("googlechat monitor webhook", () => {
       statusSink: vi.fn(),
       audienceType: "app-url",
       audience: "https://example.com/googlechat",
+      ingress: { enqueue: enqueueB },
     };
     installSimplePipeline([targetA, targetB]);
     readJsonWebhookBodyOrReject.mockResolvedValue({
@@ -571,19 +575,130 @@ describe("googlechat monitor webhook", () => {
 
     expect(logA).not.toHaveBeenCalled();
     expect(logB).not.toHaveBeenCalled();
-    expect(processEvent).toHaveBeenCalledWith(
-      {
-        type: "MESSAGE",
-        space: { name: "spaces/BBB" },
-        message: { name: "spaces/BBB/messages/1", text: "hi" },
-        user: { name: "users/123" },
-        eventTime: "2026-03-22T00:00:00.000Z",
-      },
-      targetB,
-    );
+    expect(enqueueB).toHaveBeenCalledWith({
+      type: "MESSAGE",
+      space: { name: "spaces/BBB" },
+      message: { name: "spaces/BBB/messages/1", text: "hi" },
+      user: { name: "users/123" },
+      eventTime: "2026-03-22T00:00:00.000Z",
+    });
+    expect(processEvent).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
     expect(res.body).toBe("{}");
+  });
+
+  it("acks duplicate MESSAGE deliveries without dispatching them again", async () => {
+    const logFn = vi.fn();
+    const enqueue = vi.fn(async () => ({ kind: "completed", duplicate: true }));
+    installSimplePipeline([
+      {
+        account: {
+          accountId: "acct-dup",
+          config: { appPrincipal: "chat-app" },
+        },
+        runtime: { log: logFn, error: vi.fn() },
+        statusSink: vi.fn(),
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+        ingress: { enqueue },
+      },
+    ]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        commonEventObject: { hostApp: "CHAT" },
+        authorizationEventObject: { systemIdToken: "addon-token" },
+        chat: {
+          eventTime: "2026-03-22T00:00:00.000Z",
+          user: { name: "users/123" },
+          messagePayload: {
+            space: { name: "spaces/AAA" },
+            message: { name: "spaces/AAA/messages/9", text: "hi" },
+          },
+        },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) {
+          return target;
+        }
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    const { processEvent, res } = await runWebhookHandler();
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(processEvent).not.toHaveBeenCalled();
+    expect(logFn).toHaveBeenCalledWith(
+      "[acct-dup] Google Chat webhook ignored duplicate message spaces/AAA/messages/9",
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe("{}");
+  });
+
+  it("rejects the request when durable admission fails instead of acking", async () => {
+    const enqueue = vi.fn(async () => {
+      throw new Error("sqlite unavailable");
+    });
+    installSimplePipeline([
+      {
+        account: {
+          accountId: "acct-err",
+          config: { appPrincipal: "chat-app" },
+        },
+        runtime: { log: vi.fn(), error: vi.fn() },
+        statusSink: vi.fn(),
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+        ingress: { enqueue },
+      },
+    ]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        commonEventObject: { hostApp: "CHAT" },
+        authorizationEventObject: { systemIdToken: "addon-token" },
+        chat: {
+          eventTime: "2026-03-22T00:00:00.000Z",
+          user: { name: "users/123" },
+          messagePayload: {
+            space: { name: "spaces/AAA" },
+            message: { name: "spaces/AAA/messages/1", text: "hi" },
+          },
+        },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) {
+          return target;
+        }
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    const processEvent = vi.fn(async () => {});
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets: new Map(),
+      webhookRateLimiter: {
+        isRateLimited: vi.fn(() => false),
+        size: vi.fn(() => 0),
+        clear: vi.fn(),
+      },
+      webhookInFlightLimiter: {} as never,
+      processEvent,
+    });
+    const req = createRequest();
+    const res = createResponse();
+
+    // The plugin HTTP route layer converts this rejection into a 500, so Google
+    // never sees a false 200 for an event that was not journaled.
+    await expect(handler(req, res)).rejects.toThrow("sqlite unavailable");
+    expect(processEvent).not.toHaveBeenCalled();
+    expect(res.statusCode).not.toBe(200);
   });
 
   it("rejects missing add-on bearer tokens before dispatch", async () => {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -348,6 +348,25 @@ export function createGoogleChatWebhookRequestHandler(params: {
 
         const dispatchTarget = selectedTarget;
         dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
+        const eventType = parsedEvent.type ?? (parsedEvent as { eventType?: string }).eventType;
+        if (eventType === "MESSAGE") {
+          // Google Chat treats the 200 as final and does not retry webhooks, so
+          // the event must be durable before acking; an enqueue failure
+          // propagates to the plugin route layer, which answers 500 instead.
+          const verdict = await dispatchTarget.ingress.enqueue(parsedEvent);
+          if (verdict.duplicate) {
+            dispatchTarget.runtime.log?.(
+              `[${dispatchTarget.account.accountId}] Google Chat webhook ignored duplicate message ${parsedEvent.message?.name ?? "unknown"}`,
+            );
+          }
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          res.end("{}");
+          return true;
+        }
+        // CARD_CLICKED approvals and space lifecycle events run dedicated
+        // non-agent workflows (same journal boundary as msteams #110357) and
+        // keep the detached path.
         // Reserve the detached task before the HTTP admission is released;
         // otherwise later queue work inherits a released admission root.
         void runDetachedWebhookWork(() => params.processEvent(parsedEvent, dispatchTarget)).catch(

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -14,6 +14,7 @@ import { maybeHandleGoogleChatApprovalCardClick } from "./approval-card-click.js
 import type { GoogleChatAudienceType } from "./auth.js";
 import { applyGoogleChatInboundAccessPolicy } from "./monitor-access.js";
 import { resolveGoogleChatDurableReplyOptions } from "./monitor-durable.js";
+import { createGoogleChatIngressSpool } from "./monitor-ingress.js";
 import { deliverGoogleChatReply, type GoogleChatTypingMessage } from "./monitor-reply-delivery.js";
 import {
   registerGoogleChatWebhookTarget,
@@ -31,6 +32,12 @@ import { isGoogleChatGroupSpace } from "./targets.js";
 import type { GoogleChatAttachment, GoogleChatEvent } from "./types.js";
 
 setGoogleChatWebhookEventProcessor(processGoogleChatEvent);
+
+const GOOGLECHAT_INGRESS_DRAIN_INTERVAL_MS = 500;
+
+type GoogleChatTurnAdoptionLifecycle = NonNullable<
+  Parameters<GoogleChatCoreRuntime["channel"]["inbound"]["run"]>[0]["turnAdoptionLifecycle"]
+>;
 
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
@@ -119,7 +126,11 @@ function shouldSuppressGoogleChatBotLoop(params: {
   return true;
 }
 
-async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTarget) {
+async function processGoogleChatEvent(
+  event: GoogleChatEvent,
+  target: WebhookTarget,
+  turnAdoptionLifecycle?: GoogleChatTurnAdoptionLifecycle,
+) {
   const eventType = event.type ?? (event as { eventType?: string }).eventType;
   if (eventType === "CARD_CLICKED") {
     await maybeHandleGoogleChatApprovalCardClick({ event, target });
@@ -140,6 +151,7 @@ async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTar
     core: target.core,
     statusSink: target.statusSink,
     mediaMaxMb: target.mediaMaxMb,
+    ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
   });
 }
 
@@ -173,6 +185,7 @@ async function processMessageWithPipeline(params: {
   core: GoogleChatCoreRuntime;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   mediaMaxMb: number;
+  turnAdoptionLifecycle?: GoogleChatTurnAdoptionLifecycle;
 }): Promise<void> {
   const { event, account, config, runtime, core, statusSink, mediaMaxMb } = params;
   const space = event.space;
@@ -383,6 +396,9 @@ async function processMessageWithPipeline(params: {
     channel: "googlechat",
     accountId: route.accountId,
     raw: message,
+    ...(params.turnAdoptionLifecycle
+      ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+      : {}),
     adapter: {
       ingest: () => ({
         id: message.name ?? spaceId,
@@ -485,7 +501,7 @@ function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => voi
     log: options.runtime.log,
   });
 
-  const unregisterTarget = registerGoogleChatWebhookTarget({
+  const targetBase = {
     account: options.account,
     config: options.config,
     runtime: options.runtime,
@@ -495,9 +511,33 @@ function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => voi
     audience,
     statusSink: options.statusSink,
     mediaMaxMb,
+  };
+  const ingress = createGoogleChatIngressSpool({
+    accountId: options.account.accountId,
+    runtime: options.runtime,
+    abortSignal: options.abortSignal,
+    deliver: async (event, turnAdoptionLifecycle) => {
+      await processGoogleChatEvent(event, webhookTarget, turnAdoptionLifecycle);
+    },
   });
+  const webhookTarget: WebhookTarget = { ...targetBase, ingress };
+  const unregisterTarget = registerGoogleChatWebhookTarget(webhookTarget);
+
+  const requestDrain = () => {
+    void ingress.drainOnce().catch((error: unknown) => {
+      options.runtime.error?.(
+        `[${options.account.accountId}] Google Chat ingress drain failed: ${String(error)}`,
+      );
+    });
+  };
+  const drainTimer = setInterval(requestDrain, GOOGLECHAT_INGRESS_DRAIN_INTERVAL_MS);
+  drainTimer.unref?.();
+  // Replay events journaled before a crash or restart; Google already saw a 200.
+  requestDrain();
 
   return () => {
+    clearInterval(drainTimer);
+    ingress.dispose();
     unregisterTarget();
   };
 }

--- a/extensions/googlechat/src/monitor.webhook-durability-auth.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-durability-auth.test.ts
@@ -19,11 +19,15 @@ import { createWebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-reques
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import type { GoogleChatIngressPayload } from "./monitor-ingress.js";
 import { createGoogleChatIngressSpool } from "./monitor-ingress.js";
 import type { WebhookTarget } from "./monitor-types.js";
 import { createGoogleChatWebhookRequestHandler } from "./monitor-webhook.js";
 import type { GoogleChatEvent } from "./types.js";
+
+type GoogleChatIngressPayload = {
+  version: 1;
+  rawEvent: string;
+};
 
 const PROJECT_NUMBER = "123456789012";
 const CHAT_ISSUER = "chat@system.gserviceaccount.com";
@@ -34,7 +38,7 @@ const { privateKey: attackerPrivateKey } = generateKeyPairSync("rsa", { modulusL
 // google-auth-library passes this PEM straight into node crypto verify; an SPKI
 // public-key PEM exercises the identical RSA-SHA256 signature check as the X509
 // certificate PEMs Google serves.
-const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
 
 function base64UrlJson(value: unknown): string {
   return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
@@ -165,7 +169,11 @@ function createSpool(params: {
 function createAuthedWebhookHandler(target: WebhookTarget) {
   return createGoogleChatWebhookRequestHandler({
     webhookTargets: new Map([[target.path, [target]]]),
-    webhookRateLimiter: createFixedWindowRateLimiter({ windowMs: 60_000, maxRequests: 1_000 }),
+    webhookRateLimiter: createFixedWindowRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 1_000,
+      maxTrackedKeys: 1_000,
+    }),
     webhookInFlightLimiter: createWebhookInFlightLimiter(),
     processEvent: vi.fn(async () => undefined),
   });
@@ -264,7 +272,7 @@ describe("Google Chat webhook durability through real JWT authentication", () =>
       spoolBeforeRestart.dispose();
 
       const deliverAfterRestart = vi.fn(
-        async (_event: GoogleChatEvent, lifecycle: { onAdopted: () => Promise<void> }) => {
+        async (_event: GoogleChatEvent, lifecycle: { onAdopted: () => void | Promise<void> }) => {
           await lifecycle.onAdopted();
         },
       );

--- a/extensions/googlechat/src/monitor.webhook-durability-auth.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-durability-auth.test.ts
@@ -1,0 +1,326 @@
+// Google Chat webhook durability proven through the production auth path.
+//
+// These tests drive the real inbound stack end to end: POST -> real webhook
+// handler -> verifyGoogleChatRequest -> fetchChatCerts -> fetchWithSsrFGuard ->
+// google-auth-library verifySignedJwtWithCertsAsync, with only global fetch
+// stubbed to reroute the Google cert host to a loopback impersonator. The
+// signing key is a throwaway RSA key generated in-process; the JWT is really
+// signed and really verified. No credentials are mocked, no network leaves the
+// machine. Same proof standard as the accepted reply-delivery proof in
+// monitor.reply-delivery-failure.test.ts (#110147).
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { createFixedWindowRateLimiter } from "openclaw/plugin-sdk/webhook-ingress";
+import { createWebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-request-guards";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatIngressPayload } from "./monitor-ingress.js";
+import { createGoogleChatIngressSpool } from "./monitor-ingress.js";
+import type { WebhookTarget } from "./monitor-types.js";
+import { createGoogleChatWebhookRequestHandler } from "./monitor-webhook.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const PROJECT_NUMBER = "123456789012";
+const CHAT_ISSUER = "chat@system.gserviceaccount.com";
+const KEY_ID = "loopback-chat-key-1";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const { privateKey: attackerPrivateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+// google-auth-library passes this PEM straight into node crypto verify; an SPKI
+// public-key PEM exercises the identical RSA-SHA256 signature check as the X509
+// certificate PEMs Google serves.
+const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function signChatJwt(
+  payload: Record<string, unknown>,
+  signingKey: typeof privateKey = privateKey,
+): string {
+  const header = base64UrlJson({ alg: "RS256", kid: KEY_ID, typ: "JWT" });
+  const body = base64UrlJson(payload);
+  const signature = cryptoSign("sha256", Buffer.from(`${header}.${body}`), signingKey).toString(
+    "base64url",
+  );
+  return `${header}.${body}.${signature}`;
+}
+
+function signGoogleChatWebhookToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return signChatJwt({
+    iss: CHAT_ISSUER,
+    aud: PROJECT_NUMBER,
+    iat: now - 10,
+    exp: now + 3600,
+  });
+}
+
+function createGoogleImpersonator() {
+  const certRequests: string[] = [];
+  const handler = (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => {
+    const url = new URL(req.url ?? "/", "http://stub.invalid");
+    certRequests.push(url.pathname);
+    if (
+      req.method === "GET" &&
+      url.pathname === "/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com"
+    ) {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ [KEY_ID]: publicKeyPem }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end("not found");
+  };
+  return { handler, certRequests };
+}
+
+function stubGoogleHostsFetch() {
+  const realFetch = globalThis.fetch;
+  let stubBaseUrl: string | undefined;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    const url = new URL(rawUrl);
+    if (url.hostname === "www.googleapis.com" || url.hostname === "oauth2.googleapis.com") {
+      if (!stubBaseUrl) {
+        throw new Error("stub server base URL not installed");
+      }
+      return await realFetch(`${stubBaseUrl}${url.pathname}${url.search}`, init);
+    }
+    return await realFetch(input, init);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return {
+    fetchMock,
+    pointAtStub: (baseUrl: string) => {
+      stubBaseUrl = baseUrl;
+    },
+  };
+}
+
+const account = {
+  accountId: "default",
+  enabled: true,
+  credentialSource: "none",
+  config: {},
+} as ResolvedGoogleChatAccount;
+
+const inboundEvent = {
+  type: "MESSAGE",
+  space: { name: "spaces/AAA" },
+  message: {
+    name: "spaces/AAA/messages/authed-1",
+    text: "authenticated hello",
+    sender: { name: "users/123", displayName: "Real User" },
+  },
+  user: { name: "users/123", displayName: "Real User" },
+  eventTime: "2026-03-22T00:00:00.000Z",
+};
+
+const stateDirs: string[] = [];
+const disposers: Array<() => void> = [];
+
+async function createStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-googlechat-auth-"));
+  const resolved = await realpath(created);
+  stateDirs.push(resolved);
+  return resolved;
+}
+
+function createQueue(stateDir: string) {
+  return createChannelIngressQueueForTests<GoogleChatIngressPayload>({
+    channelId: "googlechat",
+    accountId: account.accountId,
+    stateDir,
+  });
+}
+
+function createSpool(params: {
+  stateDir: string;
+  deliver: (
+    event: GoogleChatEvent,
+    lifecycle: { onAdopted: () => void | Promise<void> },
+  ) => Promise<void>;
+}) {
+  const spool = createGoogleChatIngressSpool({
+    accountId: account.accountId,
+    runtime: { log: vi.fn(), error: vi.fn() },
+    queue: createQueue(params.stateDir),
+    deliver: params.deliver,
+  });
+  disposers.push(spool.dispose);
+  return spool;
+}
+
+function createAuthedWebhookHandler(target: WebhookTarget) {
+  return createGoogleChatWebhookRequestHandler({
+    webhookTargets: new Map([[target.path, [target]]]),
+    webhookRateLimiter: createFixedWindowRateLimiter({ windowMs: 60_000, maxRequests: 1_000 }),
+    webhookInFlightLimiter: createWebhookInFlightLimiter(),
+    processEvent: vi.fn(async () => undefined),
+  });
+}
+
+function createTarget(spool: ReturnType<typeof createSpool>): WebhookTarget {
+  return {
+    account,
+    config: {} as OpenClawConfig,
+    runtime: { log: vi.fn(), error: vi.fn() },
+    core: {} as WebhookTarget["core"],
+    path: "/googlechat",
+    audienceType: "project-number",
+    audience: PROJECT_NUMBER,
+    statusSink: vi.fn(),
+    mediaMaxMb: 5,
+    ingress: spool,
+  };
+}
+
+async function postWebhook(
+  baseUrl: string,
+  params: { bearer: string },
+): Promise<{ status: number; body: string }> {
+  const response = await fetch(`${baseUrl}/googlechat`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${params.bearer}`,
+    },
+    body: JSON.stringify(inboundEvent),
+  });
+  return { status: response.status, body: await response.text() };
+}
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  for (const dispose of disposers.splice(0).toReversed()) {
+    dispose();
+  }
+  for (const stateDir of stateDirs.splice(0).toReversed()) {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+describe("Google Chat webhook durability through real JWT authentication", () => {
+  it("journals a real signed webhook before ack and replays it once after a restart", async () => {
+    const stateDir = await createStateDir();
+    const fetchControl = stubGoogleHostsFetch();
+    const google = createGoogleImpersonator();
+    await withServer(google.handler, async (googleBaseUrl) => {
+      fetchControl.pointAtStub(googleBaseUrl);
+      const deliverBeforeRestart = vi.fn(async () => undefined);
+      const spoolBeforeRestart = createSpool({
+        stateDir,
+        deliver: deliverBeforeRestart,
+      });
+      const handler = createAuthedWebhookHandler(createTarget(spoolBeforeRestart));
+
+      await withServer(
+        (req, res) => {
+          void handler(req, res);
+        },
+        async (webhookBaseUrl) => {
+          const response = await postWebhook(webhookBaseUrl, {
+            bearer: signGoogleChatWebhookToken(),
+          });
+          expect(response.status).toBe(200);
+          expect(response.body).toBe("{}");
+        },
+      );
+
+      // The production auth path ran: the cert fetch went to the Google cert
+      // host (rerouted to the loopback impersonator) and the RS256 signature
+      // verified against the served key.
+      const requestedUrls = fetchControl.fetchMock.mock.calls.map((call) => {
+        const input = call[0] as RequestInfo | URL;
+        return input instanceof Request ? input.url : String(input);
+      });
+      expect(
+        requestedUrls.some((url) =>
+          url.startsWith(
+            "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com",
+          ),
+        ),
+      ).toBe(true);
+      // Google saw a 200 after real verification, but dispatch never ran.
+      expect(deliverBeforeRestart).not.toHaveBeenCalled();
+      expect(await createQueue(stateDir).listPending()).toEqual([
+        expect.objectContaining({
+          id: "spaces/AAA/messages/authed-1",
+          laneKey: "space:spaces/AAA",
+        }),
+      ]);
+      // Crash between ack and dispatch.
+      spoolBeforeRestart.dispose();
+
+      const deliverAfterRestart = vi.fn(
+        async (_event: GoogleChatEvent, lifecycle: { onAdopted: () => Promise<void> }) => {
+          await lifecycle.onAdopted();
+        },
+      );
+      const spoolAfterRestart = createSpool({ stateDir, deliver: deliverAfterRestart });
+      await spoolAfterRestart.drainOnce();
+      await spoolAfterRestart.waitForIdle();
+
+      expect(deliverAfterRestart).toHaveBeenCalledOnce();
+      expect(deliverAfterRestart.mock.calls[0]?.[0]).toMatchObject({
+        type: "MESSAGE",
+        message: { name: "spaces/AAA/messages/authed-1", text: "authenticated hello" },
+      });
+
+      // The completed tombstone survives another restart: no second dispatch.
+      spoolAfterRestart.dispose();
+      const deliverAfterSecondRestart = vi.fn(async () => undefined);
+      const spoolAfterSecondRestart = createSpool({
+        stateDir,
+        deliver: deliverAfterSecondRestart,
+      });
+      await spoolAfterSecondRestart.drainOnce();
+      await spoolAfterSecondRestart.waitForIdle();
+      expect(deliverAfterSecondRestart).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects a webhook signed by an unknown key before journaling anything", async () => {
+    const stateDir = await createStateDir();
+    const fetchControl = stubGoogleHostsFetch();
+    const google = createGoogleImpersonator();
+    await withServer(google.handler, async (googleBaseUrl) => {
+      fetchControl.pointAtStub(googleBaseUrl);
+      const deliver = vi.fn(async () => undefined);
+      const spool = createSpool({ stateDir, deliver });
+      const handler = createAuthedWebhookHandler(createTarget(spool));
+
+      await withServer(
+        (req, res) => {
+          void handler(req, res);
+        },
+        async (webhookBaseUrl) => {
+          const now = Math.floor(Date.now() / 1000);
+          // Same claims and kid, but signed by a key the cert host never served.
+          const forgedBearer = signChatJwt(
+            { iss: CHAT_ISSUER, aud: PROJECT_NUMBER, iat: now - 10, exp: now + 3600 },
+            attackerPrivateKey,
+          );
+          const response = await postWebhook(webhookBaseUrl, { bearer: forgedBearer });
+          expect(response.status).toBe(401);
+        },
+      );
+      await spool.drainOnce();
+      await spool.waitForIdle();
+      // The forged event was never journaled, so nothing replays.
+      expect(deliver).not.toHaveBeenCalled();
+      expect(await createQueue(stateDir).listPending()).toEqual([]);
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor.webhook-durability.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-durability.test.ts
@@ -9,11 +9,15 @@ import { createWebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-reques
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import type { GoogleChatIngressPayload } from "./monitor-ingress.js";
 import { createGoogleChatIngressSpool } from "./monitor-ingress.js";
 import type { WebhookTarget } from "./monitor-types.js";
 import { createGoogleChatWebhookRequestHandler } from "./monitor-webhook.js";
 import type { GoogleChatEvent } from "./types.js";
+
+type GoogleChatIngressPayload = {
+  version: 1;
+  rawEvent: string;
+};
 
 vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(async () => ({ ok: true })),
@@ -110,7 +114,11 @@ describe("Google Chat webhook durability", () => {
     };
     const handler = createGoogleChatWebhookRequestHandler({
       webhookTargets: new Map([[target.path, [target]]]),
-      webhookRateLimiter: createFixedWindowRateLimiter({ windowMs: 60_000, maxRequests: 1_000 }),
+      webhookRateLimiter: createFixedWindowRateLimiter({
+        windowMs: 60_000,
+        maxRequests: 1_000,
+        maxTrackedKeys: 1_000,
+      }),
       webhookInFlightLimiter: createWebhookInFlightLimiter(),
       processEvent: vi.fn(async () => undefined),
     });
@@ -146,7 +154,7 @@ describe("Google Chat webhook durability", () => {
     spoolBeforeRestart.dispose();
 
     const deliverAfterRestart = vi.fn(
-      async (_event: GoogleChatEvent, lifecycle: { onAdopted: () => Promise<void> }) => {
+      async (_event: GoogleChatEvent, lifecycle: { onAdopted: () => void | Promise<void> }) => {
         await lifecycle.onAdopted();
       },
     );

--- a/extensions/googlechat/src/monitor.webhook-durability.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-durability.test.ts
@@ -1,0 +1,177 @@
+// Googlechat tests cover webhook durability across a simulated gateway restart.
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { createFixedWindowRateLimiter } from "openclaw/plugin-sdk/webhook-ingress";
+import { createWebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-request-guards";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatIngressPayload } from "./monitor-ingress.js";
+import { createGoogleChatIngressSpool } from "./monitor-ingress.js";
+import type { WebhookTarget } from "./monitor-types.js";
+import { createGoogleChatWebhookRequestHandler } from "./monitor-webhook.js";
+import type { GoogleChatEvent } from "./types.js";
+
+vi.mock("./auth.js", () => ({
+  verifyGoogleChatRequest: vi.fn(async () => ({ ok: true })),
+}));
+
+const stateDirs: string[] = [];
+const disposers: Array<() => void> = [];
+
+async function createStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-googlechat-webhook-"));
+  const resolved = await realpath(created);
+  stateDirs.push(resolved);
+  return resolved;
+}
+
+function createQueue(stateDir: string) {
+  return createChannelIngressQueueForTests<GoogleChatIngressPayload>({
+    channelId: "googlechat",
+    accountId: "default",
+    stateDir,
+  });
+}
+
+function createSpool(params: {
+  stateDir: string;
+  deliver: (
+    event: GoogleChatEvent,
+    lifecycle: { onAdopted: () => void | Promise<void> },
+  ) => Promise<void>;
+}) {
+  const spool = createGoogleChatIngressSpool({
+    accountId: "default",
+    runtime: { log: vi.fn(), error: vi.fn() },
+    queue: createQueue(params.stateDir),
+    deliver: params.deliver,
+  });
+  disposers.push(spool.dispose);
+  return spool;
+}
+
+const account = {
+  accountId: "default",
+  enabled: true,
+  credentialSource: "none",
+  config: {},
+} as ResolvedGoogleChatAccount;
+
+const inboundEvent = {
+  type: "MESSAGE",
+  space: { name: "spaces/AAA" },
+  message: {
+    name: "spaces/AAA/messages/durable-1",
+    text: "are you there?",
+    sender: { name: "users/123", displayName: "Real User" },
+  },
+  user: { name: "users/123", displayName: "Real User" },
+  eventTime: "2026-03-22T00:00:00.000Z",
+};
+
+afterEach(async () => {
+  for (const dispose of disposers.splice(0).toReversed()) {
+    dispose();
+  }
+  for (const stateDir of stateDirs.splice(0).toReversed()) {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+afterAll(() => {
+  vi.doUnmock("./auth.js");
+  vi.resetModules();
+});
+
+describe("Google Chat webhook durability", () => {
+  it("replays a 200-acked message after a restart that killed dispatch", async () => {
+    const stateDir = await createStateDir();
+    // The pre-restart deliver never runs: the gateway dies between the webhook
+    // ack and the first drain, which is exactly the old loss window.
+    const deliverBeforeRestart = vi.fn(async () => undefined);
+    const spoolBeforeRestart = createSpool({
+      stateDir,
+      deliver: deliverBeforeRestart,
+    });
+    const statusSink = vi.fn();
+    const target: WebhookTarget = {
+      account,
+      config: {} as OpenClawConfig,
+      runtime: { log: vi.fn(), error: vi.fn() },
+      core: {} as WebhookTarget["core"],
+      path: "/googlechat",
+      statusSink,
+      mediaMaxMb: 5,
+      ingress: spoolBeforeRestart,
+    };
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets: new Map([[target.path, [target]]]),
+      webhookRateLimiter: createFixedWindowRateLimiter({ windowMs: 60_000, maxRequests: 1_000 }),
+      webhookInFlightLimiter: createWebhookInFlightLimiter(),
+      processEvent: vi.fn(async () => undefined),
+    });
+
+    await withServer(
+      (req, res) => {
+        void handler(req, res);
+      },
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/googlechat`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test-token",
+          },
+          body: JSON.stringify(inboundEvent),
+        });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({});
+      },
+    );
+
+    // Google saw a 200, but dispatch never ran.
+    expect(deliverBeforeRestart).not.toHaveBeenCalled();
+    // The event is durable in the shared-state ingress queue.
+    expect(await createQueue(stateDir).listPending()).toEqual([
+      expect.objectContaining({
+        id: "spaces/AAA/messages/durable-1",
+        laneKey: "space:spaces/AAA",
+      }),
+    ]);
+    // Crash: nothing graceful, the owning monitor is gone.
+    spoolBeforeRestart.dispose();
+
+    const deliverAfterRestart = vi.fn(
+      async (_event: GoogleChatEvent, lifecycle: { onAdopted: () => Promise<void> }) => {
+        await lifecycle.onAdopted();
+      },
+    );
+    const spoolAfterRestart = createSpool({ stateDir, deliver: deliverAfterRestart });
+    await spoolAfterRestart.drainOnce();
+    await spoolAfterRestart.waitForIdle();
+
+    expect(deliverAfterRestart).toHaveBeenCalledOnce();
+    expect(deliverAfterRestart.mock.calls[0]?.[0]).toMatchObject({
+      type: "MESSAGE",
+      space: { name: "spaces/AAA" },
+      message: { name: "spaces/AAA/messages/durable-1", text: "are you there?" },
+      user: { name: "users/123" },
+      eventTime: "2026-03-22T00:00:00.000Z",
+    });
+
+    // The completed tombstone survives the restart too: no second dispatch.
+    spoolAfterRestart.dispose();
+    const deliverAfterSecondRestart = vi.fn(async () => undefined);
+    const spoolAfterSecondRestart = createSpool({
+      stateDir,
+      deliver: deliverAfterSecondRestart,
+    });
+    await spoolAfterSecondRestart.drainOnce();
+    await spoolAfterSecondRestart.waitForIdle();
+    expect(deliverAfterSecondRestart).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -98,6 +98,8 @@ function registerTwoTargets() {
   const sinkB = vi.fn();
   const logA = vi.fn();
   const logB = vi.fn();
+  const enqueueA = vi.fn(async () => ({ kind: "accepted", duplicate: false }));
+  const enqueueB = vi.fn(async () => ({ kind: "accepted", duplicate: false }));
   const core = {} as PluginRuntime;
   const config = {} as OpenClawConfig;
 
@@ -109,6 +111,7 @@ function registerTwoTargets() {
     path: "/googlechat",
     statusSink: sinkA,
     mediaMaxMb: 5,
+    ingress: { enqueue: enqueueA },
   });
   const unregisterB = registerGoogleChatWebhookTarget({
     account: baseAccount("B"),
@@ -118,6 +121,7 @@ function registerTwoTargets() {
     path: "/googlechat",
     statusSink: sinkB,
     mediaMaxMb: 5,
+    ingress: { enqueue: enqueueB },
   });
   webhookRouteHandler = expectDefined(registry.httpRoutes[0], "Google Chat webhook route").handler;
 
@@ -126,6 +130,8 @@ function registerTwoTargets() {
     logB,
     sinkA,
     sinkB,
+    enqueueA,
+    enqueueB,
     unregister: () => {
       unregisterA();
       unregisterB();


### PR DESCRIPTION
## What Problem This Solves

The Google Chat webhook acks inbound events with HTTP 200 **before** dispatching them. `extensions/googlechat/src/monitor-webhook.ts:353-363` fires `void runDetachedWebhookWork(() => params.processEvent(...))` and immediately answers `res.statusCode = 200; res.end("{}")`. There is no journal anywhere on the path — `monitor-routing.ts` wires `processEvent` straight to dispatch.

A gateway crash (or restart, OOM, deploy) in the window between the 200 and the detached dispatch permanently loses the user message: Google Chat treats the 200 as final delivery and does not retry webhooks. A dispatch failure is only logged (`runtime.error`), never recovered. The user sees their message vanish with no error on either side.

## Why This Change Was Made

This mirrors the maintainer-blessed inbound-durability wave already landed for sibling channels: sms #109866 (Twilio webhook spool), msteams #110357 (journal before webhook ack), discord #110274, whatsapp #110418, imessage #110409, mattermost #110386. Google Chat was the remaining webhook channel with the ack-then-lose window.

Mechanism, owner boundary, and storage follow the sms spool shape exactly:

- **Journal before ack** (`monitor-webhook.ts`): after auth + parse, `MESSAGE` events are admitted through `target.ingress.enqueue(event)` — a durable append to the existing shared-state `channel_ingress_events` queue (`runtime.state.openChannelIngressQueue`, same seam sms/msteams/discord already use; **no schema change**). Only after SQLite commits does the webhook answer 200. An enqueue failure propagates to the plugin HTTP route layer, which answers 500 — a honest non-ack instead of a false one.
- **Dedupe key** = the Google Chat message resource name (`spaces/<space>/messages/<message>`, the platform uniqueness contract), lane = space name, matching msteams' `event_id = activity.id, lane = conversation.id`.
- **Drain + replay** (`monitor-ingress.ts`, new): `createGoogleChatIngressSpool` wraps `createChannelIngressDrain` with retry/dead-letter classification and 24h/20k completed + 30d/1k failed tombstones (sms values). The owning monitor (`monitor.ts`) drains on a 500ms interval and once at startup, so events journaled before a crash replay after restart; entries are tombstoned only after turn adoption via `bindIngressLifecycleToReplyOptions` wired into `core.channel.inbound.run({ turnAdoptionLifecycle })`.
- **Journal boundary**: `CARD_CLICKED` approval clicks and space lifecycle events run dedicated non-agent workflows and keep the existing detached path — the same twin-check boundary msteams #110357 used (messageUpdate/votes/consent excluded). No SDK/core changes; everything lives in the googlechat plugin.

## User Impact

- A gateway crash or restart no longer loses Google Chat user messages that were already acked: they replay from the durable queue on startup.
- Redelivered duplicates (same `message.name`) are acked without dispatching twice, via completed tombstones.
- If durable admission itself fails (e.g. state DB unavailable), Google gets a 500 instead of a false 200, so the failure is visible instead of silent.
- No config, schema, or API changes; CARD_CLICKED approval flow unchanged.

## Evidence

### Loss window (before fix, `origin/main` @ `00eb33fe8e`)

`monitor-webhook.ts:351-363`: detached `runDetachedWebhookWork(processEvent)` + immediate `res.statusCode = 200; res.end("{}")`. Reverse verification: with the prod fix reverted (`git checkout HEAD -- monitor-webhook.ts monitor.ts monitor-types.ts`), the new durability test goes red exactly at the durability assertion:

```
FAIL extensions/googlechat/src/monitor.webhook-durability.test.ts
  × replays a 200-acked message after a restart that killed dispatch
AssertionError: expected [] to deeply equal [ ObjectContaining{…} ]
  - Expected: [ { id: "spaces/AAA/messages/durable-1", laneKey: "space:spaces/AAA" } ]
  + Received: []        ← 200 already sent, nothing journaled: message lost on restart
```

### Authenticated-path proof (real JWT verification, round 1 proof upgrade)

`monitor.webhook-durability-auth.test.ts` drives the **real inbound auth stack** end to end: POST through the real webhook handler, the real `verifyGoogleChatRequest` (`extensions/googlechat/src/auth.ts`), the real cert fetch through `fetchWithSsrFGuard`, and `google-auth-library`'s `verifySignedJwtWithCertsAsync` RS256 verification of a JWT really signed in-process (`iss: chat@system.gserviceaccount.com`, `aud: <project-number>`). Only the Google cert host (`www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com`) is rerouted to a loopback impersonator serving the matching RSA public key via a `vi.fn` fetch stub — the same accepted proof standard as the reply-delivery proof in #110147 (same plugin, same message-delivery class). No credentials are mocked; the auth middleware is fully real.

Transcript summary (all assertions from the passing run):

```
POST /googlechat  Authorization: Bearer <real RS256 JWT>
  -> production verifyGoogleChatRequest
  -> cert fetch observed at https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com (rerouted to loopback)
  -> google-auth-library verifySignedJwtWithCertsAsync: signature VALID
response: 200 {}
dispatch ran before restart:        false
listPending() after the 200:        [ { id: "spaces/AAA/messages/authed-1", laneKey: "space:spaces/AAA" } ]
crash (spool.dispose, no drain)
restart: fresh spool, same stateDir
deliverAfterRestart:                called exactly 1x with journaled event (text "authenticated hello" intact)
second restart:                     no redispatch (completed tombstone holds)

forgery control: same claims/kid signed by an unserved key
response: 401 (before any journaling)
listPending():                      []   (nothing replays)
```

### Real-behavior proof (after fix)

`monitor.webhook-durability.test.ts` drives the **real webhook handler** through a real loopback HTTP server (`withServer` from `plugin-sdk/test-env`) with the real body reader, rate/in-flight limiters, and a real SQLite ingress queue in a temp state dir:

1. `POST /googlechat` with a `MESSAGE` event → **200 `{}`** (auth stubbed via `vi.mock("./auth.js")`, the only mock; admission path is fully real).
2. Assert dispatch never ran and the event **is durable**: `listPending()` returns `{ id: "spaces/AAA/messages/durable-1", laneKey: "space:spaces/AAA" }`.
3. Simulate crash: `spool.dispose()` with no drain.
4. Fresh spool over the same state dir (restart) → `drainOnce()` → dispatch called **exactly once** with the journaled event payload intact (`message.text: "are you there?"`, user, eventTime preserved).
5. Second restart → tombstone holds, **no second dispatch**.

`monitor-ingress.test.ts` (real SQLite queue, no mocks) additionally proves: pending-event recovery across instances, **claimed-mid-dispatch reclaim** after owner death (the crash-between-claim-and-adopt window), completed-tombstone dedupe (`kind: "completed", duplicate: true` on re-enqueue, single dispatch), space-based lane key, and refusal to journal a `MESSAGE` event without `message.name`.

### Test suite

```
$ node scripts/run-vitest.mjs extensions/googlechat/src/monitor-ingress.test.ts \
    extensions/googlechat/src/monitor.webhook-durability.test.ts \
    extensions/googlechat/src/monitor.webhook-durability-auth.test.ts \
    extensions/googlechat/src/monitor-webhook.test.ts \
    extensions/googlechat/src/monitor.webhook-routing.test.ts \
    extensions/googlechat/src/monitor.test.ts
Test Files  6 passed (6)
     Tests  42 passed (42)
```

Full `extensions/googlechat` suite: 216/217 — the single failure (`setup.test.ts` "configures service-account auth and webhook audience") fails identically on a clean `origin/main` checkout (verified via `git stash`), pre-existing and unrelated to this diff.

### tsgo / lint / format

```
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json
(only the 3 pre-existing packages/net-policy/src/ip.ts errors; zero in touched files)
$ oxlint -c .oxlintrc.json <touched files>   → 0 findings
$ oxfmt --check <touched files>              → clean
$ git diff --check                           → clean
```

