### PR TITLE
fix(scripts): keep hosted-gate run queries under the gh relay response cap

### DIFF
--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -17,7 +17,10 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
   "Blacksmith ARM Testbox",
   "Workflow Sanity",
 ];
-const WORKFLOW_RUNS_PAGE_SIZE = 100;
+// Full workflow-run objects are large enough for a 100-row response to exceed
+// the Octopool relay cap on busy SHAs. Keep each REST page bounded and retain
+// the existing 1,000-result search window through pagination.
+const WORKFLOW_RUNS_PAGE_SIZE = 30;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
 const COMPARE_COMMITS_PAGE_SIZE = 100;
 export const HOSTED_GATE_MAX_AGE_HOURS = 24;
@@ -333,7 +336,7 @@ export function parseWorkflowRunPage(raw) {
 export function workflowRunPageCount(totalCount) {
   return Math.min(
     Math.ceil(totalCount / WORKFLOW_RUNS_PAGE_SIZE),
-    MAX_WORKFLOW_RUN_SEARCH_RESULTS / WORKFLOW_RUNS_PAGE_SIZE,
+    Math.ceil(MAX_WORKFLOW_RUN_SEARCH_RESULTS / WORKFLOW_RUNS_PAGE_SIZE),
   );
 }
 

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -925,8 +925,8 @@ describe("verify-pr-hosted-gates", () => {
         recentSha: previousSha,
       }),
     ).toEqual([
-      `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=100&page=1`,
-      `repos/openclaw/openclaw/actions/runs?head_sha=${previousSha}&per_page=100&page=1`,
+      `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=30&page=1`,
+      `repos/openclaw/openclaw/actions/runs?head_sha=${previousSha}&per_page=30&page=1`,
     ]);
     expect(HOSTED_GATE_MAX_AGE_HOURS).toBe(24);
   });
@@ -939,14 +939,17 @@ describe("verify-pr-hosted-gates", () => {
         headBranch: "codex/relax hosted gates",
       }),
     ).toEqual([
-      `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=100&page=1`,
-      "repos/openclaw/openclaw/actions/runs?branch=codex%2Frelax%20hosted%20gates&event=pull_request&per_page=100&page=1",
+      `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=30&page=1`,
+      "repos/openclaw/openclaw/actions/runs?branch=codex%2Frelax%20hosted%20gates&event=pull_request&per_page=30&page=1",
     ]);
   });
 
-  it("bounds workflow-run pagination to GitHub's search result limit", () => {
+  it("uses relay-safe pages and bounds pagination to GitHub's search result limit", () => {
     expect(workflowRunPageCount(0)).toBe(0);
-    expect(workflowRunPageCount(101)).toBe(2);
-    expect(workflowRunPageCount(10_000)).toBe(10);
+    expect(workflowRunPageCount(101)).toBe(4);
+    expect(workflowRunPageCount(10_000)).toBe(34);
+    expect(workflowRunQueryPaths("openclaw/openclaw", { sha, recentSha: "" }, 34)).toEqual([
+      `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=30&page=34`,
+    ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`scripts/pr prepare-run` fetches workflow runs for a SHA with `per_page=100`. Full run objects are large enough that on busy main SHAs (~800+ runs) the Octopool gh relay rejects the response with `github_response_too_large: GitHub response exceeded relay cap`, blocking agent landings (hit twice during the #110487 landing; required a manual PATH workaround to a non-relayed gh).

## Why This Change Was Made

Bound each REST page at 30 rows (with a comment explaining the relay constraint) while preserving the existing 1,000-result search window through the pagination the script already had. Also fixes a latent rounding bug: the page-count cap used integer division, which with non-divisible page sizes would have dropped the final partial page; it now ceils.

## User Impact

Agent tooling only: `scripts/pr` hosted-gate verification works through the relay-backed gh on busy SHAs without workarounds.

## Evidence

- Baseline repro: the exact failing query against main SHA cad4e395 hit the relay cap at per_page=100; the fixed path returned 693 rows across 24 pages with zero relay errors, and a real `verify-pr-hosted-gates` invocation for PR #110496 produced the same exact-head decision.
- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts`: 46 passed (new coverage for the page-size query and the final capped partial page).
- Structured Codex autoreview: clean, patch-correct 0.98. `git diff --check` clean.
