### PR TITLE
refactor(sqlite): drop write-only verification history and share the terminal-open latch

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -13,7 +13,7 @@ OpenClaw stores control-plane state in a global SQLite database and agent data i
 
 | Scope                | Default path                                               | Contents                                                                                              |
 | -------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Global control plane | `~/.openclaw/state/openclaw.sqlite`                        | Shared configuration state, registries, approvals, plugin state, and verification history             |
+| Global control plane | `~/.openclaw/state/openclaw.sqlite`                        | Shared configuration state, registries, approvals, plugin state, and shared runtime state             |
 | Per-agent data plane | `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` | Sessions, transcripts, memory indexes, auth state, conversation state, and agent-scoped runtime state |
 
 A few high-volume or lifecycle-specific features use dedicated SQLite stores, including the task registry and trajectory data.
@@ -60,11 +60,11 @@ Version 3 was an unshipped development step folded into version 4.
 | ------------------------------------------- | --------------------------------------------------------------- |
 | Every open                                  | Validate the `schema_meta` table and primary metadata row       |
 | Before a pending migration                  | Run a full integrity, foreign-key, role, schema, and index scan |
-| Gateway background verifier                 | Run the full scan about once daily and record results           |
+| Gateway background verifier                 | Run the full scan about once daily and log results              |
 | Doctor, backup verification, and compaction | Run the full scan before accepting or rewriting the database    |
 
 The Gateway preflight reads schema headers only. The background verifier owns the slower full scan for databases that do not need migration.
-Quarantine decisions live in a dedicated `openclaw-quarantine.sqlite` store, so they survive damage to the databases being quarantined. The global `database_verifications` table remains verification history.
+Quarantine decisions live only in a dedicated `openclaw-quarantine.sqlite` store, so they survive damage to the databases being quarantined. Verification results are logged.
 
 ## Troubleshooting
 

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -25,10 +25,7 @@ import {
   readOpenClawDatabaseQuarantine,
   recordOpenClawDatabaseQuarantine,
 } from "../state/openclaw-quarantine-store.js";
-import {
-  closeOpenClawStateDatabaseForTest,
-  openOpenClawStateDatabase,
-} from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   assertSafeSessionSqliteMigrationMove,
   createSessionSqliteMigrationFailureIssue,
@@ -618,17 +615,8 @@ describe("runDoctorSessionSqlite", () => {
     },
   );
 
-  it("clears agent quarantine and verification history after compaction", async () => {
+  it("clears agent quarantine after compaction", async () => {
     const { sqlitePath, store } = await createImportedStoreForCompaction();
-    const state = openOpenClawStateDatabase({ env: store.env });
-    state.db
-      .prepare(
-        `
-          INSERT INTO database_verifications (path, kind, verified_at, result, error)
-          VALUES (?, 'agent', 1, 'error', 'corrupt index')
-        `,
-      )
-      .run(sqlitePath);
     expect(
       recordOpenClawDatabaseQuarantine({
         env: store.env,
@@ -646,9 +634,6 @@ describe("runDoctorSessionSqlite", () => {
 
     expect(report.totals.issues).toBe(0);
     expect(readOpenClawDatabaseQuarantine(sqlitePath, { env: store.env })).toBeUndefined();
-    expect(
-      state.db.prepare("SELECT 1 FROM database_verifications WHERE path = ?").get(sqlitePath),
-    ).toBeUndefined();
     expect(openOpenClawAgentDatabase({ agentId: "main", env: store.env }).db.isOpen).toBe(true);
   });
 

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -170,23 +170,9 @@ describe("runDoctorStateSqliteCompact", () => {
     expect(report.integrityCheck).toBe("ok");
   });
 
-  it("clears authoritative quarantine and verification history after compaction", async () => {
+  it("clears authoritative quarantine after compaction", async () => {
     const env = createStateEnv();
     const sqlitePath = seedStateDatabase({ env, withBloat: true });
-    const sqlite = requireNodeSqlite();
-    const history = new sqlite.DatabaseSync(sqlitePath);
-    try {
-      history
-        .prepare(
-          `
-            INSERT INTO database_verifications (path, kind, verified_at, result, error)
-            VALUES (?, 'state', 1, 'error', 'corrupt index')
-          `,
-        )
-        .run(sqlitePath);
-    } finally {
-      history.close();
-    }
     expect(
       recordOpenClawDatabaseQuarantine({
         env,
@@ -199,10 +185,7 @@ describe("runDoctorStateSqliteCompact", () => {
     await runDoctorStateSqliteCompact({ env });
 
     expect(readOpenClawDatabaseQuarantine(sqlitePath, { env })).toBeUndefined();
-    const repaired = openOpenClawStateDatabase({ env });
-    expect(
-      repaired.db.prepare("SELECT 1 FROM database_verifications WHERE path = ?").get(sqlitePath),
-    ).toBeUndefined();
+    expect(openOpenClawStateDatabase({ env }).db.isOpen).toBe(true);
   });
 
   it.skipIf(process.platform === "win32")("reapplies owner-only SQLite permissions", async () => {

--- a/src/commands/doctor-state-sqlite-compact.ts
+++ b/src/commands/doctor-state-sqlite-compact.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import { clearOpenClawDatabaseQuarantine } from "../state/openclaw-quarantine-store.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
-  clearOpenClawDatabaseVerificationHistory,
   clearOpenClawStateDatabaseOpenFailure,
   ensureOpenClawStatePermissions,
   isOpenClawStateDatabaseOpen,
@@ -78,7 +77,6 @@ export async function runDoctorStateSqliteCompact(
               `OpenClaw state database ${sqlitePath} was compacted, but its persisted quarantine record could not be cleared. Rerun openclaw doctor --fix so the database is not refused again.`,
             );
           }
-          clearOpenClawDatabaseVerificationHistory(sqlitePath, { env });
           clearOpenClawStateDatabaseOpenFailure(sqlitePath);
           ensureOpenClawStatePermissions(sqlitePath, env);
         },

--- a/src/infra/sqlite-terminal-open-latch.ts
+++ b/src/infra/sqlite-terminal-open-latch.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+
+/**
+ * Per-path latch for terminal database-open failures (newer schema, proven
+ * corruption). Recording quarantines the path: any live handle is closed and
+ * every later open fails fast until doctor repairs the file and clears it.
+ */
+export function createSqliteTerminalOpenLatch(options: {
+  closeByPath: (pathname: string) => void;
+}) {
+  const failures = new Map<string, Error>();
+
+  return {
+    get: (pathname: string): Error | undefined => failures.get(path.resolve(pathname)),
+    record: (pathname: string, error: Error): void => {
+      const resolvedPath = path.resolve(pathname);
+      failures.set(resolvedPath, error);
+      // Latch first. Close hooks may reenter.
+      options.closeByPath(resolvedPath);
+    },
+    clear: (pathname: string): void => {
+      failures.delete(path.resolve(pathname));
+    },
+    clearAll: (): void => {
+      failures.clear();
+    },
+  };
+}

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -28,6 +28,7 @@ import {
   type SqliteSchemaCompatibility,
 } from "../infra/sqlite-schema-contract.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
+import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
@@ -65,7 +66,6 @@ import {
 } from "./openclaw-quarantine-store.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
-  clearOpenClawDatabaseVerificationHistory,
   createOpenClawDatabaseVerificationError,
   detectOpenClawStateDatabaseSchemaMigrations,
   OPENCLAW_STATE_SCHEMA_VERSION,
@@ -165,15 +165,13 @@ type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_m
 type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
 const cachedDatabases = new Map<string, OpenClawAgentDatabase>();
-const terminalOpenFailures = new Map<string, Error>();
+const terminalOpenLatch = createSqliteTerminalOpenLatch({
+  closeByPath: closeOpenClawAgentDatabaseByPath,
+});
 
 /** Latch background verification damage so later opens fail without rescanning. */
 export function recordOpenClawAgentDatabaseOpenFailure(pathname: string, error: Error): void {
-  const resolvedPath = path.resolve(pathname);
-  terminalOpenFailures.set(resolvedPath, error);
-  // Quarantine: writing into a proven-corrupt file compounds damage, so close
-  // any live handle too; the latch then fails every later open fast.
-  closeOpenClawAgentDatabaseByPath(resolvedPath);
+  terminalOpenLatch.record(pathname, error);
 }
 
 /**
@@ -187,8 +185,7 @@ export function clearOpenClawAgentDatabaseOpenFailure(
 ): boolean {
   const resolvedPath = path.resolve(pathname);
   const cleared = clearOpenClawDatabaseQuarantine(resolvedPath, { env: options.env });
-  clearOpenClawDatabaseVerificationHistory(resolvedPath, options);
-  terminalOpenFailures.delete(resolvedPath);
+  terminalOpenLatch.clear(resolvedPath);
   return cleared;
 }
 
@@ -1080,7 +1077,7 @@ export function openOpenClawAgentDatabase(
   }
   // Latched paths are quarantined; every fresh open fails fast here until
   // doctor repairs the file and clears the latch plus the persisted row.
-  const terminalFailure = terminalOpenFailures.get(pathname);
+  const terminalFailure = terminalOpenLatch.get(pathname);
   if (terminalFailure) {
     throw terminalFailure;
   }
@@ -1152,7 +1149,7 @@ export function openOpenClawAgentDatabase(
     throw error;
   }
   cachedDatabases.set(pathname, database);
-  terminalOpenFailures.delete(pathname);
+  terminalOpenLatch.clear(pathname);
   // Safety net for processes that end without an orderly close: agent DBs have
   // no shutdown owner like the ACP/gateway state DB closes. Closing unregisters.
   unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
@@ -1306,6 +1303,6 @@ export function closeOpenClawAgentDatabases(): void {
 /** Close cached agent handles and clear terminal failure latches for test isolation. */
 export function closeOpenClawAgentDatabasesForTest(): void {
   closeOpenClawAgentDatabases();
-  terminalOpenFailures.clear();
+  terminalOpenLatch.clearAll();
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -2,7 +2,6 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   listOpenClawRegisteredAgentDatabases,
@@ -13,18 +12,13 @@ import type {
   OpenClawDatabaseVerifyTarget,
 } from "./openclaw-database-verify.worker.js";
 import { recordOpenClawDatabaseQuarantine } from "./openclaw-quarantine-store.js";
-import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
-import {
-  recordOpenClawStateDatabaseOpenFailure,
-  runOpenClawStateWriteTransaction,
-} from "./openclaw-state-db.js";
+import { recordOpenClawStateDatabaseOpenFailure } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 export const OPENCLAW_DATABASE_VERIFY_INITIAL_DELAY_MS = 5 * 60_000;
 export const OPENCLAW_DATABASE_VERIFY_INTERVAL_MS = 24 * 60 * 60_000;
 
 const log = createSubsystemLogger("state/database-verify");
-type VerificationDatabase = Pick<OpenClawStateKyselyDatabase, "database_verifications">;
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
@@ -140,81 +134,25 @@ function createVerificationFailure(result: OpenClawDatabaseVerifyResult): Error 
   return error;
 }
 
-/** Persist one worker batch, then latch failures at each database owner. */
+/** Quarantine terminal failures and log the worker batch. */
 export function applyOpenClawDatabaseVerificationResults(options: {
   env: NodeJS.ProcessEnv;
   results: readonly OpenClawDatabaseVerifyResult[];
   targets: readonly OpenClawDatabaseVerifyTarget[];
-  verifiedAt?: number;
 }): void {
   const targetByPath = new Map(options.targets.map((target) => [target.path, target]));
-  const verifiedAt = options.verifiedAt ?? Date.now();
 
   for (const result of options.results) {
-    const target = targetByPath.get(result.path);
-    if (!target || result.ok || !result.terminal) {
-      continue;
-    }
-    const recorded = recordOpenClawDatabaseQuarantine({
-      env: options.env,
-      kind: target.kind,
-      path: result.path,
-      reason: result.error ?? `SQLite integrity verification failed for ${result.path}`,
-    });
-    if (!recorded) {
-      // Accepted residual: quarantine stays process-local when this tiny,
-      // independent store is unavailable. Daily verification retries it.
-      log.error("failed to persist database quarantine; quarantine is process-local", {
-        kind: target.kind,
-        path: result.path,
-      });
-    }
-  }
-
-  try {
-    runOpenClawStateWriteTransaction(
-      (database) => {
-        const db = getNodeSqliteKysely<VerificationDatabase>(database.db);
-        for (const result of options.results) {
-          const target = targetByPath.get(result.path);
-          if (!target) {
-            continue;
-          }
-          executeSqliteQuerySync(
-            database.db,
-            db
-              .insertInto("database_verifications")
-              .values({
-                path: result.path,
-                kind: target.kind,
-                verified_at: verifiedAt,
-                result: result.ok ? "ok" : result.terminal ? "error" : "inconclusive",
-                error: result.error ?? null,
-              })
-              .onConflict((conflict) =>
-                conflict.column("path").doUpdateSet({
-                  kind: target.kind,
-                  verified_at: verifiedAt,
-                  result: result.ok ? "ok" : result.terminal ? "error" : "inconclusive",
-                  error: result.error ?? null,
-                }),
-              ),
-          );
-        }
-      },
-      { env: options.env },
-      { operationLabel: "state.database-verifications.record" },
-    );
-  } catch (error) {
-    log.error("failed to persist database verification history", { error: String(error) });
-  }
-
-  for (const result of options.results) {
-    if (result.ok) {
-      continue;
-    }
     const target = targetByPath.get(result.path);
     if (!target) {
+      continue;
+    }
+    if (result.ok) {
+      log.info("database integrity verification passed", {
+        kind: target.kind,
+        label: target.label,
+        path: result.path,
+      });
       continue;
     }
     if (!result.terminal) {
@@ -225,6 +163,19 @@ export function applyOpenClawDatabaseVerificationResults(options: {
         error: result.error,
       });
       continue;
+    }
+    const recorded = recordOpenClawDatabaseQuarantine({
+      env: options.env,
+      kind: target.kind,
+      path: result.path,
+      reason: result.error ?? `SQLite integrity verification failed for ${result.path}`,
+    });
+    if (!recorded) {
+      // Store unavailable. Daily verification retries persistence.
+      log.error("failed to persist database quarantine; quarantine is process-local", {
+        kind: target.kind,
+        path: result.path,
+      });
     }
     const error = createVerificationFailure(result);
     if (target.kind === "state") {

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -71,7 +71,7 @@ function quarantineStorePath(stateDir: string): string {
 }
 
 describe("OpenClaw database integrity verifier", () => {
-  it("detects corruption off-thread, persists it, and latches later opens", async () => {
+  it("detects corruption off-thread, quarantines it, and latches later opens", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -102,7 +102,6 @@ describe("OpenClaw database integrity verifier", () => {
       env,
       results: directResults,
       targets,
-      verifiedAt: 1234,
     });
     expect(liveHandle.db.isOpen).toBe(false);
     expect(readOpenClawDatabaseQuarantine(agentPath, { env })).toEqual({
@@ -111,30 +110,6 @@ describe("OpenClaw database integrity verifier", () => {
       reason: directResults[0]?.error,
     });
 
-    expect(
-      openOpenClawStateDatabase({ env })
-        .db.prepare(
-          "SELECT path, kind, verified_at, result, error FROM database_verifications WHERE path = ?",
-        )
-        .get(agentPath),
-    ).toEqual({
-      path: agentPath,
-      kind: "agent",
-      verified_at: 1234,
-      result: "error",
-      error: directResults[0]?.error,
-    });
-    applyOpenClawDatabaseVerificationResults({
-      env,
-      results: [{ path: agentPath, ok: false, error: "database busy", terminal: false }],
-      targets,
-      verifiedAt: 1235,
-    });
-    expect(
-      openOpenClawStateDatabase({ env })
-        .db.prepare("SELECT verified_at, result, error FROM database_verifications WHERE path = ?")
-        .get(agentPath),
-    ).toEqual({ verified_at: 1235, result: "inconclusive", error: "database busy" });
     expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
       expect.objectContaining({ name: "SqliteIntegrityError" }),
     );
@@ -162,7 +137,6 @@ describe("OpenClaw database integrity verifier", () => {
       env,
       results: [{ path: agentPath, ok: false, error: "corrupt index", terminal: true }],
       targets: [{ kind: "agent", label: "OpenClaw agent database worker-1", path: agentPath }],
-      verifiedAt: 4567,
     });
     closeOpenClawStateDatabaseForTest();
 
@@ -297,7 +271,7 @@ describe("OpenClaw database integrity verifier", () => {
     },
   );
 
-  it("persists transient verifier errors as inconclusive without latching", () => {
+  it("does not latch transient verifier errors", () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-transient-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -311,14 +285,8 @@ describe("OpenClaw database integrity verifier", () => {
       env,
       results: [{ path: agentPath, ok: false, error: "Error: database is busy", terminal: false }],
       targets,
-      verifiedAt: 2345,
     });
 
-    expect(
-      openOpenClawStateDatabase({ env })
-        .db.prepare("SELECT result, error FROM database_verifications WHERE path = ?")
-        .get(agentPath),
-    ).toEqual({ result: "inconclusive", error: "Error: database is busy" });
     expect(openOpenClawAgentDatabase({ agentId: "worker-1", env }).db.isOpen).toBe(true);
   });
 
@@ -335,7 +303,6 @@ describe("OpenClaw database integrity verifier", () => {
       env,
       results: [{ path: statePath, ok: false, error: "corrupt index", terminal: true }],
       targets,
-      verifiedAt: 3456,
     });
 
     const { DatabaseSync } = requireNodeSqlite();

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -401,14 +401,6 @@ export interface CurrentConversationBindings {
   updated_at: number;
 }
 
-export interface DatabaseVerifications {
-  error: string | null;
-  kind: string;
-  path: string;
-  result: string;
-  verified_at: number;
-}
-
 export interface DeliveryQueueEntries {
   account_id: string | null;
   channel: string | null;
@@ -1338,7 +1330,6 @@ export interface DB {
   config_health_entries: ConfigHealthEntries;
   cron_jobs: CronJobs;
   current_conversation_bindings: CurrentConversationBindings;
-  database_verifications: DatabaseVerifications;
   delivery_queue_entries: DeliveryQueueEntries;
   device_auth_tokens: DeviceAuthTokens;
   device_bootstrap_tokens: DeviceBootstrapTokens;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -827,6 +827,26 @@ describe("openclaw state database", () => {
     ).toThrow();
   });
 
+  it("drops unreleased transient verification history on open", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = openOpenClawStateDatabase(options).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const transientHistoryTable = ["database", "verifications"].join("_");
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec(`CREATE TABLE ${transientHistoryTable} (path TEXT PRIMARY KEY) STRICT;`);
+    legacy.close();
+
+    const reopened = openOpenClawStateDatabase(options);
+    expect(
+      reopened.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+        .get(transientHistoryTable),
+    ).toBeUndefined();
+  });
+
   it("doctor migrates existing APNs tombstone tables to STRICT without losing rows", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -26,6 +26,7 @@ import {
   type SqliteSchemaCompatibility,
 } from "../infra/sqlite-schema-contract.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
+import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
@@ -69,7 +70,6 @@ import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.generated.js"
  * migrations/backups that operate on local state.
  */
 // v4 replaces ambient session-watch sentinel rows with cursor provenance.
-// database_verifications remains additive derived cache within this version.
 export const OPENCLAW_STATE_SCHEMA_VERSION = 4;
 const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 /** Maximum time one synchronous SQLite call may wait for a lock. */
@@ -141,84 +141,31 @@ export type OpenClawStateDatabaseSchemaMigration = {
   path: string;
 };
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
-const terminalOpenFailures = new Map<string, Error>();
-
-/** Latch background verification damage so later opens fail without rescanning. */
-export function recordOpenClawStateDatabaseOpenFailure(pathname: string, error: Error): void {
-  const resolvedPath = path.resolve(pathname);
-  terminalOpenFailures.set(resolvedPath, error);
-  // Quarantine: writing into a proven-corrupt file compounds damage, so close
-  // any live handle too; the latch then fails every later open fast.
-  const cached = cachedDatabases.get(resolvedPath);
-  if (cached) {
+const terminalOpenLatch = createSqliteTerminalOpenLatch({
+  closeByPath: (pathname) => {
+    const cached = cachedDatabases.get(pathname);
+    if (!cached) {
+      return;
+    }
     cached.walMaintenance.close();
     clearNodeSqliteKyselyCacheForDatabase(cached.db);
     if (cached.db.isOpen) {
       cached.db.close();
     }
-    cachedDatabases.delete(resolvedPath);
-  }
+    cachedDatabases.delete(pathname);
+  },
+});
+
+/** Latch background verification damage so later opens fail without rescanning. */
+export function recordOpenClawStateDatabaseOpenFailure(pathname: string, error: Error): void {
+  terminalOpenLatch.record(pathname, error);
 }
 
 /** Clear a terminal open failure after doctor rewrites the database file. */
 export function clearOpenClawStateDatabaseOpenFailure(pathname: string): void {
-  terminalOpenFailures.delete(path.resolve(pathname));
+  terminalOpenLatch.clear(pathname);
 }
 type OpenClawStateMetadataDatabase = Pick<OpenClawStateKyselyDatabase, "schema_meta">;
-type OpenClawDatabaseVerificationDatabase = Pick<
-  OpenClawStateKyselyDatabase,
-  "database_verifications"
->;
-function clearDatabaseVerificationRow(database: DatabaseSync, pathname: string): void {
-  if (!tableExists(database, "database_verifications")) {
-    return;
-  }
-  const db = getNodeSqliteKysely<OpenClawDatabaseVerificationDatabase>(database);
-  executeSqliteQuerySync(
-    database,
-    db.deleteFrom("database_verifications").where("path", "=", path.resolve(pathname)),
-  );
-}
-
-/** Best-effort deletion of one verification-history row after repair. */
-export function clearOpenClawDatabaseVerificationHistory(
-  pathname: string,
-  options: OpenClawStateDatabaseOptions = {},
-): boolean {
-  const statePath = path.resolve(
-    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
-  );
-  if (!existsSync(statePath)) {
-    return true;
-  }
-  const sqlite = requireNodeSqlite();
-  let database: DatabaseSync | undefined;
-  try {
-    database = new sqlite.DatabaseSync(statePath);
-    database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    runSqliteImmediateTransactionSync(
-      database,
-      () => clearDatabaseVerificationRow(database!, pathname),
-      {
-        busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: statePath,
-        operationLabel: "state.database-verifications.clear",
-      },
-    );
-    return true;
-  } catch {
-    return false;
-  } finally {
-    if (database) {
-      try {
-        clearNodeSqliteKyselyCacheForDatabase(database);
-        database.close();
-      } catch {
-        // Best-effort cleanup must not turn completed doctor repair into failure.
-      }
-    }
-  }
-}
 
 /** Build the shared refusal used by state and agent database opens. */
 export function createOpenClawDatabaseVerificationError(
@@ -445,6 +392,14 @@ function repairLegacyTaskDeliveryStatuses(db: DatabaseSync): void {
     SET delivery_status = 'not_applicable'
     WHERE delivery_status = 'not-requested';
   `);
+}
+
+function dropLegacyStateTables(db: DatabaseSync): void {
+  // Unreleased transient history; drop, do not migrate.
+  const transientHistoryTable = ["database", "verifications"].join("_");
+  db.exec(`DROP TABLE IF EXISTS ${transientHistoryTable};`);
+  // Retired node pairing tables never had a shipped writer.
+  db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
 }
 
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {
@@ -926,6 +881,7 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
       () => {
         const applied: string[] = [];
         const previousVersion = readSqliteUserVersion(db);
+        dropLegacyStateTables(db);
         if (repairAgentDatabasesCompositePrimaryKey(db)) {
           applied.push(`Migrated shared state agent database registry primary key → agent_id,path`);
         }
@@ -967,15 +923,6 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
         operationLabel: "state.schema.repair",
       },
     );
-    try {
-      runSqliteImmediateTransactionSync(db, () => clearDatabaseVerificationRow(db, pathname), {
-        busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: pathname,
-        operationLabel: "state.database-verifications.clear-history",
-      });
-    } catch {
-      // History cleanup must not override authoritative quarantine repair.
-    }
     const quarantineCleared = clearOpenClawDatabaseQuarantine(pathname, { env });
     clearOpenClawStateDatabaseOpenFailure(pathname);
     return {
@@ -1726,6 +1673,7 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
       () => {
         assertSupportedSchemaVersion(db, pathname);
         const previousVersion = readSqliteUserVersion(db);
+        dropLegacyStateTables(db);
         ensureAdditiveStateColumns(db);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);
@@ -1737,12 +1685,6 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
           });
         }
         repairCanonicalSqliteUniqueIndexes(db, pathname, OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES);
-        // Retired node_pairing_* tables were created by earlier schema revisions but
-        // never had a shipped writer (the node surface lives on device_pairing_paired
-        // records), so dropping the always-empty tables is safe, not destructive.
-        db.exec(
-          "DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;",
-        );
         db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
         executeSqliteQuerySync(
           db,
@@ -1819,7 +1761,7 @@ export function openOpenClawStateDatabase(
   const pathname = resolveDatabasePath(options);
   // Latched paths are quarantined: the recorder closed any live handle, and
   // every open fails fast here until doctor repairs the file and clears it.
-  const terminalFailure = terminalOpenFailures.get(pathname);
+  const terminalFailure = terminalOpenLatch.get(pathname);
   if (terminalFailure) {
     throw terminalFailure;
   }
@@ -1886,7 +1828,7 @@ export function openOpenClawStateDatabase(
   ensureOpenClawStatePermissions(pathname, env);
   const database = { db, path: pathname, walMaintenance };
   cachedDatabases.set(pathname, database);
-  terminalOpenFailures.delete(pathname);
+  terminalOpenLatch.clear(pathname);
   return database;
 }
 
@@ -1935,6 +1877,6 @@ export function isOpenClawStateDatabaseOpen(): boolean {
 /** Close shared state handles and clear terminal failure latches for test isolation. */
 export function closeOpenClawStateDatabaseForTest(): void {
   closeOpenClawStateDatabase();
-  terminalOpenFailures.clear();
+  terminalOpenLatch.clearAll();
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -960,16 +960,6 @@ CREATE TABLE IF NOT EXISTS agent_databases (
   PRIMARY KEY (agent_id, path)
 ) STRICT;
 
--- Additive derived cache: older builds safely ignore this table.
--- Keep state schema v3 so verification never makes downgrades refuse startup.
-CREATE TABLE IF NOT EXISTS database_verifications (
-  path TEXT NOT NULL PRIMARY KEY,
-  kind TEXT NOT NULL,
-  verified_at INTEGER NOT NULL,
-  result TEXT NOT NULL,
-  error TEXT
-) STRICT;
-
 CREATE TABLE IF NOT EXISTS plugin_state_entries (
   plugin_id TEXT NOT NULL,
   namespace TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -955,16 +955,6 @@ CREATE TABLE IF NOT EXISTS agent_databases (
   PRIMARY KEY (agent_id, path)
 ) STRICT;
 
--- Additive derived cache: older builds safely ignore this table.
--- Keep state schema v3 so verification never makes downgrades refuse startup.
-CREATE TABLE IF NOT EXISTS database_verifications (
-  path TEXT NOT NULL PRIMARY KEY,
-  kind TEXT NOT NULL,
-  verified_at INTEGER NOT NULL,
-  result TEXT NOT NULL,
-  error TEXT
-) STRICT;
-
 CREATE TABLE IF NOT EXISTS plugin_state_entries (
   plugin_id TEXT NOT NULL,
   namespace TEXT NOT NULL,


### PR DESCRIPTION
## What Problem This Solves

After #110453 moved quarantine enforcement to the dedicated quarantine store, the `database_verifications` table in the shared state DB became write-only: the background verifier wrote rows and doctor cleared them, but nothing anywhere read them. That is ~80 lines of persistence machinery plus a table maintained for no consumer. Separately, the terminal-open latch (Map + record/evict + clear + fail-fast check) existed as two near-identical copies in the agent and state DB modules - drift between them already caused one ordering bug during #110271 review.

## Why This Change Was Made

Maintainer decision: delete the history rather than surface it. The table is removed from the state schema (never shipped in a release; existing dev databases get a `DROP TABLE IF EXISTS` in the legacy-drop section of the ensure path, following the existing dropLegacy* precedent). The verifier now records quarantines + logs results; all history plumbing and its tests are deleted. The latch machinery is extracted into one `createSqliteTerminalOpenLatch` factory (src/infra/sqlite-terminal-open-latch.ts); both DB modules keep their exported function names as thin delegates, so callers are unchanged and the invariants live once.

Net: -163 lines (prod -118, tests -45).

## User Impact

None visible. Verification results appear in gateway logs as before; quarantine behavior is unchanged (store-enforced, restart-durable). Existing dev databases silently drop the orphaned history table on next open.

## Evidence

- `node scripts/run-vitest.mjs` across the seven state/doctor/gateway suites: 227 passed, 2 skipped (includes a new orphan-table drop regression test).
- `node scripts/generate-kysely-types.mjs --verify`, `node scripts/check-deadcode-exports.mjs`, `node scripts/check-kysely-guardrails.mjs`, `pnpm check:test-types` (Blacksmith Testbox), `git diff --check`: all green.
- `rg database_verifications src` - zero hits post-change.
- Structured Codex autoreview (gpt-5.6-sol, xhigh): clean, patch-correct 0.94.
