### PR TITLE
fix(anthropic): guard invalid timestamps in history imports

### DIFF
--- a/extensions/anthropic/session-catalog-history.test.ts
+++ b/extensions/anthropic/session-catalog-history.test.ts
@@ -20,6 +20,29 @@ vi.mock("openclaw/plugin-sdk/session-transcript-runtime", () => ({
 }));
 
 describe("importClaudeHistory", () => {
+  it("uses the import timestamp when a native row has an invalid timestamp", async () => {
+    appended.length = 0;
+    const fallbackTimestamp = new Date("2026-07-18T12:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(fallbackTimestamp);
+    try {
+      await importClaudeHistory({
+        items: [{ type: "userMessage", text: "continue", timestamp: "not-a-date", uuid: "u-1" }],
+        threadId: "thread-1",
+        sessionFile: "/tmp/unused.jsonl",
+        sessionId: "session-1",
+        sessionKey: "agent:main:catalog-adopt",
+        agentId: "main",
+        config: {} as OpenClawConfig,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(appended[0]?.timestamp).toBe(fallbackTimestamp);
+    expect(JSON.stringify(appended[0])).toContain(`"timestamp":${fallbackTimestamp}`);
+  });
+
   it("tags imported native user rows so self-echo provenance excludes them", async () => {
     appended.length = 0;
     await importClaudeHistory({

--- a/extensions/anthropic/session-catalog-history.test.ts
+++ b/extensions/anthropic/session-catalog-history.test.ts
@@ -20,7 +20,7 @@ vi.mock("openclaw/plugin-sdk/session-transcript-runtime", () => ({
 }));
 
 describe("importClaudeHistory", () => {
-  it("uses the import timestamp when a native row has an invalid or pre-epoch timestamp", async () => {
+  it("falls back for invalid timestamps while preserving valid pre-epoch dates", async () => {
     appended.length = 0;
     const fallbackTimestamp = new Date("2026-07-18T12:00:00.000Z").getTime();
     vi.useFakeTimers();
@@ -48,11 +48,8 @@ describe("importClaudeHistory", () => {
     }
 
     expect(appended).toHaveLength(2);
-    expect(appended.map((message) => message.timestamp)).toEqual([
-      fallbackTimestamp,
-      fallbackTimestamp + 1,
-    ]);
-    expect(JSON.stringify(appended)).toContain(`"timestamp":${fallbackTimestamp}`);
+    expect(appended.map((message) => message.timestamp)).toEqual([-1_000, fallbackTimestamp + 1]);
+    expect(JSON.stringify(appended)).not.toContain('"timestamp":null');
   });
 
   it("tags imported native user rows so self-echo provenance excludes them", async () => {

--- a/extensions/anthropic/session-catalog-history.test.ts
+++ b/extensions/anthropic/session-catalog-history.test.ts
@@ -20,14 +20,22 @@ vi.mock("openclaw/plugin-sdk/session-transcript-runtime", () => ({
 }));
 
 describe("importClaudeHistory", () => {
-  it("uses the import timestamp when a native row has an invalid timestamp", async () => {
+  it("uses the import timestamp when a native row has an invalid or pre-epoch timestamp", async () => {
     appended.length = 0;
     const fallbackTimestamp = new Date("2026-07-18T12:00:00.000Z").getTime();
     vi.useFakeTimers();
     vi.setSystemTime(fallbackTimestamp);
     try {
       await importClaudeHistory({
-        items: [{ type: "userMessage", text: "continue", timestamp: "not-a-date", uuid: "u-1" }],
+        items: [
+          { type: "userMessage", text: "invalid", timestamp: "not-a-date", uuid: "u-1" },
+          {
+            type: "userMessage",
+            text: "pre-epoch",
+            timestamp: "1969-12-31T23:59:59.000Z",
+            uuid: "u-2",
+          },
+        ],
         threadId: "thread-1",
         sessionFile: "/tmp/unused.jsonl",
         sessionId: "session-1",
@@ -39,8 +47,12 @@ describe("importClaudeHistory", () => {
       vi.useRealTimers();
     }
 
-    expect(appended[0]?.timestamp).toBe(fallbackTimestamp);
-    expect(JSON.stringify(appended[0])).toContain(`"timestamp":${fallbackTimestamp}`);
+    expect(appended).toHaveLength(2);
+    expect(appended.map((message) => message.timestamp)).toEqual([
+      fallbackTimestamp,
+      fallbackTimestamp + 1,
+    ]);
+    expect(JSON.stringify(appended)).toContain(`"timestamp":${fallbackTimestamp}`);
   });
 
   it("tags imported native user rows so self-echo provenance excludes them", async () => {

--- a/extensions/anthropic/session-catalog-history.ts
+++ b/extensions/anthropic/session-catalog-history.ts
@@ -8,7 +8,8 @@ function importedClaudeMessage(
   item: ClaudeTranscriptItem,
   fallbackTimestamp: number,
 ): AgentMessage {
-  const timestamp = item.timestamp ? Date.parse(item.timestamp) : fallbackTimestamp;
+  const parsedTimestamp = item.timestamp ? Date.parse(item.timestamp) : Number.NaN;
+  const timestamp = Number.isFinite(parsedTimestamp) ? parsedTimestamp : fallbackTimestamp;
   const text = item.text?.trim() || "[Unsupported Claude transcript item]";
   if (item.type === "userMessage") {
     // Imported native rows are not OpenClaw-authored; mirrorOrigin excludes them

--- a/extensions/anthropic/session-catalog-history.ts
+++ b/extensions/anthropic/session-catalog-history.ts
@@ -9,7 +9,8 @@ function importedClaudeMessage(
   fallbackTimestamp: number,
 ): AgentMessage {
   const parsedTimestamp = item.timestamp ? Date.parse(item.timestamp) : Number.NaN;
-  const timestamp = Number.isFinite(parsedTimestamp) ? parsedTimestamp : fallbackTimestamp;
+  const timestamp =
+    Number.isFinite(parsedTimestamp) && parsedTimestamp >= 0 ? parsedTimestamp : fallbackTimestamp;
   const text = item.text?.trim() || "[Unsupported Claude transcript item]";
   if (item.type === "userMessage") {
     // Imported native rows are not OpenClaw-authored; mirrorOrigin excludes them

--- a/extensions/anthropic/session-catalog-history.ts
+++ b/extensions/anthropic/session-catalog-history.ts
@@ -9,8 +9,7 @@ function importedClaudeMessage(
   fallbackTimestamp: number,
 ): AgentMessage {
   const parsedTimestamp = item.timestamp ? Date.parse(item.timestamp) : Number.NaN;
-  const timestamp =
-    Number.isFinite(parsedTimestamp) && parsedTimestamp >= 0 ? parsedTimestamp : fallbackTimestamp;
+  const timestamp = Number.isFinite(parsedTimestamp) ? parsedTimestamp : fallbackTimestamp;
   const text = item.text?.trim() || "[Unsupported Claude transcript item]";
   if (item.type === "userMessage") {
     // Imported native rows are not OpenClaw-authored; mirrorOrigin excludes them


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adopting Claude CLI history could import a native row with a malformed timestamp, causing the nested transcript message timestamp to become `NaN` and serialize as `null`.

## Why This Change Was Made

The Anthropic history importer now accepts a native timestamp only when `Date.parse()` returns a finite value; otherwise it uses the importer's existing fallback timestamp. The change stays inside the Anthropic plugin and does not alter transcript schemas or valid native timestamps.

## User Impact

Imported Claude history retains a usable message timestamp even when one native JSONL row contains an invalid date string.

## Evidence

Tested on Linux x86_64 with Node `v24.18.0`, based on `upstream/main` `7c1c4960c1f4aab65bb7e616eb533cdcfe68f362`.

### Real behavior proof

- Before / negative control: with the finite-value fence temporarily reverted, `node scripts/run-vitest.mjs extensions/anthropic/session-catalog-history.test.ts -t 'uses the import timestamp'` failed with `expected NaN to be 1784376000000`.
- Premise: `node --input-type=module` on this machine reported `Date.parse("not-a-date") -> NaN` and `JSON.stringify({ timestamp: NaN }) -> {"timestamp":null}`.
- After: an isolated-state Node harness invoked the exported production `importClaudeHistory()` with `timestamp: "not-a-date"`, then read the persisted SQLite transcript through `readSessionTranscriptEvents()`. Command: `node --import tsx --input-type=module < /tmp/anthropic-history-proof.mjs`. Observed: `{"eventCount":2,"timestamp":1784359710659,"finite":true,"serializedNull":false}`.
- Focused regression: `node scripts/run-vitest.mjs extensions/anthropic/session-catalog-history.test.ts` — 2 tests passed after rebasing onto the stated base.
- Static checks: direct `oxfmt --check`, `oxlint`, and `git diff --check` passed for the two changed files. Package-local tsgo was not claimed because this linked worktree lacks generated `openclaw/plugin-sdk/*` self-reference declarations; PR CI covers the full type lane.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` — clean, no accepted/actionable findings.

Not tested against a live Claude CLI installation; the failure and fix occur after native history has already been parsed, at the exported importer and persisted transcript boundary.

AI-assisted: yes.
