### PR TITLE
fix(meetings): wait for audio bridge cleanup

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -845,10 +845,23 @@ type TestBridgeProcess = {
   stdout?: PassThrough | null;
   stderr: PassThrough;
   killed: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
   kill: ReturnType<typeof vi.fn>;
   on: EventEmitter["on"];
   emit: EventEmitter["emit"];
 };
+
+function installTestBridgeKill(proc: TestBridgeProcess): void {
+  proc.killed = false;
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.kill = vi.fn((signal?: NodeJS.Signals) => {
+    proc.killed = true;
+    proc.signalCode = signal ?? "SIGTERM";
+    return true;
+  });
+}
 
 describe("google-meet plugin", () => {
   beforeEach(() => {
@@ -7274,11 +7287,7 @@ describe("google-meet plugin", () => {
       proc.stdin = stdio.stdin;
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
-      proc.killed = false;
-      proc.kill = vi.fn(() => {
-        proc.killed = true;
-        return true;
-      });
+      installTestBridgeKill(proc);
       return proc;
     };
     const outputStdin = new Writable({
@@ -7521,11 +7530,7 @@ describe("google-meet plugin", () => {
       proc.stdin = stdio.stdin;
       proc.stdout = stdio.stdout;
       proc.stderr = stdio.stderr;
-      proc.killed = false;
-      proc.kill = vi.fn(() => {
-        proc.killed = true;
-        return true;
-      });
+      installTestBridgeKill(proc);
       return proc;
     };
     const outputStdin = new Writable({
@@ -7650,11 +7655,7 @@ describe("google-meet plugin", () => {
       proc.stdin = stdio.stdin;
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
-      proc.killed = false;
-      proc.kill = vi.fn(() => {
-        proc.killed = true;
-        return true;
-      });
+      installTestBridgeKill(proc);
       return proc;
     };
     const outputStdin = new Writable({
@@ -7872,11 +7873,7 @@ describe("google-meet plugin", () => {
       proc.stdin = stdio.stdin;
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
-      proc.killed = false;
-      proc.kill = vi.fn(() => {
-        proc.killed = true;
-        return true;
-      });
+      installTestBridgeKill(proc);
       return proc;
     };
     const outputProcess = makeProcess({
@@ -7953,11 +7950,7 @@ describe("google-meet plugin", () => {
         proc.stdin = stdio.stdin;
         proc.stdout = stdio.stdout;
         proc.stderr = new PassThrough();
-        proc.killed = false;
-        proc.kill = vi.fn(() => {
-          proc.killed = true;
-          return true;
-        });
+        installTestBridgeKill(proc);
         return proc;
       };
       const outputProcess = makeProcess({
@@ -8169,11 +8162,7 @@ describe("google-meet plugin", () => {
       proc.stdin = stdio.stdin;
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
-      proc.killed = false;
-      proc.kill = vi.fn(() => {
-        proc.killed = true;
-        return true;
-      });
+      installTestBridgeKill(proc);
       return proc;
     };
     const outputProcess = makeProcess({ stdin: outputStdin, stdout: null });

--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 type MockChild = EventEmitter & {
   exitCode: number | null;
   signalCode: NodeJS.Signals | null;
+  ignoreSigterm: boolean;
   kill: ReturnType<typeof vi.fn>;
   stdout?: EventEmitter;
   stderr?: EventEmitter;
@@ -28,14 +29,23 @@ vi.mock("node:child_process", async (importOriginal) => {
       const child = Object.assign(new EventEmitter(), {
         exitCode: null,
         signalCode: null,
-        kill: vi.fn((signal?: NodeJS.Signals) => {
-          child.signalCode = signal ?? "SIGTERM";
-          return true;
-        }),
+        ignoreSigterm: false,
+        kill: vi.fn(),
         stdout: new EventEmitter(),
         stderr: new EventEmitter(),
         stdin: Object.assign(new EventEmitter(), { write: vi.fn() }),
       }) as MockChild;
+      child.kill.mockImplementation((signal?: NodeJS.Signals) => {
+        const resolvedSignal = signal ?? "SIGTERM";
+        if (resolvedSignal === "SIGTERM" && child.ignoreSigterm) {
+          return true;
+        }
+        queueMicrotask(() => {
+          child.signalCode = resolvedSignal;
+          child.emit("exit", null, resolvedSignal);
+        });
+        return true;
+      });
       children.push(child);
       return child;
     }),
@@ -228,6 +238,54 @@ describe("google-meet node host bridge sessions", () => {
     }
   });
 
+  it("waits for cleared SIGTERM-resistant output before acknowledging stop", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.useFakeTimers();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const start = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "realtime",
+            launch: false,
+            audioInputCommand: ["mock-rec"],
+            audioOutputCommand: ["mock-play"],
+          }),
+        ),
+      );
+      const [retiredOutput] = children;
+      if (!retiredOutput) {
+        throw new Error("expected Google Meet node host output process");
+      }
+      retiredOutput.ignoreSigterm = true;
+
+      await handleGoogleMeetNodeHostCommand(
+        JSON.stringify({ action: "clearAudio", bridgeId: start.bridgeId }),
+      );
+      let settled = false;
+      const stopPromise = handleGoogleMeetNodeHostCommand(
+        JSON.stringify({ action: "stop", bridgeId: start.bridgeId }),
+      ).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(settled).toBe(false);
+      expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"]]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(retiredOutput.signalCode).toBe("SIGKILL");
+      expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
   it("closes once when command-pair streams fail together", async () => {
     const originalPlatform = process.platform;
     children.length = 0;
@@ -265,6 +323,106 @@ describe("google-meet node host bridge sessions", () => {
       expect(inputProcess.kill).toHaveBeenCalledTimes(1);
       expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
       expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("waits for SIGTERM-resistant command-pair processes before acknowledging stop", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.useFakeTimers();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const start = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "realtime",
+            launch: false,
+            audioInputCommand: ["mock-rec"],
+            audioOutputCommand: ["mock-play"],
+          }),
+        ),
+      );
+      const [outputProcess, inputProcess] = children;
+      if (!outputProcess || !inputProcess) {
+        throw new Error("expected Google Meet node host command-pair processes");
+      }
+      outputProcess.ignoreSigterm = true;
+      inputProcess.ignoreSigterm = true;
+      let settled = false;
+      const stopPromise = handleGoogleMeetNodeHostCommand(
+        JSON.stringify({ action: "stop", bridgeId: start.bridgeId }),
+      ).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(settled).toBe(false);
+      expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(outputProcess.signalCode).toBe("SIGKILL");
+      expect(inputProcess.signalCode).toBe("SIGKILL");
+      expect(outputProcess.kill).toHaveBeenCalledWith("SIGKILL");
+      expect(inputProcess.kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("shares SIGTERM-resistant cleanup across concurrent stopByUrl calls", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.useFakeTimers();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      await handleGoogleMeetNodeHostCommand(
+        JSON.stringify({
+          action: "start",
+          url: "https://meet.google.com/xyz-abcd-uvw",
+          mode: "realtime",
+          launch: false,
+          audioInputCommand: ["mock-rec"],
+          audioOutputCommand: ["mock-play"],
+        }),
+      );
+      const [outputProcess, inputProcess] = children;
+      if (!outputProcess || !inputProcess) {
+        throw new Error("expected Google Meet node host command-pair processes");
+      }
+      outputProcess.ignoreSigterm = true;
+      inputProcess.ignoreSigterm = true;
+      let firstSettled = false;
+      let secondSettled = false;
+      const stopParams = JSON.stringify({
+        action: "stopByUrl",
+        url: "https://meet.google.com/xyz-abcd-uvw",
+        mode: "realtime",
+      });
+      const firstStop = handleGoogleMeetNodeHostCommand(stopParams).finally(() => {
+        firstSettled = true;
+      });
+      const secondStop = handleGoogleMeetNodeHostCommand(stopParams).finally(() => {
+        secondSettled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(firstSettled).toBe(false);
+      expect(secondSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const [firstResult, secondResult] = await Promise.all([firstStop, secondStop]);
+      expect(JSON.parse(firstResult)).toEqual({ ok: true, stopped: 1 });
+      expect(JSON.parse(secondResult)).toEqual({ ok: true, stopped: 0 });
+      expect(outputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+      expect(inputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
     } finally {
       Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
     }
@@ -314,7 +472,10 @@ describe("google-meet node host bridge sessions", () => {
       expect(activeList.bridges[0]?.url).toBe("https://meet.google.com/abc-defg-hij?authuser=1");
       expect(typeof activeList.bridges[0]?.createdAt).toBe("string");
 
-      children[1]?.emit("exit", 0, null);
+      if (children[1]) {
+        children[1].exitCode = 0;
+        children[1].emit("exit", 0, null);
+      }
 
       const afterExitList = JSON.parse(
         await handleGoogleMeetNodeHostCommand(

--- a/extensions/google-meet/src/realtime.process.test.ts
+++ b/extensions/google-meet/src/realtime.process.test.ts
@@ -52,6 +52,26 @@ function writeBridgeCommand(): string {
   return scriptPath;
 }
 
+function writeSigtermResistantBridgeCommand(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-resistant-bridge-"));
+  tempDirs.push(dir);
+  const scriptPath = path.join(dir, "bridge-command.mjs");
+  writeFileSync(
+    scriptPath,
+    [
+      "process.on('SIGTERM', () => {",
+      "  process.stderr.write('sigterm\\n');",
+      "});",
+      "process.stdin.resume();",
+      "setTimeout(() => process.stderr.write(`ready:${process.argv[2]}\\n`), 50);",
+      "setInterval(() => {}, 1000);",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return scriptPath;
+}
+
 function makeRecordingSpawn(): MeetRealtimeAudioSpawn {
   return (command, args, options) => {
     const child = spawnChildProcess(command, args, options);
@@ -378,6 +398,47 @@ describe("local Meet realtime transport process stream errors", () => {
         inputProcess.pid ?? "unknown"
       } outputPid=${outputProcess.pid ?? "unknown"}`,
     );
+  });
+
+  it("waits for SIGTERM-resistant bridge processes and shares the stop promise", async () => {
+    const bridgeScript = writeSigtermResistantBridgeCommand();
+    const transport = createLocalMeetingRealtimeAudioTransport({
+      inputCommand: [process.execPath, bridgeScript, "capture"],
+      outputCommand: [process.execPath, bridgeScript, "play"],
+      bargeInRmsThreshold: 10,
+      bargeInPeakThreshold: 10,
+      bargeInCooldownMs: 1,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logScope: "[google-meet]",
+      spawn: makeRecordingSpawn(),
+    });
+    const [outputProcess, inputProcess] = spawnedChildren;
+    if (!inputProcess || !outputProcess || !inputProcess.stderr || !outputProcess.stderr) {
+      throw new Error("Expected Google Meet bridge to spawn stderr-backed child processes");
+    }
+    await Promise.all([once(inputProcess.stderr, "data"), once(outputProcess.stderr, "data")]);
+    const originalInputKill = inputProcess.kill.bind(inputProcess);
+    const originalOutputKill = outputProcess.kill.bind(outputProcess);
+    const inputKillSpy = vi
+      .spyOn(inputProcess, "kill")
+      .mockImplementation((signal) => originalInputKill(signal));
+    const outputKillSpy = vi
+      .spyOn(outputProcess, "kill")
+      .mockImplementation((signal) => originalOutputKill(signal));
+
+    const startedAt = Date.now();
+    const firstStop = transport.stop();
+    const secondStop = transport.stop();
+
+    expect(secondStop).toBe(firstStop);
+    await firstStop;
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(900);
+    expect(elapsedMs).toBeLessThan(5_000);
+    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
+    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
   });
 });
 

--- a/extensions/google-meet/src/realtime.process.test.ts
+++ b/extensions/google-meet/src/realtime.process.test.ts
@@ -400,46 +400,49 @@ describe("local Meet realtime transport process stream errors", () => {
     );
   });
 
-  it("waits for SIGTERM-resistant bridge processes and shares the stop promise", async () => {
-    const bridgeScript = writeSigtermResistantBridgeCommand();
-    const transport = createLocalMeetingRealtimeAudioTransport({
-      inputCommand: [process.execPath, bridgeScript, "capture"],
-      outputCommand: [process.execPath, bridgeScript, "play"],
-      bargeInRmsThreshold: 10,
-      bargeInPeakThreshold: 10,
-      bargeInCooldownMs: 1,
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logScope: "[google-meet]",
-      spawn: makeRecordingSpawn(),
-    });
-    const [outputProcess, inputProcess] = spawnedChildren;
-    if (!inputProcess || !outputProcess || !inputProcess.stderr || !outputProcess.stderr) {
-      throw new Error("Expected Google Meet bridge to spawn stderr-backed child processes");
-    }
-    await Promise.all([once(inputProcess.stderr, "data"), once(outputProcess.stderr, "data")]);
-    const originalInputKill = inputProcess.kill.bind(inputProcess);
-    const originalOutputKill = outputProcess.kill.bind(outputProcess);
-    const inputKillSpy = vi
-      .spyOn(inputProcess, "kill")
-      .mockImplementation((signal) => originalInputKill(signal));
-    const outputKillSpy = vi
-      .spyOn(outputProcess, "kill")
-      .mockImplementation((signal) => originalOutputKill(signal));
+  it.skipIf(process.platform === "win32")(
+    "waits for SIGTERM-resistant bridge processes and shares the stop promise",
+    async () => {
+      const bridgeScript = writeSigtermResistantBridgeCommand();
+      const transport = createLocalMeetingRealtimeAudioTransport({
+        inputCommand: [process.execPath, bridgeScript, "capture"],
+        outputCommand: [process.execPath, bridgeScript, "play"],
+        bargeInRmsThreshold: 10,
+        bargeInPeakThreshold: 10,
+        bargeInCooldownMs: 1,
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        logScope: "[google-meet]",
+        spawn: makeRecordingSpawn(),
+      });
+      const [outputProcess, inputProcess] = spawnedChildren;
+      if (!inputProcess || !outputProcess || !inputProcess.stderr || !outputProcess.stderr) {
+        throw new Error("Expected Google Meet bridge to spawn stderr-backed child processes");
+      }
+      await Promise.all([once(inputProcess.stderr, "data"), once(outputProcess.stderr, "data")]);
+      const originalInputKill = inputProcess.kill.bind(inputProcess);
+      const originalOutputKill = outputProcess.kill.bind(outputProcess);
+      const inputKillSpy = vi
+        .spyOn(inputProcess, "kill")
+        .mockImplementation((signal) => originalInputKill(signal));
+      const outputKillSpy = vi
+        .spyOn(outputProcess, "kill")
+        .mockImplementation((signal) => originalOutputKill(signal));
 
-    const startedAt = Date.now();
-    const firstStop = transport.stop();
-    const secondStop = transport.stop();
+      const startedAt = Date.now();
+      const firstStop = transport.stop();
+      const secondStop = transport.stop();
 
-    expect(secondStop).toBe(firstStop);
-    await firstStop;
-    const elapsedMs = Date.now() - startedAt;
-    expect(elapsedMs).toBeGreaterThanOrEqual(900);
-    expect(elapsedMs).toBeLessThan(5_000);
-    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
-    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
-    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
-    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
-  });
+      expect(secondStop).toBe(firstStop);
+      await firstStop;
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeGreaterThanOrEqual(900);
+      expect(elapsedMs).toBeLessThan(5_000);
+      expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+      expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
+      expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+      expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
+    },
+  );
 });
 
 describe("Google Meet bidi realtime engine cleanup", () => {

--- a/src/meeting-bot/bridge-process.ts
+++ b/src/meeting-bot/bridge-process.ts
@@ -1,0 +1,82 @@
+type MeetingBridgeProcess = {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  once(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+  off(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+};
+
+type TerminateMeetingBridgeProcessOptions = {
+  graceMs: number;
+  forceKillWaitMs?: number;
+  initialSignal?: NodeJS.Signals;
+};
+
+function hasExited(proc: MeetingBridgeProcess): boolean {
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
+
+function waitForExit(proc: MeetingBridgeProcess, timeoutMs: number): Promise<boolean> {
+  if (hasExited(proc)) {
+    return Promise.resolve(true);
+  }
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      proc.off("exit", onExit);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    const timeout = setTimeout(() => finish(hasExited(proc)), timeoutMs);
+    timeout.unref?.();
+    proc.once("exit", onExit);
+    if (hasExited(proc)) {
+      finish(true);
+    }
+  });
+}
+
+/** Settles after the bridge exits or the bounded force-kill sequence finishes. */
+export async function terminateMeetingBridgeProcess(
+  proc: MeetingBridgeProcess | undefined,
+  options: TerminateMeetingBridgeProcessOptions,
+): Promise<void> {
+  if (!proc || hasExited(proc)) {
+    return;
+  }
+  const initialSignal = options.initialSignal ?? "SIGTERM";
+  try {
+    if (!proc.kill(initialSignal)) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  const forceKillWaitMs = options.forceKillWaitMs ?? 1_000;
+  if (initialSignal === "SIGKILL") {
+    await waitForExit(proc, forceKillWaitMs);
+    return;
+  }
+  if (await waitForExit(proc, options.graceMs)) {
+    return;
+  }
+  try {
+    if (!proc.kill("SIGKILL")) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  await waitForExit(proc, forceKillWaitMs);
+}

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -1,6 +1,9 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { terminateMeetingBridgeProcess } from "./bridge-process.js";
 import { MeetingNodeAudioPullWaiters } from "./node-audio-pull-waiters.js";
+
+const NODE_BRIDGE_TERMINATION_GRACE_MS = 2_000;
 
 type NodeBridgeSession = {
   id: string;
@@ -20,6 +23,8 @@ type NodeBridgeSession = {
   lastOutputBytes: number;
   closedAt?: string;
   clearCount: number;
+  stopPromise?: Promise<void>;
+  retiredOutputStops: Set<Promise<void>>;
 };
 
 export type MeetingNodeHostOptions = {
@@ -91,32 +96,6 @@ function splitCommand(argv: string[]): { command: string; args: string[] } {
   return { command, args };
 }
 
-function terminateChild(child?: ChildProcess) {
-  if (!child) {
-    return;
-  }
-  let exited = child.exitCode !== null || child.signalCode !== null;
-  child.once?.("exit", () => {
-    exited = true;
-  });
-  try {
-    child.kill("SIGTERM");
-  } catch {
-    // Best-effort cleanup for node-host child processes.
-  }
-  const timer = setTimeout(() => {
-    if (exited) {
-      return;
-    }
-    try {
-      child.kill("SIGKILL");
-    } catch {
-      // Process may have exited after the grace check.
-    }
-  }, 2_000);
-  timer.unref?.();
-}
-
 export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
   handleCommand(paramsJSON?: string | null): Promise<string>;
 } {
@@ -126,23 +105,41 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     session.waiters.wake();
   };
 
-  const stopSession = (session: NodeBridgeSession) => {
+  const retireOutputProcess = (session: NodeBridgeSession, outputProcess?: ChildProcess) => {
+    const stopPromise = terminateMeetingBridgeProcess(outputProcess, {
+      graceMs: NODE_BRIDGE_TERMINATION_GRACE_MS,
+    });
+    session.retiredOutputStops.add(stopPromise);
+    void stopPromise.finally(() => {
+      session.retiredOutputStops.delete(stopPromise);
+    });
+  };
+
+  const stopSession = (session: NodeBridgeSession): Promise<void> => {
     // Process and stream errors can arrive together during teardown. Close once
-    // so the same children do not get duplicate termination timers.
-    if (session.closed) {
-      return;
+    // so every caller shares one bounded process-termination promise.
+    if (session.stopPromise) {
+      return session.stopPromise;
     }
     session.closed = true;
     session.closedAt = new Date().toISOString();
-    terminateChild(session.input);
-    terminateChild(session.output);
     wake(session);
+    session.stopPromise = Promise.all([
+      terminateMeetingBridgeProcess(session.input, {
+        graceMs: NODE_BRIDGE_TERMINATION_GRACE_MS,
+      }),
+      terminateMeetingBridgeProcess(session.output, {
+        graceMs: NODE_BRIDGE_TERMINATION_GRACE_MS,
+      }),
+      ...session.retiredOutputStops,
+    ]).then(() => undefined);
+    return session.stopPromise;
   };
 
   const attachOutputProcessHandlers = (session: NodeBridgeSession, outputProcess: ChildProcess) => {
     const stopIfCurrent = () => {
       if (session.output === outputProcess) {
-        stopSession(session);
+        void stopSession(session);
       }
     };
     outputProcess.on("exit", stopIfCurrent);
@@ -174,6 +171,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       lastInputBytes: 0,
       lastOutputBytes: 0,
       clearCount: 0,
+      retiredOutputStops: new Set(),
     };
     const outputProcess = startOutputProcess(output);
     const inputProcess = spawn(input.command, input.args, {
@@ -191,7 +189,9 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       }
       wake(session);
     });
-    const stop = () => stopSession(session);
+    const stop = () => {
+      void stopSession(session);
+    };
     inputProcess.on("exit", stop);
     inputProcess.on("error", stop);
     inputProcess.stdout?.on("error", stop);
@@ -238,7 +238,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     try {
       session.output?.stdin?.write(audio);
     } catch {
-      stopSession(session);
+      void stopSession(session);
       throw new Error(`bridge is not open: ${bridgeId}`);
     }
     return { bridgeId, ok: true };
@@ -259,7 +259,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     attachOutputProcessHandlers(session, outputProcess);
     session.clearCount += 1;
     session.lastClearAt = new Date().toISOString();
-    terminateChild(previousOutput);
+    retireOutputProcess(session, previousOutput);
     return { bridgeId, ok: true, clearCount: session.clearCount };
   };
 
@@ -321,7 +321,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
         if (bridgeId) {
           const session = sessions.get(bridgeId);
           if (session) {
-            stopSession(session);
+            void stopSession(session);
           }
         }
         throw new Error(
@@ -391,7 +391,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     return { bridges };
   };
 
-  const stopSessionsByUrl = (params: Record<string, unknown>) => {
+  const stopSessionsByUrl = async (params: Record<string, unknown>) => {
     const urlKey = options.normalizeMeetingKey(readString(params.url));
     if (!urlKey) {
       throw new Error("url required");
@@ -399,6 +399,11 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     const mode = readString(params.mode);
     const exceptBridgeId = readString(params.exceptBridgeId);
     let stopped = 0;
+    const stopping: Array<{
+      bridgeId: string;
+      session: NodeBridgeSession;
+      stopPromise: Promise<void>;
+    }> = [];
     for (const [bridgeId, session] of sessions) {
       if (exceptBridgeId && bridgeId === exceptBridgeId) {
         continue;
@@ -410,16 +415,21 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
         continue;
       }
       const wasClosed = session.closed;
-      stopSession(session);
-      sessions.delete(bridgeId);
+      stopping.push({ bridgeId, session, stopPromise: stopSession(session) });
       if (!wasClosed) {
         stopped += 1;
+      }
+    }
+    await Promise.all(stopping.map(({ stopPromise }) => stopPromise));
+    for (const { bridgeId, session } of stopping) {
+      if (sessions.get(bridgeId) === session) {
+        sessions.delete(bridgeId);
       }
     }
     return { ok: true, stopped };
   };
 
-  const stopBrowser = (params: Record<string, unknown>) => {
+  const stopBrowser = async (params: Record<string, unknown>) => {
     const bridgeId = readString(params.bridgeId);
     if (!bridgeId) {
       return { ok: true, stopped: false };
@@ -428,8 +438,10 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     if (!session) {
       return { ok: true, stopped: false };
     }
-    stopSession(session);
-    sessions.delete(bridgeId);
+    await stopSession(session);
+    if (sessions.get(bridgeId) === session) {
+      sessions.delete(bridgeId);
+    }
     return { ok: true, stopped: true };
   };
 
@@ -461,7 +473,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
           result = listSessions(params);
           break;
         case "stopByUrl":
-          result = stopSessionsByUrl(params);
+          result = await stopSessionsByUrl(params);
           break;
         case "pullAudio":
           result = await pullAudio(params);
@@ -473,7 +485,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
           result = clearAudio(params);
           break;
         case "stop":
-          result = stopBrowser(params);
+          result = await stopBrowser(params);
           break;
         default:
           throw new Error(`unsupported ${options.commandName} action`);

--- a/src/meeting-bot/realtime-local-audio-transport.ts
+++ b/src/meeting-bot/realtime-local-audio-transport.ts
@@ -3,11 +3,16 @@ import type { Writable } from "node:stream";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeLogger } from "../plugins/runtime/types.js";
 import { createSpeechThresholdGate, readPcm16AudioStats } from "../talk/audio-energy.js";
+import { terminateMeetingBridgeProcess } from "./bridge-process.js";
 import type { MeetingRealtimeAudioTransport } from "./realtime-audio-transport.js";
+
+const LOCAL_BRIDGE_TERMINATION_GRACE_MS = 1_000;
 
 type BridgeProcess = {
   pid?: number;
   killed?: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
   stdin?: Writable | null;
   stdout?: {
     on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
@@ -23,6 +28,14 @@ type BridgeProcess = {
     listener: (code: number | null, signal: NodeJS.Signals | null) => void,
   ): unknown;
   on(event: "error", listener: (error: Error) => void): unknown;
+  once(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+  off(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
 };
 
 type MeetingRealtimeAudioSpawn = (
@@ -37,34 +50,6 @@ function splitCommand(argv: string[]): { command: string; args: string[] } {
     throw new Error("audio bridge command must not be empty");
   }
   return { command, args };
-}
-
-function terminateBridgeProcess(proc: BridgeProcess, signal: NodeJS.Signals = "SIGTERM"): void {
-  if (proc.killed && signal !== "SIGKILL") {
-    return;
-  }
-  let exited = false;
-  proc.on("exit", () => {
-    exited = true;
-  });
-  try {
-    proc.kill(signal);
-  } catch {
-    return;
-  }
-  if (signal === "SIGKILL") {
-    return;
-  }
-  const timer = setTimeout(() => {
-    if (!exited) {
-      try {
-        proc.kill("SIGKILL");
-      } catch {
-        // The process may exit between the grace check and signal.
-      }
-    }
-  }, 1_000);
-  timer.unref?.();
 }
 
 export function createLocalMeetingRealtimeAudioTransport(params: {
@@ -94,6 +79,8 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
   let inputStarted = false;
   let fatalSignaled = false;
   let fatalHandler: (() => void) | undefined;
+  let stopPromise: Promise<void> | undefined;
+  const retiredOutputStops = new Set<Promise<void>>();
 
   const signalFatal = () => {
     if (!fatalSignaled) {
@@ -167,16 +154,23 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
         }
       });
     },
-    stop: async () => {
-      if (stopped) {
-        return;
-      }
-      stopped = true;
-      terminateBridgeProcess(inputProcess);
-      terminateBridgeProcess(outputProcess);
-      if (bargeInInputProcess) {
-        terminateBridgeProcess(bargeInInputProcess);
-      }
+    stop: () => {
+      stopPromise ??= (async () => {
+        stopped = true;
+        await Promise.all([
+          terminateMeetingBridgeProcess(inputProcess, {
+            graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+          }),
+          terminateMeetingBridgeProcess(outputProcess, {
+            graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+          }),
+          terminateMeetingBridgeProcess(bargeInInputProcess, {
+            graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+          }),
+          ...retiredOutputStops,
+        ]);
+      })();
+      return stopPromise;
     },
     writeOutput: async (audio) => {
       if (stopped) {
@@ -198,7 +192,14 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
       params.logger.debug?.(
         `${params.logScope} cleared realtime audio output buffer by restarting playback command`,
       );
-      terminateBridgeProcess(previousOutput, "SIGKILL");
+      const retiredOutputStop = terminateMeetingBridgeProcess(previousOutput, {
+        graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+        initialSignal: "SIGKILL",
+      });
+      retiredOutputStops.add(retiredOutputStop);
+      void retiredOutputStop.finally(() => {
+        retiredOutputStops.delete(retiredOutputStop);
+      });
     },
     dispose: async () => {
       await transport.stop();


### PR DESCRIPTION
Related: #109209

## What Problem This Solves

Meeting shutdown could acknowledge completion while local audio bridge processes were still alive. SIGTERM-resistant capture/playback children could outlive Google Meet or Teams meeting cleanup, and concurrent stop requests could schedule duplicate termination work.

## Why This Change Was Made

The original contributor PR #109209 correctly identified the missing process-settlement contract. Current `main` has since moved Google Meet's local audio transport and node host into the shared meeting-bot owner used by Google Meet and Teams. This replacement carries the fix forward at that shared boundary:

- one bounded SIGTERM-to-SIGKILL termination helper;
- one shared stop promise per transport/session;
- retired playback processes included in final cleanup;
- command-driven stop responses wait for cleanup before returning.

Contributor credit is preserved in the implementation commit for @zhangguiping-xydt.

## User Impact

Google Meet and Teams meeting sessions now finish local audio bridge cleanup before reporting a completed stop. Resistant children are force-terminated after the grace period, while repeated stop requests share the same bounded cleanup.

## Evidence

- Focused extension proof: 180 tests passed across Google Meet node-host, realtime-process, and plugin suites.
- Real-process proof: SIGTERM-resistant input/output children remained alive during the grace window, then both exited after SIGKILL; concurrent `stop()` calls shared one promise.
- Source-blind behavior contract: real child PIDs were alive through 500 ms, dead when stop resolved at 1.002 s, with two observed SIGTERM deliveries.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, and `pnpm tsgo:extensions:test` passed.
- Targeted `oxfmt --check` passed.
- Final branch-wide autoreview: no accepted/actionable findings.

Release note: Fixed local Google Meet and Teams audio bridge processes surviving meeting cleanup (thanks @zhangguiping-xydt).
