### PR TITLE
fix(memory-core): guard invalid timestamps in dreaming rankings

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -382,6 +382,83 @@ async function readCandidateSnippets(workspaceDir: string, nowIso: string): Prom
 }
 
 describe("memory-core dreaming phases", () => {
+  it("ranks a valid duplicate ahead of an invalid dreaming timestamp", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const now = new Date("2026-04-15T12:00:00.000Z");
+    const snippet = "Use bounded retries for provider requests.";
+    const sourcePath = "memory/.dreams/session-corpus/2026-04-14.txt";
+    await fs.mkdir(path.dirname(path.join(workspaceDir, sourcePath)), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, sourcePath), `${snippet}\n`, "utf-8");
+    const entry = {
+      path: sourcePath,
+      startLine: 1,
+      endLine: 1,
+      source: "memory",
+      snippet,
+      recallCount: 1,
+      dailyCount: 0,
+      groundedCount: 0,
+      totalScore: 0.9,
+      maxScore: 0.9,
+      firstRecalledAt: "2026-04-14T12:00:00.000Z",
+      queryHashes: ["query"],
+      recallDays: ["2026-04-14"],
+      conceptTags: ["bounded", "retries"],
+    };
+    await shortTermTesting.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: now.toISOString(),
+      entries: {
+        invalid: { ...entry, key: "invalid", lastRecalledAt: "not-a-date" },
+        valid: { ...entry, key: "valid", lastRecalledAt: "2026-04-14T12:00:00.000Z" },
+      },
+    });
+    expect(
+      Object.keys(
+        (await shortTermTesting.readRecallStore(workspaceDir, now.toISOString())).entries,
+      ),
+    ).toEqual(["invalid", "valid"]);
+    const { beforeAgentReply, logger } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  timezone: "UTC",
+                  storage: { mode: "inline", separateReports: false },
+                  phases: {
+                    light: { enabled: true, limit: 1, lookbackDays: 3, dedupeSimilarity: 0.9 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      await beforeAgentReply(
+        { cleanedBody: LIGHT_SLEEP_EVENT_TEXT },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(logger.error).not.toHaveBeenCalled();
+    const phaseSignals = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      now.toISOString(),
+    );
+    expect(Object.keys(phaseSignals.entries)).toEqual(["valid"]);
+  });
+
   it("uses the hashed narrative session key for sweep-level fallback cleanup", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1456,6 +1456,20 @@ function entryAverageScore(entry: ShortTermRecallEntry): number {
   return signalCount > 0 ? Math.max(0, Math.min(1, entry.totalScore / signalCount)) : 0;
 }
 
+function parseDreamingTimestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function compareDreamingTimestampDesc(left: string, right: string): number {
+  const leftMs = parseDreamingTimestampMs(left);
+  const rightMs = parseDreamingTimestampMs(right);
+  if (leftMs === rightMs) {
+    return 0;
+  }
+  return rightMs > leftMs ? 1 : -1;
+}
+
 // Use the shared CJK-aware similarity helper so close-but-not-identical CJK
 // snippets do not slip past the dedupe threshold via the old ASCII-only path.
 function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): ShortTermRecallEntry[] {
@@ -1478,7 +1492,8 @@ function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): Shor
       ].toSorted();
       duplicate.conceptTags = uniqueStrings([...duplicate.conceptTags, ...entry.conceptTags]);
       duplicate.lastRecalledAt =
-        Date.parse(entry.lastRecalledAt) > Date.parse(duplicate.lastRecalledAt)
+        parseDreamingTimestampMs(entry.lastRecalledAt) >
+        parseDreamingTimestampMs(duplicate.lastRecalledAt)
           ? entry.lastRecalledAt
           : duplicate.lastRecalledAt;
       continue;
@@ -1718,7 +1733,7 @@ async function runLightDreaming(params: {
   });
   const rankedEntries = dedupeEntries(
     recentEntries.toSorted((a, b) => {
-      const byTime = Date.parse(b.lastRecalledAt) - Date.parse(a.lastRecalledAt);
+      const byTime = compareDreamingTimestampDesc(a.lastRecalledAt, b.lastRecalledAt);
       if (byTime !== 0) {
         return byTime;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where memory-core light dreaming could treat an invalid recall timestamp as tied with valid timestamps, preserve the wrong duplicate, and rank candidates by input order instead of recency.

## Why This Change Was Made

Dreaming ranking and owner-local duplicate merging now use the same finite-or-negative-infinity timestamp semantics already used by short-term retention. Invalid entries sort after valid entries, while recall count and existing deterministic fallbacks continue to break ties.

## User Impact

Light dreaming stages the valid, recent recall candidate when persisted recall data also contains a malformed timestamp, without changing the recall store schema or dropping entries that remain eligible through `recallDays`.

## Evidence

Tested on Linux x86_64 with Node `v24.18.0`, based on `upstream/main` `7c1c4960c1f4aab65bb7e616eb533cdcfe68f362`.

### Real behavior proof

- Before / negative control: with the timestamp parser/comparator calls temporarily reverted, `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts -t 'ranks a valid duplicate ahead of an invalid dreaming timestamp'` failed with phase signals `['invalid']` instead of `['valid']`.
- Premise: `node --input-type=module` on this machine reported `Date.parse("not-a-date") -> NaN`; a descending comparator based on subtraction kept `['invalid','valid']` because a `NaN` comparator result is treated as equality.
- After / real state path: the focused case writes two owner-valid recall entries into the real temporary SQLite plugin state, creates a real session-corpus source file, triggers production `beforeAgentReply` -> `runDreamingSweepPhases()`, and reads the persisted phase signal store. The same command passed and observed only `['valid']` staged.
- Focused regression: `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts` — 47 tests passed after rebasing onto the stated base.
- Static checks: direct `oxfmt --check`, `oxlint`, and `git diff --check` passed for the two changed files. Package-local tsgo was not claimed because this linked worktree lacks generated `openclaw/plugin-sdk/*` self-reference declarations; PR CI covers the full type lane.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

No long-running gateway or agent session was used; the proof exercises the production light-dreaming sweep with real filesystem and SQLite-backed state, not a copied comparator.

AI-assisted: yes.
