### PR TITLE
fix(agents): unblock router-to-value-agent delegation + fix compaction reconcile TypeError

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
@@ -5,7 +5,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 
 /** Persist the highest observed compaction count after a successful subscribed run. */
-export default async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
+export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   sessionKey?: string;
   agentId?: string;
   configStore?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
@@ -13,7 +13,7 @@ import {
   handleCompactionEnd,
   handleCompactionStart,
 } from "./embedded-agent-subscribe.handlers.compaction.js";
-import reconcileSessionStoreCompactionCountAfterSuccess from "./embedded-agent-subscribe.handlers.compaction.runtime.js";
+import { reconcileSessionStoreCompactionCountAfterSuccess } from "./embedded-agent-subscribe.handlers.compaction.runtime.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeZeroUsageSnapshot, type AssistantUsageSnapshot } from "./usage.js";

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -205,8 +205,9 @@ async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   observedCompactionCount: number;
   now?: number;
 }): Promise<number | undefined> {
-  const { default: reconcile } =
-    await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
+  const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } = await import(
+    "./embedded-agent-subscribe.handlers.compaction.runtime.js"
+  );
   return reconcile(params);
 }
 

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -229,6 +229,115 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(registerInput.requesterAgentId).toBe("main");
   });
 
+  it("does not cap a statically-configured target agent's tools to the parent's own effective surface", async () => {
+    // Regression test: targeting a real agents.list entry (e.g. a router
+    // delegating to a specialized value agent) must not intersect the
+    // child's own tools.allow/alsoAllow down to whatever the parent itself
+    // can call -- the parent legitimately lacks tools the target agent has.
+    hoisted.configOverride = createConfigOverride({
+      session: {
+        scope: "global",
+      },
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+            subagents: {
+              allowAgents: ["worker"],
+            },
+          },
+          {
+            id: "worker",
+            workspace: "/tmp/workspace-worker",
+          },
+        ],
+      },
+    });
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "delegate to worker",
+        agentId: "worker",
+      },
+      {
+        agentSessionKey: "global",
+        requesterAgentIdOverride: "main",
+        inheritedToolAllowlist: ["message", "sessions_spawn"],
+        inheritedToolDenylist: ["exec"],
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") {
+      throw new Error("Expected accepted spawn result");
+    }
+    const childSession = persistedStore?.[result.childSessionKey];
+    if (!childSession) {
+      throw new Error("Expected persisted child session");
+    }
+    // Allow-list inheritance is skipped for a known static target -- the
+    // child's own agents.worker.tools policy applies unmodified.
+    expect(childSession.inheritedToolAllow).toBeUndefined();
+    // Deny-list inheritance is a safety floor, not a capability grant, and
+    // still applies regardless of target.
+    expect(childSession.inheritedToolDeny).toEqual(["exec"]);
+  });
+
+  it("caps tool inheritance to the parent's effective surface when the target has no static agents.list entry", async () => {
+    // Same-agent (self) spawns are the only reachable case without a
+    // resolvable target config today; containment must still hold there.
+    hoisted.configOverride = createConfigOverride({
+      session: {
+        scope: "global",
+      },
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+        },
+        list: [],
+      },
+    });
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "spawn a helper of myself",
+      },
+      {
+        agentSessionKey: "global",
+        requesterAgentIdOverride: "main",
+        inheritedToolAllowlist: ["message", "sessions_spawn"],
+        inheritedToolDenylist: ["exec"],
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") {
+      throw new Error("Expected accepted spawn result");
+    }
+    const childSession = persistedStore?.[result.childSessionKey];
+    if (!childSession) {
+      throw new Error("Expected persisted child session");
+    }
+    expect(childSession.inheritedToolAllow).toEqual(["message", "sessions_spawn"]);
+    expect(childSession.inheritedToolDeny).toEqual(["exec"]);
+  });
+
   it("accepts a spawned run across session patching, runtime-model persistence, registry registration, and lifecycle emission", async () => {
     const operations: string[] = [];
     let persistedStore: Record<string, Record<string, unknown>> | undefined;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1301,7 +1301,14 @@ export async function spawnSubagentDirect(
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
-    ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
+    // Statically-configured named agents (targetAgentConfig resolved from
+    // agents.list) run their own vetted tools.allow/alsoAllow policy and must
+    // not be capped to the spawning parent's own effective tool surface --
+    // that intersection silently drops every plugin tool the target agent has
+    // but the router doesn't (e.g. a router delegating to a specialized value
+    // agent). Only dynamic/ad-hoc spawn targets (no static agents.list entry)
+    // inherit the parent's surface as a privilege-containment floor.
+    ...(targetAgentConfig ? {} : inheritedToolAllowPatch(ctx.inheritedToolAllowlist)),
     ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
     ...plan.initialSessionPatch,
   };


### PR DESCRIPTION
## What Problem This Solves

Two independent bugs found while standing up a live 3-agent (router + 2
specialized value-agent) deployment on local Ollama models, both surfaced
because that deployment actually exercises `sessions_spawn` delegation and
post-compaction reconciliation under tight context budgets:

1. **Subagent tool-policy security-boundary change** (`src/agents/subagent-spawn.ts`).
   A router spawning a specialized value agent ended up with only generic
   session-management tools callable in the child — none of the target
   agent's own plugin-provided tools, and no error surfaced. The child just
   silently reasoned in free text instead of calling its real tools.
2. **Compaction reconcile TypeError** (`src/agents/embedded-agent-subscribe.handlers.compaction.*`).
   Every successful compaction that also needed a late session-store count
   reconcile threw `TypeError: reconcile is not a function` in the production
   build (not reproducible via `pnpm test`, since Vitest resolves the
   `.runtime.ts` source directly and never exercises the bundled barrel chunk
   that actually breaks).

## Why This Change Was Made

### 1. Tool-policy fix — please review this one as a security-boundary change, not a routine bugfix

`sessions_spawn` builds a spawned child's `inheritedToolAllow` from the
**spawning parent's own final resolved tool list**
(`replaceWithEffectiveToolAllowlist`, `src/agents/agent-tools.ts`), then
applies it as a hard intersecting filter on top of the child's own configured
`tools.allow`/`alsoAllow` (`src/agents/agent-tools.policy.ts`, last pipeline
step in `src/agents/agent-tools.ts`). The intent (per the existing code
comment) is real and sound: a spawned child should never exceed its
spawner's own authority — "child ⊆ parent" privilege containment.

That collides with a legitimate, intentional pattern: a router agent
delegating to purpose-built value agents that hold plugin tools the router
itself was deliberately never granted (separation of concerns, not
misconfiguration). Since the router's own effective surface can never
contain those tools, no child it spawns ever could either — regardless of
what the target agent's own static config says.

Root cause confirmed by direct trace (not guessed): `agent-tools.ts:912` /
`927-928` / `1167-1168` builds the parent's effective-surface snapshot;
`subagent-spawn.ts` (pre-fix) applied it unconditionally via
`inheritedToolAllowPatch(ctx.inheritedToolAllowlist)` regardless of who the
target was.

**The fix (scoped narrowly on purpose):** skip that allow-list inheritance
only when the spawn target resolves to a statically-configured entry in
`agents.list` (`targetAgentConfig`, already computed earlier in the same
function via `resolveAgentConfig`) — i.e. only for the pre-vetted, operator-
configured roster, never for dynamic/ad-hoc targets. In that case the child
runs under exactly its own configured `tools.allow`/`alsoAllow`, not a union
with the parent's surface and not anything spawn-time-supplied. Deny-list
inheritance (`inheritedToolDenyPatch`) is untouched in both cases — it's a
safety floor, not a capability grant, and isn't part of this collision.

Threat reasoning for why this specific scope is safe, considered and
rejected against two alternatives before landing on this one:

- *Rejected: union the parent's inherited allow-list with the child's own
  config.* Also unions for dynamic/ad-hoc children whose tool grant can come
  from the spawn call itself — an injected/compromised parent could shape
  that. This fix trusts only the static `agents.list` config, never anything
  supplied at spawn time, so that hole doesn't open.
- *Rejected: cap only "dangerous" tools via inheritance, leave plugin tools
  alone.* Requires a global dangerous-vs-safe taxonomy that can't be defined
  context-free — the same tool (e.g. network/browser access) is the entire
  point for one agent and a real risk for another. Anchoring on static
  operator config sidesteps needing that taxonomy at all.
- Under this fix, a compromised router still can't grant anything a human
  operator didn't already configure for that specific named agent, and each
  agent's genuinely dangerous actions (credential access, network egress)
  stay independently gated behind their own review/egress controls
  elsewhere in the system — this change grants no new reachable capability,
  it just stops silently hiding capability the operator already granted.

Reviewer note: please scrutinize whether `targetAgentConfig` truthiness
(sourced from `resolveAgentConfig`, which returns `undefined` unless there's
a real `agents.list` entry) is actually unspoofable from the spawn-request
side in every code path that reaches this function, not just the
`sessions_spawn` tool path this was reproduced against.

### 2. Compaction reconcile fix — mechanical, low-risk

`export * from "./chunk.js"` never forwards a `default` export — that's ES
module spec, not bundler-specific. `embedded-agent-subscribe.handlers.compaction.runtime.ts`
was the **only** `.runtime.ts` file in the codebase using `export default`;
every other one already uses a named export for exactly this dynamic-import
lazy-boundary pattern. The bundler splits it into its own chunk behind an
`export *` barrel, so in the production build the caller's
`const { default: reconcile } = await import(...)` resolves `reconcile` to
`undefined`, and the call throws `reconcile is not a function`.

Fix: convert the one file to a named export and update its single caller —
brings it in line with the convention every other `.runtime.ts` file already
follows, nothing more.

## User Impact

- Fix 1 unblocks router → specialized-value-agent delegation from silently
  degrading into free-text guessing with no persisted state and no error —
  this was a correctness regression users would experience as "it looks
  like it worked but nothing was actually recorded."
- Fix 2 removes a warning-level failure that fired on effectively every
  compacted session under tight context budgets (small local models, small
  `num_ctx`), where it's frequent enough to be noisy/confusing in logs even
  though it degrades gracefully today.
- No config shape, public API, or default changes.

## Evidence

**Fix 1 — tool policy:**
- Root cause traced end-to-end via source read (`agent-tools.ts`,
  `agent-tools.policy.ts`, `subagent-spawn.ts`, `subagent-target-policy.ts`,
  `agent-scope-config.ts`), not inferred from the error alone.
- Reproduced live in a real 3-agent local-model deployment: a router
  delegating to a value agent via `sessions_spawn` produced a child session
  whose only callable tool was `sessions_yield`; the target's own
  plugin-provided tools were absent, and its persistent SQLite store stayed
  empty after a "successful" run.
- New regression tests added in `src/agents/subagent-spawn.test.ts`:
  - `does not cap a statically-configured target agent's tools to the
    parent's own effective surface` — fails without the fix
    (`expected ['message', 'sessions_spawn'] to be undefined`), passes with
    it (confirmed by temporarily reverting the fix and re-running).
  - `caps tool inheritance to the parent's effective surface when the
    target has no static agents.list entry` — proves containment is
    unchanged for the non-static case.
- Full regression sweep: 33 test files / 536 tests across
  `subagent-spawn*`, `agent-tools*`, `tool-policy*`, `tool-allowlist*`,
  `sandbox-tool-policy*`, `provider-tool-policy*` — all pass
  (`node scripts/run-vitest.mjs <files>`).

**Fix 2 — compaction reconcile:**
- Confirmed the exact failure text (`TypeError: reconcile is not a
  function`) against the actual compiled `dist/` output of a running
  deployment before touching anything.
- Isolated, dependency-free ES-module repro (no bundler involved) proves the
  mechanism precisely: `export default` through an `export *` barrel yields
  `typeof reconcile === "undefined"` and throws exactly `reconcile is not a
  function` on call; the same barrel shape with a named export instead
  yields a real callable function. This is deterministic per the ES module
  spec, not build-tool-specific.
- `src/agents/embedded-agent-subscribe.handlers.compaction.test.ts`: 11/11
  pass with the fix.
- **Pending:** the actual compiled-`dist/` verification (rebuilding this
  repo and re-checking the real barrel chunk, the way the bug was originally
  found) was not completed — the available build environment's Docker VM is
  currently capped at 4GB RAM for an unrelated local-model deployment this
  branch was built to unblock, and `tsdown` needs ~8GB heap for a full
  build. The ES-module semantics above are deterministic regardless of
  build tool, so I'm confident in the fix, but flagging this gap explicitly
  rather than claiming full build verification. A maintainer with a normal
  build environment (or a temporary RAM bump + restore) can close this in
  one `pnpm build` + dist inspection.
- Separately, the live deployment that surfaced both bugs still runs the
  pre-fix code (these are local commits, not yet in any built image), so
  Tier-1 functional re-verification against that deployment is blocked
  until this lands in a build/release.
