### PR TITLE
refactor(macos): move PortGuardian state to SQLite

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34227,7 +34227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 187,
+      "line": 250,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
@@ -34235,7 +34235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 203,
+      "line": 264,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
@@ -34243,7 +34243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 203,
+      "line": 264,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",
@@ -34251,7 +34251,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 45,
+      "line": 47,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs notification permission to show alerts for agent actions.",
       "surface": "apple",
@@ -34259,7 +34259,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 47,
+      "line": 49,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw captures the screen when the agent needs screenshots for context.",
       "surface": "apple",
@@ -34267,7 +34267,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 49,
+      "line": 51,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can capture photos or short video clips when requested by the agent.",
       "surface": "apple",
@@ -34275,7 +34275,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 55,
+      "line": 57,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can share your location when requested by the agent.",
       "surface": "apple",
@@ -34283,7 +34283,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 57,
+      "line": 59,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses the local network to connect to your remote OpenClaw gateway over LAN, Tailnet, or SSH.",
       "surface": "apple",
@@ -34291,7 +34291,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 59,
+      "line": 61,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs the mic for Voice Wake tests and agent audio capture.",
       "surface": "apple",
@@ -34299,7 +34299,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 61,
+      "line": 63,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses speech recognition to detect your Voice Wake trigger phrase.",
       "surface": "apple",
@@ -34307,7 +34307,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 63,
+      "line": 65,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs Automation (AppleScript) permission to drive Terminal and other apps for agent actions.",
       "surface": "apple",
@@ -34315,7 +34315,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 65,
+      "line": 67,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can access Reminders when requested by the agent for the apple-reminders skill.",
       "surface": "apple",

--- a/apps/ios/.swiftlint.yml
+++ b/apps/ios/.swiftlint.yml
@@ -7,6 +7,7 @@ included:
   - WatchApp
   - ../shared/OpenClawKit/Sources/OpenClawChatUI
   - ../shared/OpenClawKit/Sources/OpenClawKit
+  - ../shared/OpenClawKit/Sources/OpenClawNativeState
   - ../shared/OpenClawKit/Sources/OpenClawProtocol
   - ../swabble/Sources/SwabbleKit
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -95,7 +95,7 @@ targets:
           export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
           "$SRCROOT/../../scripts/check-swift-tools.sh" swiftformat
           swiftformat --lint --config "$SRCROOT/../../config/swiftformat" \
-            --unexclude "$SRCROOT/Sources,$SRCROOT/ShareExtension,$SRCROOT/ActivityWidget,$SRCROOT/WatchApp,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawChatUI,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawKit,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawProtocol,$SRCROOT/../swabble/Sources/SwabbleKit" \
+            --unexclude "$SRCROOT/Sources,$SRCROOT/ShareExtension,$SRCROOT/ActivityWidget,$SRCROOT/WatchApp,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawChatUI,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawKit,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawNativeState,$SRCROOT/../shared/OpenClawKit/Sources/OpenClawProtocol,$SRCROOT/../swabble/Sources/SwabbleKit" \
             --filelist "$SRCROOT/SwiftSources.input.xcfilelist"
       - name: SwiftLint
         basedOnDependencyAnalysis: false

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -47,6 +47,7 @@ let package = Package(
             dependencies: [
                 "OpenClawIPC",
                 "OpenClawDiscovery",
+                .product(name: "OpenClawNativeState", package: "OpenClawKit"),
                 .product(name: "OpenClawKit", package: "OpenClawKit"),
                 .product(name: "OpenClawChatUI", package: "OpenClawKit"),
                 .product(name: "OpenClawMLXTTSProtocol", package: "OpenClawMLXTTSProtocol"),

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -31,20 +31,32 @@ actor PortGuardian {
         let executablePath: String?
     }
 
+    struct SpawnPreparation: Sendable {
+        fileprivate let id: UUID
+        fileprivate let store: PortGuardianRecordStore
+    }
+
     /// Tunnels spawned by THIS process. SQLite holds the authoritative host-global
     /// union; this map only retains exact teardown receipts for the current process.
     private var ownRecords: [Int32: Record] = [:]
+    private var spawnReservations: Set<UUID> = []
     private let logger = Logger(subsystem: "ai.openclaw", category: "portguard")
     private let recordStoreFactory: @Sendable () throws -> PortGuardianRecordStore
+    private let postSpawnCompatibilityCheck: @Sendable () throws -> Void
     #if DEBUG
     private var testingDescriptors: [Int: Descriptor] = [:]
     #endif
     private init() {
         self.recordStoreFactory = { try PortGuardian.openRecordStore() }
+        self.postSpawnCompatibilityCheck = { try PortGuardian.requirePostSpawnCompatibility() }
     }
 
-    init(recordStoreFactory: @escaping @Sendable () throws -> PortGuardianRecordStore) {
+    init(
+        recordStoreFactory: @escaping @Sendable () throws -> PortGuardianRecordStore,
+        postSpawnCompatibilityCheck: @escaping @Sendable () throws -> Void = {})
+    {
         self.recordStoreFactory = recordStoreFactory
+        self.postSpawnCompatibilityCheck = postSpawnCompatibilityCheck
     }
 
     func sweep(mode: AppState.ConnectionMode) async {
@@ -98,16 +110,41 @@ actor PortGuardian {
         self.logger.info("port sweep done")
     }
 
-    func record(port: Int, pid: Int32, command: String, mode: AppState.ConnectionMode) throws -> Record {
-        let recordStore = try self.requireRecordStore()
+    /// Finishes legacy reconciliation before SSH starts. The returned store can
+    /// persist the child receipt without doing migration work after spawn.
+    func prepareForTunnelSpawn() throws -> SpawnPreparation {
+        let store = try self.requireRecordStore()
+        let preparation = SpawnPreparation(id: UUID(), store: store)
+        self.spawnReservations.insert(preparation.id)
+        return preparation
+    }
+
+    func cancelTunnelSpawn(_ preparation: SpawnPreparation) {
+        self.spawnReservations.remove(preparation.id)
+    }
+
+    func record(
+        port: Int,
+        pid: Int32,
+        command: String,
+        mode: AppState.ConnectionMode,
+        preparation: SpawnPreparation) throws -> Record
+    {
+        guard self.spawnReservations.contains(preparation.id) else {
+            throw PortGuardianStoreError("PortGuardian tunnel spawn preparation expired")
+        }
+        // Fail fast if an old writer appeared after preflight. Never migrate its
+        // ledger while a newly spawned SSH child is still unrecorded.
+        try self.postSpawnCompatibilityCheck()
         let record = Record(
             port: port,
             pid: pid,
             command: command,
             mode: mode.rawValue,
             timestamp: Date().timeIntervalSince1970)
-        try recordStore.upsert(record)
+        try preparation.store.upsert(record)
         self.ownRecords[pid] = record
+        self.spawnReservations.remove(preparation.id)
         return record
     }
 
@@ -648,7 +685,11 @@ actor PortGuardian {
     /// Reopen the gate for every ledger operation. An older app can launch after
     /// startup, so caching a successful mixed-version check would lose its JSON writes.
     private func requireRecordStore() throws -> PortGuardianRecordStore {
-        try self.recordStoreFactory()
+        guard self.spawnReservations.isEmpty else {
+            throw PortGuardianStoreError(
+                "PortGuardian tunnel spawn is awaiting its durable receipt")
+        }
+        return try self.recordStoreFactory()
     }
 
     private nonisolated static func openRecordStore() throws -> PortGuardianRecordStore {
@@ -670,6 +711,15 @@ actor PortGuardian {
                 process: self.tunnelProcessInfo(pid: legacy.pid))
         }
         return store
+    }
+
+    private nonisolated static func requirePostSpawnCompatibility() throws {
+        guard !self.hasLegacyOpenClawAppProcess(),
+              !FileManager.default.fileExists(atPath: PortGuardianRecordStore.liveLegacyRecordURL.path)
+        else {
+            throw PortGuardianStoreError(
+                "Older OpenClaw storage appeared after tunnel preflight; SSH launch cancelled")
+        }
     }
 
     /// Reconciles a cross-ledger PID collision from live process generation facts.

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -1,13 +1,23 @@
+import AppKit
 import Foundation
 import OSLog
+import Security
 #if canImport(Darwin)
 import Darwin
+
+@_silgen_name("csops")
+private func portGuardianCSOps(
+    _: pid_t,
+    _: UInt32,
+    _: UnsafeMutableRawPointer?,
+    _: Int) -> Int32
 #endif
 
 actor PortGuardian {
     static let shared = PortGuardian()
+    static let portGuardianStorageVersion = 2
 
-    struct Record: Codable, Equatable {
+    struct Record: Codable, Equatable, Hashable, Sendable {
         let port: Int
         let pid: Int32
         let command: String
@@ -21,25 +31,20 @@ actor PortGuardian {
         let executablePath: String?
     }
 
-    /// Tunnels spawned by THIS process. Disk (`port-guard.json`) holds the union
-    /// across app instances; entries there that we do not own are reap candidates,
-    /// never adopted — adopting them would resurrect records a sibling removed.
+    /// Tunnels spawned by THIS process. SQLite holds the authoritative host-global
+    /// union; this map only retains exact teardown receipts for the current process.
     private var ownRecords: [Int32: Record] = [:]
     private let logger = Logger(subsystem: "ai.openclaw", category: "portguard")
+    private let recordStoreFactory: @Sendable () throws -> PortGuardianRecordStore
     #if DEBUG
     private var testingDescriptors: [Int: Descriptor] = [:]
     #endif
-    private nonisolated static let appSupportDir: URL = {
-        let base = FileManager().urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return base.appendingPathComponent("OpenClaw", isDirectory: true)
-    }()
-
-    private nonisolated static var recordPath: URL {
-        self.appSupportDir.appendingPathComponent("port-guard.json", isDirectory: false)
+    private init() {
+        self.recordStoreFactory = { try PortGuardian.openRecordStore() }
     }
 
-    private nonisolated static var recordLockPath: URL {
-        self.appSupportDir.appendingPathComponent("port-guard.lock", isDirectory: false)
+    init(recordStoreFactory: @escaping @Sendable () throws -> PortGuardianRecordStore) {
+        self.recordStoreFactory = recordStoreFactory
     }
 
     func sweep(mode: AppState.ConnectionMode) async {
@@ -93,25 +98,41 @@ actor PortGuardian {
         self.logger.info("port sweep done")
     }
 
-    func record(port: Int, pid: Int32, command: String, mode: AppState.ConnectionMode) {
+    func record(port: Int, pid: Int32, command: String, mode: AppState.ConnectionMode) throws -> Record {
+        let recordStore = try self.requireRecordStore()
         let record = Record(
             port: port,
             pid: pid,
             command: command,
             mode: mode.rawValue,
             timestamp: Date().timeIntervalSince1970)
+        try recordStore.upsert(record)
         self.ownRecords[pid] = record
-        Self.persistRecords { $0[pid] = record }
+        return record
     }
 
-    func removeRecord(pid: Int32) {
-        guard let owned = self.ownRecords.removeValue(forKey: pid) else { return }
-        // Content-guarded like reap: a sibling instance may have re-recorded a
-        // recycled pid for its own new tunnel; that fresh record must survive.
-        Self.persistRecords { merged in
-            if merged[pid] == owned {
-                merged.removeValue(forKey: pid)
+    func removeRecord(_ receipt: Record) {
+        do {
+            let recordStore = try self.requireRecordStore()
+            _ = try recordStore.deleteIfMatches(receipt)
+            if self.ownRecords[receipt.pid] == receipt {
+                self.ownRecords.removeValue(forKey: receipt.pid)
             }
+        } catch {
+            // Callers remove only after the child exited. Keep the SQLite row for
+            // retry, but stop protecting its in-memory receipt from later sweeps.
+            self.relinquishRecord(receipt)
+            self.logger.error(
+                "failed to remove PortGuardian receipt pid \(receipt.pid, privacy: .public): " +
+                    "\(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Stop treating a durable receipt as actively owned without deleting it.
+    /// Deinit/failed teardown uses this so a later sweep can verify and reap.
+    func relinquishRecord(_ receipt: Record) {
+        if self.ownRecords[receipt.pid] == receipt {
+            self.ownRecords.removeValue(forKey: receipt.pid)
         }
     }
 
@@ -137,10 +158,26 @@ actor PortGuardian {
     /// leaves the tunnel reparented to launchd, holding the remote connection and
     /// squatting the preferred local port so new tunnels drift to ephemeral ports.
     func reapOrphanedTunnels() async {
+        let recordStore: PortGuardianRecordStore
+        do {
+            recordStore = try self.requireRecordStore()
+        } catch {
+            self.logger.error("PortGuardian persistence unavailable; orphan reap skipped: " +
+                "\(error.localizedDescription, privacy: .public)")
+            return
+        }
+        let canonical: [Record]
+        do {
+            canonical = try recordStore.records()
+        } catch {
+            self.logger.error("failed to read PortGuardian records: \(error.localizedDescription, privacy: .public)")
+            return
+        }
         let plan = Self.planTunnelReap(
             own: Array(self.ownRecords.values),
-            disk: Self.loadRecords(from: Self.recordPath),
-            processInfo: Self.tunnelProcessInfo(pid:))
+            disk: canonical,
+            processInfo: Self.tunnelProcessInfo(pid:),
+            currentAppPID: ProcessInfo.processInfo.processIdentifier)
         var removals = plan.drop
         for record in plan.reap {
             if await Self.terminateProcess(record.pid) {
@@ -155,16 +192,15 @@ actor PortGuardian {
             }
         }
         guard !removals.isEmpty else { return }
-        for record in removals where self.ownRecords[record.pid] == record {
-            self.ownRecords.removeValue(forKey: record.pid)
-        }
-        // Remove only records whose content still matches what was classified: a
-        // sibling instance may have re-recorded the same pid for a new tunnel in the
-        // meantime, and that fresh record must survive.
-        Self.persistRecords { merged in
-            for record in removals where merged[record.pid] == record {
-                merged.removeValue(forKey: record.pid)
+        do {
+            let deleted = try Set(recordStore.deleteIfMatches(removals))
+            for record in removals where deleted.contains(record) && self.ownRecords[record.pid] == record {
+                self.ownRecords.removeValue(forKey: record.pid)
             }
+        } catch {
+            // Keep every row for the next sweep. Forgetting an unconfirmed record
+            // would remove the only durable retry path for a still-running tunnel.
+            self.logger.error("failed to retire PortGuardian records: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -189,7 +225,11 @@ actor PortGuardian {
         return false
     }
 
-    static func classifyTunnelRecord(_ record: Record, process: TunnelProcessInfo?) -> TunnelRecordAction {
+    static func classifyTunnelRecord(
+        _ record: Record,
+        process: TunnelProcessInfo?,
+        currentAppPID: Int32? = nil) -> TunnelRecordAction
+    {
         guard let process else { return .drop }
         // No readable command line (e.g. zombie): cannot prove the pid is ours, so
         // never kill; the record drops once the process is truly gone.
@@ -200,32 +240,40 @@ actor PortGuardian {
         // user's own look-alike tunnel on the same port. Drop, never kill. Small slack
         // absorbs wall-clock steps between kernel start time and the record write.
         guard process.startedAt <= record.timestamp + 5 else { return .drop }
-        // ppid 1 means reparented to launchd: the owning app instance died. Any other
-        // live parent may be a concurrent OpenClaw instance (prod + dev), so hands off.
-        return process.parentPid == 1 ? .reap : .keep
+        // ppid 1 means the owner died. A current-app child is reapable only after
+        // its exact receipt was relinquished; planTunnelReap protects active ones.
+        if process.parentPid == 1 || process.parentPid == currentAppPID { return .reap }
+        // Any other live parent may be a concurrent OpenClaw instance (prod + dev).
+        return .keep
     }
 
     static func planTunnelReap(
         own: [Record],
         disk: [Record],
-        processInfo: (Int32) -> TunnelProcessInfo?) -> (reap: [Record], keep: [Record], drop: [Record])
+        processInfo: (Int32) -> TunnelProcessInfo?,
+        currentAppPID: Int32? = nil) -> (reap: [Record], keep: [Record], drop: [Record])
     {
-        // All app instances share port-guard.json, so disk can hold records from a
-        // crashed sibling this instance never saw. Own records win pid collisions —
-        // they are fresher than anything a dead sibling left behind.
-        var merged: [Int32: Record] = [:]
+        // SQLite stays authoritative. Only an exact current-process receipt is
+        // protected; a newer same-pid row from a sibling must remain eligible.
+        var canonical: [Int32: Record] = [:]
         for record in disk {
-            merged[record.pid] = record
+            canonical[record.pid] = record
         }
-        for record in own {
-            merged[record.pid] = record
-        }
-        let ordered = merged.values.sorted { ($0.timestamp, $0.pid) < ($1.timestamp, $1.pid) }
+        let protected = Set(own.filter { canonical[$0.pid] == $0 })
+        let ordered = canonical.values.sorted { ($0.timestamp, $0.pid) < ($1.timestamp, $1.pid) }
         var reap: [Record] = []
         var keep: [Record] = []
         var drop: [Record] = []
         for record in ordered {
-            switch self.classifyTunnelRecord(record, process: processInfo(record.pid)) {
+            if protected.contains(record) {
+                keep.append(record)
+                continue
+            }
+            switch self.classifyTunnelRecord(
+                record,
+                process: processInfo(record.pid),
+                currentAppPID: currentAppPID)
+            {
             case .keep: keep.append(record)
             case .drop: drop.append(record)
             case .reap: reap.append(record)
@@ -597,48 +645,132 @@ actor PortGuardian {
         return await self.probeGatewayHealth(port: port)
     }
 
-    private static func loadRecords(from url: URL) -> [Record] {
-        guard let data = try? Data(contentsOf: url),
-              let decoded = try? JSONDecoder().decode([Record].self, from: data)
-        else { return [] }
-        return decoded
+    /// Reopen the gate for every ledger operation. An older app can launch after
+    /// startup, so caching a successful mixed-version check would lose its JSON writes.
+    private func requireRecordStore() throws -> PortGuardianRecordStore {
+        try self.recordStoreFactory()
     }
 
-    /// The single write path for port-guard.json: read-merge-write under a file
-    /// lock so concurrent app instances (prod + dev) never clobber each other's
-    /// records — a lost record means an unreapable orphan after a crash.
-    private static func persistRecords(_ mutate: (inout [Int32: Record]) -> Void) {
-        try? FileManager().createDirectory(at: self.appSupportDir, withIntermediateDirectories: true)
-        self.withRecordFileLock {
-            let disk = self.loadRecords(from: self.recordPath)
-            var merged: [Int32: Record] = [:]
-            for record in disk {
-                merged[record.pid] = record
-            }
-            mutate(&merged)
-            let ordered = merged.values.sorted { ($0.timestamp, $0.pid) < ($1.timestamp, $1.pid) }
-            guard ordered != disk else { return }
-            guard let data = try? JSONEncoder().encode(ordered) else { return }
-            try? data.write(to: self.recordPath, options: [.atomic])
+    private nonisolated static func openRecordStore() throws -> PortGuardianRecordStore {
+        guard !self.hasLegacyOpenClawAppProcess() else {
+            throw PortGuardianStoreError(
+                "Quit older OpenClaw app copies before opening the SQLite PortGuardian ledger")
+        }
+        let legacyURL = PortGuardianRecordStore.liveLegacyRecordURL
+        guard FileManager.default.fileExists(atPath: legacyURL.path) else {
+            return try PortGuardianRecordStore(databaseURL: PortGuardianRecordStore.liveDatabaseURL)
+        }
+        let store = try PortGuardianRecordStore(
+            databaseURL: PortGuardianRecordStore.liveDatabaseURL,
+            legacyLockURL: PortGuardianRecordStore.liveLegacyLockURL)
+        try store.migrateLegacyRecords(recordURL: legacyURL) { existing, legacy in
+            try self.resolveLegacyReceipt(
+                existing: existing,
+                legacy: legacy,
+                process: self.tunnelProcessInfo(pid: legacy.pid))
+        }
+        return store
+    }
+
+    /// Reconciles a cross-ledger PID collision from live process generation facts.
+    /// Nil means both receipts are stale and the canonical row should be retired.
+    nonisolated static func resolveLegacyReceipt(
+        existing: Record?,
+        legacy: Record,
+        process: TunnelProcessInfo?) throws -> Record?
+    {
+        guard existing?.pid == nil || existing?.pid == legacy.pid else {
+            throw PortGuardianStoreError("Cannot reconcile different PortGuardian pids")
+        }
+        guard let process else { return nil }
+        guard let command = process.fullCommand, !command.isEmpty else {
+            throw PortGuardianStoreError(
+                "Could not inspect legacy PortGuardian pid \(legacy.pid); source preserved")
+        }
+        guard let existing else {
+            return self.classifyTunnelRecord(legacy, process: process) == .drop ? nil : legacy
+        }
+        let existingMatches = self.classifyTunnelRecord(existing, process: process) != .drop
+        let legacyMatches = self.classifyTunnelRecord(legacy, process: process) != .drop
+        switch (existingMatches, legacyMatches) {
+        case (true, false):
+            return existing
+        case (false, true):
+            return legacy
+        case (false, false):
+            return nil
+        case (true, true):
+            // Both receipts identify the same live process generation. Prefer the
+            // receipt written closest to spawn; ties preserve the SQLite row.
+            let existingDistance = abs(existing.timestamp - process.startedAt)
+            let legacyDistance = abs(legacy.timestamp - process.startedAt)
+            return legacyDistance < existingDistance ? legacy : existing
         }
     }
 
-    /// flock on a sidecar (atomic writes swap the json inode, so locking the json
-    /// itself would not serialize anything). The kernel releases it if we die.
-    private static func withRecordFileLock(_ body: () -> Void) {
-        #if canImport(Darwin)
-        let fd = open(self.recordLockPath.path, O_CREAT | O_RDWR, 0o644)
-        guard fd >= 0 else {
-            body()
-            return
+    /// Old app builds can create the JSON ledger after startup. The signed marker
+    /// distinguishes those writers without blocking aligned copies.
+    private nonisolated static func hasLegacyOpenClawAppProcess() -> Bool {
+        let currentPID = ProcessInfo.processInfo.processIdentifier
+        return NSWorkspace.shared.runningApplications.contains { application in
+            guard application.processIdentifier != currentPID else { return false }
+            return self.usesLegacyPortGuardianStorage(
+                bundleIdentifier: application.bundleIdentifier,
+                storageVersion: self.runningPortGuardianStorageVersion(
+                    pid: application.processIdentifier))
         }
-        defer { close(fd) }
-        _ = flock(fd, LOCK_EX)
-        defer { _ = flock(fd, LOCK_UN) }
-        body()
-        #else
-        body()
-        #endif
+    }
+
+    /// Security.framework returns the secured Info.plist for the running guest.
+    /// Validity failure is legacy/unknown: an in-place app update must not let the
+    /// old mapped executable borrow the replacement bundle's newer marker.
+    private nonisolated static func runningPortGuardianStorageVersion(pid: pid_t) -> Int? {
+        let attributes = [kSecGuestAttributePid as String: NSNumber(value: pid)] as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code) == errSecSuccess,
+              let code,
+              SecCodeCheckValidity(code, SecCSFlags(), nil) == errSecSuccess
+        else { return nil }
+        var staticCode: SecStaticCode?
+        var information: CFDictionary?
+        guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess,
+              let staticCode,
+              SecCodeCopySigningInformation(
+                  staticCode,
+                  SecCSFlags(rawValue: kSecCSSigningInformation),
+                  &information) == errSecSuccess,
+              SecCodeCheckValidity(code, SecCSFlags(), nil) == errSecSuccess,
+              let information,
+              let runningHash = self.runningCodeDirectoryHash(pid: pid),
+              let signedHash = (information as NSDictionary)[kSecCodeInfoUnique] as? Data,
+              self.codeDirectoryHashesMatch(running: runningHash, signed: signedHash),
+              let securedInfo = (information as NSDictionary)[kSecCodeInfoPList] as? NSDictionary,
+              let version = securedInfo["OpenClawPortGuardianStorageVersion"] as? NSNumber
+        else { return nil }
+        return version.intValue
+    }
+
+    private nonisolated static func runningCodeDirectoryHash(pid: pid_t) -> Data? {
+        var bytes = [UInt8](repeating: 0, count: 20)
+        let result = bytes.withUnsafeMutableBytes {
+            portGuardianCSOps(pid, 5, $0.baseAddress, $0.count)
+        }
+        return result == 0 ? Data(bytes) : nil
+    }
+
+    nonisolated static func codeDirectoryHashesMatch(running: Data?, signed: Data?) -> Bool {
+        guard let running, let signed, running.count == 20, signed.count == 20 else { return false }
+        return running == signed
+    }
+
+    nonisolated static func usesLegacyPortGuardianStorage(
+        bundleIdentifier: String?,
+        storageVersion: Int?) -> Bool
+    {
+        guard let bundleIdentifier,
+              bundleIdentifier == "ai.openclaw.mac" || bundleIdentifier.hasPrefix("ai.openclaw.mac.")
+        else { return false }
+        return (storageVersion ?? 0) < self.portGuardianStorageVersion
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/PortGuardianRecordStore.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardianRecordStore.swift
@@ -100,7 +100,7 @@ final class PortGuardianRecordStore: @unchecked Sendable {
     func upsert(_ record: PortGuardian.Record) throws -> PortGuardian.Record {
         try Self.validate(record)
         return try self.mapDatabaseError {
-            try self.database.withImmediateTransaction {
+            try self.withValidatedMutationTransaction {
                 try self.upsertUnlocked(record)
                 guard try self.readRecord(pid: record.pid) == record else {
                     throw PortGuardianStoreError("SQLite did not preserve the PortGuardian record receipt")
@@ -119,7 +119,7 @@ final class PortGuardianRecordStore: @unchecked Sendable {
     func deleteIfMatches(_ records: [PortGuardian.Record]) throws -> [PortGuardian.Record] {
         try records.forEach(Self.validate)
         return try self.mapDatabaseError {
-            try self.database.withImmediateTransaction {
+            try self.withValidatedMutationTransaction {
                 var deleted: [PortGuardian.Record] = []
                 for record in records where try self.deleteIfMatchesUnlocked(record) {
                     deleted.append(record)
@@ -226,7 +226,7 @@ final class PortGuardianRecordStore: @unchecked Sendable {
 
     private func applyLegacyMigration(_ plans: [LegacyMigrationPlan]) throws {
         try self.mapDatabaseError {
-            try self.database.withImmediateTransaction {
+            try self.withValidatedMutationTransaction {
                 for plan in plans {
                     let authoritative = try self.readRecord(pid: plan.legacy.pid)
                     guard authoritative == plan.expected else {
@@ -254,6 +254,17 @@ final class PortGuardianRecordStore: @unchecked Sendable {
                     }
                 }
             }
+        }
+    }
+
+    /// A store can outlive another runtime's schema upgrade. Revalidate under the
+    /// write lock so an older native client never mutates a newer database contract.
+    private func withValidatedMutationTransaction<T>(_ body: () throws -> T) throws -> T {
+        try self.database.withImmediateTransaction {
+            try self.database.ensureCanonicalTable(
+                .macosPortGuardianRecords,
+                allowVersionZeroCreation: false)
+            return try body()
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/PortGuardianRecordStore.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardianRecordStore.swift
@@ -1,0 +1,476 @@
+import Darwin
+import Foundation
+import OpenClawNativeState
+
+struct PortGuardianStoreError: Error, LocalizedError, Sendable {
+    let message: String
+
+    var errorDescription: String? {
+        self.message
+    }
+
+    init(_ message: String) {
+        self.message = message
+    }
+}
+
+/// Host-global SQLite ledger for SSH tunnels spawned by macOS app instances.
+/// This intentionally ignores OPENCLAW_STATE_DIR: prod, dev, and profile-specific
+/// app processes must share one orphan-recovery owner for machine-local ports.
+final class PortGuardianRecordStore: @unchecked Sendable {
+    typealias LegacyRecordResolver = (
+        _ existing: PortGuardian.Record?,
+        _ legacy: PortGuardian.Record) throws -> PortGuardian.Record?
+
+    private static let maximumLegacyBytes = 1024 * 1024
+
+    private struct LegacyFileSnapshot: Equatable {
+        let device: UInt64
+        let inode: UInt64
+        let size: UInt64
+        let modifiedAt: Date?
+    }
+
+    private struct LegacySource: Equatable {
+        let snapshot: LegacyFileSnapshot
+        let data: Data
+    }
+
+    private let database: OpenClawNativeStateSQLite
+    private let legacyLockDescriptor: Int32?
+    private let legacyCoordinationLock = NSLock()
+    private let removeLegacySource: @Sendable (URL) throws -> Void
+
+    static var liveRootURL: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return base.appendingPathComponent("OpenClaw", isDirectory: true)
+    }
+
+    static var liveDatabaseURL: URL {
+        self.liveRootURL
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("openclaw.sqlite", isDirectory: false)
+    }
+
+    static var liveLegacyRecordURL: URL {
+        self.liveRootURL.appendingPathComponent("port-guard.json", isDirectory: false)
+    }
+
+    static var liveLegacyLockURL: URL {
+        self.liveRootURL.appendingPathComponent("port-guard.lock", isDirectory: false)
+    }
+
+    init(
+        databaseURL: URL,
+        legacyLockURL: URL? = nil,
+        removeLegacySource: @escaping @Sendable (URL) throws -> Void = {
+            try FileManager.default.removeItem(at: $0)
+        }) throws
+    {
+        let legacyLockDescriptor = try legacyLockURL.map(Self.openLegacyLock)
+        let database: OpenClawNativeStateSQLite
+        do {
+            database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+        } catch {
+            Self.closeLegacyLock(legacyLockDescriptor)
+            throw Self.storeError(error)
+        }
+        self.database = database
+        self.legacyLockDescriptor = legacyLockDescriptor
+        self.removeLegacySource = removeLegacySource
+        do {
+            try self.database.withImmediateTransaction {
+                try self.database.ensureCanonicalTable(.macosPortGuardianRecords)
+            }
+        } catch {
+            Self.closeLegacyLock(legacyLockDescriptor)
+            throw Self.storeError(error)
+        }
+    }
+
+    deinit {
+        Self.closeLegacyLock(self.legacyLockDescriptor)
+    }
+
+    func records() throws -> [PortGuardian.Record] {
+        try self.readRecords()
+    }
+
+    @discardableResult
+    func upsert(_ record: PortGuardian.Record) throws -> PortGuardian.Record {
+        try Self.validate(record)
+        return try self.mapDatabaseError {
+            try self.database.withImmediateTransaction {
+                try self.upsertUnlocked(record)
+                guard try self.readRecord(pid: record.pid) == record else {
+                    throw PortGuardianStoreError("SQLite did not preserve the PortGuardian record receipt")
+                }
+                return record
+            }
+        }
+    }
+
+    @discardableResult
+    func deleteIfMatches(_ record: PortGuardian.Record) throws -> Bool {
+        try self.deleteIfMatches([record]).contains(record)
+    }
+
+    @discardableResult
+    func deleteIfMatches(_ records: [PortGuardian.Record]) throws -> [PortGuardian.Record] {
+        try records.forEach(Self.validate)
+        return try self.mapDatabaseError {
+            try self.database.withImmediateTransaction {
+                var deleted: [PortGuardian.Record] = []
+                for record in records where try self.deleteIfMatchesUnlocked(record) {
+                    deleted.append(record)
+                }
+                return deleted
+            }
+        }
+    }
+
+    /// Imports the shipped JSON ledger under its original flock protocol, then
+    /// verifies canonical rows before retiring the source.
+    @discardableResult
+    func migrateLegacyRecords(recordURL: URL) throws -> Int {
+        try self.migrateLegacyRecords(recordURL: recordURL) { existing, legacy in
+            guard let existing else { return legacy }
+            guard existing != legacy else { return existing }
+            throw PortGuardianStoreError(
+                "Legacy PortGuardian record conflicts at pid \(existing.pid); source preserved")
+        }
+    }
+
+    @discardableResult
+    func migrateLegacyRecords(
+        recordURL: URL,
+        resolveRecord: LegacyRecordResolver) throws -> Int
+    {
+        guard let legacyLockDescriptor else {
+            throw PortGuardianStoreError("Legacy PortGuardian migration requires its compatibility lock")
+        }
+        return try self.withLegacyCoordinationLock {
+            guard let source = try Self.withExclusiveLegacyLock(legacyLockDescriptor, body: {
+                try Self.readLegacySource(recordURL)
+            }) else { return 0 }
+            let byPID = try Self.decodeLegacyRecords(source.data)
+
+            // Live process inspection can invoke system tools. Never hold the old
+            // writer's flock while planning or an older app can strand spawned SSH.
+            let plans = try self.planLegacyMigration(
+                records: byPID,
+                resolveRecord: resolveRecord)
+
+            return try Self.withExclusiveLegacyLock(legacyLockDescriptor) {
+                guard let currentSource = try Self.readLegacySource(recordURL) else {
+                    // Another aligned app completed the same migration while this
+                    // instance planned without holding the shipped writer lock.
+                    return 0
+                }
+                guard currentSource == source else {
+                    throw PortGuardianStoreError(
+                        "Legacy PortGuardian source changed while migration was planned")
+                }
+                try self.applyLegacyMigration(plans)
+                try self.removeLegacySource(recordURL)
+                return byPID.count
+            }
+        }
+    }
+
+    private func withLegacyCoordinationLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.legacyCoordinationLock.lock()
+        defer { self.legacyCoordinationLock.unlock() }
+        return try body()
+    }
+
+    private static func decodeLegacyRecords(_ data: Data) throws -> [Int32: PortGuardian.Record] {
+        let decoded: [PortGuardian.Record]
+        do {
+            decoded = try JSONDecoder().decode([PortGuardian.Record].self, from: data)
+        } catch {
+            throw PortGuardianStoreError("Legacy PortGuardian source is invalid: \(error.localizedDescription)")
+        }
+        var byPID: [Int32: PortGuardian.Record] = [:]
+        for record in decoded {
+            try self.validate(record)
+            guard byPID.updateValue(record, forKey: record.pid) == nil else {
+                throw PortGuardianStoreError("Legacy PortGuardian source contains duplicate pid \(record.pid)")
+            }
+        }
+        return byPID
+    }
+
+    private typealias LegacyMigrationPlan = (
+        legacy: PortGuardian.Record,
+        expected: PortGuardian.Record?,
+        selected: PortGuardian.Record?)
+
+    private func planLegacyMigration(
+        records: [Int32: PortGuardian.Record],
+        resolveRecord: LegacyRecordResolver) throws -> [LegacyMigrationPlan]
+    {
+        try records.values.sorted { $0.pid < $1.pid }.map { legacy in
+            let existing = try self.readRecord(pid: legacy.pid)
+            let selected = try resolveRecord(existing, legacy)
+            if let selected {
+                try Self.validate(selected)
+                guard selected.pid == legacy.pid else {
+                    throw PortGuardianStoreError(
+                        "Legacy PortGuardian conflict resolver changed pid \(legacy.pid)")
+                }
+            }
+            return (legacy: legacy, expected: existing, selected: selected)
+        }
+    }
+
+    private func applyLegacyMigration(_ plans: [LegacyMigrationPlan]) throws {
+        try self.mapDatabaseError {
+            try self.database.withImmediateTransaction {
+                for plan in plans {
+                    let authoritative = try self.readRecord(pid: plan.legacy.pid)
+                    guard authoritative == plan.expected else {
+                        throw PortGuardianStoreError(
+                            "SQLite PortGuardian row changed while migrating pid \(plan.legacy.pid)")
+                    }
+                    switch (authoritative, plan.selected) {
+                    case let (existing?, selected?) where existing != selected:
+                        try self.upsertUnlocked(selected)
+                    case let (existing?, nil):
+                        guard try self.deleteIfMatchesUnlocked(existing) else {
+                            throw PortGuardianStoreError(
+                                "Could not retire stale PortGuardian pid \(existing.pid)")
+                        }
+                    case (nil, let selected?):
+                        try self.upsertUnlocked(selected)
+                    default:
+                        break
+                    }
+                }
+                for plan in plans {
+                    guard try self.readRecord(pid: plan.legacy.pid) == plan.selected else {
+                        throw PortGuardianStoreError(
+                            "SQLite did not preserve migrated PortGuardian record pid \(plan.legacy.pid)")
+                    }
+                }
+            }
+        }
+    }
+
+    private static func readLegacySource(_ recordURL: URL) throws -> LegacySource? {
+        guard FileManager.default.fileExists(atPath: recordURL.path) else { return nil }
+        let before = try self.legacySnapshot(recordURL, maximumBytes: self.maximumLegacyBytes)
+        let data = try Data(contentsOf: recordURL, options: [.mappedIfSafe])
+        let afterRead = try self.legacySnapshot(recordURL, maximumBytes: self.maximumLegacyBytes)
+        guard before == afterRead, UInt64(data.count) == before.size else {
+            throw PortGuardianStoreError("Legacy PortGuardian source changed while being claimed")
+        }
+        return LegacySource(snapshot: before, data: data)
+    }
+
+    private func readRecords() throws -> [PortGuardian.Record] {
+        try self.mapDatabaseError {
+            let statement = try self.database.prepare("""
+            SELECT port, pid, command, mode, timestamp
+            FROM macos_port_guardian_records
+            ORDER BY timestamp, pid
+            """)
+            var records: [PortGuardian.Record] = []
+            while try statement.step() == .row {
+                try records.append(Self.decodeRecord(statement))
+            }
+            return records
+        }
+    }
+
+    private func readRecord(pid: Int32) throws -> PortGuardian.Record? {
+        let statement = try self.database.prepare("""
+        SELECT port, pid, command, mode, timestamp
+        FROM macos_port_guardian_records
+        WHERE pid = ?
+        """)
+        try statement.bindInt64(Int64(pid), at: 1)
+        let result = try statement.step()
+        if result == .done { return nil }
+        let record = try Self.decodeRecord(statement)
+        guard try statement.step() == .done else {
+            throw PortGuardianStoreError("SQLite returned duplicate PortGuardian pids")
+        }
+        return record
+    }
+
+    private static func decodeRecord(
+        _ statement: OpenClawNativeStateSQLiteStatement) throws -> PortGuardian.Record
+    {
+        guard statement.valueType(at: 0) == .integer,
+              statement.valueType(at: 1) == .integer,
+              statement.valueType(at: 2) == .text,
+              statement.valueType(at: 3) == .text,
+              [.float, .integer].contains(statement.valueType(at: 4))
+        else {
+            throw PortGuardianStoreError("SQLite PortGuardian row has invalid column types")
+        }
+        let port = statement.int64(at: 0)
+        let pid = statement.int64(at: 1)
+        guard (1...65535).contains(port), (1...Int64(Int32.max)).contains(pid) else {
+            throw PortGuardianStoreError("SQLite PortGuardian row has invalid pid or port")
+        }
+        let record = try PortGuardian.Record(
+            port: Int(port),
+            pid: Int32(pid),
+            command: statement.requiredText(at: 2, field: "command"),
+            mode: statement.requiredText(at: 3, field: "mode"),
+            timestamp: statement.double(at: 4))
+        try Self.validate(record)
+        return record
+    }
+
+    private static func validate(_ record: PortGuardian.Record) throws {
+        guard record.pid > 0,
+              (1...65535).contains(record.port),
+              !record.command.isEmpty,
+              !record.mode.isEmpty,
+              record.timestamp.isFinite,
+              record.timestamp >= 0
+        else {
+            throw PortGuardianStoreError("PortGuardian record has invalid fields")
+        }
+    }
+
+    private func upsertUnlocked(_ record: PortGuardian.Record) throws {
+        let statement = try self.database.prepare("""
+        INSERT INTO macos_port_guardian_records (pid, port, command, mode, timestamp)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(pid) DO UPDATE SET
+          port = excluded.port,
+          command = excluded.command,
+          mode = excluded.mode,
+          timestamp = excluded.timestamp
+        """)
+        try Self.bind(record, to: statement)
+        guard try statement.step() == .done else {
+            throw PortGuardianStoreError("Could not upsert PortGuardian record")
+        }
+    }
+
+    private func deleteIfMatchesUnlocked(_ record: PortGuardian.Record) throws -> Bool {
+        let statement = try self.database.prepare("""
+        DELETE FROM macos_port_guardian_records
+        WHERE pid = ? AND port = ? AND command = ? AND mode = ? AND timestamp = ?
+        """)
+        try Self.bind(record, to: statement)
+        guard try statement.step() == .done else {
+            throw PortGuardianStoreError("Could not delete PortGuardian record")
+        }
+        return self.database.changes == 1
+    }
+
+    private static func bind(
+        _ record: PortGuardian.Record,
+        to statement: OpenClawNativeStateSQLiteStatement) throws
+    {
+        try statement.bindInt64(Int64(record.pid), at: 1)
+        try statement.bindInt64(Int64(record.port), at: 2)
+        try statement.bindText(record.command, at: 3)
+        try statement.bindText(record.mode, at: 4)
+        try statement.bindDouble(record.timestamp, at: 5)
+    }
+
+    private func mapDatabaseError<T>(_ body: () throws -> T) throws -> T {
+        do {
+            return try body()
+        } catch {
+            throw Self.storeError(error)
+        }
+    }
+
+    private static func storeError(_ error: Error) -> Error {
+        if let error = error as? PortGuardianStoreError { return error }
+        if let error = error as? OpenClawNativeStateError {
+            return PortGuardianStoreError(error.message)
+        }
+        return error
+    }
+
+    private static func openLegacyLock(_ lockURL: URL) throws -> Int32 {
+        try self.secureDirectory(lockURL.deletingLastPathComponent())
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else {
+            throw PortGuardianStoreError("Could not open legacy PortGuardian lock")
+        }
+        var descriptorStatus = stat()
+        var pathStatus = stat()
+        guard fstat(descriptor, &descriptorStatus) == 0,
+              lstat(lockURL.path, &pathStatus) == 0,
+              descriptorStatus.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
+              descriptorStatus.st_uid == geteuid(),
+              descriptorStatus.st_nlink == 1,
+              descriptorStatus.st_mode & mode_t(0o022) == 0,
+              descriptorStatus.st_dev == pathStatus.st_dev,
+              descriptorStatus.st_ino == pathStatus.st_ino,
+              fchmod(descriptor, 0o600) == 0
+        else {
+            close(descriptor)
+            throw PortGuardianStoreError("Legacy PortGuardian lock is unsafe or unavailable")
+        }
+        return descriptor
+    }
+
+    private static func closeLegacyLock(_ descriptor: Int32?) {
+        guard let descriptor else { return }
+        _ = flock(descriptor, LOCK_UN)
+        close(descriptor)
+    }
+
+    /// The inode stays stable for old and new app copies. The lock is short-lived:
+    /// an old app may already have spawned SSH before recording its JSON receipt,
+    /// so permanently blocking its writer would create an untracked orphan.
+    private static func withExclusiveLegacyLock<T>(
+        _ descriptor: Int32,
+        body: () throws -> T) throws -> T
+    {
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw PortGuardianStoreError("Could not acquire exclusive legacy PortGuardian lock")
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+
+    private static func legacySnapshot(_ url: URL, maximumBytes: Int) throws -> LegacyFileSnapshot {
+        let root = url.deletingLastPathComponent().standardizedFileURL
+        let candidate = url.standardizedFileURL
+        let expected = root.resolvingSymlinksInPath()
+            .appendingPathComponent(candidate.lastPathComponent, isDirectory: false)
+            .standardizedFileURL
+        guard candidate.resolvingSymlinksInPath().standardizedFileURL == expected else {
+            throw PortGuardianStoreError("Legacy PortGuardian source must not traverse symbolic links")
+        }
+        let attributes = try FileManager.default.attributesOfItem(atPath: candidate.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular,
+              let links = attributes[.referenceCount] as? NSNumber,
+              links.uint64Value == 1,
+              let device = attributes[.systemNumber] as? NSNumber,
+              let inode = attributes[.systemFileNumber] as? NSNumber,
+              let size = attributes[.size] as? NSNumber,
+              size.uint64Value <= UInt64(maximumBytes)
+        else {
+            throw PortGuardianStoreError(
+                "Legacy PortGuardian source must be a bounded regular file with exactly one link")
+        }
+        return LegacyFileSnapshot(
+            device: device.uint64Value,
+            inode: inode.uint64Value,
+            size: size.uint64Value,
+            modifiedAt: attributes[.modificationDate] as? Date)
+    }
+
+    private static func secureDirectory(_ url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        guard chmod(url.path, 0o700) == 0 else {
+            throw PortGuardianStoreError("Could not secure PortGuardian state directory")
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -160,9 +160,26 @@ final class RemotePortTunnel: @unchecked Sendable {
             Self.cleanupStderr(stderrHandle)
         }
 
+        let spawnPreparation: PortGuardian.SpawnPreparation
+        do {
+            // Legacy reconciliation can inspect many live processes. Complete it
+            // before spawn so a crash during migration cannot orphan this SSH child.
+            spawnPreparation = try await PortGuardian.shared.prepareForTunnelSpawn()
+        } catch {
+            Self.cleanupStderr(stderrHandle)
+            throw NSError(
+                domain: "RemotePortTunnel",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Could not prepare SSH tunnel ownership: \(error.localizedDescription)",
+                    NSUnderlyingErrorKey: error,
+                ])
+        }
+
         do {
             try process.run()
         } catch {
+            await PortGuardian.shared.cancelTunnelSpawn(spawnPreparation)
             Self.cleanupStderr(stderrHandle)
             throw error
         }
@@ -175,9 +192,13 @@ final class RemotePortTunnel: @unchecked Sendable {
                 port: Int(localPort),
                 pid: process.processIdentifier,
                 command: process.executableURL?.path ?? "ssh",
-                mode: .remote)
+                mode: .remote,
+                preparation: spawnPreparation)
         } catch {
             Self.terminateAndWait(process)
+            // Keep the reservation exclusive until this exact child is reaped.
+            // Only then may another operation migrate or open the ledger.
+            await PortGuardian.shared.cancelTunnelSpawn(spawnPreparation)
             Self.cleanupStderr(stderrHandle)
             throw NSError(
                 domain: "RemotePortTunnel",

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -22,6 +22,7 @@ final class RemotePortTunnel: @unchecked Sendable {
     let process: Process
     let localPort: UInt16?
     private let stderrHandle: FileHandle?
+    private let guardianReceipt: PortGuardian.Record
 
     private final class StderrCapture: @unchecked Sendable {
         private let lock = NSLock()
@@ -49,32 +50,36 @@ final class RemotePortTunnel: @unchecked Sendable {
         }
     }
 
-    private init(process: Process, localPort: UInt16?, stderrHandle: FileHandle?) {
+    private init(
+        process: Process,
+        localPort: UInt16?,
+        stderrHandle: FileHandle?,
+        guardianReceipt: PortGuardian.Record)
+    {
         self.process = process
         self.localPort = localPort
         self.stderrHandle = stderrHandle
+        self.guardianReceipt = guardianReceipt
     }
 
     deinit {
-        self.teardown(waitUntilExit: false)
+        Self.cleanupStderr(self.stderrHandle)
+        let receipt = self.guardianReceipt
+        guard self.process.isRunning else {
+            Task { await PortGuardian.shared.removeRecord(receipt) }
+            return
+        }
+        // deinit cannot wait. Leave the receipt durable until a later sweep proves
+        // the child exited; deleting it after TERM alone can orphan a resistant SSH.
+        Task { await PortGuardian.shared.relinquishRecord(receipt) }
+        self.process.terminate()
     }
 
     func terminate() {
-        self.teardown(waitUntilExit: true)
-    }
-
-    /// deinit cannot block on waitUntilExit; explicit terminate() must, so callers
-    /// can rebind the tunnel's local port immediately after it returns.
-    private func teardown(waitUntilExit: Bool) {
+        Self.terminateAndWait(self.process)
         Self.cleanupStderr(self.stderrHandle)
-        let pid = self.process.processIdentifier
-        if self.process.isRunning {
-            self.process.terminate()
-            if waitUntilExit {
-                self.process.waitUntilExit()
-            }
-        }
-        Task { await PortGuardian.shared.removeRecord(pid: pid) }
+        let receipt = self.guardianReceipt
+        Task { await PortGuardian.shared.removeRecord(receipt) }
     }
 
     static func configuration(remotePort: Int) throws -> Configuration {
@@ -155,23 +160,60 @@ final class RemotePortTunnel: @unchecked Sendable {
             Self.cleanupStderr(stderrHandle)
         }
 
-        try process.run()
+        do {
+            try process.run()
+        } catch {
+            Self.cleanupStderr(stderrHandle)
+            throw error
+        }
 
-        try await Self.waitForListener(
+        let receipt: PortGuardian.Record
+        do {
+            // Persist immediately after spawn. Waiting for listener readiness first leaves
+            // a crash window where a live SSH process has no durable reap receipt.
+            receipt = try await PortGuardian.shared.record(
+                port: Int(localPort),
+                pid: process.processIdentifier,
+                command: process.executableURL?.path ?? "ssh",
+                mode: .remote)
+        } catch {
+            Self.terminateAndWait(process)
+            Self.cleanupStderr(stderrHandle)
+            throw NSError(
+                domain: "RemotePortTunnel",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Could not persist SSH tunnel ownership: \(error.localizedDescription)",
+                    NSUnderlyingErrorKey: error,
+                ])
+        }
+
+        do {
+            try await Self.waitForListener(
+                process: process,
+                localPort: localPort,
+                stderrHandle: stderrHandle,
+                stderrCapture: stderrCapture)
+        } catch {
+            Self.terminateAndWait(process)
+            Self.cleanupStderr(stderrHandle)
+            await PortGuardian.shared.removeRecord(receipt)
+            throw error
+        }
+
+        return RemotePortTunnel(
             process: process,
             localPort: localPort,
             stderrHandle: stderrHandle,
-            stderrCapture: stderrCapture)
+            guardianReceipt: receipt)
+    }
 
-        // Record before returning: a crash inside this window would otherwise leave
-        // an untracked (unreapable) orphan.
-        await PortGuardian.shared.record(
-            port: Int(localPort),
-            pid: process.processIdentifier,
-            command: process.executableURL?.path ?? "ssh",
-            mode: .remote)
-
-        return RemotePortTunnel(process: process, localPort: localPort, stderrHandle: stderrHandle)
+    private static func terminateAndWait(_ process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+        // waitUntilExit reaps this exact child before its pid can be reused. A
+        // delayed raw kill(pid) could otherwise signal an unrelated process.
+        process.waitUntilExit()
     }
 
     private static func waitForListener(
@@ -193,13 +235,11 @@ final class RemotePortTunnel: @unchecked Sendable {
             do {
                 try await Task.sleep(nanoseconds: 100_000_000)
             } catch {
-                process.terminate()
                 throw error
             }
         } while Date() < deadline
 
-        process.terminate()
-        let stderr = Self.drainStderr(stderrHandle, captured: stderrCapture.snapshot())
+        let stderr = stderrCapture.snapshot()
         let msg = stderr.isEmpty ? "ssh tunnel did not open local port \(localPort)" : "ssh tunnel failed: \(stderr)"
         throw NSError(domain: "RemotePortTunnel", code: 4, userInfo: [NSLocalizedDescriptionKey: msg])
     }
@@ -433,6 +473,10 @@ final class RemotePortTunnel: @unchecked Sendable {
 
     static func _testDrainStderr(_ handle: FileHandle) -> String {
         self.drainStderr(handle, captured: "")
+    }
+
+    static func _testTerminateAndWait(_ process: Process) {
+        self.terminateAndWait(process)
     }
 
     #endif

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -40,6 +40,8 @@
     <string></string>
     <key>OpenClawGitCommit</key>
     <string></string>
+    <key>OpenClawPortGuardianStorageVersion</key>
+    <integer>2</integer>
 
     <key>NSUserNotificationUsageDescription</key>
     <string>OpenClaw needs notification permission to show alerts for agent actions.</string>

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -159,44 +159,52 @@ struct LowCoverageHelperTests {
         #expect(PortGuardian._testIsExpected(
             command: "com.docker.backend",
             fullCommand: "com.docker.backend",
-            port: port, mode: .remote) == true)
+            port: port,
+            mode: .remote) == true)
 
         #expect(PortGuardian._testIsExpected(
             command: "ssh",
             fullCommand: "ssh -L \(port):localhost:\(port) user@host",
-            port: port, mode: .remote) == true)
+            port: port,
+            mode: .remote) == true)
 
         #expect(PortGuardian._testIsExpected(
             command: "podman",
             fullCommand: "podman",
-            port: port, mode: .remote) == true)
+            port: port,
+            mode: .remote) == true)
     }
 
     @Test func `port guardian local mode still rejects unexpected`() {
         #expect(PortGuardian._testIsExpected(
             command: "com.docker.backend",
             fullCommand: "com.docker.backend",
-            port: 18789, mode: .local) == false)
+            port: 18789,
+            mode: .local) == false)
 
         #expect(PortGuardian._testIsExpected(
             command: "python",
             fullCommand: "python server.py",
-            port: 18789, mode: .local) == false)
+            port: 18789,
+            mode: .local) == false)
 
         #expect(PortGuardian._testIsExpected(
             command: "node",
             fullCommand: "openclaw-gateway",
-            port: 18789, mode: .local) == true)
+            port: 18789,
+            mode: .local) == true)
 
         #expect(PortGuardian._testIsExpected(
             command: "node",
             fullCommand: "node /path/to/gateway-daemon",
-            port: 18789, mode: .local) == true)
+            port: 18789,
+            mode: .local) == true)
     }
 
     @Test func `port guardian remote mode report accepts any listener`() {
         let dockerReport = PortGuardian._testBuildReport(
-            port: 18789, mode: .remote,
+            port: 18789,
+            mode: .remote,
             listeners: [(
                 pid: 99,
                 command: "com.docker.backend",
@@ -205,7 +213,8 @@ struct LowCoverageHelperTests {
         #expect(dockerReport.offenders.isEmpty)
 
         let localDockerReport = PortGuardian._testBuildReport(
-            port: 18789, mode: .local,
+            port: 18789,
+            mode: .local,
             listeners: [(
                 pid: 99,
                 command: "com.docker.backend",
@@ -272,27 +281,55 @@ struct LowCoverageHelperTests {
             "/usr/bin/ssh -o BatchMode=yes -n -N -L \(port):127.0.0.1:18789 -- user@host"
         }
 
-        // pid 10: our live tunnel (parent alive). Disk-only records from a crashed
-        // sibling instance: pid 20 orphaned, pid 30 already gone.
+        // pid 10: our exact live receipt. Disk-only records from a crashed sibling
+        // instance: pid 20 orphaned, pid 30 already gone.
         let own = [record(pid: 10, port: 18790, timestamp: 300)]
         let disk = [
             record(pid: 20, port: 18789, timestamp: 100),
             record(pid: 30, port: 18791, timestamp: 200),
-            record(pid: 10, port: 1, timestamp: 1), // superseded by the own record
+            own[0],
         ]
-        let plan = PortGuardian.planTunnelReap(own: own, disk: disk, processInfo: { pid in
-            switch pid {
-            case 10: .init(parentPid: 987, startedAt: 299, fullCommand: tunnel(port: 18790))
-            case 20: .init(parentPid: 1, startedAt: 99, fullCommand: tunnel(port: 18789))
-            default: nil
-            }
-        })
+        let currentAppPID: Int32 = 987
+        let plan = PortGuardian.planTunnelReap(
+            own: own,
+            disk: disk,
+            processInfo: { pid in
+                switch pid {
+                // Even a current-parent observation cannot reap a receipt this
+                // process still owns exactly.
+                case 10: .init(parentPid: currentAppPID, startedAt: 299, fullCommand: tunnel(port: 18790))
+                case 20: .init(parentPid: 1, startedAt: 99, fullCommand: tunnel(port: 18789))
+                default: nil
+                }
+            },
+            currentAppPID: currentAppPID)
         #expect(plan.reap.map(\.pid) == [20])
         #expect(plan.keep.map(\.pid) == [10])
         #expect(plan.keep.first?.port == 18790)
-        // The dead pid 30 is reported as a drop; the shadowed pid-10 disk record is
-        // superseded, not dropped, so a reap cycle cannot delete the fresh record.
+        // The dead pid 30 is reported as a drop; the exact owned pid-10 receipt is kept.
         #expect(plan.drop.map(\.pid) == [30])
+
+        let replacement = record(pid: 10, port: 18792, timestamp: 400)
+        let replacementPlan = PortGuardian.planTunnelReap(
+            own: own,
+            disk: [replacement],
+            processInfo: { _ in
+                .init(parentPid: currentAppPID, startedAt: 399, fullCommand: tunnel(port: replacement.port))
+            },
+            currentAppPID: currentAppPID)
+        #expect(replacementPlan.reap == [replacement])
+        #expect(replacementPlan.keep.isEmpty)
+
+        let sibling = record(pid: 40, port: 18793, timestamp: 500)
+        let siblingPlan = PortGuardian.planTunnelReap(
+            own: [],
+            disk: [sibling],
+            processInfo: { _ in
+                .init(parentPid: 654, startedAt: 499, fullCommand: tunnel(port: sibling.port))
+            },
+            currentAppPID: currentAppPID)
+        #expect(siblingPlan.keep == [sibling])
+        #expect(siblingPlan.reap.isEmpty)
     }
 
     @Test func `port guardian classifies a real orphaned tunnel process for reaping`() async throws {
@@ -338,7 +375,10 @@ struct LowCoverageHelperTests {
 
         // A record predating this process (reused pid) must drop, not reap.
         let predates = PortGuardian.Record(
-            port: port, pid: pid, command: "/usr/bin/ssh", mode: "remote",
+            port: port,
+            pid: pid,
+            command: "/usr/bin/ssh",
+            mode: "remote",
             timestamp: orphan.startedAt - 3600)
         #expect(PortGuardian.classifyTunnelRecord(predates, process: orphan) == .drop)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -490,7 +490,7 @@ struct PortGuardianRecordStoreTests {
         }
 
         let newerURL = fixture.root.appendingPathComponent("newer.sqlite")
-        try Self.execute(newerURL, "PRAGMA user_version = 4")
+        try Self.execute(newerURL, "PRAGMA user_version = 5")
         #expect(throws: PortGuardianStoreError.self) {
             try PortGuardianRecordStore(databaseURL: newerURL)
         }

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -56,21 +56,46 @@ struct PortGuardianRecordStoreTests {
         defer { fixture.cleanup() }
         let legacyWriterRunning = LockIsolated(false)
         let attempts = LockIsolated(0)
-        let guardian = PortGuardian(recordStoreFactory: {
-            attempts.withValue { $0 += 1 }
-            guard !legacyWriterRunning.withValue({ $0 }) else {
-                throw PortGuardianStoreError("legacy writer running")
-            }
-            return try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
-        })
+        let guardian = PortGuardian(
+            recordStoreFactory: {
+                attempts.withValue { $0 += 1 }
+                return try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+            },
+            postSpawnCompatibilityCheck: {
+                guard !legacyWriterRunning.withValue({ $0 }) else {
+                    throw PortGuardianStoreError("legacy writer running")
+                }
+            })
 
-        _ = try await guardian.record(port: 18789, pid: 4242, command: "/usr/bin/ssh", mode: .remote)
+        let firstPreparation = try await guardian.prepareForTunnelSpawn()
+        _ = try await guardian.record(
+            port: 18789,
+            pid: 4242,
+            command: "/usr/bin/ssh",
+            mode: .remote,
+            preparation: firstPreparation)
+        let threatenedPreparation = try await guardian.prepareForTunnelSpawn()
         legacyWriterRunning.withValue { $0 = true }
         await #expect(throws: PortGuardianStoreError.self) {
-            try await guardian.record(port: 18790, pid: 4243, command: "/usr/bin/ssh", mode: .remote)
+            try await guardian.record(
+                port: 18790,
+                pid: 4243,
+                command: "/usr/bin/ssh",
+                mode: .remote,
+                preparation: threatenedPreparation)
         }
+        await #expect(throws: PortGuardianStoreError.self) {
+            try await guardian.prepareForTunnelSpawn()
+        }
+        await guardian.cancelTunnelSpawn(threatenedPreparation)
         legacyWriterRunning.withValue { $0 = false }
-        _ = try await guardian.record(port: 18791, pid: 4244, command: "/usr/bin/ssh", mode: .remote)
+        let finalPreparation = try await guardian.prepareForTunnelSpawn()
+        _ = try await guardian.record(
+            port: 18791,
+            pid: 4244,
+            command: "/usr/bin/ssh",
+            mode: .remote,
+            preparation: finalPreparation)
 
         #expect(attempts.withValue { $0 } == 3)
     }
@@ -83,7 +108,8 @@ struct PortGuardianRecordStoreTests {
         let guardian = PortGuardian(recordStoreFactory: {
             try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
         })
-        let receipt = try await guardian.record(
+        let receipt = try await Self.record(
+            guardian: guardian,
             port: 18789,
             pid: 2_000_000_000,
             command: "/usr/bin/ssh",
@@ -107,10 +133,13 @@ struct PortGuardianRecordStoreTests {
                 $0 += 1
                 return $0
             }
-            guard attempt != 2 else { throw PortGuardianStoreError("injected delete failure") }
+            guard attempt != 2 else {
+                throw PortGuardianStoreError("injected delete failure")
+            }
             return try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
         })
-        let receipt = try await guardian.record(
+        let receipt = try await Self.record(
+            guardian: guardian,
             port: 18789,
             pid: 2_000_000_000,
             command: "/usr/bin/ssh",
@@ -139,13 +168,15 @@ struct PortGuardianRecordStoreTests {
         })
 
         await #expect(throws: PortGuardianStoreError.self) {
-            try await guardian.record(
+            try await Self.record(
+                guardian: guardian,
                 port: 18789,
                 pid: 4242,
                 command: "/usr/bin/ssh",
                 mode: .remote)
         }
-        let receipt = try await guardian.record(
+        let receipt = try await Self.record(
+            guardian: guardian,
             port: 18789,
             pid: 4242,
             command: "/usr/bin/ssh",
@@ -153,6 +184,24 @@ struct PortGuardianRecordStoreTests {
 
         #expect(receipt.pid == 4242)
         #expect(attempts.withValue { $0 } == 2)
+    }
+
+    @Test
+    func `spawn preparation excludes migration until receipt or cancellation`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let guardian = PortGuardian(recordStoreFactory: {
+            try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+
+        let first = try await guardian.prepareForTunnelSpawn()
+        await #expect(throws: PortGuardianStoreError.self) {
+            try await guardian.prepareForTunnelSpawn()
+        }
+
+        await guardian.cancelTunnelSpawn(first)
+        let second = try await guardian.prepareForTunnelSpawn()
+        await guardian.cancelTunnelSpawn(second)
     }
 
     @Test
@@ -602,5 +651,21 @@ struct PortGuardianRecordStoreTests {
         }
         defer { _ = flock(descriptor, LOCK_UN) }
         try JSONEncoder().encode(records).write(to: recordURL, options: [.atomic])
+    }
+
+    private static func record(
+        guardian: PortGuardian,
+        port: Int,
+        pid: Int32,
+        command: String,
+        mode: AppState.ConnectionMode) async throws -> PortGuardian.Record
+    {
+        let preparation = try await guardian.prepareForTunnelSpawn()
+        return try await guardian.record(
+            port: port,
+            pid: pid,
+            command: command,
+            mode: mode,
+            preparation: preparation)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -562,6 +562,34 @@ struct PortGuardianRecordStoreTests {
     }
 
     @Test
+    func `retained store rejects mutations after schema advances`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        let existing = Self.record(pid: 4242, port: 18789, timestamp: 42)
+        try store.upsert(existing)
+        try JSONEncoder().encode([existing]).write(to: fixture.legacyURL, options: [.atomic])
+
+        try Self.execute(fixture.databaseURL, "PRAGMA user_version = 5")
+
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.upsert(Self.record(pid: 4243, port: 18790, timestamp: 43))
+        }
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.deleteIfMatches(existing)
+        }
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL)
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+        #expect(try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT COUNT(*) FROM macos_port_guardian_records") == 1)
+    }
+
+    @Test
     func `legacy compatibility lock rejects symbolic links`() throws {
         let fixture = try Self.fixture()
         defer { fixture.cleanup() }

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -1,0 +1,606 @@
+import ConcurrencyExtras
+import Foundation
+import SQLite3
+import Testing
+@testable import OpenClaw
+
+struct PortGuardianRecordStoreTests {
+    @Test
+    func `storage marker distinguishes older OpenClaw writers from aligned copies`() {
+        #expect(!PortGuardian.usesLegacyPortGuardianStorage(
+            bundleIdentifier: "com.example.unrelated",
+            storageVersion: nil))
+        #expect(PortGuardian.usesLegacyPortGuardianStorage(
+            bundleIdentifier: "ai.openclaw.mac",
+            storageVersion: nil))
+        #expect(PortGuardian.usesLegacyPortGuardianStorage(
+            bundleIdentifier: "ai.openclaw.mac.debug",
+            storageVersion: 1))
+        #expect(!PortGuardian.usesLegacyPortGuardianStorage(
+            bundleIdentifier: "ai.openclaw.mac",
+            storageVersion: 2))
+        #expect(!PortGuardian.usesLegacyPortGuardianStorage(
+            bundleIdentifier: "ai.openclaw.mac.debug",
+            storageVersion: 3))
+    }
+
+    @Test
+    func `storage marker in app bundle matches runtime capability`() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let infoURL = macOSRoot.appendingPathComponent("Sources/OpenClaw/Resources/Info.plist")
+        let data = try Data(contentsOf: infoURL)
+        let values = try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+        let version = try #require(values["OpenClawPortGuardianStorageVersion"] as? NSNumber)
+
+        #expect(version.intValue == PortGuardian.portGuardianStorageVersion)
+    }
+
+    @Test
+    func `storage marker requires the running code directory hash`() {
+        let running = Data(repeating: 0x11, count: 20)
+        let replacement = Data(repeating: 0x22, count: 20)
+
+        #expect(PortGuardian.codeDirectoryHashesMatch(running: running, signed: running))
+        #expect(!PortGuardian.codeDirectoryHashesMatch(running: running, signed: replacement))
+        #expect(!PortGuardian.codeDirectoryHashesMatch(running: nil, signed: running))
+        #expect(!PortGuardian.codeDirectoryHashesMatch(running: Data(), signed: Data()))
+    }
+
+    @Test
+    func `guardian rechecks compatibility after a successful open`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let legacyWriterRunning = LockIsolated(false)
+        let attempts = LockIsolated(0)
+        let guardian = PortGuardian(recordStoreFactory: {
+            attempts.withValue { $0 += 1 }
+            guard !legacyWriterRunning.withValue({ $0 }) else {
+                throw PortGuardianStoreError("legacy writer running")
+            }
+            return try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+
+        _ = try await guardian.record(port: 18789, pid: 4242, command: "/usr/bin/ssh", mode: .remote)
+        legacyWriterRunning.withValue { $0 = true }
+        await #expect(throws: PortGuardianStoreError.self) {
+            try await guardian.record(port: 18790, pid: 4243, command: "/usr/bin/ssh", mode: .remote)
+        }
+        legacyWriterRunning.withValue { $0 = false }
+        _ = try await guardian.record(port: 18791, pid: 4244, command: "/usr/bin/ssh", mode: .remote)
+
+        #expect(attempts.withValue { $0 } == 3)
+    }
+
+    @Test
+    func `relinquished receipt remains durable but becomes reap eligible`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        let guardian = PortGuardian(recordStoreFactory: {
+            try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+        let receipt = try await guardian.record(
+            port: 18789,
+            pid: 2_000_000_000,
+            command: "/usr/bin/ssh",
+            mode: .remote)
+
+        await guardian.relinquishRecord(receipt)
+        #expect(try store.records() == [receipt])
+        await guardian.reapOrphanedTunnels()
+
+        #expect(try store.records().isEmpty)
+    }
+
+    @Test
+    func `failed receipt deletion relinquishes ownership for sweep retry`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        let attempts = LockIsolated(0)
+        let guardian = PortGuardian(recordStoreFactory: {
+            let attempt = attempts.withValue {
+                $0 += 1
+                return $0
+            }
+            guard attempt != 2 else { throw PortGuardianStoreError("injected delete failure") }
+            return try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+        let receipt = try await guardian.record(
+            port: 18789,
+            pid: 2_000_000_000,
+            command: "/usr/bin/ssh",
+            mode: .remote)
+
+        await guardian.removeRecord(receipt)
+        #expect(try store.records() == [receipt])
+        await guardian.reapOrphanedTunnels()
+
+        #expect(attempts.withValue { $0 } == 3)
+        #expect(try store.records().isEmpty)
+    }
+
+    @Test
+    func `guardian retries store creation after a transient failure`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let attempts = LockIsolated(0)
+        let guardian = PortGuardian(recordStoreFactory: {
+            let attempt = attempts.withValue {
+                $0 += 1
+                return $0
+            }
+            guard attempt > 1 else { throw PortGuardianStoreError("transient store failure") }
+            return try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+
+        await #expect(throws: PortGuardianStoreError.self) {
+            try await guardian.record(
+                port: 18789,
+                pid: 4242,
+                command: "/usr/bin/ssh",
+                mode: .remote)
+        }
+        let receipt = try await guardian.record(
+            port: 18789,
+            pid: 4242,
+            command: "/usr/bin/ssh",
+            mode: .remote)
+
+        #expect(receipt.pid == 4242)
+        #expect(attempts.withValue { $0 } == 2)
+    }
+
+    @Test
+    func `round trips orders replaces and content guards records`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        #expect(!FileManager.default.fileExists(atPath: fixture.lockURL.path))
+        let later = Self.record(pid: 22, port: 18790, timestamp: 20)
+        let earlier = Self.record(pid: 11, port: 18789, timestamp: 10)
+        try store.upsert(later)
+        try store.upsert(earlier)
+
+        #expect(try store.records() == [earlier, later])
+
+        let replacement = Self.record(pid: earlier.pid, port: 19000, timestamp: 30)
+        try store.upsert(replacement)
+        #expect(try store.deleteIfMatches(earlier) == false)
+        #expect(try store.records() == [later, replacement])
+        #expect(try store.deleteIfMatches(replacement))
+        #expect(try store.records() == [later])
+    }
+
+    @Test
+    func `independent concurrent connections preserve their union`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let databaseURL = fixture.databaseURL
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for index in 1...12 {
+                group.addTask {
+                    let store = try PortGuardianRecordStore(databaseURL: databaseURL)
+                    try store.upsert(Self.record(
+                        pid: Int32(1000 + index),
+                        port: 20000 + index,
+                        timestamp: Double(index)))
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let store = try PortGuardianRecordStore(databaseURL: databaseURL)
+        #expect(try store.records().map(\.pid) == (1...12).map { Int32(1000 + $0) })
+    }
+
+    @Test
+    func `identity first version zero database composes without losing identity`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        try Self.execute(fixture.databaseURL, """
+        CREATE TABLE device_identities (
+          identity_key TEXT NOT NULL PRIMARY KEY,
+          device_id TEXT NOT NULL,
+          public_key_pem TEXT NOT NULL,
+          private_key_pem TEXT NOT NULL,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL
+        ) STRICT;
+        CREATE INDEX idx_device_identities_device
+          ON device_identities(device_id, updated_at_ms DESC);
+        INSERT INTO device_identities VALUES ('primary', 'device-1', 'public', 'private', 10, 20);
+        """)
+
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        try store.upsert(Self.record(pid: 4242, port: 18789, timestamp: 42))
+
+        #expect(try Self.scalarInt(fixture.databaseURL, "PRAGMA user_version") == 0)
+        #expect(try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT COUNT(*) FROM device_identities WHERE identity_key = 'primary'") == 1)
+        #expect(try store.records().map(\.pid) == [4242])
+    }
+
+    @Test
+    func `legacy migration merges verifies and retires source`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        let existing = Self.record(pid: 10, port: 18789, timestamp: 20)
+        let imported = Self.record(pid: 20, port: 18790, timestamp: 30)
+        try store.upsert(existing)
+        // The lock must not strand a shipped app after it has spawned SSH but
+        // before it records JSON. A later aligned startup can still import it.
+        try Self.writeLegacyRecords(
+            [existing, imported],
+            recordURL: fixture.legacyURL,
+            lockURL: fixture.lockURL)
+
+        #expect(try store.migrateLegacyRecords(recordURL: fixture.legacyURL) == 2)
+        #expect(try store.records() == [existing, imported])
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.lockURL.path))
+    }
+
+    @Test
+    func `legacy migration rejects every divergent same pid receipt`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        let canonical = Self.record(pid: 30, port: 18789, timestamp: 20)
+        try store.upsert(canonical)
+        let older = Self.record(pid: 30, port: 19000, timestamp: 10)
+        try JSONEncoder().encode([older]).write(to: fixture.legacyURL, options: [.atomic])
+
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL)
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+        #expect(try store.records() == [canonical])
+
+        try FileManager.default.removeItem(at: fixture.legacyURL)
+        let newer = Self.record(pid: 30, port: 19001, timestamp: 30)
+        try JSONEncoder().encode([newer]).write(to: fixture.legacyURL, options: [.atomic])
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL)
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+        #expect(try store.records() == [canonical])
+    }
+
+    @Test
+    func `legacy migration applies preplanned replacement and retirement decisions`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        let existing = Self.record(pid: 50, port: 18789, timestamp: 10)
+        let legacy = Self.record(pid: 50, port: 18790, timestamp: 20)
+        try store.upsert(existing)
+        try JSONEncoder().encode([legacy]).write(to: fixture.legacyURL, options: [.atomic])
+
+        _ = try store.migrateLegacyRecords(recordURL: fixture.legacyURL) { _, legacy in legacy }
+        #expect(try store.records() == [legacy])
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+
+        let staleLegacy = Self.record(pid: 50, port: 18791, timestamp: 30)
+        try JSONEncoder().encode([staleLegacy]).write(to: fixture.legacyURL, options: [.atomic])
+        _ = try store.migrateLegacyRecords(recordURL: fixture.legacyURL) { _, _ in nil }
+        #expect(try store.records().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+    }
+
+    @Test
+    func `live process generation resolves divergent legacy receipts`() throws {
+        let existing = Self.record(pid: 60, port: 18789, timestamp: 90)
+        let legacy = Self.record(pid: 60, port: 18790, timestamp: 101)
+        let legacyProcess = PortGuardian.TunnelProcessInfo(
+            parentPid: 1,
+            startedAt: 100,
+            fullCommand: "/usr/bin/ssh -N -L 18790:127.0.0.1:18789 host")
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: existing,
+            legacy: legacy,
+            process: legacyProcess) == legacy)
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: nil,
+            legacy: legacy,
+            process: legacyProcess) == legacy)
+
+        let existingProcess = PortGuardian.TunnelProcessInfo(
+            parentPid: 1,
+            startedAt: 89,
+            fullCommand: "/usr/bin/ssh -N -L 18789:127.0.0.1:18789 host")
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: existing,
+            legacy: legacy,
+            process: existingProcess) == existing)
+
+        let unrelated = PortGuardian.TunnelProcessInfo(
+            parentPid: 1,
+            startedAt: 100,
+            fullCommand: "node server.js")
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: existing,
+            legacy: legacy,
+            process: unrelated) == nil)
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: existing,
+            legacy: legacy,
+            process: nil) == nil)
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: nil,
+            legacy: legacy,
+            process: nil) == nil)
+
+        let unreadable = PortGuardian.TunnelProcessInfo(parentPid: 1, startedAt: 100, fullCommand: nil)
+        #expect(throws: PortGuardianStoreError.self) {
+            try PortGuardian.resolveLegacyReceipt(
+                existing: existing,
+                legacy: legacy,
+                process: unreadable)
+        }
+
+        let sameForward = Self.record(pid: 60, port: 18789, timestamp: 89.25)
+        #expect(try PortGuardian.resolveLegacyReceipt(
+            existing: existing,
+            legacy: sameForward,
+            process: existingProcess) == sameForward)
+    }
+
+    @Test
+    func `retired legacy receipt stays retired after source removal retry`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let removalAttempts = LockIsolated(0)
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL,
+            removeLegacySource: { url in
+                let attempt = removalAttempts.withValue {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else { throw PortGuardianStoreError("injected removal failure") }
+                try FileManager.default.removeItem(at: url)
+            })
+        let canonical = Self.record(pid: 70, port: 18789, timestamp: 10)
+        let legacy = Self.record(pid: 70, port: 18790, timestamp: 20)
+        try store.upsert(canonical)
+        try JSONEncoder().encode([legacy]).write(to: fixture.legacyURL, options: [.atomic])
+        var observedExisting: [PortGuardian.Record?] = []
+
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL) { existing, _ in
+                observedExisting.append(existing)
+                return nil
+            }
+        }
+        #expect(try store.records().isEmpty)
+        #expect(FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+
+        _ = try store.migrateLegacyRecords(recordURL: fixture.legacyURL) { existing, _ in
+            observedExisting.append(existing)
+            return nil
+        }
+        #expect(observedExisting.count == 2)
+        #expect(observedExisting[0] == canonical)
+        #expect(observedExisting[1] == nil)
+        #expect(try store.records().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+    }
+
+    @Test
+    func `legacy planning releases the writer lock and tolerates peer completion`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        let peerStore = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        let legacy = Self.record(pid: 80, port: 18789, timestamp: 20)
+        try JSONEncoder().encode([legacy]).write(to: fixture.legacyURL, options: [.atomic])
+        let planningStarted = DispatchSemaphore(value: 0)
+        let finishPlanning = DispatchSemaphore(value: 0)
+        let migration = Task.detached {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL) { _, legacy in
+                planningStarted.signal()
+                _ = finishPlanning.wait(timeout: .now() + 5)
+                return legacy
+            }
+        }
+
+        let started = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: planningStarted.wait(timeout: .now() + 2) == .success)
+            }
+        }
+        #expect(started)
+        let descriptor = open(fixture.lockURL.path, O_RDWR | O_CLOEXEC | O_NOFOLLOW)
+        #expect(descriptor >= 0)
+        if descriptor >= 0 {
+            #expect(flock(descriptor, LOCK_EX | LOCK_NB) == 0)
+            _ = flock(descriptor, LOCK_UN)
+            close(descriptor)
+        }
+        #expect(try peerStore.migrateLegacyRecords(recordURL: fixture.legacyURL) == 1)
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+        finishPlanning.signal()
+
+        #expect(try await migration.value == 0)
+        #expect(try store.records() == [legacy])
+    }
+
+    @Test
+    func `invalid duplicate and linked legacy sources fail closed`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(
+            databaseURL: fixture.databaseURL,
+            legacyLockURL: fixture.lockURL)
+        try Data("not-json".utf8).write(to: fixture.legacyURL)
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL)
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.legacyURL.path))
+        #expect(try store.records().isEmpty)
+
+        let duplicate = Self.record(pid: 40, port: 18789, timestamp: 10)
+        try JSONEncoder().encode([duplicate, duplicate]).write(to: fixture.legacyURL, options: [.atomic])
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL)
+        }
+        #expect(try store.records().isEmpty)
+
+        try FileManager.default.removeItem(at: fixture.legacyURL)
+        let target = fixture.root.appendingPathComponent("legacy-target.json")
+        try JSONEncoder().encode([duplicate]).write(to: target)
+        try FileManager.default.createSymbolicLink(at: fixture.legacyURL, withDestinationURL: target)
+        #expect(throws: PortGuardianStoreError.self) {
+            try store.migrateLegacyRecords(recordURL: fixture.legacyURL)
+        }
+        #expect(FileManager.default.fileExists(atPath: target.path))
+        #expect(try store.records().isEmpty)
+    }
+
+    @Test
+    func `foreign newer and incompatible databases fail closed`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+
+        let foreignURL = fixture.root.appendingPathComponent("foreign.sqlite")
+        try Self.execute(foreignURL, "CREATE TABLE unrelated (id INTEGER PRIMARY KEY) STRICT")
+        #expect(throws: PortGuardianStoreError.self) {
+            try PortGuardianRecordStore(databaseURL: foreignURL)
+        }
+
+        let newerURL = fixture.root.appendingPathComponent("newer.sqlite")
+        try Self.execute(newerURL, "PRAGMA user_version = 4")
+        #expect(throws: PortGuardianStoreError.self) {
+            try PortGuardianRecordStore(databaseURL: newerURL)
+        }
+
+        let uniqueIndexURL = fixture.root.appendingPathComponent("unique-index.sqlite")
+        try Self.execute(uniqueIndexURL, """
+        CREATE TABLE macos_port_guardian_records (
+          pid INTEGER NOT NULL PRIMARY KEY,
+          port INTEGER NOT NULL,
+          command TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          timestamp REAL NOT NULL
+        ) STRICT;
+        CREATE UNIQUE INDEX idx_macos_port_guardian_records_port
+          ON macos_port_guardian_records(port, timestamp DESC);
+        """)
+        #expect(throws: PortGuardianStoreError.self) {
+            try PortGuardianRecordStore(databaseURL: uniqueIndexURL)
+        }
+    }
+
+    @Test
+    func `legacy compatibility lock rejects symbolic links`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let target = fixture.root.appendingPathComponent("lock-target")
+        try Data().write(to: target)
+        try FileManager.default.createSymbolicLink(at: fixture.lockURL, withDestinationURL: target)
+
+        #expect(throws: PortGuardianStoreError.self) {
+            try PortGuardianRecordStore(
+                databaseURL: fixture.databaseURL,
+                legacyLockURL: fixture.lockURL)
+        }
+    }
+
+    private struct Fixture: @unchecked Sendable {
+        let root: URL
+        let databaseURL: URL
+        let legacyURL: URL
+        let lockURL: URL
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+
+    private static func fixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("port-guardian-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return Fixture(
+            root: root,
+            databaseURL: root.appendingPathComponent("state/openclaw.sqlite"),
+            legacyURL: root.appendingPathComponent("port-guard.json"),
+            lockURL: root.appendingPathComponent("port-guard.lock"))
+    }
+
+    private static func record(pid: Int32, port: Int, timestamp: TimeInterval) -> PortGuardian.Record {
+        PortGuardian.Record(
+            port: port,
+            pid: pid,
+            command: "/usr/bin/ssh",
+            mode: "remote",
+            timestamp: timestamp)
+    }
+
+    private static func execute(_ databaseURL: URL, _ sql: String) throws {
+        try FileManager.default.createDirectory(
+            at: databaseURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        var database: OpaquePointer?
+        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK, let database else {
+            throw PortGuardianStoreError("Could not open test database")
+        }
+        defer { sqlite3_close(database) }
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw PortGuardianStoreError(String(cString: sqlite3_errmsg(database)))
+        }
+    }
+
+    private static func scalarInt(_ databaseURL: URL, _ sql: String) throws -> Int64 {
+        var database: OpaquePointer?
+        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK, let database else {
+            throw PortGuardianStoreError("Could not open test database")
+        }
+        defer { sqlite3_close(database) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw PortGuardianStoreError(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw PortGuardianStoreError(String(cString: sqlite3_errmsg(database)))
+        }
+        return sqlite3_column_int64(statement, 0)
+    }
+
+    private static func writeLegacyRecords(
+        _ records: [PortGuardian.Record],
+        recordURL: URL,
+        lockURL: URL) throws
+    {
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else { throw PortGuardianStoreError("Could not open test legacy lock") }
+        defer { close(descriptor) }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            throw PortGuardianStoreError("New store blocked the shipped PortGuardian writer")
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        try JSONEncoder().encode(records).write(to: recordURL, options: [.atomic])
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/RemotePortTunnelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RemotePortTunnelTests.swift
@@ -37,6 +37,18 @@ struct RemotePortTunnelTests {
         #expect(drained.isEmpty)
     }
 
+    @Test func `termination waits for the original child to exit`() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        try process.run()
+
+        RemotePortTunnel._testTerminateAndWait(process)
+        #expect(!process.isRunning)
+        #expect(process.terminationReason == .uncaughtSignal)
+        #expect(process.terminationStatus == SIGTERM)
+    }
+
     @Test func `port is free detects I pv4 listener`() {
         var fd = socket(AF_INET, SOCK_STREAM, 0)
         #expect(fd >= 0)

--- a/apps/shared/OpenClawKit/Package.swift
+++ b/apps/shared/OpenClawKit/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     ],
     products: [
         .library(name: "OpenClawProtocol", targets: ["OpenClawProtocol"]),
+        .library(name: "OpenClawNativeState", targets: ["OpenClawNativeState"]),
         .library(name: "OpenClawKit", targets: ["OpenClawKit"]),
         .library(name: "OpenClawChatUI", targets: ["OpenClawChatUI"]),
     ],
@@ -31,8 +32,15 @@ let package = Package(
                 .enableUpcomingFeature("StrictConcurrency"),
             ]),
         .target(
+            name: "OpenClawNativeState",
+            path: "Sources/OpenClawNativeState",
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency"),
+            ]),
+        .target(
             name: "OpenClawKit",
             dependencies: [
+                "OpenClawNativeState",
                 "OpenClawProtocol",
                 .product(
                     name: "ElevenLabsKit",
@@ -62,6 +70,14 @@ let package = Package(
             name: "OpenClawKitTests",
             dependencies: ["OpenClawKit", "OpenClawChatUI", "OpenClawProtocol"],
             path: "Tests/OpenClawKitTests",
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency"),
+                .enableExperimentalFeature("SwiftTesting"),
+            ]),
+        .testTarget(
+            name: "OpenClawNativeStateTests",
+            dependencies: ["OpenClawNativeState"],
+            path: "Tests/OpenClawNativeStateTests",
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
                 .enableExperimentalFeature("SwiftTesting"),

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -78,6 +78,20 @@ enum DeviceIdentitySQLiteStore {
         }
     }
 
+    private struct SchemaObject: Hashable {
+        let type: String
+        let name: String
+    }
+
+    /// Native stores may seed their canonical tables before Node expands the shared schema.
+    /// Keep names closed here; each store separately validates the exact shape it owns.
+    private static let nativeBootstrapSchemaObjects: Set<SchemaObject> = [
+        SchemaObject(type: "index", name: "idx_device_identities_device"),
+        SchemaObject(type: "index", name: "idx_macos_port_guardian_records_port"),
+        SchemaObject(type: "table", name: "device_identities"),
+        SchemaObject(type: "table", name: "macos_port_guardian_records"),
+    ]
+
     static func loadOrCreate(
         databaseURL: URL,
         destinationStateDirURL: URL,
@@ -329,12 +343,10 @@ enum DeviceIdentitySQLiteStore {
         }
 
         if try !self.schemaObjectExists(database, type: "table", name: self.tableName) {
-            let objectCount = try self.queryInt64(
-                database,
-                sql: "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'")
-            guard allowFreshCreation, userVersion == 0, objectCount == 0 else {
+            guard allowFreshCreation, userVersion == 0 else {
                 throw DeviceIdentityStore.storageError("Nonempty OpenClaw database is missing device_identities")
             }
+            try self.validateVersionZeroDatabaseOwnership(database, requireIdentityObjects: false)
             try self.execute(database, sql: self.createSchemaSQL)
         }
         try self.validateDatabaseOwnership(database, userVersion: userVersion)
@@ -370,33 +382,7 @@ enum DeviceIdentitySQLiteStore {
         userVersion: Int64) throws
     {
         if userVersion == 0 {
-            let statement = try self.prepare(
-                database,
-                sql: """
-                SELECT type, name
-                FROM sqlite_schema
-                WHERE name NOT LIKE 'sqlite_%'
-                ORDER BY type, name
-                """)
-            defer { sqlite3_finalize(statement) }
-            var objects: [(String, String)] = []
-            while true {
-                let result = sqlite3_step(statement)
-                if result == SQLITE_DONE { break }
-                guard result == SQLITE_ROW else {
-                    throw self.databaseError(database, operation: "validate Swift identity database ownership")
-                }
-                try objects.append((
-                    self.requiredText(statement, column: 0, field: "schema object type"),
-                    self.requiredText(statement, column: 1, field: "schema object name")))
-            }
-            guard objects.count == 2,
-                  objects[0].0 == "index", objects[0].1 == self.indexName,
-                  objects[1].0 == "table", objects[1].1 == self.tableName
-            else {
-                throw DeviceIdentityStore.storageError(
-                    "Schema version zero database contains objects not owned by the Swift identity store")
-            }
+            try self.validateVersionZeroDatabaseOwnership(database, requireIdentityObjects: true)
             return
         }
 
@@ -412,6 +398,45 @@ enum DeviceIdentitySQLiteStore {
         else {
             throw DeviceIdentityStore.storageError(
                 "OpenClaw state database schema metadata does not match its global schema version")
+        }
+    }
+
+    private static func validateVersionZeroDatabaseOwnership(
+        _ database: OpaquePointer,
+        requireIdentityObjects: Bool) throws
+    {
+        let statement = try self.prepare(
+            database,
+            sql: """
+            SELECT type, name
+            FROM sqlite_schema
+            WHERE name NOT LIKE 'sqlite_%'
+            ORDER BY type, name
+            """)
+        defer { sqlite3_finalize(statement) }
+        var objects = Set<SchemaObject>()
+        while true {
+            let result = sqlite3_step(statement)
+            if result == SQLITE_DONE { break }
+            guard result == SQLITE_ROW else {
+                throw self.databaseError(database, operation: "validate native state database ownership")
+            }
+            try objects.insert(SchemaObject(
+                type: self.requiredText(statement, column: 0, field: "schema object type"),
+                name: self.requiredText(statement, column: 1, field: "schema object name")))
+        }
+        guard objects.isSubset(of: self.nativeBootstrapSchemaObjects) else {
+            throw DeviceIdentityStore.storageError(
+                "Schema version zero database contains objects not owned by a native OpenClaw store")
+        }
+        if requireIdentityObjects {
+            let required: Set<SchemaObject> = [
+                SchemaObject(type: "index", name: self.indexName),
+                SchemaObject(type: "table", name: self.tableName),
+            ]
+            guard required.isSubset(of: objects) else {
+                throw DeviceIdentityStore.storageError("Schema version zero database is missing device identity objects")
+            }
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -1,32 +1,15 @@
 import CryptoKit
 import Darwin
 import Foundation
+import OpenClawNativeState
 import SQLite3
 
 enum DeviceIdentitySQLiteStore {
-    // Keep aligned with OPENCLAW_STATE_SCHEMA_VERSION. Swift never upgrades this database.
-    private static let maximumSupportedSchemaVersion: Int64 = 4
     private static let busyTimeoutMilliseconds: Int32 = 5000
     private static let maximumLegacyIdentityBytes = 64 * 1024
     private static let maximumLegacyAuthBytes = 4 * 1024 * 1024
     private static let doctorClaimSuffix = ".doctor-importing"
     private static let nativeClaimSuffix = ".native-importing"
-    private static let tableName = "device_identities"
-    private static let indexName = "idx_device_identities_device"
-
-    private static let createSchemaSQL = """
-    CREATE TABLE IF NOT EXISTS device_identities (
-      identity_key TEXT NOT NULL PRIMARY KEY,
-      device_id TEXT NOT NULL,
-      public_key_pem TEXT NOT NULL,
-      private_key_pem TEXT NOT NULL,
-      created_at_ms INTEGER NOT NULL,
-      updated_at_ms INTEGER NOT NULL
-    ) STRICT;
-
-    CREATE INDEX IF NOT EXISTS idx_device_identities_device
-      ON device_identities(device_id, updated_at_ms DESC);
-    """
 
     private struct LegacyClaim {
         let source: DeviceIdentityPaths.LegacyIdentitySource
@@ -46,14 +29,6 @@ enum DeviceIdentitySQLiteStore {
     private struct LegacyAuthCandidate {
         let data: Data
         let store: DeviceAuthStoreFile
-    }
-
-    private struct Column: Equatable {
-        let name: String
-        let type: String
-        let notNull: Bool
-        let primaryKeyPosition: Int32
-        let hidden: Int32
     }
 
     private final class IdentityCoordinator {
@@ -77,20 +52,6 @@ enum DeviceIdentitySQLiteStore {
             if let releaseError { throw releaseError }
         }
     }
-
-    private struct SchemaObject: Hashable {
-        let type: String
-        let name: String
-    }
-
-    /// Native stores may seed their canonical tables before Node expands the shared schema.
-    /// Keep names closed here; each store separately validates the exact shape it owns.
-    private static let nativeBootstrapSchemaObjects: Set<SchemaObject> = [
-        SchemaObject(type: "index", name: "idx_device_identities_device"),
-        SchemaObject(type: "index", name: "idx_macos_port_guardian_records_port"),
-        SchemaObject(type: "table", name: "device_identities"),
-        SchemaObject(type: "table", name: "macos_port_guardian_records"),
-    ]
 
     static func loadOrCreate(
         databaseURL: URL,
@@ -125,6 +86,27 @@ enum DeviceIdentitySQLiteStore {
     }
 
     private static func loadOrCreateOwned(
+        databaseURL: URL,
+        destinationStateDirURL: URL,
+        profile: GatewayDeviceIdentityProfile,
+        legacySources: [DeviceIdentityPaths.LegacyIdentitySource],
+        beforeLegacyClaim: ((DeviceIdentityPaths.LegacyIdentitySource) throws -> Void)?,
+        afterLegacyCommit: (() throws -> Void)?) throws -> DeviceIdentity
+    {
+        do {
+            return try self.loadOrCreateNativeState(
+                databaseURL: databaseURL,
+                destinationStateDirURL: destinationStateDirURL,
+                profile: profile,
+                legacySources: legacySources,
+                beforeLegacyClaim: beforeLegacyClaim,
+                afterLegacyCommit: afterLegacyCommit)
+        } catch let error as OpenClawNativeStateError {
+            throw DeviceIdentityStore.storageError(error.message)
+        }
+    }
+
+    private static func loadOrCreateNativeState(
         databaseURL: URL,
         destinationStateDirURL: URL,
         profile: GatewayDeviceIdentityProfile,
@@ -170,65 +152,42 @@ enum DeviceIdentitySQLiteStore {
         let generatedMaterial = claims.isEmpty ? DeviceIdentityStore.generateMaterial() : nil
         let writeTimestampMs = Int64(Date().timeIntervalSince1970 * 1000)
 
-        var database: OpaquePointer?
-        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
-        let openResult = sqlite3_open_v2(databaseURL.path, &database, flags, nil)
-        guard openResult == SQLITE_OK, let database else {
-            let message = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown SQLite error"
-            if let database { sqlite3_close(database) }
-            throw DeviceIdentityStore.storageError("Could not open device identity database: \(message)")
-        }
-        defer {
-            sqlite3_close(database)
-            try? self.secureDatabaseFiles(databaseURL)
-        }
-        guard sqlite3_busy_timeout(database, self.busyTimeoutMilliseconds) == SQLITE_OK else {
-            throw self.databaseError(database, operation: "configure SQLite busy timeout")
-        }
-        try self.secureDatabaseFiles(databaseURL)
-
-        try self.execute(database, sql: "BEGIN IMMEDIATE")
-        var committed = false
-        defer {
-            if !committed {
-                try? self.execute(database, sql: "ROLLBACK")
+        let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+        let authoritative = try database.withImmediateTransaction {
+            try database.ensureCanonicalTable(.deviceIdentities)
+            let existing = try self.readIdentity(database, key: profile.rawValue)
+            let selected: DeviceIdentityMaterial
+            if let existing {
+                if let migrated = claims.first?.material,
+                   !self.hasSameKeyMaterial(migrated, existing)
+                {
+                    throw DeviceIdentityStore.storageError(
+                        "Legacy device identity conflicts with SQLite identity key " +
+                            "\(profile.rawValue); source preserved")
+                }
+                selected = existing
+            } else {
+                guard let candidate = claims.first?.material ?? generatedMaterial else {
+                    throw DeviceIdentityStore.storageError("Device identity candidate is unavailable")
+                }
+                selected = candidate
+                try self.insertIdentity(
+                    database,
+                    key: profile.rawValue,
+                    material: selected,
+                    updatedAtMs: writeTimestampMs)
             }
-        }
 
-        try self.ensureSchema(database, allowFreshCreation: true)
-        let existing = try self.readIdentity(database, key: profile.rawValue)
-        let selected: DeviceIdentityMaterial
-        if let existing {
-            if let migrated = claims.first?.material,
-               !self.hasSameKeyMaterial(migrated, existing)
-            {
-                throw DeviceIdentityStore.storageError(
-                    "Legacy device identity conflicts with SQLite identity key \(profile.rawValue); source preserved")
+            // The row reread under the write transaction is authoritative. Never return generated
+            // or migrated key material unless SQLite reports the exact canonical receipt.
+            guard let authoritative = try self.readIdentity(database, key: profile.rawValue),
+                  authoritative == selected
+            else {
+                throw DeviceIdentityStore.storageError("SQLite did not preserve the authoritative device identity")
             }
-            selected = existing
-        } else {
-            guard let candidate = claims.first?.material ?? generatedMaterial else {
-                throw DeviceIdentityStore.storageError("Device identity candidate is unavailable")
-            }
-            selected = candidate
-            try self.insertIdentity(
-                database,
-                key: profile.rawValue,
-                material: selected,
-                updatedAtMs: writeTimestampMs)
+            try database.ensureCanonicalTable(.deviceIdentities, allowVersionZeroCreation: false)
+            return authoritative
         }
-
-        // The row reread under the write transaction is authoritative. Never return generated
-        // or migrated key material unless SQLite reports the exact canonical receipt.
-        guard let authoritative = try self.readIdentity(database, key: profile.rawValue),
-              authoritative == selected
-        else {
-            throw DeviceIdentityStore.storageError("SQLite did not preserve the authoritative device identity")
-        }
-        try self.ensureSchema(database, allowFreshCreation: false)
-        try self.execute(database, sql: "COMMIT")
-        committed = true
-        try self.secureDatabaseFiles(databaseURL)
 
         if !claims.isEmpty {
             try afterLegacyCommit?()
@@ -271,9 +230,17 @@ enum DeviceIdentitySQLiteStore {
         }
         do {
             guard sqlite3_busy_timeout(database, self.busyTimeoutMilliseconds) == SQLITE_OK else {
-                throw self.databaseError(database, operation: "configure device identity coordinator timeout")
+                throw DeviceIdentityStore.storageError(
+                    "Could not configure device identity coordinator timeout: " +
+                        String(cString: sqlite3_errmsg(database)))
             }
-            try self.execute(database, sql: "BEGIN EXCLUSIVE")
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            guard sqlite3_exec(database, "BEGIN EXCLUSIVE", nil, nil, &errorMessage) == SQLITE_OK else {
+                let detail = errorMessage.map { String(cString: $0) }
+                    ?? String(cString: sqlite3_errmsg(database))
+                sqlite3_free(errorMessage)
+                throw DeviceIdentityStore.storageError("Could not acquire device identity coordinator: \(detail)")
+            }
             try self.secureFile(coordinatorURL)
             return IdentityCoordinator(database: database)
         } catch {
@@ -333,228 +300,54 @@ enum DeviceIdentitySQLiteStore {
         return canonical.standardizedFileURL.path
     }
 
-    private static func ensureSchema(_ database: OpaquePointer, allowFreshCreation: Bool) throws {
-        let userVersion = try self.queryInt64(database, sql: "PRAGMA user_version")
-        guard userVersion <= self.maximumSupportedSchemaVersion else {
-            let message =
-                "Device identity database uses newer schema version \(userVersion); " +
-                "this build supports \(self.maximumSupportedSchemaVersion)"
-            throw DeviceIdentityStore.storageError(message)
-        }
-
-        if try !self.schemaObjectExists(database, type: "table", name: self.tableName) {
-            guard allowFreshCreation, userVersion == 0 else {
-                throw DeviceIdentityStore.storageError("Nonempty OpenClaw database is missing device_identities")
-            }
-            try self.validateVersionZeroDatabaseOwnership(database, requireIdentityObjects: false)
-            try self.execute(database, sql: self.createSchemaSQL)
-        }
-        try self.validateDatabaseOwnership(database, userVersion: userVersion)
-
-        let expectedColumns = [
-            Column(name: "identity_key", type: "TEXT", notNull: true, primaryKeyPosition: 1, hidden: 0),
-            Column(name: "device_id", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
-            Column(name: "public_key_pem", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
-            Column(name: "private_key_pem", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
-            Column(name: "created_at_ms", type: "INTEGER", notNull: true, primaryKeyPosition: 0, hidden: 0),
-            Column(name: "updated_at_ms", type: "INTEGER", notNull: true, primaryKeyPosition: 0, hidden: 0),
-        ]
-        guard try self.tableColumns(database) == expectedColumns else {
-            throw DeviceIdentityStore.storageError("device_identities has an incompatible schema")
-        }
-        let tableSQL = try self.queryText(
-            database,
-            sql: "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'device_identities'") ?? ""
-        let normalizedTableSQL = tableSQL
-            .split(whereSeparator: \.isWhitespace)
-            .joined(separator: " ")
-            .uppercased()
-        guard normalizedTableSQL.hasSuffix(") STRICT") else {
-            throw DeviceIdentityStore.storageError("device_identities must be a STRICT table")
-        }
-        guard try self.validRequiredIndex(database) else {
-            throw DeviceIdentityStore.storageError("idx_device_identities_device has an incompatible schema")
-        }
-    }
-
-    private static func validateDatabaseOwnership(
-        _ database: OpaquePointer,
-        userVersion: Int64) throws
-    {
-        if userVersion == 0 {
-            try self.validateVersionZeroDatabaseOwnership(database, requireIdentityObjects: true)
-            return
-        }
-
-        let statement = try self.prepare(
-            database,
-            sql: "SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
-        defer { sqlite3_finalize(statement) }
-        guard sqlite3_step(statement) == SQLITE_ROW,
-              try self.requiredText(statement, column: 0, field: "schema role") == "global",
-              sqlite3_column_type(statement, 1) == SQLITE_INTEGER,
-              sqlite3_column_int64(statement, 1) == userVersion,
-              sqlite3_step(statement) == SQLITE_DONE
-        else {
-            throw DeviceIdentityStore.storageError(
-                "OpenClaw state database schema metadata does not match its global schema version")
-        }
-    }
-
-    private static func validateVersionZeroDatabaseOwnership(
-        _ database: OpaquePointer,
-        requireIdentityObjects: Bool) throws
-    {
-        let statement = try self.prepare(
-            database,
-            sql: """
-            SELECT type, name
-            FROM sqlite_schema
-            WHERE name NOT LIKE 'sqlite_%'
-            ORDER BY type, name
-            """)
-        defer { sqlite3_finalize(statement) }
-        var objects = Set<SchemaObject>()
-        while true {
-            let result = sqlite3_step(statement)
-            if result == SQLITE_DONE { break }
-            guard result == SQLITE_ROW else {
-                throw self.databaseError(database, operation: "validate native state database ownership")
-            }
-            try objects.insert(SchemaObject(
-                type: self.requiredText(statement, column: 0, field: "schema object type"),
-                name: self.requiredText(statement, column: 1, field: "schema object name")))
-        }
-        guard objects.isSubset(of: self.nativeBootstrapSchemaObjects) else {
-            throw DeviceIdentityStore.storageError(
-                "Schema version zero database contains objects not owned by a native OpenClaw store")
-        }
-        if requireIdentityObjects {
-            let required: Set<SchemaObject> = [
-                SchemaObject(type: "index", name: self.indexName),
-                SchemaObject(type: "table", name: self.tableName),
-            ]
-            guard required.isSubset(of: objects) else {
-                throw DeviceIdentityStore.storageError("Schema version zero database is missing device identity objects")
-            }
-        }
-    }
-
-    private static func tableColumns(_ database: OpaquePointer) throws -> [Column] {
-        let statement = try self.prepare(database, sql: "PRAGMA table_xinfo('device_identities')")
-        defer { sqlite3_finalize(statement) }
-        var columns: [Column] = []
-        while true {
-            let result = sqlite3_step(statement)
-            if result == SQLITE_DONE { return columns }
-            guard result == SQLITE_ROW else {
-                throw self.databaseError(database, operation: "inspect device identity columns")
-            }
-            try columns.append(Column(
-                name: self.requiredText(statement, column: 1, field: "column name"),
-                type: self.requiredText(statement, column: 2, field: "column type").uppercased(),
-                notNull: sqlite3_column_int(statement, 3) == 1,
-                primaryKeyPosition: sqlite3_column_int(statement, 5),
-                hidden: sqlite3_column_int(statement, 6)))
-        }
-    }
-
-    private static func validRequiredIndex(_ database: OpaquePointer) throws -> Bool {
-        let list = try self.prepare(database, sql: "PRAGMA index_list('device_identities')")
-        defer { sqlite3_finalize(list) }
-        var found = false
-        while true {
-            let result = sqlite3_step(list)
-            if result == SQLITE_DONE { break }
-            guard result == SQLITE_ROW else {
-                throw self.databaseError(database, operation: "inspect device identity indexes")
-            }
-            let name = try self.requiredText(list, column: 1, field: "index name")
-            if name == self.indexName {
-                found = sqlite3_column_int(list, 2) == 0 && sqlite3_column_int(list, 4) == 0
-            }
-        }
-        guard found else { return false }
-
-        let details = try self.prepare(database, sql: "PRAGMA index_xinfo('idx_device_identities_device')")
-        defer { sqlite3_finalize(details) }
-        var keyColumns: [(String, Bool)] = []
-        while true {
-            let result = sqlite3_step(details)
-            if result == SQLITE_DONE { break }
-            guard result == SQLITE_ROW else {
-                throw self.databaseError(database, operation: "inspect device identity index columns")
-            }
-            guard sqlite3_column_int(details, 5) == 1 else { continue }
-            try keyColumns.append((
-                self.requiredText(details, column: 2, field: "index column"),
-                sqlite3_column_int(details, 3) == 1))
-        }
-        return keyColumns.count == 2
-            && keyColumns[0].0 == "device_id" && !keyColumns[0].1
-            && keyColumns[1].0 == "updated_at_ms" && keyColumns[1].1
-    }
-
     private static func readIdentity(
-        _ database: OpaquePointer,
+        _ database: OpenClawNativeStateSQLite,
         key: String) throws -> DeviceIdentityMaterial?
     {
-        let statement = try self.prepare(
-            database,
-            sql: """
-            SELECT device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
-            FROM device_identities
-            WHERE identity_key = ?
-            """)
-        defer { sqlite3_finalize(statement) }
-        try self.bindText(statement, index: 1, value: key, database: database)
-        let result = sqlite3_step(statement)
-        if result == SQLITE_DONE { return nil }
-        guard result == SQLITE_ROW else {
-            throw self.databaseError(database, operation: "read device identity")
-        }
-        guard sqlite3_column_type(statement, 3) == SQLITE_INTEGER,
-              sqlite3_column_type(statement, 4) == SQLITE_INTEGER,
-              sqlite3_column_int64(statement, 4) >= 0
+        let statement = try database.prepare("""
+        SELECT device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
+        FROM device_identities
+        WHERE identity_key = ?
+        """)
+        try statement.bindText(key, at: 1)
+        let result = try statement.step()
+        if result == .done { return nil }
+        guard statement.valueType(at: 3) == .integer,
+              statement.valueType(at: 4) == .integer,
+              statement.int64(at: 4) >= 0
         else {
             throw DeviceIdentityStore.storageError("SQLite device identity timestamps must be integers")
         }
         let material = try DeviceIdentityStore.material(
-            deviceId: self.requiredText(statement, column: 0, field: "device_id"),
-            publicKeyPEM: self.requiredText(statement, column: 1, field: "public_key_pem"),
-            privateKeyPEM: self.requiredText(statement, column: 2, field: "private_key_pem"),
-            createdAtMs: sqlite3_column_int64(statement, 3))
-        guard sqlite3_step(statement) == SQLITE_DONE else {
+            deviceId: statement.requiredText(at: 0, field: "device_id"),
+            publicKeyPEM: statement.requiredText(at: 1, field: "public_key_pem"),
+            privateKeyPEM: statement.requiredText(at: 2, field: "private_key_pem"),
+            createdAtMs: statement.int64(at: 3))
+        guard try statement.step() == .done else {
             throw DeviceIdentityStore.storageError("SQLite returned duplicate device identity keys")
         }
         return material
     }
 
     private static func insertIdentity(
-        _ database: OpaquePointer,
+        _ database: OpenClawNativeStateSQLite,
         key: String,
         material: DeviceIdentityMaterial,
         updatedAtMs: Int64) throws
     {
-        let statement = try self.prepare(
-            database,
-            sql: """
-            INSERT INTO device_identities (
-              identity_key, device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            """)
-        defer { sqlite3_finalize(statement) }
-        try self.bindText(statement, index: 1, value: key, database: database)
-        try self.bindText(statement, index: 2, value: material.identity.deviceId, database: database)
-        try self.bindText(statement, index: 3, value: material.publicKeyPEM, database: database)
-        try self.bindText(statement, index: 4, value: material.privateKeyPEM, database: database)
-        guard sqlite3_bind_int64(statement, 5, material.identity.createdAtMs) == SQLITE_OK,
-              sqlite3_bind_int64(statement, 6, updatedAtMs) == SQLITE_OK
-        else {
-            throw self.databaseError(database, operation: "bind device identity timestamps")
-        }
-        guard sqlite3_step(statement) == SQLITE_DONE, sqlite3_changes(database) == 1 else {
-            throw self.databaseError(database, operation: "insert device identity")
+        let statement = try database.prepare("""
+        INSERT INTO device_identities (
+          identity_key, device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """)
+        try statement.bindText(key, at: 1)
+        try statement.bindText(material.identity.deviceId, at: 2)
+        try statement.bindText(material.publicKeyPEM, at: 3)
+        try statement.bindText(material.privateKeyPEM, at: 4)
+        try statement.bindInt64(material.identity.createdAtMs, at: 5)
+        try statement.bindInt64(updatedAtMs, at: 6)
+        guard try statement.step() == .done, database.changes == 1 else {
+            throw DeviceIdentityStore.storageError("SQLite did not insert the device identity")
         }
     }
 
@@ -881,103 +674,6 @@ enum DeviceIdentitySQLiteStore {
                 "Could not restore legacy device identity: \(String(cString: strerror(renameError)))")
         }
     }
-
-    private static func schemaObjectExists(
-        _ database: OpaquePointer,
-        type: String,
-        name: String) throws -> Bool
-    {
-        let statement = try self.prepare(
-            database,
-            sql: "SELECT 1 FROM sqlite_schema WHERE type = ? AND name = ? LIMIT 1")
-        defer { sqlite3_finalize(statement) }
-        try self.bindText(statement, index: 1, value: type, database: database)
-        try self.bindText(statement, index: 2, value: name, database: database)
-        let result = sqlite3_step(statement)
-        if result == SQLITE_ROW { return true }
-        if result == SQLITE_DONE { return false }
-        throw self.databaseError(database, operation: "inspect SQLite schema")
-    }
-
-    private static func queryInt64(_ database: OpaquePointer, sql: String) throws -> Int64 {
-        let statement = try self.prepare(database, sql: sql)
-        defer { sqlite3_finalize(statement) }
-        guard sqlite3_step(statement) == SQLITE_ROW,
-              sqlite3_column_type(statement, 0) == SQLITE_INTEGER
-        else {
-            throw self.databaseError(database, operation: "read SQLite integer")
-        }
-        let value = sqlite3_column_int64(statement, 0)
-        guard sqlite3_step(statement) == SQLITE_DONE else {
-            throw DeviceIdentityStore.storageError("SQLite integer query returned multiple rows")
-        }
-        return value
-    }
-
-    private static func queryText(_ database: OpaquePointer, sql: String) throws -> String? {
-        let statement = try self.prepare(database, sql: sql)
-        defer { sqlite3_finalize(statement) }
-        let result = sqlite3_step(statement)
-        if result == SQLITE_DONE { return nil }
-        guard result == SQLITE_ROW else {
-            throw self.databaseError(database, operation: "read SQLite text")
-        }
-        let value = try self.requiredText(statement, column: 0, field: "query result")
-        guard sqlite3_step(statement) == SQLITE_DONE else {
-            throw DeviceIdentityStore.storageError("SQLite text query returned multiple rows")
-        }
-        return value
-    }
-
-    private static func execute(_ database: OpaquePointer, sql: String) throws {
-        var errorMessage: UnsafeMutablePointer<CChar>?
-        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
-        guard result == SQLITE_OK else {
-            let detail = errorMessage.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(database))
-            sqlite3_free(errorMessage)
-            throw DeviceIdentityStore.storageError("SQLite operation failed: \(detail)")
-        }
-    }
-
-    private static func prepare(_ database: OpaquePointer, sql: String) throws -> OpaquePointer {
-        var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
-            throw self.databaseError(database, operation: "prepare SQLite statement")
-        }
-        return statement
-    }
-
-    private static func bindText(
-        _ statement: OpaquePointer,
-        index: Int32,
-        value: String,
-        database: OpaquePointer) throws
-    {
-        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        guard sqlite3_bind_text(statement, index, value, -1, transient) == SQLITE_OK else {
-            throw self.databaseError(database, operation: "bind SQLite text")
-        }
-    }
-
-    private static func requiredText(
-        _ statement: OpaquePointer,
-        column: Int32,
-        field: String) throws -> String
-    {
-        guard sqlite3_column_type(statement, column) == SQLITE_TEXT,
-              let pointer = sqlite3_column_text(statement, column)
-        else {
-            throw DeviceIdentityStore.storageError("SQLite \(field) must be text")
-        }
-        return String(cString: pointer)
-    }
-
-    private static func databaseError(
-        _ database: OpaquePointer,
-        operation: String) -> NSError
-    {
-        DeviceIdentityStore.storageError("Could not \(operation): \(String(cString: sqlite3_errmsg(database)))")
-    }
 }
 
 extension DeviceIdentitySQLiteStore {
@@ -998,12 +694,5 @@ extension DeviceIdentitySQLiteStore {
         attributes[.protectionKey] = FileProtectionType.completeUntilFirstUserAuthentication
         #endif
         try FileManager.default.setAttributes(attributes, ofItemAtPath: url.path)
-    }
-
-    private static func secureDatabaseFiles(_ databaseURL: URL) throws {
-        try self.secureFile(databaseURL)
-        for suffix in ["-wal", "-shm", "-journal"] {
-            try self.secureFile(URL(fileURLWithPath: databaseURL.path + suffix, isDirectory: false))
-        }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
@@ -430,19 +430,38 @@ public final class OpenClawNativeStateSQLite: @unchecked Sendable {
         try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
     }
 
-    private static func secureDatabaseFiles(_ databaseURL: URL) throws {
-        for url in [
-            databaseURL,
-            URL(fileURLWithPath: databaseURL.path + "-wal", isDirectory: false),
-            URL(fileURLWithPath: databaseURL.path + "-shm", isDirectory: false),
-            URL(fileURLWithPath: databaseURL.path + "-journal", isDirectory: false),
-        ] where FileManager.default.fileExists(atPath: url.path) {
+    static func secureDatabaseFiles(
+        _ databaseURL: URL,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        setAttributes: ([FileAttributeKey: Any], String) throws -> Void = {
+            try FileManager.default.setAttributes($0, ofItemAtPath: $1)
+        }) throws
+    {
+        for (url, isTransient) in [
+            (databaseURL, false),
+            (URL(fileURLWithPath: databaseURL.path + "-wal", isDirectory: false), true),
+            (URL(fileURLWithPath: databaseURL.path + "-shm", isDirectory: false), true),
+            (URL(fileURLWithPath: databaseURL.path + "-journal", isDirectory: false), true),
+        ] where fileExists(url.path) {
             var attributes: [FileAttributeKey: Any] = [.posixPermissions: 0o600]
             #if os(iOS) || os(watchOS)
             attributes[.protectionKey] = FileProtectionType.completeUntilFirstUserAuthentication
             #endif
-            try FileManager.default.setAttributes(attributes, ofItemAtPath: url.path)
+            do {
+                try setAttributes(attributes, url.path)
+            } catch where isTransient && Self.isMissingFileError(error) {
+                // SQLite can remove sidecars between the probe and chmod. A vanished sidecar is
+                // already secure; surfacing it after COMMIT would misreport a durable write.
+                continue
+            }
         }
+    }
+
+    private static func isMissingFileError(_ error: Error) -> Bool {
+        let error = error as NSError
+        return (error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError)
+            || (error.domain == NSPOSIXErrorDomain
+                && error.code == Int(POSIXErrorCode.ENOENT.rawValue))
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
@@ -1,0 +1,539 @@
+import Foundation
+import SQLite3
+
+public struct OpenClawNativeStateError: Error, LocalizedError, Sendable {
+    public let message: String
+
+    public var errorDescription: String? {
+        self.message
+    }
+
+    public init(_ message: String) {
+        self.message = message
+    }
+}
+
+public enum OpenClawNativeStateCanonicalTable: Sendable {
+    case deviceIdentities
+    case macosPortGuardianRecords
+}
+
+public enum OpenClawNativeStateSQLiteStep: Equatable, Sendable {
+    case row
+    case done
+}
+
+public enum OpenClawNativeStateSQLiteValueType: Equatable, Sendable {
+    case integer
+    case float
+    case text
+    case blob
+    case null
+}
+
+/// Synchronous access to the shared native SQLite bootstrap surface.
+/// One recursive connection lock serializes transactions and statement access.
+public final class OpenClawNativeStateSQLite: @unchecked Sendable {
+    // Keep aligned with OPENCLAW_STATE_SCHEMA_VERSION. Native clients never upgrade this database.
+    private static let maximumSupportedSchemaVersion: Int64 = 4
+    private static let defaultBusyTimeoutMilliseconds: Int32 = 5000
+
+    private struct SchemaObject: Hashable {
+        let type: String
+        let name: String
+    }
+
+    private struct Column: Equatable {
+        let name: String
+        let type: String
+        let notNull: Bool
+        let primaryKeyPosition: Int32
+        let hidden: Int32
+    }
+
+    private struct IndexColumn: Equatable {
+        let name: String
+        let descending: Bool
+    }
+
+    private struct CanonicalTable {
+        let name: String
+        let indexName: String
+        let createSQL: String
+        let columns: [Column]
+        let indexColumns: [IndexColumn]
+
+        var objects: Set<SchemaObject> {
+            [
+                SchemaObject(type: "index", name: self.indexName),
+                SchemaObject(type: "table", name: self.name),
+            ]
+        }
+    }
+
+    private static let deviceIdentities = CanonicalTable(
+        name: "device_identities",
+        indexName: "idx_device_identities_device",
+        createSQL: """
+        CREATE TABLE IF NOT EXISTS device_identities (
+          identity_key TEXT NOT NULL PRIMARY KEY,
+          device_id TEXT NOT NULL,
+          public_key_pem TEXT NOT NULL,
+          private_key_pem TEXT NOT NULL,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_device_identities_device
+          ON device_identities(device_id, updated_at_ms DESC);
+        """,
+        columns: [
+            Column(name: "identity_key", type: "TEXT", notNull: true, primaryKeyPosition: 1, hidden: 0),
+            Column(name: "device_id", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "public_key_pem", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "private_key_pem", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "created_at_ms", type: "INTEGER", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "updated_at_ms", type: "INTEGER", notNull: true, primaryKeyPosition: 0, hidden: 0),
+        ],
+        indexColumns: [
+            IndexColumn(name: "device_id", descending: false),
+            IndexColumn(name: "updated_at_ms", descending: true),
+        ])
+
+    private static let macosPortGuardianRecords = CanonicalTable(
+        name: "macos_port_guardian_records",
+        indexName: "idx_macos_port_guardian_records_port",
+        createSQL: """
+        CREATE TABLE IF NOT EXISTS macos_port_guardian_records (
+          pid INTEGER NOT NULL PRIMARY KEY,
+          port INTEGER NOT NULL,
+          command TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          timestamp REAL NOT NULL
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_macos_port_guardian_records_port
+          ON macos_port_guardian_records(port, timestamp DESC);
+        """,
+        columns: [
+            Column(name: "pid", type: "INTEGER", notNull: true, primaryKeyPosition: 1, hidden: 0),
+            Column(name: "port", type: "INTEGER", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "command", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "mode", type: "TEXT", notNull: true, primaryKeyPosition: 0, hidden: 0),
+            Column(name: "timestamp", type: "REAL", notNull: true, primaryKeyPosition: 0, hidden: 0),
+        ],
+        indexColumns: [
+            IndexColumn(name: "port", descending: false),
+            IndexColumn(name: "timestamp", descending: true),
+        ])
+
+    private static let canonicalTables = [
+        OpenClawNativeStateSQLite.deviceIdentities,
+        OpenClawNativeStateSQLite.macosPortGuardianRecords,
+    ]
+
+    private let databaseURL: URL
+    fileprivate let database: OpaquePointer
+    fileprivate let connectionLock = NSRecursiveLock()
+
+    public init(databaseURL: URL, busyTimeoutMilliseconds: Int32 = 5000) throws {
+        self.databaseURL = databaseURL
+        try Self.secureDirectory(databaseURL.deletingLastPathComponent())
+        var database: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        let result = sqlite3_open_v2(databaseURL.path, &database, flags, nil)
+        guard result == SQLITE_OK, let database else {
+            let detail = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown SQLite error"
+            if let database { sqlite3_close(database) }
+            throw OpenClawNativeStateError("Could not open native state database: \(detail)")
+        }
+        var initializationSucceeded = false
+        defer {
+            if !initializationSucceeded { sqlite3_close(database) }
+        }
+        self.database = database
+        let timeout = busyTimeoutMilliseconds > 0
+            ? busyTimeoutMilliseconds
+            : Self.defaultBusyTimeoutMilliseconds
+        guard sqlite3_busy_timeout(database, timeout) == SQLITE_OK else {
+            throw self.databaseError(operation: "configure SQLite busy timeout")
+        }
+        try Self.secureDatabaseFiles(databaseURL)
+        initializationSucceeded = true
+    }
+
+    deinit {
+        sqlite3_close(self.database)
+        try? Self.secureDatabaseFiles(self.databaseURL)
+    }
+
+    public var changes: Int32 {
+        self.withConnectionLock { sqlite3_changes(self.database) }
+    }
+
+    public func withImmediateTransaction<T>(_ body: () throws -> T) throws -> T {
+        try self.withConnectionLock {
+            try self.execute("BEGIN IMMEDIATE")
+            var committed = false
+            defer {
+                if !committed { try? self.execute("ROLLBACK") }
+            }
+            let value = try body()
+            try self.execute("COMMIT")
+            committed = true
+            try Self.secureDatabaseFiles(self.databaseURL)
+            return value
+        }
+    }
+
+    /// Creates a requested table only in an owned schema-version-zero bootstrap database.
+    /// Node-owned versioned databases must already contain the canonical table.
+    public func ensureCanonicalTable(
+        _ table: OpenClawNativeStateCanonicalTable,
+        allowVersionZeroCreation: Bool = true) throws
+    {
+        try self.withConnectionLock {
+            let descriptor = Self.descriptor(table)
+            let userVersion = try self.scalarInt64("PRAGMA user_version")
+            guard userVersion <= Self.maximumSupportedSchemaVersion else {
+                throw OpenClawNativeStateError(
+                    "Native state database uses newer schema version \(userVersion); " +
+                        "this build supports \(Self.maximumSupportedSchemaVersion)")
+            }
+
+            if userVersion == 0 {
+                try self.validateVersionZeroOwnership()
+                if try !self.schemaObjectExists(type: "table", name: descriptor.name) {
+                    guard allowVersionZeroCreation else {
+                        throw OpenClawNativeStateError(
+                            "Schema version zero database is missing \(descriptor.name)")
+                    }
+                    try self.execute(descriptor.createSQL)
+                }
+                try self.validateVersionZeroOwnership()
+            } else {
+                try self.validateSharedDatabaseMetadata(userVersion: userVersion)
+                guard try self.schemaObjectExists(type: "table", name: descriptor.name) else {
+                    throw OpenClawNativeStateError(
+                        "Versioned OpenClaw state database is missing \(descriptor.name)")
+                }
+            }
+            try self.validateCanonicalTable(table)
+        }
+    }
+
+    public func validateCanonicalTable(_ table: OpenClawNativeStateCanonicalTable) throws {
+        try self.withConnectionLock {
+            try self.validateTableShape(Self.descriptor(table))
+        }
+    }
+
+    public func prepare(_ sql: String) throws -> OpenClawNativeStateSQLiteStatement {
+        try self.withConnectionLock {
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(self.database, sql, -1, &statement, nil) == SQLITE_OK,
+                  let statement
+            else {
+                throw self.databaseError(operation: "prepare SQLite statement")
+            }
+            return OpenClawNativeStateSQLiteStatement(connection: self, statement: statement)
+        }
+    }
+
+    public func execute(_ sql: String) throws {
+        try self.withConnectionLock {
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            let result = sqlite3_exec(self.database, sql, nil, nil, &errorMessage)
+            guard result == SQLITE_OK else {
+                let detail = errorMessage.map { String(cString: $0) }
+                    ?? String(cString: sqlite3_errmsg(self.database))
+                sqlite3_free(errorMessage)
+                throw OpenClawNativeStateError("SQLite operation failed: \(detail)")
+            }
+        }
+    }
+
+    public func scalarInt64(_ sql: String) throws -> Int64 {
+        try self.withConnectionLock {
+            let statement = try self.prepare(sql)
+            guard try statement.step() == .row,
+                  statement.valueType(at: 0) == .integer
+            else {
+                throw OpenClawNativeStateError("SQLite integer query did not return one integer row")
+            }
+            let value = statement.int64(at: 0)
+            guard try statement.step() == .done else {
+                throw OpenClawNativeStateError("SQLite integer query returned multiple rows")
+            }
+            return value
+        }
+    }
+
+    public func scalarText(_ sql: String) throws -> String? {
+        try self.withConnectionLock {
+            let statement = try self.prepare(sql)
+            let result = try statement.step()
+            if result == .done { return nil }
+            let value = try statement.requiredText(at: 0, field: "query result")
+            guard try statement.step() == .done else {
+                throw OpenClawNativeStateError("SQLite text query returned multiple rows")
+            }
+            return value
+        }
+    }
+
+    public func schemaObjectExists(type: String, name: String) throws -> Bool {
+        try self.withConnectionLock {
+            let statement = try self.prepare(
+                "SELECT 1 FROM sqlite_schema WHERE type = ? AND name = ? LIMIT 1")
+            try statement.bindText(type, at: 1)
+            try statement.bindText(name, at: 2)
+            let result = try statement.step()
+            if result == .done { return false }
+            guard try statement.step() == .done else {
+                throw OpenClawNativeStateError("SQLite schema query returned multiple rows")
+            }
+            return true
+        }
+    }
+
+    fileprivate func databaseError(operation: String) -> OpenClawNativeStateError {
+        OpenClawNativeStateError(
+            "Could not \(operation): \(String(cString: sqlite3_errmsg(self.database)))")
+    }
+
+    fileprivate func withConnectionLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.connectionLock.lock()
+        defer { self.connectionLock.unlock() }
+        return try body()
+    }
+
+    private static func descriptor(_ table: OpenClawNativeStateCanonicalTable) -> CanonicalTable {
+        switch table {
+        case .deviceIdentities: self.deviceIdentities
+        case .macosPortGuardianRecords: self.macosPortGuardianRecords
+        }
+    }
+
+    private func validateVersionZeroOwnership() throws {
+        let statement = try self.prepare("""
+        SELECT type, name
+        FROM sqlite_schema
+        WHERE name NOT LIKE 'sqlite_%'
+        ORDER BY type, name
+        """)
+        var objects = Set<SchemaObject>()
+        while try statement.step() == .row {
+            try objects.insert(SchemaObject(
+                type: statement.requiredText(at: 0, field: "schema object type"),
+                name: statement.requiredText(at: 1, field: "schema object name")))
+        }
+        let allowedObjects = Self.canonicalTables.reduce(into: Set<SchemaObject>()) {
+            $0.formUnion($1.objects)
+        }
+        guard objects.isSubset(of: allowedObjects) else {
+            throw OpenClawNativeStateError(
+                "Schema version zero database contains objects not owned by a native OpenClaw store")
+        }
+
+        // A known name is not enough: every present native table must be complete and exact
+        // before another store composes its own schema into the same version-zero database.
+        for table in Self.canonicalTables where !objects.isDisjoint(with: table.objects) {
+            guard table.objects.isSubset(of: objects) else {
+                throw OpenClawNativeStateError(
+                    "Schema version zero database has incomplete objects for \(table.name)")
+            }
+            try self.validateTableShape(table)
+        }
+    }
+
+    private func validateSharedDatabaseMetadata(userVersion: Int64) throws {
+        guard try self.schemaObjectExists(type: "table", name: "schema_meta") else {
+            throw OpenClawNativeStateError("Versioned OpenClaw state database is missing schema_meta")
+        }
+        let statement = try self.prepare(
+            "SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
+        guard try statement.step() == .row,
+              try statement.requiredText(at: 0, field: "schema role") == "global",
+              statement.valueType(at: 1) == .integer,
+              statement.int64(at: 1) == userVersion,
+              try statement.step() == .done
+        else {
+            throw OpenClawNativeStateError(
+                "OpenClaw state database schema metadata does not match its global schema version")
+        }
+    }
+
+    private func validateTableShape(_ table: CanonicalTable) throws {
+        guard try self.tableColumns(table.name) == table.columns else {
+            throw OpenClawNativeStateError("\(table.name) has an incompatible schema")
+        }
+        let tableSQL = try self.scalarText(
+            "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = '\(table.name)'") ?? ""
+        let normalizedTableSQL = tableSQL
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .uppercased()
+        guard normalizedTableSQL.hasSuffix(") STRICT") else {
+            throw OpenClawNativeStateError("\(table.name) must be a STRICT table")
+        }
+        guard try self.validRequiredIndex(table) else {
+            throw OpenClawNativeStateError("\(table.indexName) has an incompatible schema")
+        }
+    }
+
+    private func tableColumns(_ tableName: String) throws -> [Column] {
+        let statement = try self.prepare("PRAGMA table_xinfo('\(tableName)')")
+        var columns: [Column] = []
+        while try statement.step() == .row {
+            try columns.append(Column(
+                name: statement.requiredText(at: 1, field: "column name"),
+                type: statement.requiredText(at: 2, field: "column type").uppercased(),
+                notNull: statement.int32(at: 3) == 1,
+                primaryKeyPosition: statement.int32(at: 5),
+                hidden: statement.int32(at: 6)))
+        }
+        return columns
+    }
+
+    private func validRequiredIndex(_ table: CanonicalTable) throws -> Bool {
+        let list = try self.prepare("PRAGMA index_list('\(table.name)')")
+        var found = false
+        while try list.step() == .row {
+            let name = try list.requiredText(at: 1, field: "index name")
+            if name == table.indexName {
+                found = try list.int32(at: 2) == 0
+                    && (list.requiredText(at: 3, field: "index origin")) == "c"
+                    && list.int32(at: 4) == 0
+            }
+        }
+        guard found else { return false }
+
+        let details = try self.prepare("PRAGMA index_xinfo('\(table.indexName)')")
+        var keyColumns: [IndexColumn] = []
+        while try details.step() == .row {
+            guard details.int32(at: 5) == 1 else { continue }
+            try keyColumns.append(IndexColumn(
+                name: details.requiredText(at: 2, field: "index column"),
+                descending: details.int32(at: 3) == 1))
+        }
+        return keyColumns == table.indexColumns
+    }
+
+    private static func secureDirectory(_ url: URL) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        var attributes: [FileAttributeKey: Any] = [.posixPermissions: 0o700]
+        #if os(iOS) || os(watchOS)
+        attributes[.protectionKey] = FileProtectionType.completeUntilFirstUserAuthentication
+        #endif
+        try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
+    }
+
+    private static func secureDatabaseFiles(_ databaseURL: URL) throws {
+        for url in [
+            databaseURL,
+            URL(fileURLWithPath: databaseURL.path + "-wal", isDirectory: false),
+            URL(fileURLWithPath: databaseURL.path + "-shm", isDirectory: false),
+            URL(fileURLWithPath: databaseURL.path + "-journal", isDirectory: false),
+        ] where FileManager.default.fileExists(atPath: url.path) {
+            var attributes: [FileAttributeKey: Any] = [.posixPermissions: 0o600]
+            #if os(iOS) || os(watchOS)
+            attributes[.protectionKey] = FileProtectionType.completeUntilFirstUserAuthentication
+            #endif
+            try FileManager.default.setAttributes(attributes, ofItemAtPath: url.path)
+        }
+    }
+}
+
+public final class OpenClawNativeStateSQLiteStatement {
+    private let connection: OpenClawNativeStateSQLite
+    private let statement: OpaquePointer
+
+    fileprivate init(connection: OpenClawNativeStateSQLite, statement: OpaquePointer) {
+        self.connection = connection
+        self.statement = statement
+    }
+
+    deinit {
+        _ = self.connection.withConnectionLock {
+            sqlite3_finalize(self.statement)
+        }
+    }
+
+    public func step() throws -> OpenClawNativeStateSQLiteStep {
+        try self.connection.withConnectionLock {
+            switch sqlite3_step(self.statement) {
+            case SQLITE_ROW: .row
+            case SQLITE_DONE: .done
+            default: throw self.connection.databaseError(operation: "step SQLite statement")
+            }
+        }
+    }
+
+    public func bindText(_ value: String, at index: Int32) throws {
+        try self.connection.withConnectionLock {
+            let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            guard sqlite3_bind_text(self.statement, index, value, -1, transient) == SQLITE_OK else {
+                throw self.connection.databaseError(operation: "bind SQLite text")
+            }
+        }
+    }
+
+    public func bindInt64(_ value: Int64, at index: Int32) throws {
+        try self.connection.withConnectionLock {
+            guard sqlite3_bind_int64(self.statement, index, value) == SQLITE_OK else {
+                throw self.connection.databaseError(operation: "bind SQLite integer")
+            }
+        }
+    }
+
+    public func bindDouble(_ value: Double, at index: Int32) throws {
+        try self.connection.withConnectionLock {
+            guard sqlite3_bind_double(self.statement, index, value) == SQLITE_OK else {
+                throw self.connection.databaseError(operation: "bind SQLite double")
+            }
+        }
+    }
+
+    public func valueType(at column: Int32) -> OpenClawNativeStateSQLiteValueType {
+        self.connection.withConnectionLock {
+            switch sqlite3_column_type(self.statement, column) {
+            case SQLITE_INTEGER: .integer
+            case SQLITE_FLOAT: .float
+            case SQLITE_TEXT: .text
+            case SQLITE_BLOB: .blob
+            default: .null
+            }
+        }
+    }
+
+    public func int32(at column: Int32) -> Int32 {
+        self.connection.withConnectionLock {
+            sqlite3_column_int(self.statement, column)
+        }
+    }
+
+    public func int64(at column: Int32) -> Int64 {
+        self.connection.withConnectionLock {
+            sqlite3_column_int64(self.statement, column)
+        }
+    }
+
+    public func double(at column: Int32) -> Double {
+        self.connection.withConnectionLock {
+            sqlite3_column_double(self.statement, column)
+        }
+    }
+
+    public func requiredText(at column: Int32, field: String) throws -> String {
+        try self.connection.withConnectionLock {
+            guard self.valueType(at: column) == .text,
+                  let value = sqlite3_column_text(self.statement, column)
+            else {
+                throw OpenClawNativeStateError("SQLite \(field) must be text")
+            }
+            return String(cString: value)
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeStateBootstrapTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeStateBootstrapTests.swift
@@ -24,7 +24,7 @@ struct NativeStateBootstrapTests {
         INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 'remote', 42.5);
         """)
 
-        _ = try DeviceIdentityStore.loadOrCreate(
+        _ = try DeviceIdentitySQLiteStore.loadOrCreate(
             databaseURL: databaseURL,
             destinationStateDirURL: tempDir,
             profile: .primary)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeStateBootstrapTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeStateBootstrapTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import OpenClawKit
+
+struct NativeStateBootstrapTests {
+    @Test
+    func `version zero database composes identity and port guardian tables`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let databaseURL = tempDir.appendingPathComponent("openclaw.sqlite", isDirectory: false)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try Self.execute(databaseURL, """
+        CREATE TABLE macos_port_guardian_records (
+          pid INTEGER NOT NULL PRIMARY KEY,
+          port INTEGER NOT NULL,
+          command TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          timestamp REAL NOT NULL
+        ) STRICT;
+        CREATE INDEX idx_macos_port_guardian_records_port
+          ON macos_port_guardian_records(port, timestamp DESC);
+        INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 'remote', 42.5);
+        """)
+
+        _ = try DeviceIdentityStore.loadOrCreate(
+            databaseURL: databaseURL,
+            destinationStateDirURL: tempDir,
+            profile: .primary)
+
+        #expect(try Self.scalarInt(databaseURL, "PRAGMA user_version") == 0)
+        #expect(try Self.scalarInt(
+            databaseURL,
+            "SELECT COUNT(*) FROM macos_port_guardian_records WHERE pid = 4242") == 1)
+        #expect(try Self.scalarText(
+            databaseURL,
+            """
+            SELECT group_concat(type || ':' || name, ',')
+            FROM (SELECT type, name FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name)
+            """) == "index:idx_device_identities_device,index:idx_macos_port_guardian_records_port," +
+            "table:device_identities,table:macos_port_guardian_records")
+    }
+
+    private static func execute(_ databaseURL: URL, _ sql: String) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK, let database else {
+            throw DeviceIdentityStore.storageError("Could not open test database")
+        }
+        defer { sqlite3_close(database) }
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw DeviceIdentityStore.storageError(String(cString: sqlite3_errmsg(database)))
+        }
+    }
+
+    private static func scalarInt(_ databaseURL: URL, _ sql: String) throws -> Int64 {
+        try self.scalar(databaseURL, sql) { sqlite3_column_int64($0, 0) }
+    }
+
+    private static func scalarText(_ databaseURL: URL, _ sql: String) throws -> String? {
+        try self.scalar(databaseURL, sql) { statement in
+            sqlite3_column_text(statement, 0).map { String(cString: $0) }
+        }
+    }
+
+    private static func scalar<T>(
+        _ databaseURL: URL,
+        _ sql: String,
+        transform: (OpaquePointer) -> T) throws -> T
+    {
+        var database: OpaquePointer?
+        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK, let database else {
+            throw DeviceIdentityStore.storageError("Could not open test database")
+        }
+        defer { sqlite3_close(database) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw DeviceIdentityStore.storageError(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw DeviceIdentityStore.storageError(String(cString: sqlite3_errmsg(database)))
+        }
+        return transform(statement)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawNativeStateTests/OpenClawNativeStateSQLiteTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawNativeStateTests/OpenClawNativeStateSQLiteTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import OpenClawNativeState
+import Testing
+
+struct OpenClawNativeStateSQLiteTests {
+    @Test
+    func `version zero composes exact canonical tables`() throws {
+        try self.withDatabase { database in
+            try database.withImmediateTransaction {
+                try database.ensureCanonicalTable(.macosPortGuardianRecords)
+                try database.execute("""
+                INSERT INTO macos_port_guardian_records (pid, port, command, mode, timestamp)
+                VALUES (4242, 18789, '/usr/bin/ssh', 'remote', 42.5)
+                """)
+                try database.ensureCanonicalTable(.deviceIdentities)
+            }
+
+            #expect(try database.scalarInt64("PRAGMA user_version") == 0)
+            #expect(try database.scalarInt64(
+                "SELECT COUNT(*) FROM macos_port_guardian_records WHERE pid = 4242") == 1)
+            #expect(try database.scalarInt64(
+                "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'") == 4)
+        }
+    }
+
+    @Test
+    func `version zero rejects incomplete known sibling schema`() throws {
+        try self.withDatabase { database in
+            try database.execute("""
+            CREATE TABLE macos_port_guardian_records (
+              pid INTEGER NOT NULL PRIMARY KEY,
+              port INTEGER NOT NULL,
+              command TEXT NOT NULL,
+              mode TEXT NOT NULL,
+              timestamp REAL NOT NULL
+            ) STRICT
+            """)
+
+            #expect(throws: OpenClawNativeStateError.self) {
+                try database.ensureCanonicalTable(.deviceIdentities)
+            }
+        }
+    }
+
+    @Test
+    func `versioned database never synthesizes a missing canonical table`() throws {
+        try self.withDatabase { database in
+            try database.execute("""
+            CREATE TABLE schema_meta (
+              meta_key TEXT NOT NULL PRIMARY KEY,
+              role TEXT NOT NULL,
+              schema_version INTEGER NOT NULL
+            ) STRICT;
+            INSERT INTO schema_meta (meta_key, role, schema_version)
+            VALUES ('primary', 'global', 3);
+            PRAGMA user_version = 3;
+            """)
+
+            #expect(throws: OpenClawNativeStateError.self) {
+                try database.ensureCanonicalTable(.deviceIdentities)
+            }
+            #expect(try database.schemaObjectExists(type: "table", name: "device_identities") == false)
+        }
+    }
+
+    @Test
+    func `immediate transaction rolls back all writes`() throws {
+        try self.withDatabase { database in
+            try database.withImmediateTransaction {
+                try database.ensureCanonicalTable(.macosPortGuardianRecords)
+            }
+
+            #expect(throws: TestError.self) {
+                try database.withImmediateTransaction {
+                    try database.execute("""
+                    INSERT INTO macos_port_guardian_records (pid, port, command, mode, timestamp)
+                    VALUES (4242, 18789, '/usr/bin/ssh', 'remote', 42.5)
+                    """)
+                    throw TestError.expected
+                }
+            }
+            #expect(try database.scalarInt64("SELECT COUNT(*) FROM macos_port_guardian_records") == 0)
+        }
+    }
+
+    @Test
+    func `concurrent version zero stores compose different tables`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("openclaw.sqlite", isDirectory: false)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for table in [
+                OpenClawNativeStateCanonicalTable.deviceIdentities,
+                .macosPortGuardianRecords,
+            ] {
+                group.addTask {
+                    let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+                    try database.withImmediateTransaction {
+                        try database.ensureCanonicalTable(table)
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+        #expect(try database.scalarInt64(
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'") == 4)
+    }
+
+    private enum TestError: Error {
+        case expected
+    }
+
+    private func withDatabase(
+        body: (OpenClawNativeStateSQLite) throws -> Void) throws
+    {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let database = try OpenClawNativeStateSQLite(
+            databaseURL: directory.appendingPathComponent("openclaw.sqlite", isDirectory: false))
+        try body(database)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawNativeStateTests/OpenClawNativeStateSQLiteTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawNativeStateTests/OpenClawNativeStateSQLiteTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import OpenClawNativeState
 import Testing
+@testable import OpenClawNativeState
 
 struct OpenClawNativeStateSQLiteTests {
     @Test
@@ -108,6 +108,53 @@ struct OpenClawNativeStateSQLiteTests {
         let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
         #expect(try database.scalarInt64(
             "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'") == 4)
+    }
+
+    @Test
+    func `vanished transient sidecar does not fail committed write cleanup`() throws {
+        let databaseURL = URL(fileURLWithPath: "/tmp/openclaw-native-state.sqlite")
+        var attemptedPaths: [String] = []
+
+        try OpenClawNativeStateSQLite.secureDatabaseFiles(
+            databaseURL,
+            fileExists: { _ in true },
+            setAttributes: { _, path in
+                attemptedPaths.append(path)
+                if path.hasSuffix("-wal") {
+                    throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError)
+                }
+            })
+
+        #expect(attemptedPaths == [
+            databaseURL.path,
+            databaseURL.path + "-wal",
+            databaseURL.path + "-shm",
+            databaseURL.path + "-journal",
+        ])
+    }
+
+    @Test
+    func `missing database or nonmissing sidecar failure remains fatal`() {
+        let databaseURL = URL(fileURLWithPath: "/tmp/openclaw-native-state.sqlite")
+        let missing = NSError(domain: NSPOSIXErrorDomain, code: Int(POSIXErrorCode.ENOENT.rawValue))
+        let denied = NSError(domain: NSPOSIXErrorDomain, code: Int(POSIXErrorCode.EACCES.rawValue))
+
+        #expect(throws: NSError.self) {
+            try OpenClawNativeStateSQLite.secureDatabaseFiles(
+                databaseURL,
+                fileExists: { _ in true },
+                setAttributes: { _, path in
+                    if path == databaseURL.path { throw missing }
+                })
+        }
+        #expect(throws: NSError.self) {
+            try OpenClawNativeStateSQLite.secureDatabaseFiles(
+                databaseURL,
+                fileExists: { _ in true },
+                setAttributes: { _, path in
+                    if path.hasSuffix("-wal") { throw denied }
+                })
+        }
     }
 
     private enum TestError: Error {

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -1238,7 +1238,17 @@ sessionId})`; create, branch, continue, list, and fork flows live in their
   logs go to unified logging, and durable Gateway diagnostics stay SQLite-backed.
 - The macOS port-guardian record list now uses typed shared SQLite
   `macos_port_guardian_records` rows instead of an Application Support JSON file
-  or opaque singleton blob.
+  or opaque singleton blob. All macOS app profiles use the same host-global native
+  database because they coordinate machine-local ports. Every ledger operation
+  blocks while an older JSON-writing app copy is running. Migration joins the old
+  ledger's stable file-lock protocol only to snapshot and later revalidate the
+  source. It resolves every legacy row from live command and process-start facts
+  without holding that lock, then rereads authoritative SQLite rows, applies the
+  plan, verifies every receipt, and removes the source. Removal retries replan
+  missing rows so retired stale receipts cannot resurrect. The lock stays
+  short-lived so it cannot strand an older writer after SSH has spawned. Cutover is
+  intentionally one-way: steady-state runtime never reads, projects, or writes JSON,
+  and rollback to JSON-only builds does not preserve newer SQLite receipts.
 - Gateway singleton locks now use typed shared SQLite `state_leases` rows under
   the `gateway_locks` scope instead of temp-dir lock files. Fly and OAuth
   troubleshooting docs now point at the SQLite lease/auth refresh lock instead

--- a/scripts/check-database-first-legacy-stores.d.mts
+++ b/scripts/check-database-first-legacy-stores.d.mts
@@ -3,6 +3,16 @@ export function collectDatabaseFirstLegacyStoreSourceFiles(
   sourceRoots: string[],
 ): Promise<string[]>;
 /**
+ * Finds database-first legacy-store violations in one native Swift source file.
+ */
+export function collectDatabaseFirstNativeLegacyStoreViolations(
+  content: string,
+  relativePath: string,
+): {
+  kind: string;
+  line: number;
+}[];
+/**
  * Finds database-first legacy-store violations in one TypeScript/JavaScript source file.
  */
 export function collectDatabaseFirstLegacyStoreViolations(

--- a/scripts/check-database-first-legacy-stores.mjs
+++ b/scripts/check-database-first-legacy-stores.mjs
@@ -15,6 +15,10 @@ import {
 import { resolveRepoRoot, runAsScript, toLine, unwrapExpression } from "./lib/ts-guard-utils.mjs";
 
 const databaseFirstLegacyStoreSourceRoots = ["src", "extensions", "packages"];
+const databaseFirstNativeSourceRoots = ["apps/macos/Sources/OpenClaw"];
+const nativeLegacyPortGuardianMigrationPath =
+  "apps/macos/Sources/OpenClaw/PortGuardianRecordStore.swift";
+const nativeLegacyPortGuardianFilenamePattern = /\bport-guard\.(?:json|lock)\b/u;
 
 const legacyWriteCallees = new Set([
   "appendFile",
@@ -341,6 +345,45 @@ async function collectSourceFiles(targetPath) {
 
 export async function collectDatabaseFirstLegacyStoreSourceFiles(sourceRoots) {
   return (await Promise.all(sourceRoots.map((root) => collectSourceFiles(root)))).flat();
+}
+
+async function collectNativeSourceFiles(targetPath) {
+  let stat;
+  try {
+    stat = await fs.stat(targetPath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  if (stat.isFile()) {
+    return path.extname(targetPath) === ".swift" ? [targetPath] : [];
+  }
+  const entries = await fs.readdir(targetPath, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectNativeSourceFiles(entryPath)));
+    } else if (entry.isFile() && path.extname(entryPath) === ".swift") {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+export function collectDatabaseFirstNativeLegacyStoreViolations(content, relativePath) {
+  if (relativePath === nativeLegacyPortGuardianMigrationPath) {
+    return [];
+  }
+  return content
+    .split("\n")
+    .flatMap((line, index) =>
+      nativeLegacyPortGuardianFilenamePattern.test(line)
+        ? [{ kind: "legacy PortGuardian file reference", line: index + 1 }]
+        : [],
+    );
 }
 
 function importSource(node) {
@@ -9808,6 +9851,8 @@ export async function main() {
   const repoRoot = resolveRepoRoot(import.meta.url);
   const sourceRoots = databaseFirstLegacyStoreSourceRoots.map((root) => path.join(repoRoot, root));
   const files = await collectDatabaseFirstLegacyStoreSourceFiles(sourceRoots);
+  const nativeSourceRoots = databaseFirstNativeSourceRoots.map((root) => path.join(repoRoot, root));
+  const nativeFiles = (await Promise.all(nativeSourceRoots.map(collectNativeSourceFiles))).flat();
   const violations = [];
   const currentLegacyWriteAllowances = currentLegacyWriteViolationAllowances();
 
@@ -9823,6 +9868,16 @@ export async function main() {
   for (const fingerprint of currentLegacyWriteAllowances.keys()) {
     const relativePath = currentLegacyWriteViolationPath(fingerprint) ?? "<unknown>";
     violations.push(`${relativePath}:1 stale current legacy write allowlist`);
+  }
+  for (const filePath of nativeFiles) {
+    const relativePath = path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+    const content = await fs.readFile(filePath, "utf8");
+    for (const violation of collectDatabaseFirstNativeLegacyStoreViolations(
+      content,
+      relativePath,
+    )) {
+      violations.push(`${relativePath}:${violation.line} ${violation.kind}`);
+    }
   }
 
   if (violations.length === 0) {

--- a/scripts/format-swift.sh
+++ b/scripts/format-swift.sh
@@ -19,6 +19,7 @@ if [[ "$scope" != "ios" ]]; then
     --exclude '**/OpenClawProtocol'
   swiftformat --lint \
     apps/macos-mlx-tts/Sources \
+    apps/shared/OpenClawKit/Sources/OpenClawNativeState \
     apps/shared/OpenClawMLXTTSProtocol/Sources \
     apps/swabble/Sources \
     --config config/swiftformat
@@ -33,6 +34,6 @@ node scripts/ios-write-swift-filelist.mjs
   cd apps/ios
   swiftformat --lint \
     --config ../../config/swiftformat \
-    --unexclude "$PWD/Sources,$PWD/ShareExtension,$PWD/ActivityWidget,$PWD/WatchApp,$PWD/../shared/OpenClawKit/Sources/OpenClawChatUI,$PWD/../shared/OpenClawKit/Sources/OpenClawKit,$PWD/../shared/OpenClawKit/Sources/OpenClawProtocol,$PWD/../swabble/Sources/SwabbleKit" \
+    --unexclude "$PWD/Sources,$PWD/ShareExtension,$PWD/ActivityWidget,$PWD/WatchApp,$PWD/../shared/OpenClawKit/Sources/OpenClawChatUI,$PWD/../shared/OpenClawKit/Sources/OpenClawKit,$PWD/../shared/OpenClawKit/Sources/OpenClawNativeState,$PWD/../shared/OpenClawKit/Sources/OpenClawProtocol,$PWD/../swabble/Sources/SwabbleKit" \
     --filelist SwiftSources.input.xcfilelist
 )

--- a/scripts/ios-write-swift-filelist.mjs
+++ b/scripts/ios-write-swift-filelist.mjs
@@ -16,6 +16,7 @@ const iosSourceRoots = [
 const sharedSourceRoots = [
   path.join("..", "shared", "OpenClawKit", "Sources", "OpenClawChatUI"),
   path.join("..", "shared", "OpenClawKit", "Sources", "OpenClawKit"),
+  path.join("..", "shared", "OpenClawKit", "Sources", "OpenClawNativeState"),
   path.join("..", "shared", "OpenClawKit", "Sources", "OpenClawProtocol"),
   path.join("..", "swabble", "Sources", "SwabbleKit"),
 ];

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -241,6 +241,11 @@ if [ ! -f "$INFO_PLIST_SRC" ]; then
   exit 1
 fi
 cp "$INFO_PLIST_SRC" "$APP_ROOT/Contents/Info.plist"
+PORT_GUARDIAN_STORAGE_VERSION="$(plist_print_required "$APP_ROOT/Contents/Info.plist" OpenClawPortGuardianStorageVersion)"
+if [[ ! "$PORT_GUARDIAN_STORAGE_VERSION" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: OpenClawPortGuardianStorageVersion must be a positive integer." >&2
+  exit 1
+fi
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleIdentifier "$BUNDLE_ID"
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleShortVersionString "$APP_VERSION"
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleVersion "$APP_BUILD"

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -890,6 +890,45 @@ INSERT INTO device_identities VALUES (
     );
   });
 
+  it("adopts a canonical native PortGuardian seed without losing records", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const seed = new DatabaseSync(databasePath);
+    seed.exec(`
+CREATE TABLE macos_port_guardian_records (
+  pid INTEGER NOT NULL PRIMARY KEY,
+  port INTEGER NOT NULL,
+  command TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  timestamp REAL NOT NULL
+) STRICT;
+CREATE INDEX idx_macos_port_guardian_records_port
+  ON macos_port_guardian_records(port, timestamp DESC);
+INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 'remote', 42.5);
+`);
+    seed.close();
+
+    const database = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+
+    expect(
+      database.db.prepare("SELECT * FROM macos_port_guardian_records WHERE pid = 4242").get(),
+    ).toEqual({
+      pid: 4242,
+      port: 18789,
+      command: "/usr/bin/ssh",
+      mode: "remote",
+      timestamp: 42.5,
+    });
+    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+    expect(collectSqliteSchemaShape(database.db)).toEqual(
+      createSqliteSchemaShapeFromSql(new URL("./openclaw-state-schema.sql", import.meta.url)),
+    );
+  });
+
   it("doctor migrates existing APNs tombstone tables to STRICT without losing rows", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };

--- a/test/scripts/check-database-first-legacy-stores.test.ts
+++ b/test/scripts/check-database-first-legacy-stores.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  collectDatabaseFirstNativeLegacyStoreViolations,
   collectDatabaseFirstLegacyStoreSourceFiles,
   collectDatabaseFirstLegacyStoreViolations,
 } from "../../scripts/check-database-first-legacy-stores.mjs";
@@ -8732,6 +8733,20 @@ describe("check-database-first-legacy-stores", () => {
     );
 
     expect(violations).toEqual([]);
+  });
+
+  it("keeps legacy PortGuardian filenames inside the native migration owner", () => {
+    const runtimeViolations = collectDatabaseFirstNativeLegacyStoreViolations(
+      'let path = root.appendingPathComponent("port-guard.json")\n',
+      "apps/macos/Sources/OpenClaw/PortGuardian.swift",
+    );
+    const migrationViolations = collectDatabaseFirstNativeLegacyStoreViolations(
+      'let path = root.appendingPathComponent("port-guard.json")\n',
+      "apps/macos/Sources/OpenClaw/PortGuardianRecordStore.swift",
+    );
+
+    expect(runtimeViolations).toEqual([{ kind: "legacy PortGuardian file reference", line: 1 }]);
+    expect(migrationViolations).toEqual([]);
   });
 
   it("allows the workspace Doctor migration owner to claim legacy sidecars", () => {


### PR DESCRIPTION
#110392 landed as prerequisite commit `98410d986eee7ce7cff8e8466c6d5f9314ae784b`; this PR now targets `main`.

## What Problem This Solves

The macOS PortGuardian orphan-tunnel ledger remains in a host-global JSON file even though OpenClaw already ships a canonical SQLite table for the same durable records. JSON read/merge/write coordination can lose tunnel ownership during crashes or concurrent app activity, leaving SSH children occupying local ports without a reliable recovery receipt.

## Why This Change Was Made

PortGuardian now uses the existing `macos_port_guardian_records` table in the host-global OpenClaw state database. The logical record shape remains unchanged: `pid`, `port`, `command`, `mode`, and `timestamp`. This is additive at the schema and API boundaries: no table change, schema-version bump, wire-format change, or dual-write path.

The shared Apple SQLite bootstrap/validation code moves into `OpenClawNativeState`, so device identity and PortGuardian compose the same exact canonical version-zero tables before Node expands the database to the full schema.

Legacy `port-guard.json` is a one-time migration input only. Migration snapshots under the shipped Darwin lock, plans process reconciliation outside both the file lock and SQLite transaction, revalidates the exact source, applies a short synchronous transaction, verifies receipts, and retires the JSON file. Runtime then reads and writes SQLite only.

Mixed-version app copies fail closed. A signed storage-capability marker is accepted only when Security.framework metadata matches the running process kernel CDHash. Tunnel launch holds a guardian reservation from completed legacy reconciliation through process spawn and durable receipt commit. Every mutation transaction revalidates the supported schema and canonical table, including retained connections after another process advances the database.

## User Impact

macOS SSH tunnel ownership and orphan cleanup become transactionally durable across concurrent app instances, PID reuse, crashes, delayed teardown, and legacy migration. Fresh installs no longer create the JSON ledger or lock sidecar.

This is a one-way storage cutover. Downgrading afterward to an older JSON-only app does not expose receipts written only to SQLite; rollback requires restoring a compatible backup or upgrading again.

## Maintainer Decision

Accepted by the maintainer's explicit `land all` instruction:

1. Native-runtime migration, bounded to interoperability with the shipped Darwin lock and signed mixed-copy detection.
2. One-way downgrade/mixed-version behavior: old JSON-only copies must not share the migrated state directory.

## Evidence

- Exact head: `bd1fc1eb3b93c55cc5d8269ecb0438454cafb449`, targeting `main` after #110392 landed. `git range-diff` proves all 9 PortGuardian commits patch-identical to prior fully reviewed head `d4889f49d1dbdb8e9a4f7bc440f81b7387696f7a`.
- Developer-ID-signed candidate proof on the patch-equivalent pre-restack head: released v2026.7.1 had no storage marker; mixed-version exclusion preserved JSON and the live SSH child; one-time migration preserved one exact SQLite receipt; restart was idempotent; orphan recovery killed the child and compare-deleted its receipt. The guest ended `SIGNED_PORTGUARDIAN_PROOF=PASS`, then snapshot restore stopped the VM.
- Current-head TypeScript proof: 87 state-database tests passed with 1 skip, 490 database-first guard tests passed, and 46 device-identity/migration tests passed.
- Final PortGuardian store proof: 21 Swift tests passed, including retained-connection rejection after a newer schema appears. Earlier signed-app scope passed 47 PortGuardian/tunnel tests.
- Current exact-head hosted CI is green: 90 passed checks, 29 intentional skips, and no failure or pending check. Capacity-only queued native lanes were rerun as attempt 2; `macos-swift`, `ios-build`, and `openclaw/ci-gate` all passed in run 29652606607.
- Full architecture chain, Kysely guardrails, dead-code exports, iOS SwiftFormat, generated baseline, and diff checks pass on the final stack. The final head also passes a focused `OpenClawKit` target build and exact SwiftFormat check.
- Fresh autoreview of the final PortGuardian test-caller cleanup: clean, no accepted/actionable findings, confidence 0.95. The preceding identity caller cleanup was clean at 0.99, PortGuardian tree-delta review at 0.98, stale-schema hardening at 0.96, and identity error-type cleanup at 0.97.

AI assistance was used for implementation and review. Maintainer-directed design, focused tests, signed native behavior proof, and patch-identity checks were performed before handoff.
