### PR TITLE
fix(codex): stop stale MCP child processes with revalidated SIGKILL escalation

### DIFF
--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1431,7 +1431,9 @@ describe("killStaleComputerUseMcpChildren SIGKILL escalation", () => {
 
   async function runWithTimers(killImpl: (pid: number, signal?: string | number) => boolean) {
     vi.useFakeTimers();
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(killImpl);
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(killImpl as unknown as typeof process.kill);
     const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
     await vi.advanceTimersByTimeAsync(0);
     await promise;

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1429,7 +1429,7 @@ describe("killStaleComputerUseMcpChildren SIGKILL escalation", () => {
     vi.useRealTimers();
   });
 
-  async function runWithTimers(killImpl: typeof process.kill) {
+  async function runWithTimers(killImpl: (pid: number, signal?: string | number) => boolean) {
     vi.useFakeTimers();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(killImpl);
     const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1405,183 +1405,87 @@ function pluginSummary(
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
 
-// ---------------------------------------------------------------------------
-// killStaleComputerUseMcpChildren — SIGTERM → SIGKILL escalation
-// ---------------------------------------------------------------------------
-
+// killStaleComputerUseMcpChildren — SIGTERM → revalidated SIGKILL escalation
 const runExecMock = vi.hoisted(() => vi.fn());
-
-vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
-  runExec: runExecMock,
-}));
-
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({ runExec: runExecMock }));
 import { killStaleComputerUseMcpChildren } from "./computer-use.js";
 
-describe("killStaleComputerUseMcpChildren", () => {
-  // lstart format: Ddd Mmm DD HH:MM:SS YYYY (5 space-separated tokens)
-  const LSTART_1234 = "Sat Jul 18 14:00:00 2026";
-  const LSTART_5678 = "Sat Jul 18 14:00:01 2026";
-  const LSTART_9999 = "Sat Jul 18 14:00:02 2026";
-  const DEFAULT_PS_OUTPUT = [
-    `  1234     1 ${LSTART_1234} /usr/bin/node SkyComputerUseClient mcp --flag`,
-    `  5678     1 ${LSTART_5678} /bin/bash`,
-    `  9999  1234 ${LSTART_9999} /usr/bin/node SkyComputerUseClient something-else`,
+describe("killStaleComputerUseMcpChildren SIGKILL escalation", () => {
+  const LSTART = "Sat Jul 18 14:00:00 2026";
+  const PS = [
+    `  1234     1 ${LSTART} /usr/bin/node SkyComputerUseClient mcp --flag`,
+    `  5678     1 Sat Jul 18 14:00:01 2026 /bin/bash`,
   ].join("\n");
-
-  function assertSIGTERM(mock: ReturnType<typeof vi.fn>, pid: number) {
-    expect(mock).toHaveBeenCalledWith(pid, "SIGTERM");
-  }
-
-  function assertSIGKILL(mock: ReturnType<typeof vi.fn>, pid: number) {
-    expect(mock).toHaveBeenCalledWith(pid, "SIGKILL");
-  }
 
   let platformSpy: ReturnType<typeof vi.spyOn>;
   beforeAll(() => {
     platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
   });
-
   afterAll(() => {
     platformSpy.mockRestore();
   });
-
   afterEach(() => {
     runExecMock.mockReset();
+    vi.useRealTimers();
   });
 
-  it("sends SIGTERM to a stale MCP child", async () => {
-    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    await killStaleComputerUseMcpChildren({ ancestorPid: 1 });
-
-    assertSIGTERM(killSpy, 1234);
-    killSpy.mockRestore();
-  });
-
-  it("revalidates process identity and sends SIGKILL when still scoped", async () => {
+  async function runWithTimers(killImpl: typeof process.kill) {
     vi.useFakeTimers();
-    // First ps call: find stale process
-    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
-    // Second ps call (revalidation): same process still present
-    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
-
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(killImpl);
     const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
     await vi.advanceTimersByTimeAsync(0);
     await promise;
-
-    // SIGTERM sent
-    assertSIGTERM(killSpy, 1234);
-
-    // Advance 2 seconds — quick existence check passes, revalidation ps runs, SIGKILL sent
     await vi.advanceTimersByTimeAsync(2_000);
-    // Wait for the async IIFE inside setTimeout to complete
     await vi.advanceTimersByTimeAsync(0);
-    assertSIGKILL(killSpy, 1234);
-    // Verify the existence check was called: process.kill(1234, 0)
+    return killSpy;
+  }
+
+  it("SIGTERM then SIGKILL after revalidating the same scoped child", async () => {
+    runExecMock.mockResolvedValueOnce({ stdout: PS }).mockResolvedValueOnce({ stdout: PS });
+    const killSpy = await runWithTimers(() => true);
+    expect(killSpy).toHaveBeenCalledWith(1234, "SIGTERM");
     expect(killSpy).toHaveBeenCalledWith(1234, 0);
-
+    expect(killSpy).toHaveBeenCalledWith(1234, "SIGKILL");
     killSpy.mockRestore();
-    vi.useRealTimers();
   });
 
-  it("skips SIGKILL when the process already exited", async () => {
-    vi.useFakeTimers();
-    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
-
-    let callCount = 0;
-    const killSpy = vi
-      .spyOn(process, "kill")
-      .mockImplementation((_pid: number, signal?: string | number) => {
-        callCount++;
-        // The timed callback's quick existence check (signal 0) throws ESRCH
-        if (callCount === 2 && signal === 0) {
-          const err = new Error("ESRCH") as NodeJS.ErrnoException;
-          err.code = "ESRCH";
-          throw err;
-        }
-        return true;
-      });
-
-    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
-    await vi.advanceTimersByTimeAsync(0);
-    await promise;
-    assertSIGTERM(killSpy, 1234);
-
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(0);
-
-    // SIGKILL was never sent
-    const sigkillCall = killSpy.mock.calls.find(
-      (call) => call[0] === 1234 && call[1] === "SIGKILL",
+  it.each([
+    {
+      name: "process already exited",
+      setupKill: () => {
+        let n = 0;
+        return (_pid: number, signal?: string | number) => {
+          n += 1;
+          if (n === 2 && signal === 0) {
+            const err = new Error("ESRCH") as NodeJS.ErrnoException;
+            err.code = "ESRCH";
+            throw err;
+          }
+          return true;
+        };
+      },
+      revalidateStdout: undefined as string | undefined,
+    },
+    {
+      name: "command no longer matches stale MCP child",
+      setupKill: () => () => true,
+      revalidateStdout: `  1234     1 ${LSTART} /usr/bin/node something-else`,
+    },
+    {
+      name: "PID reused with same command but different lstart",
+      setupKill: () => () => true,
+      revalidateStdout: `  1234     1 Sat Jul 18 14:00:05 2026 /usr/bin/node SkyComputerUseClient mcp --flag`,
+    },
+  ])("skips SIGKILL when $name", async ({ setupKill, revalidateStdout }) => {
+    runExecMock.mockResolvedValueOnce({ stdout: PS });
+    if (revalidateStdout !== undefined) {
+      runExecMock.mockResolvedValueOnce({ stdout: revalidateStdout });
+    }
+    const killSpy = await runWithTimers(setupKill());
+    expect(killSpy).toHaveBeenCalledWith(1234, "SIGTERM");
+    expect(killSpy.mock.calls.some((call) => call[0] === 1234 && call[1] === "SIGKILL")).toBe(
+      false,
     );
-    expect(sigkillCall).toBeUndefined();
-
     killSpy.mockRestore();
-    vi.useRealTimers();
-  });
-
-  it("skips SIGKILL when the process identity changed", async () => {
-    vi.useFakeTimers();
-    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
-    // Revalidation ps: PID 1234 now has a different command (not stale MCP child)
-    runExecMock.mockResolvedValueOnce({
-      stdout: [`  1234     1 ${LSTART_1234} /usr/bin/node something-else`].join("\n"),
-    });
-
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
-    await vi.advanceTimersByTimeAsync(0);
-    await promise;
-    assertSIGTERM(killSpy, 1234);
-
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(0);
-
-    // SIGKILL was never sent — identity check blocked it
-    const sigkillCall = killSpy.mock.calls.find(
-      (call) => call[0] === 1234 && call[1] === "SIGKILL",
-    );
-    expect(sigkillCall).toBeUndefined();
-
-    killSpy.mockRestore();
-    vi.useRealTimers();
-  });
-
-  it("skips SIGKILL when PID was reused by another matching MCP child (same command, different lstart)", async () => {
-    vi.useFakeTimers();
-    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
-    // Revalidation ps: PID 1234 still has a matching MCP command,
-    // but the start time differs (PID was reused by a replacement child).
-    const REPLACEMENT_LSTART = "Sat Jul 18 14:00:05 2026";
-    runExecMock.mockResolvedValueOnce({
-      stdout: [
-        `  1234     1 ${REPLACEMENT_LSTART} /usr/bin/node SkyComputerUseClient mcp --flag`,
-        `  5678     1 ${LSTART_5678} /bin/bash`,
-      ].join("\n"),
-    });
-
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
-    await vi.advanceTimersByTimeAsync(0);
-    await promise;
-    assertSIGTERM(killSpy, 1234);
-
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(0);
-
-    // SIGKILL was never sent — lstart mismatch blocked it even though
-    // command and ancestry still match.
-    const sigkillCall = killSpy.mock.calls.find(
-      (call) => call[0] === 1234 && call[1] === "SIGKILL",
-    );
-    expect(sigkillCall).toBeUndefined();
-
-    killSpy.mockRestore();
-    vi.useRealTimers();
   });
 });

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1418,10 +1418,14 @@ vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
 import { killStaleComputerUseMcpChildren } from "./computer-use.js";
 
 describe("killStaleComputerUseMcpChildren", () => {
+  // lstart format: Ddd Mmm DD HH:MM:SS YYYY (5 space-separated tokens)
+  const LSTART_1234 = "Sat Jul 18 14:00:00 2026";
+  const LSTART_5678 = "Sat Jul 18 14:00:01 2026";
+  const LSTART_9999 = "Sat Jul 18 14:00:02 2026";
   const DEFAULT_PS_OUTPUT = [
-    "  1234     1 /usr/bin/node SkyComputerUseClient mcp --flag",
-    "  5678     1 /bin/bash",
-    "  9999  1234 /usr/bin/node SkyComputerUseClient something-else",
+    `  1234     1 ${LSTART_1234} /usr/bin/node SkyComputerUseClient mcp --flag`,
+    `  5678     1 ${LSTART_5678} /bin/bash`,
+    `  9999  1234 ${LSTART_9999} /usr/bin/node SkyComputerUseClient something-else`,
   ].join("\n");
 
   function assertSIGTERM(mock: ReturnType<typeof vi.fn>, pid: number) {
@@ -1524,7 +1528,7 @@ describe("killStaleComputerUseMcpChildren", () => {
     runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
     // Revalidation ps: PID 1234 now has a different command (not stale MCP child)
     runExecMock.mockResolvedValueOnce({
-      stdout: ["  1234     1 /usr/bin/node something-else"].join("\n"),
+      stdout: [`  1234     1 ${LSTART_1234} /usr/bin/node something-else`].join("\n"),
     });
 
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -1538,6 +1542,40 @@ describe("killStaleComputerUseMcpChildren", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     // SIGKILL was never sent — identity check blocked it
+    const sigkillCall = killSpy.mock.calls.find(
+      (call) => call[0] === 1234 && call[1] === "SIGKILL",
+    );
+    expect(sigkillCall).toBeUndefined();
+
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("skips SIGKILL when PID was reused by another matching MCP child (same command, different lstart)", async () => {
+    vi.useFakeTimers();
+    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
+    // Revalidation ps: PID 1234 still has a matching MCP command,
+    // but the start time differs (PID was reused by a replacement child).
+    const REPLACEMENT_LSTART = "Sat Jul 18 14:00:05 2026";
+    runExecMock.mockResolvedValueOnce({
+      stdout: [
+        `  1234     1 ${REPLACEMENT_LSTART} /usr/bin/node SkyComputerUseClient mcp --flag`,
+        `  5678     1 ${LSTART_5678} /bin/bash`,
+      ].join("\n"),
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    assertSIGTERM(killSpy, 1234);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // SIGKILL was never sent — lstart mismatch blocked it even though
+    // command and ancestry still match.
     const sigkillCall = killSpy.mock.calls.find(
       (call) => call[0] === 1234 && call[1] === "SIGKILL",
     );

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1,7 +1,7 @@
 // Codex tests cover computer use plugin behavior.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { resolveCodexNativeConfigFenceKey } from "./shared-client.js";
@@ -1404,3 +1404,146 @@ function pluginSummary(
   };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+// ---------------------------------------------------------------------------
+// killStaleComputerUseMcpChildren — SIGTERM → SIGKILL escalation
+// ---------------------------------------------------------------------------
+
+const runExecMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
+  runExec: runExecMock,
+}));
+
+import { killStaleComputerUseMcpChildren } from "./computer-use.js";
+
+describe("killStaleComputerUseMcpChildren", () => {
+  const DEFAULT_PS_OUTPUT = [
+    "  1234     1 /usr/bin/node SkyComputerUseClient mcp --flag",
+    "  5678     1 /bin/bash",
+    "  9999  1234 /usr/bin/node SkyComputerUseClient something-else",
+  ].join("\n");
+
+  function assertSIGTERM(mock: ReturnType<typeof vi.fn>, pid: number) {
+    expect(mock).toHaveBeenCalledWith(pid, "SIGTERM");
+  }
+
+  function assertSIGKILL(mock: ReturnType<typeof vi.fn>, pid: number) {
+    expect(mock).toHaveBeenCalledWith(pid, "SIGKILL");
+  }
+
+  let platformSpy: ReturnType<typeof vi.spyOn>;
+  beforeAll(() => {
+    platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+  });
+
+  afterAll(() => {
+    platformSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    runExecMock.mockReset();
+  });
+
+  it("sends SIGTERM to a stale MCP child", async () => {
+    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await killStaleComputerUseMcpChildren({ ancestorPid: 1 });
+
+    assertSIGTERM(killSpy, 1234);
+    killSpy.mockRestore();
+  });
+
+  it("revalidates process identity and sends SIGKILL when still scoped", async () => {
+    vi.useFakeTimers();
+    // First ps call: find stale process
+    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
+    // Second ps call (revalidation): same process still present
+    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    // SIGTERM sent
+    assertSIGTERM(killSpy, 1234);
+
+    // Advance 2 seconds — quick existence check passes, revalidation ps runs, SIGKILL sent
+    await vi.advanceTimersByTimeAsync(2_000);
+    // Wait for the async IIFE inside setTimeout to complete
+    await vi.advanceTimersByTimeAsync(0);
+    assertSIGKILL(killSpy, 1234);
+    // Verify the existence check was called: process.kill(1234, 0)
+    expect(killSpy).toHaveBeenCalledWith(1234, 0);
+
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("skips SIGKILL when the process already exited", async () => {
+    vi.useFakeTimers();
+    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
+
+    let callCount = 0;
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((_pid: number, signal?: string | number) => {
+        callCount++;
+        // The timed callback's quick existence check (signal 0) throws ESRCH
+        if (callCount === 2 && signal === 0) {
+          const err = new Error("ESRCH") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        return true;
+      });
+
+    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    assertSIGTERM(killSpy, 1234);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // SIGKILL was never sent
+    const sigkillCall = killSpy.mock.calls.find(
+      (call) => call[0] === 1234 && call[1] === "SIGKILL",
+    );
+    expect(sigkillCall).toBeUndefined();
+
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("skips SIGKILL when the process identity changed", async () => {
+    vi.useFakeTimers();
+    runExecMock.mockResolvedValueOnce({ stdout: DEFAULT_PS_OUTPUT });
+    // Revalidation ps: PID 1234 now has a different command (not stale MCP child)
+    runExecMock.mockResolvedValueOnce({
+      stdout: ["  1234     1 /usr/bin/node something-else"].join("\n"),
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const promise = killStaleComputerUseMcpChildren({ ancestorPid: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    assertSIGTERM(killSpy, 1234);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // SIGKILL was never sent — identity check blocked it
+    const sigkillCall = killSpy.mock.calls.find(
+      (call) => call[0] === 1234 && call[1] === "SIGKILL",
+    );
+    expect(sigkillCall).toBeUndefined();
+
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -1204,9 +1204,9 @@ function parsePsOutput(
   return stdout
     .split(/\r?\n/u)
     .flatMap((line) => {
-      // pid ppid lstart(5 tokens) command
+      // pid ppid lstart(5 tokens: day, mon, date, time, year) command
       const match =
-        /^\s*(\d+)\s+(\d+)\s+((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+\S+\s+\S+\s+\S+\s+\S+)\s+(.+)$/u.exec(
+        /^\s*(\d+)\s+(\d+)\s+((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(.+)$/u.exec(
           line,
         );
       if (!match) {

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -1117,7 +1117,7 @@ export async function killStaleComputerUseMcpChildren(
   }
   let stdout: string;
   try {
-    const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,command="], {
+    const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,lstart=,command="], {
       logOutput: false,
       maxBuffer: 5 * 1024 * 1024,
     });
@@ -1149,6 +1149,7 @@ export async function killStaleComputerUseMcpChildren(
       // process traps or ignores SIGTERM. Revalidate process identity
       // before escalating — the PID could have been reused.
       const ancestorPid = options.ancestorPid;
+      const launchStart = processInfo.lstart;
       const sigkillTimer = setTimeout(() => {
         void (async () => {
           try {
@@ -1158,7 +1159,7 @@ export async function killStaleComputerUseMcpChildren(
             return; // already exited
           }
           try {
-            const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,command="], {
+            const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,lstart=,command="], {
               logOutput: false,
               maxBuffer: 5 * 1024 * 1024,
             });
@@ -1166,6 +1167,7 @@ export async function killStaleComputerUseMcpChildren(
             const current = currentInfos.find((info) => info.pid === processInfo.pid);
             if (
               !current ||
+              current.lstart !== launchStart ||
               !isStaleComputerUseMcpChild(current.command) ||
               !isDescendantOfPid(current.pid, ancestorPid, currentInfos)
             ) {
@@ -1196,15 +1198,28 @@ export async function killStaleComputerUseMcpChildren(
   };
 }
 
-function parsePsOutput(stdout: string): Array<{ pid: number; ppid: number; command: string }> {
+function parsePsOutput(
+  stdout: string,
+): Array<{ pid: number; ppid: number; lstart: string; command: string }> {
   return stdout
     .split(/\r?\n/u)
     .flatMap((line) => {
-      const match = /^\s*(\d+)\s+(\d+)\s+(.+)$/u.exec(line);
+      // pid ppid lstart(5 tokens) command
+      const match =
+        /^\s*(\d+)\s+(\d+)\s+((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+\S+\s+\S+\s+\S+\s+\S+)\s+(.+)$/u.exec(
+          line,
+        );
       if (!match) {
         return [];
       }
-      return [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] ?? "" }];
+      return [
+        {
+          pid: Number(match[1]),
+          ppid: Number(match[2]),
+          lstart: match[3] ?? "",
+          command: match[4] ?? "",
+        },
+      ];
     })
     .filter(
       (processInfo) =>

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -1145,6 +1145,40 @@ export async function killStaleComputerUseMcpChildren(
     try {
       process.kill(processInfo.pid, "SIGTERM");
       killedPids.push(processInfo.pid);
+      // Schedule a SIGKILL escalation after a grace period, in case the
+      // process traps or ignores SIGTERM. Revalidate process identity
+      // before escalating — the PID could have been reused.
+      const ancestorPid = options.ancestorPid;
+      const sigkillTimer = setTimeout(() => {
+        void (async () => {
+          try {
+            // Quick existence check before running ps.
+            process.kill(processInfo.pid, 0);
+          } catch {
+            return; // already exited
+          }
+          try {
+            const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,command="], {
+              logOutput: false,
+              maxBuffer: 5 * 1024 * 1024,
+            });
+            const currentInfos = parsePsOutput(result.stdout);
+            const current = currentInfos.find((info) => info.pid === processInfo.pid);
+            if (
+              !current ||
+              !isStaleComputerUseMcpChild(current.command) ||
+              !isDescendantOfPid(current.pid, ancestorPid, currentInfos)
+            ) {
+              // Process identity changed — abort SIGKILL.
+              return;
+            }
+            process.kill(processInfo.pid, "SIGKILL");
+          } catch {
+            // ps failure or ESRCH — process is gone, no-op.
+          }
+        })();
+      }, 2_000);
+      sigkillTimer.unref();
     } catch (error) {
       warnings.push(
         `Could not terminate stale Computer Use MCP child pid ${processInfo.pid}: ${describeControlFailure(error)}`,


### PR DESCRIPTION
## What Problem This Solves

`killStaleComputerUseMcpChildren` in `extensions/codex/src/app-server/computer-use.ts:1146` sends `process.kill(pid, "SIGTERM")` and immediately records the pid as killed — without verifying the process actually terminated. If a child process traps or ignores SIGTERM (e.g. `process.on('SIGTERM', ...)` without `process.exit()`), it survives and becomes a zombie that the periodic health monitor can never clear.

## Why This Change Was Made

The fix schedules a SIGKILL after a 2-second grace period. Before sending SIGKILL, it **revalidates process identity** using three checks:
1. **PID existence**: `process.kill(pid, 0)` — quick liveness probe
2. **Immutable launch identity**: `lstart` (process start time) from `/bin/ps` — a PID reused by another matching MCP child within the grace period has a different start time, so the SIGKILL is correctly aborted even when command and ancestry match
3. **Command class + ancestry**: re-confirms the PID is still a `SkyComputerUseClient` MCP child descendant of the original ancestor PID

The `lstart` field is parsed from `/bin/ps -axo pid=,ppid=,lstart=,command=` using a precise date regex (`\w{3} \d{1,2} \d{2}:\d{2}:\d{2} \d{4}`) — not generic `\S+` tokens — so the lstart capture never leaks into the command field.

The timer is `unref()`'d so it does not keep the event loop alive. The kill path is macOS-gated (`process.platform !== "darwin"` early return) — no change to the platform guard.

The function returns `killedPids` immediately after SIGTERM (current contract), while the SIGKILL escalation is asynchronous. This is intentional: the repair reports what was terminated on the best-effort SIGTERM path, and the async SIGKILL handles the remaining misbehaving children silently.

Collision check: searched open PRs for `killStaleComputerUseMcpChildren`, `SIGKILL`, `lstart`, `computer-use`; no same-file or same-problem open PR was found.

## User Impact

Codex app-server health monitor now reliably terminates stale Computer Use MCP child processes, even those that ignore SIGTERM. PID reuse is guarded by immutable launch identity (`lstart`) comparison — a replacement MCP child with the same command and ancestry will not be mistakenly killed.

## Evidence

Exact head: `746a4c7a2dd54538cbd956e7c5750ca9cd5e26c8`

### Format and diff check

```
$ oxfmt --check extensions/codex/src/app-server/computer-use.ts extensions/codex/src/app-server/computer-use.test.ts
All matched files use the correct format.

$ git diff --check origin/main -- extensions/codex/src/app-server/computer-use.ts extensions/codex/src/app-server/computer-use.test.ts && echo ok
ok
```

### Vitest

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/computer-use.test.ts --run

 Test Files  1 passed (1)
      Tests  36 passed (36)
```

### Mutation checks

Revert SIGKILL escalation (remove `process.kill(pid, "SIGKILL")`):

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/computer-use.test.ts -t "SIGTERM then SIGKILL" --run

 Test Files  1 failed (1)
      Tests  1 failed | 35 skipped (36)
```
→ Test correctly catches missing SIGKILL. Restore → 36/36 passed.

Revert lstart identity check (remove `current.lstart !== launchStart ||`):

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/computer-use.test.ts -t "PID reused" --run

 Test Files  1 failed (1)
      Tests  1 failed | 35 skipped (36)
```
→ Test correctly catches missing lstart guard. Restore → 36/36 passed.

### Real behavior proof

Exercises the **production function** (`killStaleComputerUseMcpChildren`) on real POSIX processes. The platform guard is temporarily satisfied (`process.platform → "darwin"`), then real child processes matching the `SkyComputerUseClient mcp` pattern are spawned, SIGTERM'd, and the escalated SIGKILL lifecycle is verified. POSIX signal semantics and `/bin/ps -axo lstart=` format are identical across Darwin and Linux.

```
$ HEAD_SHA=746a4c7a2dd54538cbd956e7c5750ca9cd5e26c8 node --import tsx proof-codex-sigkill-escalation.mts
node=v22.22.0
head=746a4c7a2dd54538cbd956e7c5750ca9cd5e26c8

── Scenario 1: Production function kills stale MCP child ──
Pre-import stale child PID: 2563710
Child matches stale MCP pattern: true
Child lstart: Mon Jul 20 11:32:08 2026
killedPids: [2563710]
warnings: []
After SIGTERM: child alive = true
Waiting 3s for SIGKILL escalation...
After SIGKILL grace period: child alive = false
  ok: s1: stale MCP child found and SIGTERM sent (pid in killedPids)
  ok: s1: child survives SIGTERM (traps it)
  ok: s1: child killed by escalated SIGKILL
  ok: s1: child no longer in ps after SIGKILL

── Scenario 2: Clean SIGTERM exit — no zombie ──
Clean child PID: 2563882, lstart: Mon Jul 20 11:32:11 2026
killedPids: [2563882]
After SIGTERM: child exited = true
After 2s grace: child still dead = true
  ok: s2: clean child sent SIGTERM
  ok: s2: clean child exited on SIGTERM

── Scenario 3: No stale children ──
killedPids: []
  ok: s3: no stale children → zero killedPids
  ok: s3: no stale children → attempted=true

── Scenario 4: Multiple stale children ──
Spawned 3 stale children: [2564303,2564304,2564310]
killedPids: [2564303,2564304,2564310]
After SIGKILL: survivors = []
  ok: s4: all stale children sent SIGTERM
  ok: s4: all stale children dead after SIGKILL

── Scenario 5: Non-MCP child is untouched ──
Normal child PID: 2564519 (no SkyComputerUseClient in command)
killedPids: []
  ok: s5: non-MCP child NOT in killedPids
  ok: s5: non-MCP child still alive

── Scenario 6: ESRCH detection works ──
Short-lived child PID: 2564533, exited: true, ESRCH: true
  ok: s6: short-lived child already exited
  ok: s6: kill(pid, 0) correctly throws ESRCH

=== Summary ===
ALL PROOF ASSERTIONS: 14 passed, 0 failed
```

Six scenarios against the **production function** on real processes:
1. **SIGTERM→SIGKILL**: stale child traps SIGTERM → escalated SIGKILL kills it
2. **Clean exit**: well-behaved child exits on SIGTERM → no zombie
3. **No stale children**: function correctly returns zero killedPids
4. **Multiple children**: all 3 stale children are found and killed
5. **Non-MCP exclusion**: normal child without `SkyComputerUseClient mcp` is untouched
6. **ESRCH guard**: `kill(pid, 0)` correctly throws ESRCH for exited process

### Not tested

- macOS live app-server process lifecycle (function is macOS-gated; POSIX signal behavior and `/bin/ps lstart` format are identical across Darwin and Linux; the real-process proof above exercises the production function on real processes with identical POSIX semantics)
- Real Codex MCP child processes in a running macOS app-server
- PID reuse race condition in production (covered via unit tests with timer mocking and lstart mismatch)