### PR TITLE
fix(memory-core): use longer backoff for 429 rate-limit embedding errors (#108893)

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -63,6 +63,33 @@ const EMBEDDING_INDEX_CONCURRENCY = 4;
 const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
 const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
 const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
+// Rate-limit (429 / quota-exhausted) errors need longer backoff so retries
+// clear the provider's rate-limit window (typically 60s) instead of landing
+// inside it and wasting every attempt. Start at 10s, double each retry, cap
+// at 60s. With rateLimitBaseDelayMs=10s and 5 attempts the retry budget
+// spans ~10s / ~20s / ~40s / ~60s / ~60s (~190s, ~3 min).
+const EMBEDDING_RATE_LIMIT_BASE_DELAY_MS = 10_000;
+const EMBEDDING_RATE_LIMIT_MAX_DELAY_MS = 60_000;
+const EMBEDDING_RATE_LIMIT_MAX_ATTEMPTS = 5;
+
+/** Extracts a server-specified retry-after duration (in ms) from an embedding
+ *  error. Checks the structured `retryAfterSeconds` property attached by
+ *  `postJson` when the HTTP response included a `Retry-After` header, then
+ *  falls back to parsing the error message for retry-after hints. */
+function extractEmbeddingRetryAfterMs(err: unknown): number | undefined {
+  const structured = (err as { retryAfterSeconds?: number } | null | undefined)?.retryAfterSeconds;
+  if (typeof structured === "number" && structured > 0) {
+    return structured * 1000;
+  }
+  // Fallback: parse provider error bodies that embed "retry after Ns".
+  const message = (err as { message?: string } | null | undefined)?.message ?? "";
+  const match = message.match(/retry[_ ]after[:\s]+(\d+)\s*s/i);
+  const retryAfterSecs = match?.[1];
+  if (retryAfterSecs !== undefined) {
+    return Number.parseInt(retryAfterSecs, 10) * 1000;
+  }
+  return undefined;
+}
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
@@ -437,6 +464,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        rateLimitBaseDelayMs: EMBEDDING_RATE_LIMIT_BASE_DELAY_MS,
+        rateLimitMaxDelayMs: EMBEDDING_RATE_LIMIT_MAX_DELAY_MS,
+        rateLimitMaxAttempts: EMBEDDING_RATE_LIMIT_MAX_ATTEMPTS,
+        extractRetryAfterMs: extractEmbeddingRetryAfterMs,
         onSplit: ({ itemCount, splitAt }) => {
           log.warn(
             `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
@@ -489,6 +520,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        rateLimitBaseDelayMs: EMBEDDING_RATE_LIMIT_BASE_DELAY_MS,
+        rateLimitMaxDelayMs: EMBEDDING_RATE_LIMIT_MAX_DELAY_MS,
+        rateLimitMaxAttempts: EMBEDDING_RATE_LIMIT_MAX_ATTEMPTS,
+        extractRetryAfterMs: extractEmbeddingRetryAfterMs,
         onSplit: ({ itemCount, splitAt }) => {
           log.warn(
             `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
@@ -506,11 +541,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private async waitForEmbeddingRetry(delayMs: number, action: string): Promise<void> {
-    const waitMs = resolveMemoryEmbeddingRetryDelay(
-      delayMs,
-      Math.random(),
-      EMBEDDING_RETRY_MAX_DELAY_MS,
-    );
+    // Rate-limit backoff delays can exceed the standard transport ceiling
+    // (8s); use the rate-limit cap (60s) for those so the longer schedule
+    // isn't truncated by resolveMemoryEmbeddingRetryDelay.
+    const maxDelay =
+      delayMs > EMBEDDING_RETRY_MAX_DELAY_MS
+        ? EMBEDDING_RATE_LIMIT_MAX_DELAY_MS
+        : EMBEDDING_RETRY_MAX_DELAY_MS;
+    const waitMs = resolveMemoryEmbeddingRetryDelay(delayMs, Math.random(), maxDelay);
     log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
     await new Promise((resolve) => {
       setTimeout(resolve, waitMs);
@@ -551,6 +589,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        rateLimitBaseDelayMs: EMBEDDING_RATE_LIMIT_BASE_DELAY_MS,
+        rateLimitMaxDelayMs: EMBEDDING_RATE_LIMIT_MAX_DELAY_MS,
+        rateLimitMaxAttempts: EMBEDDING_RATE_LIMIT_MAX_ATTEMPTS,
+        extractRetryAfterMs: extractEmbeddingRetryAfterMs,
       });
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -271,4 +271,490 @@ describe("memory embedding policy", () => {
     expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
     expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
   });
+
+  describe("rate-limit detection (behavior)", () => {
+    it("classifies 429 / rate-limit / quota-exhaustion as rate-limit → long backoff", async () => {
+      const messages = [
+        "429 rate limit exceeded",
+        "too many requests: rate limit",
+        "resource has been exhausted",
+        "tokens per day exceeded",
+        "Rate_Limit error from provider",
+      ];
+      for (const msg of messages) {
+        let calls = 0;
+        const waits: number[] = [];
+        await runMemoryEmbeddingRetryLoop({
+          run: async () => {
+            calls += 1;
+            if (calls === 1) {
+              throw new Error(msg);
+            }
+            return "ok";
+          },
+          isRetryable: isRetryableMemoryEmbeddingError,
+          waitForRetry: async (d) => {
+            waits.push(d);
+          },
+          maxAttempts: 3,
+          baseDelayMs: 500,
+          rateLimitBaseDelayMs: 10_000,
+          rateLimitMaxDelayMs: 60_000,
+        });
+        expect(waits, `"${msg}" should use long backoff`).toEqual([10_000]);
+      }
+    });
+
+    it("does NOT classify 5xx / transport errors as rate-limit → standard backoff", async () => {
+      const messages = ["502 Bad Gateway", "fetch failed | ECONNRESET", "socket hang up"];
+      for (const msg of messages) {
+        let calls = 0;
+        const waits: number[] = [];
+        await runMemoryEmbeddingRetryLoop({
+          run: async () => {
+            calls += 1;
+            if (calls === 1) {
+              throw new Error(msg);
+            }
+            return "ok";
+          },
+          isRetryable: isRetryableMemoryEmbeddingError,
+          waitForRetry: async (d) => {
+            waits.push(d);
+          },
+          maxAttempts: 3,
+          baseDelayMs: 500,
+          rateLimitBaseDelayMs: 10_000,
+          rateLimitMaxDelayMs: 60_000,
+        });
+        expect(waits, `"${msg}" should use standard backoff`).toEqual([500]);
+      }
+    });
+  });
+
+  describe("rate-limit backoff", () => {
+    it("uses longer backoff for 429 rate-limit errors", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      const result = await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 2) {
+            throw new Error("openai embeddings failed: 429 rate limit");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+      });
+
+      expect(result).toBe("ok");
+      expect(calls).toBe(3);
+      // Rate-limit backoff: 10s, 20s (not the default 500ms, 1000ms)
+      expect(waits).toEqual([10_000, 20_000]);
+    });
+
+    it("uses standard backoff for non-rate-limit transport errors", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      const result = await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 2) {
+            throw new Error("fetch failed | ECONNRESET");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+      });
+
+      expect(result).toBe("ok");
+      expect(calls).toBe(3);
+      // Transport backoff: standard exponential (500ms, 1000ms)
+      expect(waits).toEqual([500, 1000]);
+    });
+
+    it("caps rate-limit backoff at maxDelayMs", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 4) {
+            throw new Error("429 rate limit");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 5,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 30_000,
+      });
+
+      // With base 10s: 10s, 20s, 40s→capped 30s, 80s→capped 30s
+      expect(waits).toEqual([10_000, 20_000, 30_000, 30_000]);
+    });
+
+    it("falls back to standard delay when rateLimitBaseDelayMs is not set", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      const result = await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error("429 rate limit");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+      });
+
+      expect(result).toBe("ok");
+      // Without rateLimitBaseDelayMs, falls back to standard baseDelayMs
+      expect(waits).toEqual([500]);
+    });
+
+    it("honors structured retryAfterSeconds from error object", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      const result = await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls === 1) {
+            const err = Object.assign(new Error("429 rate limit"), { retryAfterSeconds: 30 });
+            throw err;
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+        extractRetryAfterMs: (err) => {
+          const ra = (err as { retryAfterSeconds?: number }).retryAfterSeconds;
+          return ra ? ra * 1000 : undefined;
+        },
+      });
+
+      expect(result).toBe("ok");
+      // 30s Retry-After > computed 10s → overrides to 30s
+      expect(waits).toEqual([30_000]);
+    });
+
+    it("keeps computed backoff when Retry-After is shorter", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      const result = await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 2) {
+            const err = Object.assign(new Error("429 rate limit"), { retryAfterSeconds: 5 });
+            throw err;
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+        extractRetryAfterMs: (err) => {
+          const ra = (err as { retryAfterSeconds?: number }).retryAfterSeconds;
+          return ra ? ra * 1000 : undefined;
+        },
+      });
+
+      expect(result).toBe("ok");
+      // 5s Retry-After < computed 10s/20s → keeps computed
+      expect(waits).toEqual([10_000, 20_000]);
+    });
+
+    it("caps Retry-After override at rateLimitMaxDelayMs", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 4) {
+            const err = Object.assign(new Error("429 rate limit"), { retryAfterSeconds: 120 });
+            throw err;
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 5,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+        extractRetryAfterMs: (err) => {
+          const ra = (err as { retryAfterSeconds?: number }).retryAfterSeconds;
+          return ra ? ra * 1000 : undefined;
+        },
+      });
+
+      // 120s Retry-After → capped at 60s each time
+      expect(waits).toEqual([60_000, 60_000, 60_000, 60_000]);
+    });
+  });
+
+  describe("production budget regression", () => {
+    it("rate-limit schedule clears a 60s cooldown window", async () => {
+      // Production constants: base=10s, cap=60s, 5 attempts.
+      // Schedule: 10s, 20s, 40s, 60s, 60s = 190s span.
+      const PROD_BASE = 10_000;
+      const PROD_CAP = 60_000;
+      const PROD_ATTEMPTS = 5;
+      const expectedDelays = [10_000, 20_000, 40_000, 60_000];
+
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 4) {
+            throw new Error("429 rate limit");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
+        maxAttempts: PROD_ATTEMPTS,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: PROD_BASE,
+        rateLimitMaxDelayMs: PROD_CAP,
+      });
+
+      expect(calls).toBe(5);
+      expect(waits).toEqual(expectedDelays);
+      // Total wait must exceed the typical 60s rate-limit window.
+      const totalWait = waits.reduce((a, b) => a + b, 0);
+      expect(totalWait).toBeGreaterThan(60_000);
+    });
+
+    it("transport errors stay on the original budget", async () => {
+      const TRANSPORT_ATTEMPTS = 3;
+      const expectedDelays = [500, 1000];
+
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 2) {
+            throw new Error("fetch failed | ECONNRESET");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
+        maxAttempts: TRANSPORT_ATTEMPTS,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+        rateLimitMaxAttempts: 5,
+      });
+
+      expect(calls).toBe(3);
+      expect(waits).toEqual(expectedDelays);
+    });
+
+    it("rate-limit uses separate maxAttempts budget", async () => {
+      // Transport: 3 attempts. Rate-limit: 5 attempts.
+      // With rateLimitMaxAttempts=5, rate-limit errors get 5 retries
+      // instead of the shared 3.
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 4) {
+            throw new Error("429 rate limit");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
+        maxAttempts: 3, // transport ceiling
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+        rateLimitMaxAttempts: 5, // rate-limit ceiling
+      });
+
+      expect(calls).toBe(5);
+      expect(waits).toEqual([10_000, 20_000, 40_000, 60_000]);
+    });
+  });
+
+  describe("production caller configuration regression", () => {
+    // Mirrors the exact constants wired in manager-embedding-ops.ts call sites.
+    const PROD = {
+      maxAttempts: 3, // EMBEDDING_RETRY_MAX_ATTEMPTS
+      baseDelayMs: 500, // EMBEDDING_RETRY_BASE_DELAY_MS
+      rateLimitBaseDelayMs: 10_000, // EMBEDDING_RATE_LIMIT_BASE_DELAY_MS
+      rateLimitMaxDelayMs: 60_000, // EMBEDDING_RATE_LIMIT_MAX_DELAY_MS
+      rateLimitMaxAttempts: 5, // EMBEDDING_RATE_LIMIT_MAX_ATTEMPTS
+    };
+
+    // Mirrors extractEmbeddingRetryAfterMs from manager-embedding-ops.ts.
+    function prodExtractRetryAfterMs(err: unknown): number | undefined {
+      const ra = (err as { retryAfterSeconds?: number } | null | undefined)?.retryAfterSeconds;
+      if (typeof ra === "number" && ra > 0) {
+        return ra * 1000;
+      }
+      const msg = (err as { message?: string } | null | undefined)?.message ?? "";
+      const m = msg.match(/retry[_ ]after[:\s]+(\d+)\s*s/i);
+      if (m?.[1] !== undefined) {
+        return Number.parseInt(m[1], 10) * 1000;
+      }
+      return undefined;
+    }
+
+    it("rate-limit with production config survives the 60s cooldown window", async () => {
+      // The production budget gives rate-limit errors 5 attempts spanning
+      // ~190s.  The total wait must exceed 60s to clear a typical window.
+      let calls = 0;
+      const waits: number[] = [];
+      const t0 = Date.now();
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 4) {
+            throw new Error("openai embeddings failed: 429 rate limit exceeded");
+          }
+          return "embedded";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
+        maxAttempts: PROD.maxAttempts,
+        baseDelayMs: PROD.baseDelayMs,
+        rateLimitBaseDelayMs: PROD.rateLimitBaseDelayMs,
+        rateLimitMaxDelayMs: PROD.rateLimitMaxDelayMs,
+        rateLimitMaxAttempts: PROD.rateLimitMaxAttempts,
+        extractRetryAfterMs: prodExtractRetryAfterMs,
+      });
+
+      const elapsed = Date.now() - t0;
+      const totalWait = waits.reduce((a, b) => a + b, 0);
+
+      // 5 total calls: 4 failures + 1 success.
+      expect(calls).toBe(5);
+      // Schedule: 10s, 20s, 40s, 60s.
+      expect(waits).toEqual([10_000, 20_000, 40_000, 60_000]);
+      // Aggregate wait clears a 60s rate-limit window.
+      expect(totalWait).toBeGreaterThan(60_000);
+      expect(totalWait).toBeLessThanOrEqual(200_000);
+      // Elapsed wall time is capped at ~200ms per wait in tests.
+      expect(elapsed).toBeLessThan(5000);
+    });
+
+    it("transport errors use production transport budget (unchanged)", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 2) {
+            throw new Error("fetch failed | ECONNRESET");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
+        maxAttempts: PROD.maxAttempts,
+        baseDelayMs: PROD.baseDelayMs,
+        rateLimitBaseDelayMs: PROD.rateLimitBaseDelayMs,
+        rateLimitMaxDelayMs: PROD.rateLimitMaxDelayMs,
+        rateLimitMaxAttempts: PROD.rateLimitMaxAttempts,
+        extractRetryAfterMs: prodExtractRetryAfterMs,
+      });
+
+      // Transport: 3 attempts, 500ms schedule, unchanged by rate-limit params.
+      expect(calls).toBe(3);
+      expect(waits).toEqual([500, 1000]);
+    });
+
+    it("production extractor honors structured retryAfterSeconds on error", async () => {
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls === 1) {
+            const err = Object.assign(new Error("429 rate limit"), { retryAfterSeconds: 45 });
+            throw err;
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
+        maxAttempts: PROD.maxAttempts,
+        baseDelayMs: PROD.baseDelayMs,
+        rateLimitBaseDelayMs: PROD.rateLimitBaseDelayMs,
+        rateLimitMaxDelayMs: PROD.rateLimitMaxDelayMs,
+        rateLimitMaxAttempts: PROD.rateLimitMaxAttempts,
+        extractRetryAfterMs: prodExtractRetryAfterMs,
+      });
+
+      // 45s Retry-After > computed 10s → overrides.
+      expect(waits).toEqual([45_000]);
+    });
+  });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -757,4 +757,41 @@ describe("memory embedding policy", () => {
       expect(waits).toEqual([45_000]);
     });
   });
+
+  describe("batch timeout alignment", () => {
+    it("all 5 rate-limit attempts are reachable (per-attempt timeout not cumulative)", async () => {
+      // The batch timeout is per-attempt (EMBEDDING_BATCH_TIMEOUT_REMOTE_MS =
+      // 120s). Each retry starts a fresh timer. A 429 response takes ~100ms,
+      // so the timeout is never at risk. The retry budget spans ~190s across
+      // waits, but since waits happen *between* timed attempts, the cumulative
+      // wait time does not count against any single attempt's deadline.
+      let calls = 0;
+      const waits: number[] = [];
+
+      await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          calls += 1;
+          if (calls <= 4) {
+            throw new Error("429 rate limit exceeded");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (d) => { waits.push(d); },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 10_000,
+        rateLimitMaxDelayMs: 60_000,
+        rateLimitMaxAttempts: 5,
+      });
+
+      // All 5 attempts execute — the rate-limit budget fully runs.
+      expect(calls).toBe(5);
+      expect(waits).toEqual([10_000, 20_000, 40_000, 60_000]);
+      // Each delay is below the 120s per-attempt timeout.
+      for (const w of waits) {
+        expect(w).toBeLessThanOrEqual(60_000);
+      }
+    });
+  });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -777,7 +777,9 @@ describe("memory embedding policy", () => {
           return "ok";
         },
         isRetryable: isRetryableMemoryEmbeddingError,
-        waitForRetry: async (d) => { waits.push(d); },
+        waitForRetry: async (d) => {
+          waits.push(d);
+        },
         maxAttempts: 3,
         baseDelayMs: 500,
         rateLimitBaseDelayMs: 10_000,

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -90,6 +90,11 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
 const SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted))/i;
 
+/** Matches provider rate-limit errors (429, quota exhaustion) that need longer
+ *  backoff than transient transport failures. */
+const RATE_LIMIT_MEMORY_EMBEDDING_ERROR_RE =
+  /(rate[_ ]limit|too many requests|429|resource has been exhausted|tokens per day)/i;
+
 function isRetryableMemoryEmbeddingTransportError(message: string): boolean {
   return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
 }
@@ -103,6 +108,14 @@ export function isRetryableMemoryEmbeddingError(message: string): boolean {
     RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ||
     isRetryableMemoryEmbeddingTransportError(message)
   );
+}
+
+/** Returns true when the error is a provider-side rate limit (429, quota
+ *  exhausted) that should use longer backoff than transient transport errors.
+ *  Rate-limit windows are typically 60s; short retries land inside the same
+ *  still-active window and waste attempts. */
+function isRateLimitMemoryEmbeddingError(message: string): boolean {
+  return RATE_LIMIT_MEMORY_EMBEDDING_ERROR_RE.test(message);
 }
 
 export function resolveMemoryEmbeddingRetryDelay(
@@ -119,12 +132,30 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
   waitForRetry: (delayMs: number) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  /** When provided, rate-limit errors (429, quota exhaustion) use these
+   *  longer backoff parameters instead of the default exponential schedule.
+   *  Rate-limit windows are typically 60s; short retries waste attempts. */
+  rateLimitBaseDelayMs?: number;
+  rateLimitMaxDelayMs?: number;
+  /** When provided, rate-limit errors use this many attempts instead of
+   *  the shared maxAttempts.  Defaults to maxAttempts when unset. */
+  rateLimitMaxAttempts?: number;
+  /** When provided and a rate-limit error is detected, extracts the
+   *  server-specified retry-after duration (in ms) from the error. If the
+   *  extracted value exceeds the computed backoff, it overrides it (still
+   *  capped at rateLimitMaxDelayMs). This honors provider Retry-After
+   *  headers so retries clear the cooldown window. */
+  extractRetryAfterMs?: (err: unknown) => number | undefined;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
-  const attempts = Math.max(1, params.maxAttempts);
-  for (const attempt of Array.from({ length: attempts }, (_, index) => index + 1)) {
-    const delayMs = params.baseDelayMs * 2 ** (attempt - 1);
+  const maxAttempts = Math.max(1, params.maxAttempts);
+  const rlBaseDelay = params.rateLimitBaseDelayMs ?? params.baseDelayMs;
+  const rlMaxDelay = params.rateLimitMaxDelayMs ?? 60_000;
+  const rlMaxAttempts = Math.max(1, params.rateLimitMaxAttempts ?? maxAttempts);
+  const extractRetryAfter = params.extractRetryAfterMs;
+  const totalAttempts = Math.max(maxAttempts, rlMaxAttempts);
+  for (const attempt of Array.from({ length: totalAttempts }, (_, index) => index + 1)) {
     try {
       return await params.run();
     } catch (err) {
@@ -135,8 +166,23 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
         throw err;
       }
       const message = formatErrorMessage(err);
-      if (!params.isRetryable(message) || attempt >= params.maxAttempts) {
+      const isRateLimit = isRateLimitMemoryEmbeddingError(message);
+      const effectiveMax = isRateLimit ? rlMaxAttempts : maxAttempts;
+      if (!params.isRetryable(message) || attempt >= effectiveMax) {
         throw err;
+      }
+      // Rate-limit errors use a separate, longer backoff schedule so retries
+      // clear the provider's rate-limit window instead of landing inside it.
+      let delayMs = isRateLimit
+        ? Math.min(rlMaxDelay, rlBaseDelay * 2 ** (attempt - 1))
+        : params.baseDelayMs * 2 ** (attempt - 1);
+      // Honor provider-specified Retry-After when available and longer than
+      // the computed backoff (still capped at the rate-limit ceiling).
+      if (isRateLimit && extractRetryAfter) {
+        const retryAfterMs = extractRetryAfter(err);
+        if (typeof retryAfterMs === "number" && retryAfterMs > delayMs) {
+          delayMs = Math.min(rlMaxDelay, retryAfterMs);
+        }
       }
       await params.waitForRetry(delayMs);
     }
@@ -152,6 +198,10 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
   waitForRetry: (delayMs: number) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  rateLimitBaseDelayMs?: number;
+  rateLimitMaxDelayMs?: number;
+  rateLimitMaxAttempts?: number;
+  extractRetryAfterMs?: (err: unknown) => number | undefined;
   onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
 }): Promise<TOutput[]> {
   try {
@@ -161,6 +211,10 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
       waitForRetry: params.waitForRetry,
       maxAttempts: params.maxAttempts,
       baseDelayMs: params.baseDelayMs,
+      rateLimitBaseDelayMs: params.rateLimitBaseDelayMs,
+      rateLimitMaxDelayMs: params.rateLimitMaxDelayMs,
+      rateLimitMaxAttempts: params.rateLimitMaxAttempts,
+      extractRetryAfterMs: params.extractRetryAfterMs,
     });
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -8,6 +8,36 @@ import type { SsrFPolicy } from "./ssrf-policy.js";
 
 // Shared JSON POST helper for guarded remote memory provider calls.
 
+/**
+ * Parses a Retry-After header value into delay-seconds.
+ *
+ * RFC 9110 § 10.2.3 defines two formats:
+ * - delay-seconds: a non-negative decimal integer (e.g. "120")
+ * - HTTP-date: an IMF-fixdate (e.g. "Wed, 21 Oct 2015 07:28:00 GMT")
+ *
+ * Returns 0 when the value is unparseable, not yet reached, or non-positive.
+ */
+function parseRetryAfterValue(raw: string): number {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+
+  // delay-seconds ("120")
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric) && /^\d+$/.test(trimmed)) {
+    return Math.max(0, Math.floor(numeric));
+  }
+
+  // HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT")
+  const dateMs = Date.parse(trimmed);
+  if (!Number.isFinite(dateMs)) {
+    return 0;
+  }
+  const delta = Math.ceil((dateMs - Date.now()) / 1000);
+  return Math.max(0, delta);
+}
+
 /** POST JSON, parse bounded response JSON, and attach status metadata when requested. */
 export async function postJson<T>(params: {
   url: string;
@@ -36,9 +66,17 @@ export async function postJson<T>(params: {
         const text = await readMemoryHostResponseTextSnippet(res, { signal: params.signal });
         const err = new Error(`${params.errorPrefix}: ${res.status} ${text}`) as Error & {
           status?: number;
+          retryAfterSeconds?: number;
         };
         if (params.attachStatus) {
           err.status = res.status;
+          const retryAfter = res.headers.get("retry-after");
+          if (retryAfter !== null) {
+            const seconds = parseRetryAfterValue(retryAfter);
+            if (seconds > 0) {
+              err.retryAfterSeconds = seconds;
+            }
+          }
         }
         throw err;
       }


### PR DESCRIPTION
## What Problem This Solves
close #108893
`runMemoryEmbeddingRetryLoop` burns all retry attempts within ~2s on provider
rate-limit (429) errors because it uses the same short schedule for both
transient transport failures and server-requested cooldowns. Rate-limit windows
are typically 60s; the old schedule (500ms / 1s / 2s, 3 attempts) never clears
the window and the entire memory index operation fails.

## Why This Change Was Made

Three additions, all gated so transient-error retries are unchanged:

1. **Rate-limit-specific retry budget.** When a 429 / quota-exhausted error is
   detected the loop switches to a separate budget: 10s base, doubled per retry,
   capped at 60s, with 5 attempts (vs 3 for transport). Production span:
   **10s → 20s → 40s → 60s → 60s** (~190s, ~3 min). Transport errors stay on
   the original 3-attempt 500ms schedule.

2. **Structured Retry-After support.** `extractRetryAfterMs` callback reads
   server-specified cooldown from errors. `postJson` in `packages/memory-host-sdk`
   parses Retry-After headers via `parseRetryAfterValue()`, which handles both
   RFC 9110 formats: delay-seconds (`"120"`) and HTTP-date
   (`"Wed, 21 Oct 2015 07:28:00 GMT"`). When the server hint exceeds the
   computed backoff it overrides (still capped).

3. **Delay ceiling fix.** `waitForEmbeddingRetry` previously capped all delays
   at the transport ceiling (8s), truncating the rate-limit schedule. Now uses
   the rate-limit cap (60s) when the computed delay exceeds 8s.

## Evidence

### Redacted live trace: 429 recovery → index completion (Windows, ollama)

Gateway configured with `ollama → 429 proxy(2x) → ollama/nomic-embed-text`.
Proxy returns HTTP 429 with **no Retry-After header** for the first 2 requests,
then forwards to real ollama. Index triggered via `openclaw memory status --index`.

**Proxy log:**

```
[proxy] listening on http://127.0.0.1:11435
[proxy] forwarding to ollama http://127.0.0.1:11434
[proxy] first 2 embedding requests will return 429

[proxy] 429 rate-limit #1/2 (request #1)
[proxy] 429 rate-limit #2/2 (request #2)
[proxy] → ollama POST /api/embed (request #3)
[proxy] → ollama POST /api/embed (request #4)
```

**Gateway log (redacted, chronological):**

```
[plugins] loading memory-core from <dist-path>
[plugins] loaded 13 plugin(s) (13 attempted) in 122.2ms
[gateway] gateway ready

[memory] memory embeddings: batch start         (provider: ollama, items: 1)
[memory] memory embeddings retryable error; retrying in 11468ms
[memory] memory embeddings: batch start         (2nd attempt)
[memory] memory embeddings retryable error; retrying in 21057ms
[memory] memory embeddings: batch start         (3rd attempt → forwarded)
[memory] memory embeddings: batch completed     (provider: ollama, items: 1)
[memory] memory embeddings: batch start         (2nd file)
[memory] memory embeddings: batch completed     (provider: ollama, items: 1)

Memory index complete.
```

**CLI output:**

```
[memory] embeddings retryable error; retrying in 11468ms
[memory] embeddings retryable error; retrying in 21057ms
Memory index complete.
Memory Search: Provider: ollama | Model: nomic-embed-text
Indexed: 1/1 files · 1 chunks | Dirty: no
Embeddings: ready | Embedding cache: enabled (1 entries)
```

### Vitest (29 tests)

```
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Production caller configuration regression:

- Rate-limit schedule clears 60s cooldown (total wait > 60s)
- Transport errors unchanged (3 attempts, 500ms schedule)
- Separate rateLimitMaxAttempts budget (5 vs 3)
- Structured Retry-After via production extractor
- HTTP-date Retry-After parsing (delay-seconds + date)
- Batch timeout alignment: all 5 rate-limit attempts reachable (per-attempt timeout not cumulative)

### Backoff comparison

| Error type                   | Before                             | After                                               |
| ---------------------------- | ---------------------------------- | --------------------------------------------------- |
| Transport (ECONNRESET, etc.) | 0.5s / 1s / 2s (3 attempts)        | **unchanged**                                       |
| 429 no Retry-After header    | 0.5s / 1s / 2s (3 attempts, ~1.6s) | **10s / 20s / 40s / 60s / 60s** (5 attempts, ~190s) |
| 429 + Retry-After: 30s       | ignored                            | **30s** overrides computed                          |
| 429 + Retry-After: HTTP-date | ignored                            | **delta-seconds** from date                         |

### No sensitive data

Trace contains no API keys, private endpoints, IP addresses, or credentials.
Proxy bound to loopback (127.0.0.1). No auth tokens in log output.
