### PR TITLE
fix(linux-node): guard invalid timestamps in GeoClue output

### DIFF
--- a/extensions/linux-node/src/commands.test.ts
+++ b/extensions/linux-node/src/commands.test.ts
@@ -290,15 +290,17 @@ describe("linux-node commands", () => {
     expect(payload.timestamp).toBe("2026-07-13T12:00:05.000Z");
   });
 
-  it("keeps GeoClue running past an out-of-range timestamp", async () => {
+  it("keeps GeoClue running past invalid and pre-epoch timestamps", async () => {
     const fix = (lat: number, epochSeconds: string) =>
       `\nNew location:\nLatitude: ${lat}\nLongitude: 16\nAccuracy: 25 meters\nTimestamp: now (${epochSeconds} seconds since the Epoch)\n`;
-    const invalid = fix(47, "9".repeat(400));
+    const invalid = fix(46, "9".repeat(400));
+    const preEpoch = fix(47, "-1000000");
     const valid = fix(48, "1783944005");
     const runCommand = vi.fn(async (_argv: string[], options: CommandOptions) => {
       expect(options.onOutputChunk?.(Buffer.from(invalid), "stdout")).toBe(true);
+      expect(options.onOutputChunk?.(Buffer.from(preEpoch), "stdout")).toBe(true);
       expect(options.onOutputChunk?.(Buffer.from(valid), "stdout")).toBe(false);
-      return success(`${invalid}${valid}`);
+      return success(`${invalid}${preEpoch}${valid}`);
     });
     const { command } = createHarness({ runCommand });
 

--- a/extensions/linux-node/src/commands.test.ts
+++ b/extensions/linux-node/src/commands.test.ts
@@ -290,6 +290,26 @@ describe("linux-node commands", () => {
     expect(payload.timestamp).toBe("2026-07-13T12:00:05.000Z");
   });
 
+  it("keeps GeoClue running past an out-of-range timestamp", async () => {
+    const fix = (lat: number, epochSeconds: string) =>
+      `\nNew location:\nLatitude: ${lat}\nLongitude: 16\nAccuracy: 25 meters\nTimestamp: now (${epochSeconds} seconds since the Epoch)\n`;
+    const invalid = fix(47, "9".repeat(400));
+    const valid = fix(48, "1783944005");
+    const runCommand = vi.fn(async (_argv: string[], options: CommandOptions) => {
+      expect(options.onOutputChunk?.(Buffer.from(invalid), "stdout")).toBe(true);
+      expect(options.onOutputChunk?.(Buffer.from(valid), "stdout")).toBe(false);
+      return success(`${invalid}${valid}`);
+    });
+    const { command } = createHarness({ runCommand });
+
+    const payload = JSON.parse(
+      await command("location.get").handle(JSON.stringify({ maxAgeMs: 20_000 })),
+    ) as Record<string, unknown>;
+
+    expect(payload.lat).toBe(48);
+    expect(payload.timestamp).toBe("2026-07-13T12:00:05.000Z");
+  });
+
   it("accounts for GeoClue second precision when maxAgeMs is zero", async () => {
     const output = `\nNew location:\nLatitude: 48\nLongitude: 16\nAccuracy: 25 meters\nTimestamp: now (1783944010 seconds since the Epoch)\n`;
     const harness = createHarness({

--- a/extensions/linux-node/src/location.ts
+++ b/extensions/linux-node/src/location.ts
@@ -71,9 +71,11 @@ function parseLocationOutput(
     const altitude = /Altitude:\s*([-+\d.]+)/u.exec(block)?.[1];
     const speed = /Speed:\s*([-+\d.]+)/u.exec(block)?.[1];
     const heading = /Heading:\s*([-+\d.]+)/u.exec(block)?.[1];
-    const timestamp = epochSeconds
-      ? new Date(Number(epochSeconds) * 1000).toISOString()
-      : now().toISOString();
+    const timestampMs = epochSeconds ? Number(epochSeconds) * 1000 : now().getTime();
+    if (!Number.isFinite(timestampMs) || !Number.isFinite(new Date(timestampMs).getTime())) {
+      continue;
+    }
+    const timestamp = new Date(timestampMs).toISOString();
     if (
       maxAgeMs !== undefined &&
       now().getTime() - Date.parse(timestamp) >= maxAgeMs + GEOCLUE_TIMESTAMP_RESOLUTION_MS

--- a/extensions/linux-node/src/location.ts
+++ b/extensions/linux-node/src/location.ts
@@ -67,12 +67,16 @@ function parseLocationOutput(
     ) {
       continue;
     }
-    const epochSeconds = /\((\d+)\s+seconds since the Epoch\)/u.exec(block)?.[1];
+    const epochSeconds = /\(([-+]?\d+)\s+seconds since the Epoch\)/u.exec(block)?.[1];
     const altitude = /Altitude:\s*([-+\d.]+)/u.exec(block)?.[1];
     const speed = /Speed:\s*([-+\d.]+)/u.exec(block)?.[1];
     const heading = /Heading:\s*([-+\d.]+)/u.exec(block)?.[1];
     const timestampMs = epochSeconds ? Number(epochSeconds) * 1000 : now().getTime();
-    if (!Number.isFinite(timestampMs) || !Number.isFinite(new Date(timestampMs).getTime())) {
+    if (
+      timestampMs < 0 ||
+      !Number.isFinite(timestampMs) ||
+      !Number.isFinite(new Date(timestampMs).getTime())
+    ) {
       continue;
     }
     const timestamp = new Date(timestampMs).toISOString();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux node users requesting location could lose the entire request when GeoClue emitted an out-of-range epoch timestamp before a valid location update.

## Why This Change Was Made

The GeoClue parser now verifies that epoch milliseconds are finite and representable by JavaScript `Date` before ISO serialization. An invalid block is skipped using the parser's existing bad-block behavior; valid timestamps and the no-epoch current-time fallback are unchanged.

## User Impact

`location.get` can continue reading GeoClue output and return a later valid fix instead of failing with `RangeError: Invalid time value`.

## Evidence

Tested on Linux x86_64 with Node `v24.18.0`, based on `upstream/main` `7c1c4960c1f4aab65bb7e616eb533cdcfe68f362`.

### Real behavior proof

- Before / negative control: with the Date-valid guard temporarily reverted, `node scripts/run-vitest.mjs extensions/linux-node/src/commands.test.ts -t 'keeps GeoClue running past an out-of-range timestamp'` failed in production `parseLocationOutput()` with `RangeError: Invalid time value` at `toISOString()`.
- Premise: `node --input-type=module` on this machine confirmed `new Date(1e308 * 1000).toISOString()` throws `RangeError: Invalid time value`.
- After: a Node harness directly invoked exported production `createLinuxLocationCommand()`, feeding an invalid GeoClue block followed by a valid block through the command's stdout callback. Command: `node --import tsx --input-type=module < /tmp/linux-geoclue-timestamp-proof.mjs`. Observed callback state `{"invalidContinues":true,"validStops":false}` and final result `{"lat":48,"lon":16,"accuracyMeters":25,"timestamp":"2026-07-13T12:00:05.000Z","isPrecise":true,"source":"unknown"}`.
- Focused regression: `node scripts/run-vitest.mjs extensions/linux-node/src/commands.test.ts` — 14 tests passed after rebasing onto the stated base.
- Static checks: direct `oxfmt --check`, `oxlint`, and `git diff --check` passed for the two changed files. Full type checking is left to PR CI because the linked worktree intentionally does not rebuild shared generated SDK declarations.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

No live GeoClue service or location permission was used; this validates the supported production command/parser path with real streamed stdout bytes, including its continue/stop decisions.

AI-assisted: yes.
