### PR TITLE
perf(ui): drop typebox from Control UI startup by lazy-loading the approval page

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -10,9 +10,9 @@ const KIB = 1024;
 // Small, explicit headroom over the optimized baseline. Budget changes should
 // accompany an intentional loading or chunking decision.
 export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze({
-  startupJsRequests: 28,
+  startupJsRequests: 20,
   startupCssRequests: 1,
-  startupJsGzipBytes: 370 * KIB,
+  startupJsGzipBytes: 340 * KIB,
   startupCssGzipBytes: 42 * KIB,
   largestJsGzipBytes: 215 * KIB,
   largestCssGzipBytes: 42 * KIB,

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -51,7 +51,6 @@ import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
-import "../pages/approval/approval-page-registration.ts";
 import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
 import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
 import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
@@ -63,6 +62,7 @@ import {
 } from "./context.ts";
 import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
 import {
+  APPROVAL_PAGE_ELEMENT,
   BROWSER_PANEL_ELEMENT,
   COMMAND_PALETTE_ELEMENT,
   ensureOptionalElementForHost,
@@ -243,6 +243,9 @@ class OpenClawApp extends OpenClawLightDomElement {
     this.runtime = bootstrapApplication();
     if (this.terminalOnly) {
       preloadOptionalElement(this, TERMINAL_PANEL_ELEMENT);
+    }
+    if (this.runtime.documentMode?.kind === "approval") {
+      preloadOptionalElement(this, APPROVAL_PAGE_ELEMENT);
     }
     const context = this.runtime.context;
     this.initialAuthPresent = hasStoredGatewayAuth(context.gateway.connection);

--- a/ui/src/app/lazy-custom-element.ts
+++ b/ui/src/app/lazy-custom-element.ts
@@ -56,6 +56,14 @@ export const BROWSER_PANEL_ELEMENT = {
   loadModule: () => import("../components/browser/browser-panel.ts"),
 } satisfies OptionalCustomElement;
 
+// Loaded only for approval document URLs: the approval page pulls the protocol
+// validators (typebox runtime) and must stay out of the normal startup graph.
+export const APPROVAL_PAGE_ELEMENT = {
+  tagName: "openclaw-approval-page",
+  label: "approval page",
+  loadModule: () => import("../pages/approval/approval-page-registration.ts"),
+} satisfies OptionalCustomElement;
+
 const hostElementLoads = new WeakMap<UpdatingHost, Map<string, Promise<void>>>();
 
 export function isOptionalElementDefined(element: OptionalCustomElement): boolean {

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -6,6 +6,13 @@
       "kind": "object-property",
       "name": "label",
       "path": "ui/src/app/lazy-custom-element.ts",
+      "text": "approval page"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/app/lazy-custom-element.ts",
       "text": "browser panel"
     },
     {


### PR DESCRIPTION
## What Problem This Solves

Control UI initial loads carry more JavaScript than the page needs: every boot downloads and evaluates the full typebox runtime (schema builders, value checks, format validators, and its locale tables) even though only the standalone `/approve` document page uses it. That inflates cold loads, updates (new hashed assets), and remote/Tailscale sessions where the startup payload dominates time-to-interactive.

## Why This Change Was Made

Follow-up to #110472. Startup-bundle attribution through the build sourcemaps showed typebox as the single largest startup module group (130 KiB raw), reachable only via `app-host.ts`'s static import of the approval page registration — the one page not behind a lazy route. The approval page imports `approval-result-validators`, which compiles protocol schemas with typebox at module init.

The fix uses the repo's existing `OptionalCustomElement` seam (already used for the terminal panel, browser panel, and command palette): `openclaw-approval-page` now registers through a lazy module load, preloaded only when bootstrap resolves an approval document mode from the URL. The approval document template already renders a booting splash as light-DOM fallback, so the load gap is covered by design. Startup budgets are ratcheted to the new baseline (340 KiB gzip, 20 requests) per the budget script's "budget changes accompany an intentional loading decision" contract, so the win cannot silently erode.

## User Impact

Every Control UI load ships 47 KiB gzip (~250 KiB raw) less JavaScript and makes 9 fewer startup requests: startup JS drops from 369.1 KiB gzip / 22 requests to 321.8 KiB / 13 requests (−13%). Cold loads, post-update loads, and slow links benefit most. The `/approve` approval flow is unchanged: the page lazy-loads on approval URLs and renders identically.

## Evidence

- Startup attribution (sourcemap byte accounting across startup chunks): typebox 130.4 KiB raw was the largest npm group, present only via the approval-page chain; `frame-guards` and the other boot-reachable protocol modules are type-only imports and stay startup-safe.
- `node scripts/check-control-ui-performance.mjs`: startup JS 321.8 KiB gzip / 13 requests (was 369.1 KiB / 22 on main); all budgets green including the new tighter limits.
- Live verification on a real-data dev gateway: `/approve/<id>` lazy-defines and renders the approval page (correct "Approval unavailable" state for an unknown id); normal chat boot renders with no approval module in the network log.
- `node scripts/run-vitest.mjs ui/src/e2e/approval-page.e2e.test.ts` — 6 e2e tests drive a real browser against the built UI at `/approve` and pass through the lazy path.
- Focused units: `ui/src/app` (273 tests), `approval-page.test.ts` (12), `test/scripts/control-ui-performance.test.ts` — all pass.
- Full local `ui/src` sweep: 6 unrelated files fail identically on clean `main` (Node 26 experimental `localStorage` artifact; CI truth is Node 24).
- Structured autoreview (gpt-5.6-sol): clean, no findings.
