### PR TITLE
fix(agents): prefer ordered eligible credentials in discovery map

### DIFF
--- a/src/agents/agent-auth-credentials.ts
+++ b/src/agents/agent-auth-credentials.ts
@@ -2,8 +2,10 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles.js";
+import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 
 // Converts auth-profile credentials into the compact credential map consumed by
 // agent runtimes. Secret refs can be represented by markers without reading
@@ -22,6 +24,10 @@ export type AgentCredentialMap = Record<string, AgentCredential>;
 
 type ResolveAgentCredentialMapOptions = {
   includeSecretRefPlaceholders?: boolean;
+  /** Optional config so discovery can honor `auth.order` / auth.profiles. */
+  config?: OpenClawConfig;
+  /** Session or caller preferred profile id for providers that match it. */
+  preferredProfile?: string;
 };
 
 const AGENT_SECRET_REF_CONFIGURED_MARKER = "openclaw-secret-ref-configured";
@@ -71,7 +77,9 @@ function convertAuthProfileCredentialToAgent(
     const access = normalizeOptionalString(cred.access) ?? "";
     const refresh = normalizeOptionalString(cred.refresh) ?? "";
     const expires = asDateTimestampMs(cred.expires);
-    if (!access || !refresh || expires === undefined || expires <= 0) {
+    // Reject expired OAuth the same way tokens are rejected so discovery cannot
+    // surface a dead access token as a usable provider credential.
+    if (!access || !refresh || expires === undefined || Date.now() >= expires) {
       return null;
     }
     return {
@@ -85,20 +93,47 @@ function convertAuthProfileCredentialToAgent(
   return null;
 }
 
+function listProvidersInStore(store: AuthProfileStore): string[] {
+  const providers = new Set<string>();
+  for (const credential of Object.values(store.profiles)) {
+    const provider = normalizeProviderId(credential.provider ?? "");
+    if (provider) {
+      providers.add(provider);
+    }
+  }
+  // Deterministic map key order for stable discovery payloads / prompt cache.
+  return [...providers].toSorted();
+}
+
 /** Build one credential per normalized provider from an auth profile store. */
 export function resolveAgentCredentialMapFromStore(
   store: AuthProfileStore,
   options?: ResolveAgentCredentialMapOptions,
 ): AgentCredentialMap {
   const credentials: AgentCredentialMap = {};
-  for (const credential of Object.values(store.profiles)) {
-    const provider = normalizeProviderId(credential.provider ?? "");
-    if (!provider || credentials[provider]) {
-      continue;
-    }
-    const converted = convertAuthProfileCredentialToAgent(credential, options);
-    if (converted) {
-      credentials[provider] = converted;
+  const readinessMode = options?.includeSecretRefPlaceholders === true ? "read-only" : "execution";
+
+  // Prefer the canonical auth-profile order (auth.order, OAuth-over-api_key,
+  // eligibility) instead of raw store insertion order. First convertible
+  // profile in that order wins for each provider.
+  for (const provider of listProvidersInStore(store)) {
+    const profileIds = resolveAuthProfileOrder({
+      store,
+      provider,
+      cfg: options?.config,
+      preferredProfile: options?.preferredProfile,
+      readinessMode,
+    });
+    for (const profileId of profileIds) {
+      const credential = store.profiles[profileId];
+      if (!credential) {
+        continue;
+      }
+      const converted = convertAuthProfileCredentialToAgent(credential, options);
+      if (converted) {
+        credentials[provider] = converted;
+        break;
+      }
     }
   }
   return credentials;

--- a/src/agents/agent-auth-discovery.ts
+++ b/src/agents/agent-auth-discovery.ts
@@ -52,6 +52,9 @@ export function resolveAgentCredentialsForDiscovery(
   const credentials = addEnvBackedAgentCredentials(
     resolveAgentCredentialMapFromStore(store, {
       includeSecretRefPlaceholders: options?.readOnly === true,
+      // Pass config so discovery uses the same auth.order / profile ranking as
+      // interactive resolution instead of raw store insertion order.
+      ...(options?.config ? { config: options.config } : {}),
     }),
     {
       config: options?.config,

--- a/src/agents/agent-model-discovery.auth.test.ts
+++ b/src/agents/agent-model-discovery.auth.test.ts
@@ -130,6 +130,94 @@ describe("discoverAuthStorage", () => {
     expect(credentials.openai).toBeUndefined();
   });
 
+  it("prefers OAuth over an earlier same-provider api_key in store insertion order", () => {
+    // Background discovery used to keep the first convertible profile in raw
+    // store order, which broke ChatGPT-mode paths when api_key preceded OAuth.
+    const credentials = resolveAgentCredentialMapFromStore({
+      version: 1,
+      profiles: {
+        "openai:api-first": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-api-first",
+        },
+        "openai:oauth-second": {
+          type: "oauth",
+          provider: "openai",
+          access: "oauth-access",
+          refresh: "oauth-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    expect(credentials.openai).toEqual({
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "oauth-refresh",
+      expires: expect.any(Number),
+    });
+  });
+
+  it("honors auth.order when selecting one discovery credential per provider", () => {
+    const credentials = resolveAgentCredentialMapFromStore(
+      {
+        version: 1,
+        profiles: {
+          "openai:a": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-order-a",
+          },
+          "openai:b": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-order-b",
+          },
+        },
+      },
+      {
+        config: {
+          auth: {
+            order: {
+              openai: ["openai:b", "openai:a"],
+            },
+          },
+        } as never,
+      },
+    );
+
+    expect(credentials.openai).toEqual({
+      type: "api_key",
+      key: "sk-order-b",
+    });
+  });
+
+  it("skips expired OAuth and falls through to a later same-provider credential", () => {
+    const credentials = resolveAgentCredentialMapFromStore({
+      version: 1,
+      profiles: {
+        "openai:expired-oauth": {
+          type: "oauth",
+          provider: "openai",
+          access: "oauth-expired-access",
+          refresh: "oauth-refresh",
+          expires: Date.now() - 1_000,
+        },
+        "openai:api-fallback": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-api-fallback",
+        },
+      },
+    });
+
+    expect(credentials.openai).toEqual({
+      type: "api_key",
+      key: "sk-api-fallback",
+    });
+  });
+
   it("keeps keyRef and tokenRef profiles visible only for read-only agent discovery", () => {
     const credentials = resolveAgentCredentialMapFromStore({
       version: 1,

--- a/src/agents/agent-model-discovery.auth.test.ts
+++ b/src/agents/agent-model-discovery.auth.test.ts
@@ -267,9 +267,67 @@ describe("discoverAuthStorage", () => {
 
     expect(credentials.openrouter).toBeUndefined();
     expect(credentials.anthropic).toBeUndefined();
-    expect(discoveryCredentials.openrouter?.type).toBe("api_key");
-    expect(discoveryCredentials.anthropic?.type).toBe("api_key");
+    // Read-only discovery must keep configured SecretRef markers, not drop the
+    // provider when resolveAuthProfileOrder runs in readinessMode "read-only".
+    expect(discoveryCredentials.openrouter).toEqual({
+      type: "api_key",
+      key: "openclaw-secret-ref-configured",
+    });
+    expect(discoveryCredentials.anthropic).toEqual({
+      type: "api_key",
+      key: "openclaw-secret-ref-configured",
+    });
     expect(discoveryCredentials.expired).toBeUndefined();
+  });
+
+  it("keeps keyRef-only profiles through ordered read-only discovery", () => {
+    // Regression for SecretRef-backed providers: ordering must not filter
+    // unresolved_ref profiles when discovery requests placeholders.
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai:ref-only": {
+          type: "api_key" as const,
+          provider: "openai",
+          keyRef: { source: "env" as const, provider: "default", id: "OPENAI_API_KEY" },
+        },
+        "openai:literal-second": {
+          type: "api_key" as const,
+          provider: "openai",
+          key: "sk-literal-fallback",
+        },
+      },
+    };
+    const executionMap = resolveAgentCredentialMapFromStore(store, {
+      config: {
+        auth: {
+          order: {
+            openai: ["openai:ref-only", "openai:literal-second"],
+          },
+        },
+      } as never,
+    });
+    const readOnlyMap = resolveAgentCredentialMapFromStore(store, {
+      includeSecretRefPlaceholders: true,
+      config: {
+        auth: {
+          order: {
+            openai: ["openai:ref-only", "openai:literal-second"],
+          },
+        },
+      } as never,
+    });
+
+    // Execution mode cannot resolve the SecretRef, so it falls through.
+    expect(executionMap.openai).toEqual({
+      type: "api_key",
+      key: "sk-literal-fallback",
+    });
+    // Read-only discovery keeps the ordered keyRef profile as the configured marker.
+    expect(readOnlyMap.openai).toEqual({
+      type: "api_key",
+      key: "openclaw-secret-ref-configured",
+    });
   });
 
   it("marks keyRef-only auth profiles configured for read-only model discovery", async () => {


### PR DESCRIPTION
Fixes #110488

## What Problem This Solves

Fixes an issue where automatic/background credential discovery would pick the first same-provider auth profile in raw store insertion order, ignoring `auth.order`, OAuth-over-api_key preference, and OAuth expiry. That caused ChatGPT-mode background paths (for example automatic compaction) to fail with unusable credentials while the same session still worked through profile-aware interactive resolution.

## Why This Change Was Made

Background discovery now builds its one-credential-per-provider map through the same canonical `resolveAuthProfileOrder` ranking used for interactive profile selection, and OAuth conversion rejects expired access tokens the same way tokens already do. Discovery still does not prompt for secrets or persist resolved credentials; session-specific `authProfileOverride` plumbing for every background caller remains a follow-up if needed beyond global ordering.

Compatibility: no config/schema changes; reuses existing order/eligibility helpers. Performance: one order resolve per provider present in the store. Usability: automatic paths fail less often when a usable OAuth profile exists after an earlier api_key. Security: expired OAuth is no longer surfaced as a usable discovery credential.

## User Impact

Automatic compaction and other non-interactive model calls for a provider should select the same preferred eligible credential as interactive resolution when profiles are ordered by type or `auth.order`, instead of silently binding the first raw store entry.

## Evidence

Verification host: local macOS (focused Vitest; isolated state dir for discovery runtime proof).

```text
$ node scripts/run-vitest.mjs src/agents/agent-model-discovery.auth.test.ts
 ✓ |agents| src/agents/agent-model-discovery.auth.test.ts (10 tests)
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Coverage includes: OAuth preferred over earlier same-provider api_key; `auth.order` honored; expired OAuth skipped with fallthrough; configured SecretRef markers kept under ordered read-only discovery (`openclaw-secret-ref-configured`); keyRef-only providers visible to `discoverAuthStorage({ readOnly: true })` and omitted at runtime.

## Real behavior proof

- Behavior addressed: provider-level discovery map prefers ordered eligible credentials (OAuth / `auth.order`) over raw store insertion order; expired OAuth is not converted as usable; read-only discovery keeps configured SecretRef markers after routing through `resolveAuthProfileOrder` with `readinessMode: "read-only"`.
- Environment: local macOS + openclaw checkout at PR head `fbd95eaf28`; focused Vitest agents lane; isolated `OPENCLAW_STATE_DIR` for a real `discoverAuthStorage` path against a temporary agent SQLite auth store (no live cloud secrets).
- Current-main contrast: with api_key inserted before OAuth for the same provider, the discovery map kept the api_key; expired OAuth with `expires > 0` still converted; this patch orders via the shared resolver and rejects expired OAuth.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/agent-model-discovery.auth.test.ts` (10/10 pass), including SecretRef marker + ordered keyRef-only cases.
  2. Runtime discovery proof (redacted): temporary agent dir with SQLite auth profiles — openai api_key first + later OAuth, plus `fixture-ref` keyRef-only profile; call `resolveAgentCredentialMapFromStore` and `discoverAuthStorage` with/without `readOnly: true`.
- Evidence after fix (redacted runtime output at head `fbd95eaf28`):

```json
{
  "head": "fbd95eaf28",
  "orderedDiscoveryMap": {
    "fixture-ref": { "type": "api_key", "key": "openclaw-secret-ref-configured" },
    "openai": { "type": "oauth", "access": "oauth-access-REDACTED", "refresh": "oauth-refresh-REDACTED" }
  },
  "executionMap": {
    "openai": { "type": "oauth", "access": "oauth-access-REDACTED", "refresh": "oauth-refresh-REDACTED" }
  },
  "readOnlyHasAuth": { "openai": true, "fixture-ref": true },
  "runtimeHasAuth": { "openai": true, "fixture-ref": false }
}
```

- Control check: SecretRef-only providers stay visible only for read-only discovery; runtime discovery does not claim auth for unresolved SecretRefs; OAuth still wins over an earlier api_key for the same provider.
- Observed result after fix: discovery map returns OAuth when it ranks above api_key; returns order-selected credentials when configured; returns the configured SecretRef marker for keyRef-only profiles under read-only discovery; runtime omit of SecretRef-only providers is unchanged.
- What was not tested: live ChatGPT-mode compaction against a real OpenAI OAuth account; session `authProfileOverride` threading through every background caller.


---

This PR was authored with AI assistance (Grok).

