### PR TITLE
refactor(update): split update-command into focused modules under the line limit

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -672,7 +672,6 @@ src/cli/skills-cli.commands.test.ts
 src/cli/skills-cli.ts
 src/cli/update-cli.test.ts
 src/cli/update-cli/update-command-service.ts
-src/cli/update-cli/update-command.ts
 src/commands/agent-via-gateway.test.ts
 src/commands/agent-via-gateway.ts
 src/commands/agent.test.ts

--- a/src/cli/update-cli/update-command-dry-run.ts
+++ b/src/cli/update-cli/update-command-dry-run.ts
@@ -1,0 +1,179 @@
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import type { UpdateChannel } from "../../infra/update-channels.js";
+import { canResolveRegistryVersionForPackageTarget } from "../../infra/update-global.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import type { OpenClawDatabaseSchemaPreflight } from "../../state/openclaw-database-preflight.js";
+import { resolveGlobalManager } from "./shared.js";
+import { formatSchemaRefusalLines, hasSchemaRefusal } from "./update-command-git.js";
+import type { ManagedServiceRootRedirect } from "./update-command-service.js";
+
+type UpdateDryRunPreview = {
+  dryRun: true;
+  root: string;
+  installKind: "git" | "package" | "unknown";
+  mode: UpdateRunResult["mode"];
+  updateInstallKind: "git" | "package" | "unknown";
+  switchToGit: boolean;
+  switchToPackage: boolean;
+  restart: boolean;
+  requestedChannel: UpdateChannel | null;
+  storedChannel: UpdateChannel | null;
+  effectiveChannel: UpdateChannel;
+  tag: string;
+  currentVersion: string | null;
+  targetVersion: string | null;
+  downgradeRisk: boolean;
+  actions: string[];
+  notes: string[];
+};
+
+function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): void {
+  if (jsonMode) {
+    defaultRuntime.writeJson(preview);
+    return;
+  }
+
+  defaultRuntime.log(theme.heading("Update dry-run"));
+  defaultRuntime.log(theme.muted("No changes were applied."));
+  defaultRuntime.log("");
+  defaultRuntime.log(`  Root: ${theme.muted(preview.root)}`);
+  defaultRuntime.log(`  Install kind: ${theme.muted(preview.installKind)}`);
+  defaultRuntime.log(`  Mode: ${theme.muted(preview.mode)}`);
+  defaultRuntime.log(`  Channel: ${theme.muted(preview.effectiveChannel)}`);
+  defaultRuntime.log(`  Tag/spec: ${theme.muted(preview.tag)}`);
+  if (preview.currentVersion) {
+    defaultRuntime.log(`  Current version: ${theme.muted(preview.currentVersion)}`);
+  }
+  if (preview.targetVersion) {
+    defaultRuntime.log(`  Target version: ${theme.muted(preview.targetVersion)}`);
+  }
+  if (preview.downgradeRisk) {
+    defaultRuntime.log(theme.warn("  Downgrade confirmation would be required in a real run."));
+  }
+
+  defaultRuntime.log("");
+  defaultRuntime.log(theme.heading("Planned actions:"));
+  for (const action of preview.actions) {
+    defaultRuntime.log(`  - ${action}`);
+  }
+
+  if (preview.notes.length > 0) {
+    defaultRuntime.log("");
+    defaultRuntime.log(theme.heading("Notes:"));
+    for (const note of preview.notes) {
+      defaultRuntime.log(`  - ${theme.muted(note)}`);
+    }
+  }
+}
+
+export async function printUpdateDryRun(params: {
+  root: string;
+  installKind: "git" | "package" | "unknown";
+  updateInstallKind: "git" | "package" | "unknown";
+  switchToGit: boolean;
+  switchToPackage: boolean;
+  shouldRestart: boolean;
+  requestedChannel: UpdateChannel | null;
+  storedChannel: UpdateChannel | null;
+  channel: UpdateChannel;
+  tag: string;
+  packageInstallSpec: string | null;
+  currentVersion: string | null;
+  targetVersion: string | null;
+  downgradeRisk: boolean;
+  packageAlreadyCurrent: boolean;
+  fallbackToLatest: boolean;
+  managedServiceRootRedirect: ManagedServiceRootRedirect | null;
+  explicitTag: string | null;
+  packageSchemaPreflight: OpenClawDatabaseSchemaPreflight;
+  timeoutMs: number;
+  opts: { tag?: string; json?: boolean };
+}): Promise<void> {
+  let mode: UpdateRunResult["mode"] = "unknown";
+  if (params.updateInstallKind === "git") {
+    mode = "git";
+  } else if (params.updateInstallKind === "package") {
+    mode = await resolveGlobalManager({
+      root: params.root,
+      installKind: params.installKind,
+      timeoutMs: params.timeoutMs,
+    });
+  }
+
+  const actions: string[] = [];
+  if (params.requestedChannel && params.requestedChannel !== params.storedChannel) {
+    actions.push(`Persist update.channel=${params.requestedChannel} in config`);
+  }
+  if (params.switchToGit) {
+    actions.push("Switch install mode from package to git checkout (dev channel)");
+  } else if (params.switchToPackage) {
+    actions.push(`Switch install mode from git to package manager (${mode})`);
+  } else if (params.updateInstallKind === "git") {
+    actions.push(`Run git update flow on channel ${params.channel} (fetch/rebase/build/doctor)`);
+  } else if (params.packageAlreadyCurrent) {
+    actions.push(
+      `Refresh package install with spec ${params.packageInstallSpec ?? params.tag}; current version already matches ${params.targetVersion}`,
+    );
+  } else {
+    actions.push(
+      `Run global package manager update with spec ${params.packageInstallSpec ?? params.tag}`,
+    );
+  }
+  actions.push("Run plugin update sync after core update");
+  actions.push("Refresh shell completion cache (if needed)");
+  actions.push(
+    params.shouldRestart
+      ? "Restart gateway service and run doctor checks"
+      : "Skip restart (because --no-restart is set)",
+  );
+
+  const notes: string[] = [];
+  if (params.opts.tag && params.updateInstallKind === "git") {
+    notes.push("--tag applies to npm installs only; git updates ignore it.");
+  }
+  if (params.fallbackToLatest) {
+    notes.push("Beta channel resolves to latest for this run (fallback).");
+  }
+  if (params.managedServiceRootRedirect) {
+    notes.push(
+      `Package update targets managed service root ${params.managedServiceRootRedirect.root} instead of invoking root ${params.managedServiceRootRedirect.previousRoot}.`,
+    );
+  }
+  if (params.explicitTag && !canResolveRegistryVersionForPackageTarget(params.tag)) {
+    notes.push("Non-registry package specs skip npm version lookup and downgrade previews.");
+  }
+  if (hasSchemaRefusal(params.packageSchemaPreflight)) {
+    notes.push(...formatSchemaRefusalLines(params.packageSchemaPreflight, true));
+  }
+  if (params.updateInstallKind === "git") {
+    // The git target revision is resolved inside the real update run, so its
+    // schema support cannot be previewed here without duplicating that flow.
+    notes.push(
+      "Database schema compatibility of the git target is verified during the real update; this preview does not check it.",
+    );
+  }
+
+  printDryRunPreview(
+    {
+      dryRun: true,
+      root: params.root,
+      installKind: params.installKind,
+      mode,
+      updateInstallKind: params.updateInstallKind,
+      switchToGit: params.switchToGit,
+      switchToPackage: params.switchToPackage,
+      restart: params.shouldRestart,
+      requestedChannel: params.requestedChannel,
+      storedChannel: params.storedChannel,
+      effectiveChannel: params.channel,
+      tag: params.packageInstallSpec ?? params.tag,
+      currentVersion: params.currentVersion,
+      targetVersion: params.targetVersion,
+      downgradeRisk: params.downgradeRisk,
+      actions,
+      notes,
+    },
+    Boolean(params.opts.json),
+  );
+}

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -1,0 +1,255 @@
+import type { ResolvedGlobalInstallTarget } from "../../infra/update-global.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import { replaceCliName, resolveCliName } from "../cli-name.js";
+import { formatCliCommand } from "../command-format.js";
+import { createUpdateProgress } from "./progress.js";
+import { resolveGitInstallDir, type UpdateCommandOptions } from "./shared.js";
+import {
+  checkTargetDatabaseSchemas,
+  createBeforeGitMutation,
+  formatSchemaRefusalLines,
+  hasSchemaRefusal,
+  runGitUpdate,
+} from "./update-command-git.js";
+import { runPackageInstallUpdate } from "./update-command-package.js";
+import {
+  createAggregateErrorWithCause,
+  maybeRestartServiceAfterFailedMutableUpdate,
+  maybeResumeWindowsTaskAutoStartAfterPackageUpdate,
+  maybeStopManagedServiceBeforeMutableUpdate,
+  shouldBlockMutableUpdateFromGatewayServiceEnv,
+  UpdateCommandAbort,
+  type ManagedServiceRootRedirect,
+  type PreManagedServiceStop,
+  type UpdateCommandRecoveryState,
+} from "./update-command-service.js";
+
+const CLI_NAME = resolveCliName();
+
+type MutableUpdateExecutionResult = {
+  result: UpdateRunResult;
+  preManagedServiceStop: PreManagedServiceStop | undefined;
+};
+
+export async function executeMutableUpdate(params: {
+  root: string;
+  installKind: "git" | "package" | "unknown";
+  updateInstallKind: "git" | "package" | "unknown";
+  switchToGit: boolean;
+  timeoutMs: number | undefined;
+  updateStepTimeoutMs: number;
+  startedAt: number;
+  progress: ReturnType<typeof createUpdateProgress>["progress"];
+  stop: () => void;
+  channel: "stable" | "extended-stable" | "beta" | "dev";
+  tag: string;
+  showProgress: boolean;
+  opts: UpdateCommandOptions;
+  shouldRestart: boolean;
+  devTargetRef?: string;
+  packageInstallSpec: string | null;
+  packageInstallEnv?: NodeJS.ProcessEnv;
+  packageInstallTarget?: ResolvedGlobalInstallTarget;
+  packageTargetSchemaVersions?: OpenClawSchemaVersions;
+  packageUpdateNodeRunner?: string;
+  managedServiceNodeRunner?: string;
+  managedServiceRootRedirect: ManagedServiceRootRedirect | null;
+  invocationCwd?: string;
+  recoveryState: UpdateCommandRecoveryState;
+}): Promise<MutableUpdateExecutionResult | null> {
+  let preManagedServiceStop: PreManagedServiceStop | undefined;
+  let schemaRefusalAfterStop = false;
+  const gitMutationRoots =
+    params.updateInstallKind === "git"
+      ? params.switchToGit
+        ? [params.root, resolveGitInstallDir()]
+        : [params.root]
+      : null;
+  const stopManagedServiceBeforeMutableUpdate = async (
+    mutationRoots: readonly string[] = [params.root],
+  ) => {
+    if (params.updateInstallKind !== "package" && params.updateInstallKind !== "git") {
+      return;
+    }
+    try {
+      const uniqueMutationRoots = Array.from(new Set(mutationRoots));
+      for (const mutationRoot of uniqueMutationRoots) {
+        preManagedServiceStop = await maybeStopManagedServiceBeforeMutableUpdate({
+          updateInstallKind: params.updateInstallKind,
+          root: mutationRoot,
+          shouldRestart: params.shouldRestart,
+          jsonMode: Boolean(params.opts.json),
+        });
+        if (preManagedServiceStop.windowsTaskAutoStartRecovery) {
+          params.recoveryState.windowsTaskAutoStartRecovery =
+            preManagedServiceStop.windowsTaskAutoStartRecovery;
+        }
+        if (
+          preManagedServiceStop.stopped ||
+          preManagedServiceStop.blockMessage ||
+          shouldBlockMutableUpdateFromGatewayServiceEnv({ preManagedServiceStop }) ||
+          !preManagedServiceStop.inspected ||
+          !preManagedServiceStop.running ||
+          !params.shouldRestart
+        ) {
+          break;
+        }
+      }
+    } catch (err) {
+      if (err instanceof UpdateCommandAbort) {
+        throw err;
+      }
+      params.stop();
+      defaultRuntime.error(`Failed to stop managed gateway service before update: ${String(err)}`);
+      defaultRuntime.exit(1);
+      throw new UpdateCommandAbort();
+    }
+
+    if (preManagedServiceStop?.blockMessage) {
+      params.stop();
+      defaultRuntime.error(preManagedServiceStop.blockMessage);
+      defaultRuntime.exit(1);
+      throw new UpdateCommandAbort();
+    }
+
+    if (shouldBlockMutableUpdateFromGatewayServiceEnv({ preManagedServiceStop })) {
+      params.stop();
+      const updateLabel = params.updateInstallKind === "git" ? "Git updates" : "Package updates";
+      defaultRuntime.error(
+        [
+          `${updateLabel} cannot run from inside the gateway service process.`,
+          "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
+          `Run \`${replaceCliName(formatCliCommand("openclaw update"), CLI_NAME)}\` from a shell outside the gateway service, or stop the gateway service first and then update.`,
+        ].join("\n"),
+      );
+      defaultRuntime.exit(1);
+      throw new UpdateCommandAbort();
+    }
+  };
+
+  if (params.updateInstallKind === "package") {
+    try {
+      await stopManagedServiceBeforeMutableUpdate();
+    } catch (err) {
+      if (err instanceof UpdateCommandAbort) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  const postStopPackageSchemaPreflight =
+    params.updateInstallKind === "package"
+      ? checkTargetDatabaseSchemas(
+          params.packageTargetSchemaVersions,
+          preManagedServiceStop?.serviceEnv ?? process.env,
+        )
+      : { incompatible: [], indeterminate: [] };
+  if (hasSchemaRefusal(postStopPackageSchemaPreflight)) {
+    schemaRefusalAfterStop = true;
+    defaultRuntime.error(formatSchemaRefusalLines(postStopPackageSchemaPreflight).join("\n"));
+  }
+
+  let result: UpdateRunResult;
+  try {
+    result =
+      params.updateInstallKind === "package" && hasSchemaRefusal(postStopPackageSchemaPreflight)
+        ? {
+            status: "error",
+            mode: params.packageInstallTarget?.manager ?? "unknown",
+            root: params.root,
+            reason: "database-schema-preflight",
+            steps: [],
+            durationMs: Date.now() - params.startedAt,
+          }
+        : params.updateInstallKind === "package"
+          ? await runPackageInstallUpdate({
+              root: params.root,
+              installKind: params.installKind,
+              tag: params.tag,
+              installSpec: params.packageInstallSpec ?? undefined,
+              timeoutMs: params.updateStepTimeoutMs,
+              startedAt: params.startedAt,
+              progress: params.progress,
+              jsonMode: Boolean(params.opts.json),
+              allowGatewayServiceRepair: preManagedServiceStop?.serviceMatchesMutationRoot === true,
+              allowGatewayActivation:
+                params.shouldRestart &&
+                preManagedServiceStop?.stopped === true &&
+                preManagedServiceStop.serviceMatchesMutationRoot === true,
+              managedServiceEnv: preManagedServiceStop?.serviceEnv,
+              invocationCwd: params.invocationCwd,
+              honorPackageRoot:
+                params.managedServiceRootRedirect !== null ||
+                params.managedServiceNodeRunner !== undefined,
+              nodeRunner: params.packageUpdateNodeRunner,
+              installEnv: params.packageInstallEnv,
+              installTarget: params.packageInstallTarget,
+            })
+          : await runGitUpdate({
+              root: params.root,
+              switchToGit: params.switchToGit,
+              installKind: params.installKind,
+              timeoutMs: params.timeoutMs,
+              startedAt: params.startedAt,
+              progress: params.progress,
+              channel: params.channel,
+              tag: params.tag,
+              showProgress: params.showProgress,
+              opts: params.opts,
+              stop: params.stop,
+              devTargetRef: params.devTargetRef,
+              beforeGitMutation:
+                params.updateInstallKind === "git"
+                  ? createBeforeGitMutation({
+                      roots: gitMutationRoots ?? [params.root],
+                      shouldRestart: params.shouldRestart,
+                      stopManagedService: stopManagedServiceBeforeMutableUpdate,
+                      getPreManagedServiceStop: () => preManagedServiceStop,
+                      markSchemaRefusalAfterStop: () => {
+                        schemaRefusalAfterStop = true;
+                      },
+                    })
+                  : undefined,
+              allowGatewayServiceRepair: false,
+              allowGatewayActivation: false,
+            });
+  } catch (err) {
+    params.stop();
+    if (err instanceof UpdateCommandAbort) {
+      if (schemaRefusalAfterStop) {
+        if (preManagedServiceStop?.stopped === true) {
+          await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop).catch(
+            () => undefined,
+          );
+          await maybeRestartServiceAfterFailedMutableUpdate({
+            preManagedServiceStop,
+            jsonMode: Boolean(params.opts.json),
+          });
+        }
+        defaultRuntime.exit(1);
+      }
+      return null;
+    }
+    try {
+      await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop);
+    } catch (resumeErr) {
+      params.recoveryState.windowsTaskAutoStartRecovery?.complete();
+      params.recoveryState.windowsTaskAutoStartRecovery = undefined;
+      throw createAggregateErrorWithCause(
+        [err, resumeErr],
+        `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
+        err,
+      );
+    }
+    await maybeRestartServiceAfterFailedMutableUpdate({
+      preManagedServiceStop,
+      jsonMode: Boolean(params.opts.json),
+    });
+    throw err;
+  }
+
+  return { result, preManagedServiceStop };
+}

--- a/src/cli/update-cli/update-command-git.ts
+++ b/src/cli/update-cli/update-command-git.ts
@@ -1,0 +1,219 @@
+import type { UpdateChannel } from "../../infra/update-channels.js";
+import {
+  createGlobalInstallEnv,
+  globalInstallArgs,
+  resolveGlobalInstallTarget,
+  resolvePnpmGlobalDirFromGlobalRoot,
+} from "../../infra/update-global.js";
+import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import {
+  OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
+  preflightOpenClawDatabaseSchemas,
+  type IncompatibleOpenClawDatabase,
+  type IndeterminateOpenClawDatabase,
+  type OpenClawDatabaseSchemaPreflight,
+} from "../../state/openclaw-database-preflight.js";
+import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import { createUpdateProgress, printResult } from "./progress.js";
+import {
+  createGlobalCommandRunner,
+  ensureGitCheckout,
+  resolveGitInstallDir,
+  resolveGlobalManager,
+  runUpdateStep,
+  type UpdateCommandOptions,
+} from "./shared.js";
+import { UpdateCommandAbort, type PreManagedServiceStop } from "./update-command-service.js";
+
+const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
+
+type BeforeGitMutation = (target: {
+  schemaVersions?: OpenClawSchemaVersions;
+  metadataUnreadable?: string;
+}) => Promise<{
+  allowGatewayServiceRepair?: boolean;
+  allowGatewayActivation?: boolean;
+} | void>;
+
+export function formatSchemaRefusalLines(
+  schemas: {
+    incompatible: readonly IncompatibleOpenClawDatabase[];
+    indeterminate: readonly IndeterminateOpenClawDatabase[];
+  },
+  dryRun = false,
+): string[] {
+  const prefix = dryRun ? "Would refuse update" : "Update refused";
+  return [
+    ...schemas.incompatible.map((database) => {
+      const agent = database.agentId ? ` (agent ${database.agentId})` : "";
+      return `${prefix}: ${database.kind} database${agent} ${database.path} has schema ${database.foundVersion}; target supports ${database.supportedVersion}; writer build ${database.writerAppVersion ?? "unknown"}.`;
+    }),
+    ...schemas.indeterminate.map(
+      (database) =>
+        `${prefix}: could not inspect ${database.kind} database ${database.path}: ${database.reason}; retry once the gateway releases it.`,
+    ),
+    OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
+    "Installing manually via npm bypasses this guard; back up first and verify compatibility.",
+  ];
+}
+
+export function checkTargetDatabaseSchemas(
+  supportedVersions: OpenClawSchemaVersions | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): OpenClawDatabaseSchemaPreflight {
+  return supportedVersions
+    ? preflightOpenClawDatabaseSchemas({ env, supportedVersions })
+    : { incompatible: [], indeterminate: [] };
+}
+
+export function hasSchemaRefusal(schemas: OpenClawDatabaseSchemaPreflight): boolean {
+  return schemas.incompatible.length > 0 || schemas.indeterminate.length > 0;
+}
+
+export function createBeforeGitMutation(params: {
+  roots: readonly string[];
+  shouldRestart: boolean;
+  stopManagedService: (roots: readonly string[]) => Promise<void>;
+  getPreManagedServiceStop: () => PreManagedServiceStop | undefined;
+  markSchemaRefusalAfterStop: () => void;
+}): BeforeGitMutation {
+  return async (target) => {
+    if (target?.metadataUnreadable) {
+      defaultRuntime.error(
+        `Update refused: could not inspect the target's schema support (${target.metadataUnreadable}). Retry, or see ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
+      );
+      defaultRuntime.exit(1);
+      throw new UpdateCommandAbort();
+    }
+    const preStopSchemas = checkTargetDatabaseSchemas(target?.schemaVersions);
+    if (hasSchemaRefusal(preStopSchemas)) {
+      defaultRuntime.error(formatSchemaRefusalLines(preStopSchemas).join("\n"));
+      defaultRuntime.exit(1);
+      throw new UpdateCommandAbort();
+    }
+    await params.stopManagedService(params.roots);
+    const preManagedServiceStop = params.getPreManagedServiceStop();
+    const postStopSchemas = checkTargetDatabaseSchemas(
+      target?.schemaVersions,
+      preManagedServiceStop?.serviceEnv ?? process.env,
+    );
+    if (hasSchemaRefusal(postStopSchemas)) {
+      params.markSchemaRefusalAfterStop();
+      defaultRuntime.error(formatSchemaRefusalLines(postStopSchemas).join("\n"));
+      throw new UpdateCommandAbort();
+    }
+    return {
+      // Only a positively owned service may be rewritten. Activation
+      // additionally requires this update to have stopped it.
+      allowGatewayServiceRepair: preManagedServiceStop?.serviceMatchesMutationRoot === true,
+      allowGatewayActivation:
+        params.shouldRestart &&
+        preManagedServiceStop?.stopped === true &&
+        preManagedServiceStop.serviceMatchesMutationRoot === true,
+    };
+  };
+}
+
+export async function runGitUpdate(params: {
+  root: string;
+  switchToGit: boolean;
+  installKind: "git" | "package" | "unknown";
+  timeoutMs: number | undefined;
+  startedAt: number;
+  progress: ReturnType<typeof createUpdateProgress>["progress"];
+  channel: UpdateChannel;
+  tag: string;
+  showProgress: boolean;
+  opts: UpdateCommandOptions;
+  stop: () => void;
+  devTargetRef?: string;
+  beforeGitMutation?: BeforeGitMutation;
+  allowGatewayServiceRepair: boolean;
+  allowGatewayActivation: boolean;
+}): Promise<UpdateRunResult> {
+  const updateRoot = params.switchToGit ? resolveGitInstallDir() : params.root;
+  const effectiveTimeout = params.timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
+  const installEnv = await createGlobalInstallEnv();
+
+  const cloneStep = params.switchToGit
+    ? await ensureGitCheckout({
+        dir: updateRoot,
+        env: installEnv,
+        timeoutMs: effectiveTimeout,
+        progress: params.progress,
+      })
+    : null;
+
+  if (cloneStep && cloneStep.exitCode !== 0) {
+    const result: UpdateRunResult = {
+      status: "error",
+      mode: "git",
+      root: updateRoot,
+      reason: cloneStep.name,
+      steps: [cloneStep],
+      durationMs: Date.now() - params.startedAt,
+    };
+    params.stop();
+    printResult(result, { ...params.opts, hideSteps: params.showProgress });
+    defaultRuntime.exit(1);
+    return result;
+  }
+
+  const updateResult = await runGatewayUpdate({
+    cwd: updateRoot,
+    argv1: params.switchToGit ? undefined : process.argv[1],
+    timeoutMs: params.timeoutMs,
+    progress: params.progress,
+    channel: params.channel,
+    tag: params.tag,
+    devTargetRef: params.devTargetRef,
+    deferConfiguredPluginInstallRepair: true,
+    allowGatewayServiceRepair: params.allowGatewayServiceRepair,
+    allowGatewayActivation: params.allowGatewayActivation,
+    beforeGitMutation: params.beforeGitMutation,
+  });
+  const steps = [...(cloneStep ? [cloneStep] : []), ...updateResult.steps];
+
+  if (params.switchToGit && updateResult.status === "ok") {
+    const manager = await resolveGlobalManager({
+      root: params.root,
+      installKind: params.installKind,
+      timeoutMs: effectiveTimeout,
+    });
+    const runCommand = createGlobalCommandRunner();
+    const installTarget = await resolveGlobalInstallTarget({
+      manager,
+      runCommand,
+      timeoutMs: effectiveTimeout,
+      pkgRoot: params.root,
+    });
+    const installLocation =
+      installTarget.manager === "pnpm"
+        ? resolvePnpmGlobalDirFromGlobalRoot(installTarget.globalRoot)
+        : null;
+    const installStep = await runUpdateStep({
+      name: "global install",
+      argv: globalInstallArgs(installTarget, updateRoot, undefined, installLocation, updateRoot),
+      cwd: updateRoot,
+      env: installEnv,
+      timeoutMs: effectiveTimeout,
+      progress: params.progress,
+    });
+    steps.push(installStep);
+
+    const failedStep = installStep.exitCode !== 0 ? installStep : null;
+    return {
+      ...updateResult,
+      status: updateResult.status === "ok" && !failedStep ? "ok" : "error",
+      steps,
+      durationMs: Date.now() - params.startedAt,
+    };
+  }
+
+  return {
+    ...updateResult,
+    steps,
+    durationMs: Date.now() - params.startedAt,
+  };
+}

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -1,0 +1,208 @@
+import path from "node:path";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import {
+  UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
+  UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION_ENV,
+  UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR_ENV,
+  UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
+  UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART_ENV,
+} from "../../commands/doctor/shared/update-phase.js";
+import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
+import { createLowDiskSpaceWarning } from "../../infra/disk-space.js";
+import {
+  markPackagePostInstallDoctorAdvisory,
+  runGlobalPackageUpdateSteps,
+} from "../../infra/package-update-steps.js";
+import {
+  consumeUpdatePostInstallDoctorResult,
+  createUpdatePostInstallDoctorResultPath,
+  UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
+} from "../../infra/update-doctor-result.js";
+import {
+  createGlobalInstallEnv,
+  cleanupGlobalRenameDirs,
+  resolveGlobalInstallSpec,
+  resolveGlobalInstallTarget,
+  type ResolvedGlobalInstallTarget,
+} from "../../infra/update-global.js";
+import {
+  resolveUpdateDoctorExecutionPolicy,
+  type UpdateRunResult,
+} from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import { resolveCliName } from "../cli-name.js";
+import { createUpdateProgress } from "./progress.js";
+import {
+  DEFAULT_PACKAGE_NAME,
+  createGlobalCommandRunner,
+  readPackageName,
+  readPackageVersion,
+  resolveGlobalManager,
+  resolveNodeRunner,
+  runUpdateStep,
+} from "./shared.js";
+import { createUpdateConfigSnapshot } from "./update-command-config.js";
+import { resolvePostInstallDoctorEnv } from "./update-command-service.js";
+
+const CLI_NAME = resolveCliName();
+
+export async function runPackageInstallUpdate(params: {
+  root: string;
+  installKind: "git" | "package" | "unknown";
+  tag: string;
+  installSpec?: string;
+  timeoutMs: number;
+  startedAt: number;
+  progress: ReturnType<typeof createUpdateProgress>["progress"];
+  jsonMode: boolean;
+  allowGatewayServiceRepair: boolean;
+  allowGatewayActivation: boolean;
+  managedServiceEnv?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+  honorPackageRoot?: boolean;
+  nodeRunner?: string;
+  installEnv?: NodeJS.ProcessEnv;
+  installTarget?: ResolvedGlobalInstallTarget;
+}): Promise<UpdateRunResult> {
+  const installEnv = params.installEnv ?? (await createGlobalInstallEnv());
+  const runCommand = createGlobalCommandRunner();
+  let installTarget = params.installTarget;
+  if (!installTarget) {
+    const manager = await resolveGlobalManager({
+      root: params.root,
+      installKind: params.installKind,
+      timeoutMs: params.timeoutMs,
+    });
+    installTarget = await resolveGlobalInstallTarget({
+      manager,
+      runCommand,
+      timeoutMs: params.timeoutMs,
+      pkgRoot: params.root,
+      honorPackageRoot: params.honorPackageRoot === true,
+    });
+  }
+  const pkgRoot = installTarget.packageRoot;
+  const packageName =
+    (pkgRoot ? await readPackageName(pkgRoot) : await readPackageName(params.root)) ??
+    DEFAULT_PACKAGE_NAME;
+  const installSpec =
+    params.installSpec ??
+    resolveGlobalInstallSpec({
+      packageName,
+      tag: params.tag,
+      env: installEnv,
+    });
+
+  const beforeVersion = pkgRoot ? await readPackageVersion(pkgRoot) : null;
+  if (pkgRoot) {
+    await cleanupGlobalRenameDirs({
+      globalRoot: path.dirname(pkgRoot),
+      packageName,
+    });
+  }
+
+  const diskWarning = createLowDiskSpaceWarning({
+    targetPath: pkgRoot ? path.dirname(pkgRoot) : params.root,
+    purpose: "global package update",
+  });
+  if (diskWarning) {
+    if (params.jsonMode) {
+      defaultRuntime.error(`Warning: ${diskWarning}`);
+    } else {
+      defaultRuntime.log(theme.warn(diskWarning));
+    }
+  }
+
+  const packageUpdate = await runGlobalPackageUpdateSteps({
+    installTarget,
+    installSpec,
+    packageName,
+    packageRoot: pkgRoot,
+    runCommand,
+    timeoutMs: params.timeoutMs,
+    ...(installEnv === undefined ? {} : { env: installEnv }),
+    runStep: (stepParams) =>
+      runUpdateStep({
+        ...stepParams,
+        progress: params.progress,
+      }),
+    postVerifyStep: async (verifiedPackageRoot) => {
+      const entryPath = await resolveGatewayInstallEntrypoint(verifiedPackageRoot);
+      if (!entryPath) {
+        return null;
+      }
+      await createUpdateConfigSnapshot();
+      const candidateHostVersion = await readPackageVersion(verifiedPackageRoot);
+      const doctorResultPath = createUpdatePostInstallDoctorResultPath();
+      const doctorPolicy = resolveUpdateDoctorExecutionPolicy({
+        targetVersion: candidateHostVersion,
+        allowGatewayServiceRepair: params.allowGatewayServiceRepair,
+      });
+      const doctorArgv = [
+        params.nodeRunner ?? resolveNodeRunner(),
+        entryPath,
+        "doctor",
+        "--non-interactive",
+        ...(doctorPolicy.fix ? ["--fix"] : []),
+      ];
+      const doctorProgressInfo = {
+        name: `${CLI_NAME} doctor`,
+        command: doctorArgv.join(" "),
+        index: 0,
+        total: 0,
+      };
+      params.progress?.onStepStart?.(doctorProgressInfo);
+      const doctorStep = await runUpdateStep({
+        name: `${CLI_NAME} doctor`,
+        argv: doctorArgv,
+        cwd: verifiedPackageRoot,
+        env: {
+          ...resolvePostInstallDoctorEnv({
+            serviceEnv: params.managedServiceEnv,
+            invocationCwd: params.invocationCwd,
+          }),
+          OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+          [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+          [UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART_ENV]: "1",
+          [UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR_ENV]: params.allowGatewayServiceRepair
+            ? "1"
+            : "0",
+          [UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION_ENV]: params.allowGatewayActivation ? "1" : "0",
+          ...(doctorPolicy.serviceRepairPolicy
+            ? { OPENCLAW_SERVICE_REPAIR_POLICY: doctorPolicy.serviceRepairPolicy }
+            : {}),
+          [UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV]: doctorResultPath,
+          ...(candidateHostVersion === null
+            ? {}
+            : { OPENCLAW_COMPATIBILITY_HOST_VERSION: candidateHostVersion }),
+        },
+        timeoutMs: params.timeoutMs,
+      });
+      const doctorResult = await consumeUpdatePostInstallDoctorResult(doctorResultPath);
+      const completedDoctorStep = markPackagePostInstallDoctorAdvisory(doctorStep, doctorResult);
+      params.progress?.onStepComplete?.({
+        ...doctorProgressInfo,
+        durationMs: completedDoctorStep.durationMs,
+        exitCode: completedDoctorStep.exitCode,
+        stderrTail: completedDoctorStep.stderrTail,
+        signal: completedDoctorStep.signal,
+        killed: completedDoctorStep.killed,
+        termination: completedDoctorStep.termination,
+        advisory: completedDoctorStep.advisory,
+      });
+      return completedDoctorStep;
+    },
+  });
+
+  return {
+    status: packageUpdate.failedStep ? "error" : "ok",
+    mode: installTarget.manager,
+    root: packageUpdate.verifiedPackageRoot ?? params.root,
+    reason: packageUpdate.failedStep ? packageUpdate.failedStep.name : undefined,
+    before: { version: beforeVersion },
+    after: { version: packageUpdate.afterVersion ?? beforeVersion },
+    steps: packageUpdate.steps,
+    durationMs: Date.now() - params.startedAt,
+  };
+}

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -1,0 +1,427 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import type { UpdateChannel } from "../../infra/update-channels.js";
+import { compareSemverStrings } from "../../infra/update-check.js";
+import {
+  buildControlPlaneUpdateRestartHealthPendingResult,
+  readControlPlaneUpdateSentinelMeta,
+} from "../../infra/update-control-plane-sentinel.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
+import { defaultRuntime } from "../../runtime.js";
+import { VERSION } from "../../version.js";
+import { replaceCliName, resolveCliName } from "../cli-name.js";
+import { formatCliCommand } from "../command-format.js";
+import { printResult } from "./progress.js";
+import { prepareRestartScript } from "./restart-helper.js";
+import {
+  readPackageVersion,
+  tryWriteCompletionCache,
+  type UpdateCommandOptions,
+} from "./shared.js";
+import {
+  persistRequestedUpdateChannel,
+  restoreDroppedPreUpdateChannels,
+} from "./update-command-config.js";
+import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
+import {
+  continuePostCoreUpdateInFreshProcess,
+  markControlPlaneUpdateRestartSentinelFailureBestEffort,
+  shouldResumePostCoreUpdateInFreshProcess,
+  writeControlPlaneUpdateRestartSentinelBestEffort,
+} from "./update-command-post-core.js";
+import {
+  gatewayServiceCommandUsesRoot,
+  maybeRestartService,
+  maybeRestartServiceAfterFailedMutableUpdate,
+  resolvePostUpdateServiceStateReadEnv,
+  resolveUpdatedGatewayRestartPort,
+  restoreWindowsTaskAutoStartOrExit,
+  shouldPrepareUpdatedInstallRestart,
+  tryInstallShellCompletion,
+  type PreManagedServiceStop,
+} from "./update-command-service.js";
+
+const CLI_NAME = resolveCliName();
+
+const UPDATE_QUIPS = [
+  "Leveled up! New skills unlocked. You're welcome.",
+  "Fresh code, same lobster. Miss me?",
+  "Back and better. Did you even notice I was gone?",
+  "Update complete. I learned some new tricks while I was out.",
+  "Upgraded! Now with 23% more sass.",
+  "I've evolved. Try to keep up.",
+  "New version, who dis? Oh right, still me but shinier.",
+  "Patched, polished, and ready to pinch. Let's go.",
+  "The lobster has molted. Harder shell, sharper claws.",
+  "Update done! Check the changelog or just trust me, it's good.",
+  "Reborn from the boiling waters of npm. Stronger now.",
+  "I went away and came back smarter. You should try it sometime.",
+  "Update complete. The bugs feared me, so they left.",
+  "New version installed. Old version sends its regards.",
+  "Firmware fresh. Brain wrinkles: increased.",
+  "I've seen things you wouldn't believe. Anyway, I'm updated.",
+  "Back online. The changelog is long but our friendship is longer.",
+  "Upgraded! Peter fixed stuff. Blame him if it breaks.",
+  "Molting complete. Please don't look at my soft shell phase.",
+  "Version bump! Same chaos energy, fewer crashes (probably).",
+];
+
+function pickUpdateQuip(): string {
+  return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
+}
+
+export async function finishUpdate(params: {
+  result: UpdateRunResult;
+  root: string;
+  configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  requestedChannel: UpdateChannel | null;
+  storedChannel: UpdateChannel | null;
+  channel: UpdateChannel;
+  downgradeRisk: boolean;
+  shouldRestart: boolean;
+  opts: UpdateCommandOptions;
+  showProgress: boolean;
+  preManagedServiceStop?: PreManagedServiceStop;
+  controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
+  preUpdatePluginInstallRecords: Awaited<ReturnType<typeof loadInstalledPluginIndexInstallRecords>>;
+  startedAt: number;
+  packageUpdateNodeRunner?: string;
+  updateStepTimeoutMs: number;
+  invocationCwd?: string;
+}): Promise<void> {
+  if (!params.opts.json || params.result.status !== "ok") {
+    printResult(params.result, { ...params.opts, hideSteps: params.showProgress });
+  }
+
+  if (params.result.status === "error") {
+    if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+      return;
+    }
+    await writeControlPlaneUpdateRestartSentinelBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      result: params.result,
+      jsonMode: Boolean(params.opts.json),
+    });
+    await maybeRestartServiceAfterFailedMutableUpdate({
+      preManagedServiceStop: params.preManagedServiceStop,
+      jsonMode: Boolean(params.opts.json),
+    });
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  if (params.result.status === "skipped") {
+    if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+      return;
+    }
+    await writeControlPlaneUpdateRestartSentinelBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      result: params.result,
+      jsonMode: Boolean(params.opts.json),
+    });
+    await maybeRestartServiceAfterFailedMutableUpdate({
+      preManagedServiceStop: params.preManagedServiceStop,
+      jsonMode: Boolean(params.opts.json),
+    });
+    if (params.result.reason === "dirty") {
+      defaultRuntime.error(theme.error("Update blocked: local files are edited in this checkout."));
+      defaultRuntime.log(
+        theme.warn(
+          "Git-based updates need a clean working tree before they can switch commits, fetch, or rebase.",
+        ),
+      );
+      defaultRuntime.log(
+        theme.muted("Commit, stash, or discard the local changes, then rerun `openclaw update`."),
+      );
+    }
+    if (params.result.reason === "not-git-install") {
+      defaultRuntime.log(
+        theme.warn(
+          `Skipped: this OpenClaw install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run \`${replaceCliName(formatCliCommand("openclaw doctor"), CLI_NAME)}\` and \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\`.`,
+        ),
+      );
+      defaultRuntime.log(
+        theme.muted(
+          `Examples: \`${replaceCliName("npm i -g openclaw@latest", CLI_NAME)}\` or \`${replaceCliName("pnpm add -g openclaw@latest", CLI_NAME)}\``,
+        ),
+      );
+    }
+    defaultRuntime.exit(0);
+    return;
+  }
+
+  const shouldResumePostCoreInFreshProcess = shouldResumePostCoreUpdateInFreshProcess({
+    result: params.result,
+    downgradeRisk: params.downgradeRisk,
+  });
+
+  let postUpdateConfigSnapshot = await readConfigFileSnapshot({
+    skipPluginValidation: true,
+    suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
+  });
+  if (!shouldResumePostCoreInFreshProcess) {
+    postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
+      configSnapshot: postUpdateConfigSnapshot,
+      requestedChannel: params.requestedChannel,
+    });
+  }
+  if (
+    params.requestedChannel &&
+    params.configSnapshot.valid &&
+    params.requestedChannel !== params.storedChannel &&
+    !shouldResumePostCoreInFreshProcess &&
+    !params.opts.json
+  ) {
+    defaultRuntime.log(theme.muted(`Update channel set to ${params.requestedChannel}.`));
+  } else if (
+    params.requestedChannel &&
+    params.configSnapshot.valid &&
+    params.requestedChannel !== params.storedChannel &&
+    shouldResumePostCoreInFreshProcess &&
+    !params.opts.json
+  ) {
+    defaultRuntime.log(theme.muted(`Update channel will be set to ${params.requestedChannel}.`));
+  }
+
+  const postUpdateRoot = params.result.root ?? params.root;
+
+  let postCorePluginUpdate;
+  let pluginsUpdatedInFreshProcess = false;
+  if (shouldResumePostCoreInFreshProcess) {
+    const freshProcessResult = await continuePostCoreUpdateInFreshProcess({
+      root: postUpdateRoot,
+      channel: params.channel,
+      requestedChannel: params.requestedChannel,
+      opts: params.opts,
+      pluginInstallRecords: params.preUpdatePluginInstallRecords,
+      updateStartedAtMs: params.startedAt,
+      nodeRunner: params.packageUpdateNodeRunner,
+      preUpdateConfig: params.configSnapshot.valid
+        ? {
+            sourceConfig: params.configSnapshot.sourceConfig,
+            authoredConfig: isRecord(params.configSnapshot.parsed)
+              ? (params.configSnapshot.parsed as OpenClawConfig)
+              : params.configSnapshot.sourceConfig,
+          }
+        : undefined,
+    });
+    if (freshProcessResult.exitCode !== undefined) {
+      if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+        return;
+      }
+      defaultRuntime.exit(freshProcessResult.exitCode);
+      throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
+    }
+    pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
+    postCorePluginUpdate = freshProcessResult.pluginUpdate;
+  }
+
+  if (!pluginsUpdatedInFreshProcess) {
+    if (shouldResumePostCoreInFreshProcess) {
+      postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
+        configSnapshot: postUpdateConfigSnapshot,
+        requestedChannel: params.requestedChannel,
+      });
+    }
+    const restoredConfig = restoreDroppedPreUpdateChannels(
+      postUpdateConfigSnapshot,
+      params.configSnapshot.valid
+        ? {
+            sourceConfig: params.configSnapshot.sourceConfig,
+            authoredConfig: isRecord(params.configSnapshot.parsed)
+              ? (params.configSnapshot.parsed as OpenClawConfig)
+              : params.configSnapshot.sourceConfig,
+          }
+        : undefined,
+    );
+    postUpdateConfigSnapshot = restoredConfig.snapshot;
+    // Current-process post-core convergence still reports the pre-update
+    // VERSION. During downgrades, pin compatibility checks to the installed
+    // target so incompatible newer plugins are disabled before restart.
+    const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
+    const versionComparison =
+      postUpdateInstalledVersion && VERSION
+        ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
+        : null;
+    const compatibilityDowngradeTarget =
+      versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
+    const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+    if (compatibilityDowngradeTarget) {
+      process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
+    }
+    try {
+      postCorePluginUpdate = await updatePluginsAfterCoreUpdate({
+        root: postUpdateRoot,
+        channel: params.channel,
+        configSnapshot: postUpdateConfigSnapshot,
+        configChanged: restoredConfig.changed,
+        restoredAuthoredChannels: restoredConfig.authoredChannels,
+        opts: params.opts,
+        timeoutMs: params.updateStepTimeoutMs,
+        pluginInstallRecords: params.preUpdatePluginInstallRecords,
+      });
+    } finally {
+      if (compatibilityDowngradeTarget) {
+        if (previousCompatibilityHostVersion === undefined) {
+          delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+        } else {
+          process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
+        }
+      }
+    }
+  }
+
+  const resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate
+    ? {
+        ...params.result,
+        status: postCorePluginUpdate.status === "error" ? "error" : params.result.status,
+        ...(postCorePluginUpdate.status === "error" ? { reason: "post-update-plugins" } : {}),
+        postUpdate: {
+          ...params.result.postUpdate,
+          plugins: postCorePluginUpdate,
+        },
+      }
+    : params.result;
+
+  if (postCorePluginUpdate?.status === "error") {
+    if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+      return;
+    }
+    await writeControlPlaneUpdateRestartSentinelBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      result: resultWithPostUpdate,
+      jsonMode: Boolean(params.opts.json),
+    });
+    if (params.opts.json) {
+      defaultRuntime.writeJson(resultWithPostUpdate);
+    } else {
+      defaultRuntime.error(theme.error("Update failed during plugin post-update sync."));
+    }
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  let restartScriptPath: string | null = null;
+  let refreshGatewayServiceEnv = false;
+  let gatewayServiceEnv: NodeJS.ProcessEnv | undefined;
+  let skipLegacyServiceRestart = false;
+  let gatewayPort = resolveUpdatedGatewayRestartPort({
+    config: postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
+    processEnv: process.env,
+  });
+  if (params.shouldRestart) {
+    try {
+      const serviceState = await readGatewayServiceState(resolveGatewayService(), {
+        env: resolvePostUpdateServiceStateReadEnv({
+          updateMode: resultWithPostUpdate.mode,
+          processEnv: process.env,
+          preManagedServiceEnv: params.preManagedServiceStop?.serviceEnv,
+        }),
+      });
+      const serviceMatchesUpdateRoot =
+        (await gatewayServiceCommandUsesRoot({
+          root: postUpdateRoot,
+          command: serviceState.command,
+        })) ?? undefined;
+      const serviceOwnershipConfirmed =
+        params.preManagedServiceStop?.serviceMatchesMutationRoot === true ||
+        serviceMatchesUpdateRoot === true;
+      const knownForeignService =
+        params.preManagedServiceStop?.serviceMatchesMutationRoot === false &&
+        serviceMatchesUpdateRoot !== true;
+      skipLegacyServiceRestart =
+        knownForeignService ||
+        (resultWithPostUpdate.mode === "git" &&
+          serviceState.installed &&
+          serviceState.loaded &&
+          params.preManagedServiceStop?.stopped !== true &&
+          serviceMatchesUpdateRoot === false);
+      if (
+        !knownForeignService &&
+        shouldPrepareUpdatedInstallRestart({
+          updateMode: resultWithPostUpdate.mode,
+          serviceInstalled: serviceState.installed,
+          serviceLoaded: serviceState.loaded,
+          serviceStoppedForUpdate: params.preManagedServiceStop?.stopped,
+          serviceMatchesMutationRoot: serviceOwnershipConfirmed
+            ? true
+            : params.preManagedServiceStop?.serviceMatchesMutationRoot,
+          serviceMatchesUpdateRoot,
+        })
+      ) {
+        gatewayServiceEnv = serviceState.env;
+        gatewayPort = resolveUpdatedGatewayRestartPort({
+          config: postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
+          processEnv: process.env,
+          serviceEnv: gatewayServiceEnv,
+        });
+        restartScriptPath = await prepareRestartScript(
+          serviceState.env,
+          gatewayPort,
+          serviceOwnershipConfirmed ? serviceState.command?.programArguments : undefined,
+        );
+        // An ambiguous wrapper may be stopped and restored, but only proven
+        // ownership authorizes rewriting the service definition.
+        refreshGatewayServiceEnv = serviceOwnershipConfirmed;
+      }
+    } catch {
+      // Ignore errors during pre-check; fallback to standard restart
+    }
+  }
+
+  await tryWriteCompletionCache(postUpdateRoot, Boolean(params.opts.json));
+  await tryInstallShellCompletion({
+    jsonMode: Boolean(params.opts.json),
+    skipPrompt: Boolean(params.opts.yes),
+  });
+
+  await writeControlPlaneUpdateRestartSentinelBestEffort({
+    meta: params.controlPlaneUpdateSentinelMeta,
+    result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
+    jsonMode: Boolean(params.opts.json),
+  });
+
+  if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+    return;
+  }
+  const restartOk = await maybeRestartService({
+    shouldRestart: params.shouldRestart,
+    result: resultWithPostUpdate,
+    opts: params.opts,
+    refreshServiceEnv: refreshGatewayServiceEnv,
+    serviceEnv: gatewayServiceEnv,
+    gatewayPort,
+    restartScriptPath,
+    invocationCwd: params.invocationCwd,
+    nodeRunner: params.packageUpdateNodeRunner,
+    skipLegacyServiceRestart,
+    requireRunningServiceAfterRestart:
+      resultWithPostUpdate.mode === "git" && params.preManagedServiceStop?.stopped === true,
+    timeoutMs: params.updateStepTimeoutMs,
+  });
+  if (!restartOk) {
+    await markControlPlaneUpdateRestartSentinelFailureBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      reason: "restart-unhealthy",
+      jsonMode: Boolean(params.opts.json),
+    });
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  await writeControlPlaneUpdateRestartSentinelBestEffort({
+    meta: params.controlPlaneUpdateSentinelMeta,
+    result: resultWithPostUpdate,
+    jsonMode: Boolean(params.opts.json),
+  });
+
+  if (!params.opts.json) {
+    defaultRuntime.log(theme.muted(pickUpdateQuip()));
+  } else {
+    defaultRuntime.writeJson(resultWithPostUpdate);
+  }
+}

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -1,0 +1,106 @@
+import { readConfigFileSnapshot } from "../../config/config.js";
+import { normalizeUpdateChannel } from "../../infra/update-channels.js";
+import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
+import { defaultRuntime } from "../../runtime.js";
+import { VERSION } from "../../version.js";
+import { readPackageVersion, type UpdateCommandOptions } from "./shared.js";
+import {
+  persistRequestedUpdateChannel,
+  readPostCorePreUpdateSourceConfig,
+  restoreDroppedPreUpdateChannels,
+} from "./update-command-config.js";
+import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
+import {
+  POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV,
+  POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV,
+  POST_CORE_UPDATE_RESULT_PATH_ENV,
+  readPostCorePluginInstallRecordsFile,
+  resolvePostCoreUpdateStartedAtMs,
+  writePostCorePluginUpdateResultFile,
+} from "./update-command-post-core.js";
+
+export async function resumePostCoreUpdate(params: {
+  root: string;
+  channel: string | undefined;
+  opts: UpdateCommandOptions;
+  timeoutMs: number;
+}): Promise<void> {
+  if (
+    params.channel !== "stable" &&
+    params.channel !== "extended-stable" &&
+    params.channel !== "beta" &&
+    params.channel !== "dev"
+  ) {
+    defaultRuntime.error("Missing post-core update channel context.");
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  const requestedChannelInput = process.env[POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV]?.trim() ?? "";
+  const requestedChannel = requestedChannelInput
+    ? normalizeUpdateChannel(requestedChannelInput)
+    : null;
+  if (requestedChannelInput && !requestedChannel) {
+    defaultRuntime.error("Invalid post-core requested update channel context.");
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION =
+    (await readPackageVersion(params.root)) ?? VERSION;
+
+  let configSnapshot = await readConfigFileSnapshot({
+    skipPluginValidation: true,
+    suppressFutureVersionWarning: true,
+  });
+  const preUpdateSourceConfig = await readPostCorePreUpdateSourceConfig({
+    sourceConfigPath: process.env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV],
+    currentSnapshot: configSnapshot,
+    updateStartedAtMs: await resolvePostCoreUpdateStartedAtMs(process.env),
+  });
+  configSnapshot = await persistRequestedUpdateChannel({
+    configSnapshot,
+    requestedChannel,
+  });
+  const restoredConfig = restoreDroppedPreUpdateChannels(configSnapshot, preUpdateSourceConfig);
+  const parentPluginInstallRecords = await readPostCorePluginInstallRecordsFile(
+    process.env[POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV],
+  );
+  // The updated doctor may have repaired plugin installs before this fresh process resumed.
+  const currentPluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
+  const pluginInstallRecords =
+    Object.keys(currentPluginInstallRecords).length > 0
+      ? currentPluginInstallRecords
+      : parentPluginInstallRecords;
+
+  const pluginUpdate = await updatePluginsAfterCoreUpdate({
+    root: params.root,
+    channel: params.channel,
+    configSnapshot: restoredConfig.snapshot,
+    configChanged: restoredConfig.changed,
+    restoredAuthoredChannels: restoredConfig.authoredChannels,
+    opts: params.opts,
+    timeoutMs: params.timeoutMs,
+    pluginInstallRecords,
+  });
+  if (process.env[POST_CORE_UPDATE_RESULT_PATH_ENV]) {
+    await writePostCorePluginUpdateResultFile(
+      process.env[POST_CORE_UPDATE_RESULT_PATH_ENV],
+      pluginUpdate,
+    );
+  }
+  if (params.opts.json && !process.env[POST_CORE_UPDATE_RESULT_PATH_ENV]) {
+    const result: UpdateRunResult = {
+      status: pluginUpdate.status === "error" ? "error" : "ok",
+      mode: "unknown",
+      root: params.root,
+      steps: [],
+      durationMs: 0,
+      postUpdate: { plugins: pluginUpdate },
+    };
+    defaultRuntime.writeJson(result);
+  }
+  defaultRuntime.exit(0);
+}

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,41 +1,23 @@
 // Main update orchestration for source checkouts and package installs.
-import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import {
-  UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
-  UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION_ENV,
-  UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR_ENV,
-  UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
-  UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART_ENV,
-} from "../../commands/doctor/shared/update-phase.js";
 import {
   assertConfigWriteAllowedInCurrentMode,
   readConfigFileSnapshot,
 } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
-import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
-import { createLowDiskSpaceWarning } from "../../infra/disk-space.js";
 import {
   formatExternalSupervisorUpdateRequired,
   isGatewayExternallySupervised,
 } from "../../infra/gateway-supervision.js";
-import {
-  markPackagePostInstallDoctorAdvisory,
-  runGlobalPackageUpdateSteps,
-} from "../../infra/package-update-steps.js";
 import {
   channelToNpmTag,
   DEFAULT_GIT_CHANNEL,
   DEFAULT_PACKAGE_CHANNEL,
   EXTENDED_STABLE_TAG_UNSUPPORTED_REASON,
   normalizeUpdateChannel,
-  type UpdateChannel,
 } from "../../infra/update-channels.js";
 import { fetchNpmPackageTargetStatus } from "../../infra/update-check-package-target.js";
 import {
@@ -44,511 +26,62 @@ import {
   resolveExtendedStablePackage,
   resolveNpmChannelTag,
 } from "../../infra/update-check.js";
-import {
-  buildControlPlaneUpdateRestartHealthPendingResult,
-  readControlPlaneUpdateSentinelMeta,
-} from "../../infra/update-control-plane-sentinel.js";
-import {
-  consumeUpdatePostInstallDoctorResult,
-  createUpdatePostInstallDoctorResultPath,
-  UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
-} from "../../infra/update-doctor-result.js";
+import { readControlPlaneUpdateSentinelMeta } from "../../infra/update-control-plane-sentinel.js";
 import {
   canResolveRegistryVersionForPackageTarget,
   createGlobalInstallEnv,
-  cleanupGlobalRenameDirs,
-  globalInstallArgs,
-  resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
-  resolvePnpmGlobalDirFromGlobalRoot,
+  resolveGlobalInstallTarget,
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
-import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
-import {
-  resolveUpdateDoctorExecutionPolicy,
-  runGatewayUpdate,
-  type UpdateRunResult,
-} from "../../infra/update-runner.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { defaultRuntime } from "../../runtime.js";
-import {
-  OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
-  preflightOpenClawDatabaseSchemas,
-  type IncompatibleOpenClawDatabase,
-  type IndeterminateOpenClawDatabase,
-  type OpenClawDatabaseSchemaPreflight,
-} from "../../state/openclaw-database-preflight.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
-import { VERSION } from "../../version.js";
-import { replaceCliName, resolveCliName } from "../cli-name.js";
-import { formatCliCommand } from "../command-format.js";
-import { createUpdateProgress, printResult } from "./progress.js";
-import { prepareRestartScript } from "./restart-helper.js";
+import { resolveCliName } from "../cli-name.js";
+import { createUpdateProgress } from "./progress.js";
 import {
   DEFAULT_PACKAGE_NAME,
   createGlobalCommandRunner,
-  ensureGitCheckout,
   normalizeTag,
   parseTimeoutMsOrExit,
   readPackageName,
   readPackageVersion,
-  resolveGitInstallDir,
   resolveGlobalManager,
   resolveNodeRunner,
   resolveTargetVersion,
   resolveUpdateRoot,
-  runUpdateStep,
-  tryWriteCompletionCache,
   type UpdateCommandOptions,
 } from "./shared.js";
 import { suppressDeprecations } from "./suppress-deprecations.js";
+import { maybeRepairLegacyConfigForUpdateChannel } from "./update-command-config.js";
+import { printUpdateDryRun } from "./update-command-dry-run.js";
+import { executeMutableUpdate } from "./update-command-execution.js";
 import {
-  createUpdateConfigSnapshot,
-  maybeRepairLegacyConfigForUpdateChannel,
-  persistRequestedUpdateChannel,
-  readPostCorePreUpdateSourceConfig,
-  restoreDroppedPreUpdateChannels,
-} from "./update-command-config.js";
+  checkTargetDatabaseSchemas,
+  formatSchemaRefusalLines,
+  hasSchemaRefusal,
+} from "./update-command-git.js";
 import {
-  updatePluginsAfterCoreUpdate,
-  type PostCorePluginUpdateResult,
-} from "./update-command-plugins.js";
-import {
-  continuePostCoreUpdateInFreshProcess,
-  markControlPlaneUpdateRestartSentinelFailureBestEffort,
   POST_CORE_UPDATE_CHANNEL_ENV,
   POST_CORE_UPDATE_ENV,
-  POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV,
-  POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV,
-  POST_CORE_UPDATE_RESULT_PATH_ENV,
-  readPostCorePluginInstallRecordsFile,
   reportPreMutationUpdateFailure,
-  resolvePostCoreUpdateStartedAtMs,
-  shouldResumePostCoreUpdateInFreshProcess,
-  writeControlPlaneUpdateRestartSentinelBestEffort,
-  writePostCorePluginUpdateResultFile,
 } from "./update-command-post-core.js";
+import { finishUpdate } from "./update-command-post-update.js";
+import { resumePostCoreUpdate } from "./update-command-resume.js";
 import {
-  createAggregateErrorWithCause,
   gatewayServiceCommandUsesRoot,
-  maybeRestartService,
-  maybeRestartServiceAfterFailedMutableUpdate,
-  maybeResumeWindowsTaskAutoStartAfterPackageUpdate,
-  maybeStopManagedServiceBeforeMutableUpdate,
   resolveManagedServiceNodeRunnerOverride,
   resolveManagedServicePackageUpdateRoot,
   resolvePackageRuntimePreflight,
-  resolvePostInstallDoctorEnv,
-  resolvePostUpdateServiceStateReadEnv,
-  resolveUpdatedGatewayRestartPort,
-  restoreWindowsTaskAutoStartOrExit,
-  shouldBlockMutableUpdateFromGatewayServiceEnv,
-  shouldPrepareUpdatedInstallRestart,
-  tryInstallShellCompletion,
   tryResolveInvocationCwd,
-  UpdateCommandAbort,
   type ManagedServiceRootRedirect,
-  type PreManagedServiceStop,
   type UpdateCommandRecoveryState,
 } from "./update-command-service.js";
-
 export { updateFinalizeCommand } from "./update-command-post-core.js";
 
 const CLI_NAME = resolveCliName();
 const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
-
-const UPDATE_QUIPS = [
-  "Leveled up! New skills unlocked. You're welcome.",
-  "Fresh code, same lobster. Miss me?",
-  "Back and better. Did you even notice I was gone?",
-  "Update complete. I learned some new tricks while I was out.",
-  "Upgraded! Now with 23% more sass.",
-  "I've evolved. Try to keep up.",
-  "New version, who dis? Oh right, still me but shinier.",
-  "Patched, polished, and ready to pinch. Let's go.",
-  "The lobster has molted. Harder shell, sharper claws.",
-  "Update done! Check the changelog or just trust me, it's good.",
-  "Reborn from the boiling waters of npm. Stronger now.",
-  "I went away and came back smarter. You should try it sometime.",
-  "Update complete. The bugs feared me, so they left.",
-  "New version installed. Old version sends its regards.",
-  "Firmware fresh. Brain wrinkles: increased.",
-  "I've seen things you wouldn't believe. Anyway, I'm updated.",
-  "Back online. The changelog is long but our friendship is longer.",
-  "Upgraded! Peter fixed stuff. Blame him if it breaks.",
-  "Molting complete. Please don't look at my soft shell phase.",
-  "Version bump! Same chaos energy, fewer crashes (probably).",
-];
-
-function pickUpdateQuip(): string {
-  return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
-}
-type UpdateDryRunPreview = {
-  dryRun: true;
-  root: string;
-  installKind: "git" | "package" | "unknown";
-  mode: UpdateRunResult["mode"];
-  updateInstallKind: "git" | "package" | "unknown";
-  switchToGit: boolean;
-  switchToPackage: boolean;
-  restart: boolean;
-  requestedChannel: UpdateChannel | null;
-  storedChannel: UpdateChannel | null;
-  effectiveChannel: UpdateChannel;
-  tag: string;
-  currentVersion: string | null;
-  targetVersion: string | null;
-  downgradeRisk: boolean;
-  actions: string[];
-  notes: string[];
-};
-
-function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): void {
-  if (jsonMode) {
-    defaultRuntime.writeJson(preview);
-    return;
-  }
-
-  defaultRuntime.log(theme.heading("Update dry-run"));
-  defaultRuntime.log(theme.muted("No changes were applied."));
-  defaultRuntime.log("");
-  defaultRuntime.log(`  Root: ${theme.muted(preview.root)}`);
-  defaultRuntime.log(`  Install kind: ${theme.muted(preview.installKind)}`);
-  defaultRuntime.log(`  Mode: ${theme.muted(preview.mode)}`);
-  defaultRuntime.log(`  Channel: ${theme.muted(preview.effectiveChannel)}`);
-  defaultRuntime.log(`  Tag/spec: ${theme.muted(preview.tag)}`);
-  if (preview.currentVersion) {
-    defaultRuntime.log(`  Current version: ${theme.muted(preview.currentVersion)}`);
-  }
-  if (preview.targetVersion) {
-    defaultRuntime.log(`  Target version: ${theme.muted(preview.targetVersion)}`);
-  }
-  if (preview.downgradeRisk) {
-    defaultRuntime.log(theme.warn("  Downgrade confirmation would be required in a real run."));
-  }
-
-  defaultRuntime.log("");
-  defaultRuntime.log(theme.heading("Planned actions:"));
-  for (const action of preview.actions) {
-    defaultRuntime.log(`  - ${action}`);
-  }
-
-  if (preview.notes.length > 0) {
-    defaultRuntime.log("");
-    defaultRuntime.log(theme.heading("Notes:"));
-    for (const note of preview.notes) {
-      defaultRuntime.log(`  - ${theme.muted(note)}`);
-    }
-  }
-}
-
-function formatSchemaRefusalLines(
-  schemas: {
-    incompatible: readonly IncompatibleOpenClawDatabase[];
-    indeterminate: readonly IndeterminateOpenClawDatabase[];
-  },
-  dryRun = false,
-): string[] {
-  const prefix = dryRun ? "Would refuse update" : "Update refused";
-  return [
-    ...schemas.incompatible.map((database) => {
-      const agent = database.agentId ? ` (agent ${database.agentId})` : "";
-      return `${prefix}: ${database.kind} database${agent} ${database.path} has schema ${database.foundVersion}; target supports ${database.supportedVersion}; writer build ${database.writerAppVersion ?? "unknown"}.`;
-    }),
-    ...schemas.indeterminate.map(
-      (database) =>
-        `${prefix}: could not inspect ${database.kind} database ${database.path}: ${database.reason}; retry once the gateway releases it.`,
-    ),
-    OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
-    "Installing manually via npm bypasses this guard; back up first and verify compatibility.",
-  ];
-}
-
-function checkTargetDatabaseSchemas(
-  supportedVersions: OpenClawSchemaVersions | undefined,
-  env: NodeJS.ProcessEnv = process.env,
-): OpenClawDatabaseSchemaPreflight {
-  return supportedVersions
-    ? preflightOpenClawDatabaseSchemas({ env, supportedVersions })
-    : { incompatible: [], indeterminate: [] };
-}
-
-function hasSchemaRefusal(schemas: OpenClawDatabaseSchemaPreflight): boolean {
-  return schemas.incompatible.length > 0 || schemas.indeterminate.length > 0;
-}
-
-async function runPackageInstallUpdate(params: {
-  root: string;
-  installKind: "git" | "package" | "unknown";
-  tag: string;
-  installSpec?: string;
-  timeoutMs: number;
-  startedAt: number;
-  progress: ReturnType<typeof createUpdateProgress>["progress"];
-  jsonMode: boolean;
-  allowGatewayServiceRepair: boolean;
-  allowGatewayActivation: boolean;
-  managedServiceEnv?: NodeJS.ProcessEnv;
-  invocationCwd?: string;
-  honorPackageRoot?: boolean;
-  nodeRunner?: string;
-  installEnv?: NodeJS.ProcessEnv;
-  installTarget?: ResolvedGlobalInstallTarget;
-}): Promise<UpdateRunResult> {
-  const installEnv = params.installEnv ?? (await createGlobalInstallEnv());
-  const runCommand = createGlobalCommandRunner();
-  let installTarget = params.installTarget;
-  if (!installTarget) {
-    const manager = await resolveGlobalManager({
-      root: params.root,
-      installKind: params.installKind,
-      timeoutMs: params.timeoutMs,
-    });
-    installTarget = await resolveGlobalInstallTarget({
-      manager,
-      runCommand,
-      timeoutMs: params.timeoutMs,
-      pkgRoot: params.root,
-      honorPackageRoot: params.honorPackageRoot === true,
-    });
-  }
-  const pkgRoot = installTarget.packageRoot;
-  const packageName =
-    (pkgRoot ? await readPackageName(pkgRoot) : await readPackageName(params.root)) ??
-    DEFAULT_PACKAGE_NAME;
-  const installSpec =
-    params.installSpec ??
-    resolveGlobalInstallSpec({
-      packageName,
-      tag: params.tag,
-      env: installEnv,
-    });
-
-  const beforeVersion = pkgRoot ? await readPackageVersion(pkgRoot) : null;
-  if (pkgRoot) {
-    await cleanupGlobalRenameDirs({
-      globalRoot: path.dirname(pkgRoot),
-      packageName,
-    });
-  }
-
-  const diskWarning = createLowDiskSpaceWarning({
-    targetPath: pkgRoot ? path.dirname(pkgRoot) : params.root,
-    purpose: "global package update",
-  });
-  if (diskWarning) {
-    if (params.jsonMode) {
-      defaultRuntime.error(`Warning: ${diskWarning}`);
-    } else {
-      defaultRuntime.log(theme.warn(diskWarning));
-    }
-  }
-
-  const packageUpdate = await runGlobalPackageUpdateSteps({
-    installTarget,
-    installSpec,
-    packageName,
-    packageRoot: pkgRoot,
-    runCommand,
-    timeoutMs: params.timeoutMs,
-    ...(installEnv === undefined ? {} : { env: installEnv }),
-    runStep: (stepParams) =>
-      runUpdateStep({
-        ...stepParams,
-        progress: params.progress,
-      }),
-    postVerifyStep: async (verifiedPackageRoot) => {
-      const entryPath = await resolveGatewayInstallEntrypoint(verifiedPackageRoot);
-      if (entryPath) {
-        await createUpdateConfigSnapshot();
-        const candidateHostVersion = await readPackageVersion(verifiedPackageRoot);
-        const doctorResultPath = createUpdatePostInstallDoctorResultPath();
-        const doctorPolicy = resolveUpdateDoctorExecutionPolicy({
-          targetVersion: candidateHostVersion,
-          allowGatewayServiceRepair: params.allowGatewayServiceRepair,
-        });
-        const doctorArgv = [
-          params.nodeRunner ?? resolveNodeRunner(),
-          entryPath,
-          "doctor",
-          "--non-interactive",
-          ...(doctorPolicy.fix ? ["--fix"] : []),
-        ];
-        const doctorProgressInfo = {
-          name: `${CLI_NAME} doctor`,
-          command: doctorArgv.join(" "),
-          index: 0,
-          total: 0,
-        };
-        params.progress?.onStepStart?.(doctorProgressInfo);
-        const doctorStep = await runUpdateStep({
-          name: `${CLI_NAME} doctor`,
-          argv: doctorArgv,
-          cwd: verifiedPackageRoot,
-          env: {
-            ...resolvePostInstallDoctorEnv({
-              serviceEnv: params.managedServiceEnv,
-              invocationCwd: params.invocationCwd,
-            }),
-            OPENCLAW_UPDATE_IN_PROGRESS: "1",
-            [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
-            [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
-            [UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART_ENV]: "1",
-            [UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR_ENV]: params.allowGatewayServiceRepair
-              ? "1"
-              : "0",
-            [UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION_ENV]: params.allowGatewayActivation
-              ? "1"
-              : "0",
-            ...(doctorPolicy.serviceRepairPolicy
-              ? { OPENCLAW_SERVICE_REPAIR_POLICY: doctorPolicy.serviceRepairPolicy }
-              : {}),
-            [UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV]: doctorResultPath,
-            ...(candidateHostVersion === null
-              ? {}
-              : { OPENCLAW_COMPATIBILITY_HOST_VERSION: candidateHostVersion }),
-          },
-          timeoutMs: params.timeoutMs,
-        });
-        const doctorResult = await consumeUpdatePostInstallDoctorResult(doctorResultPath);
-        const completedDoctorStep = markPackagePostInstallDoctorAdvisory(doctorStep, doctorResult);
-        params.progress?.onStepComplete?.({
-          ...doctorProgressInfo,
-          durationMs: completedDoctorStep.durationMs,
-          exitCode: completedDoctorStep.exitCode,
-          stderrTail: completedDoctorStep.stderrTail,
-          signal: completedDoctorStep.signal,
-          killed: completedDoctorStep.killed,
-          termination: completedDoctorStep.termination,
-          advisory: completedDoctorStep.advisory,
-        });
-        return completedDoctorStep;
-      }
-      return null;
-    },
-  });
-
-  return {
-    status: packageUpdate.failedStep ? "error" : "ok",
-    mode: installTarget.manager,
-    root: packageUpdate.verifiedPackageRoot ?? params.root,
-    reason: packageUpdate.failedStep ? packageUpdate.failedStep.name : undefined,
-    before: { version: beforeVersion },
-    after: { version: packageUpdate.afterVersion ?? beforeVersion },
-    steps: packageUpdate.steps,
-    durationMs: Date.now() - params.startedAt,
-  };
-}
-
-async function runGitUpdate(params: {
-  root: string;
-  switchToGit: boolean;
-  installKind: "git" | "package" | "unknown";
-  timeoutMs: number | undefined;
-  startedAt: number;
-  progress: ReturnType<typeof createUpdateProgress>["progress"];
-  channel: UpdateChannel;
-  tag: string;
-  showProgress: boolean;
-  opts: UpdateCommandOptions;
-  stop: () => void;
-  devTargetRef?: string;
-  beforeGitMutation?: (target: {
-    schemaVersions?: OpenClawSchemaVersions;
-    metadataUnreadable?: string;
-  }) => Promise<{
-    allowGatewayServiceRepair?: boolean;
-    allowGatewayActivation?: boolean;
-  } | void>;
-  allowGatewayServiceRepair: boolean;
-  allowGatewayActivation: boolean;
-}): Promise<UpdateRunResult> {
-  const updateRoot = params.switchToGit ? resolveGitInstallDir() : params.root;
-  const effectiveTimeout = params.timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
-  const installEnv = await createGlobalInstallEnv();
-
-  const cloneStep = params.switchToGit
-    ? await ensureGitCheckout({
-        dir: updateRoot,
-        env: installEnv,
-        timeoutMs: effectiveTimeout,
-        progress: params.progress,
-      })
-    : null;
-
-  if (cloneStep && cloneStep.exitCode !== 0) {
-    const result: UpdateRunResult = {
-      status: "error",
-      mode: "git",
-      root: updateRoot,
-      reason: cloneStep.name,
-      steps: [cloneStep],
-      durationMs: Date.now() - params.startedAt,
-    };
-    params.stop();
-    printResult(result, { ...params.opts, hideSteps: params.showProgress });
-    defaultRuntime.exit(1);
-    return result;
-  }
-
-  const updateResult = await runGatewayUpdate({
-    cwd: updateRoot,
-    argv1: params.switchToGit ? undefined : process.argv[1],
-    timeoutMs: params.timeoutMs,
-    progress: params.progress,
-    channel: params.channel,
-    tag: params.tag,
-    devTargetRef: params.devTargetRef,
-    deferConfiguredPluginInstallRepair: true,
-    allowGatewayServiceRepair: params.allowGatewayServiceRepair,
-    allowGatewayActivation: params.allowGatewayActivation,
-    beforeGitMutation: params.beforeGitMutation,
-  });
-  const steps = [...(cloneStep ? [cloneStep] : []), ...updateResult.steps];
-
-  if (params.switchToGit && updateResult.status === "ok") {
-    const manager = await resolveGlobalManager({
-      root: params.root,
-      installKind: params.installKind,
-      timeoutMs: effectiveTimeout,
-    });
-    const runCommand = createGlobalCommandRunner();
-    const installTarget = await resolveGlobalInstallTarget({
-      manager,
-      runCommand,
-      timeoutMs: effectiveTimeout,
-      pkgRoot: params.root,
-    });
-    const installLocation =
-      installTarget.manager === "pnpm"
-        ? resolvePnpmGlobalDirFromGlobalRoot(installTarget.globalRoot)
-        : null;
-    const installStep = await runUpdateStep({
-      name: "global install",
-      argv: globalInstallArgs(installTarget, updateRoot, undefined, installLocation, updateRoot),
-      cwd: updateRoot,
-      env: installEnv,
-      timeoutMs: effectiveTimeout,
-      progress: params.progress,
-    });
-    steps.push(installStep);
-
-    const failedStep = installStep.exitCode !== 0 ? installStep : null;
-    return {
-      ...updateResult,
-      status: updateResult.status === "ok" && !failedStep ? "ok" : "error",
-      steps,
-      durationMs: Date.now() - params.startedAt,
-    };
-  }
-
-  return {
-    ...updateResult,
-    steps,
-    durationMs: Date.now() - params.startedAt,
-  };
-}
 
 async function withUpdateInProgressEnv<T>(run: () => Promise<T>): Promise<T> {
   const previousUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
@@ -586,9 +119,6 @@ async function updateCommandInternal(
   const invocationCwd = tryResolveInvocationCwd();
   const postCoreUpdateResume = process.env[POST_CORE_UPDATE_ENV] === "1";
   const postCoreUpdateChannel = process.env[POST_CORE_UPDATE_CHANNEL_ENV]?.trim();
-  const postCoreRequestedChannelInput =
-    process.env[POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV]?.trim() ?? "";
-  const postCoreInstallRecordsPath = process.env[POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV];
 
   const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
   const shouldRestart = opts.restart !== false;
@@ -612,85 +142,12 @@ async function updateCommandInternal(
 
   let root = await resolveUpdateRoot();
   if (postCoreUpdateResume) {
-    if (
-      postCoreUpdateChannel !== "stable" &&
-      postCoreUpdateChannel !== "extended-stable" &&
-      postCoreUpdateChannel !== "beta" &&
-      postCoreUpdateChannel !== "dev"
-    ) {
-      defaultRuntime.error("Missing post-core update channel context.");
-      defaultRuntime.exit(1);
-      return;
-    }
-
-    const postCoreRequestedChannel = postCoreRequestedChannelInput
-      ? normalizeUpdateChannel(postCoreRequestedChannelInput)
-      : null;
-    if (postCoreRequestedChannelInput && !postCoreRequestedChannel) {
-      defaultRuntime.error("Invalid post-core requested update channel context.");
-      defaultRuntime.exit(1);
-      return;
-    }
-
-    process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = (await readPackageVersion(root)) ?? VERSION;
-
-    let postCoreConfigSnapshot = await readConfigFileSnapshot({
-      skipPluginValidation: true,
-      suppressFutureVersionWarning: true,
-    });
-    const preUpdateSourceConfig = await readPostCorePreUpdateSourceConfig({
-      sourceConfigPath: process.env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV],
-      currentSnapshot: postCoreConfigSnapshot,
-      updateStartedAtMs: await resolvePostCoreUpdateStartedAtMs(process.env),
-    });
-    postCoreConfigSnapshot = await persistRequestedUpdateChannel({
-      configSnapshot: postCoreConfigSnapshot,
-      requestedChannel: postCoreRequestedChannel,
-    });
-    const restoredPostCoreConfig = restoreDroppedPreUpdateChannels(
-      postCoreConfigSnapshot,
-      preUpdateSourceConfig,
-    );
-    const parentPluginInstallRecords = await readPostCorePluginInstallRecordsFile(
-      postCoreInstallRecordsPath,
-    );
-    // The updated doctor may have repaired plugin installs before this fresh process resumed.
-    const currentPluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
-    const pluginInstallRecords =
-      Object.keys(currentPluginInstallRecords).length > 0
-        ? currentPluginInstallRecords
-        : parentPluginInstallRecords;
-
-    const pluginUpdate = await updatePluginsAfterCoreUpdate({
+    await resumePostCoreUpdate({
       root,
       channel: postCoreUpdateChannel,
-      configSnapshot: restoredPostCoreConfig.snapshot,
-      configChanged: restoredPostCoreConfig.changed,
-      restoredAuthoredChannels: restoredPostCoreConfig.authoredChannels,
       opts,
       timeoutMs: updateStepTimeoutMs,
-      pluginInstallRecords,
     });
-    if (process.env[POST_CORE_UPDATE_RESULT_PATH_ENV]) {
-      await writePostCorePluginUpdateResultFile(
-        process.env[POST_CORE_UPDATE_RESULT_PATH_ENV],
-        pluginUpdate,
-      );
-    }
-    if (opts.json) {
-      if (!process.env[POST_CORE_UPDATE_RESULT_PATH_ENV]) {
-        const result: UpdateRunResult = {
-          status: pluginUpdate.status === "error" ? "error" : "ok",
-          mode: "unknown",
-          root,
-          steps: [],
-          durationMs: 0,
-          postUpdate: { plugins: pluginUpdate },
-        };
-        defaultRuntime.writeJson(result);
-      }
-    }
-    defaultRuntime.exit(0);
     return;
   }
 
@@ -971,90 +428,29 @@ async function updateCommandInternal(
   }
 
   if (opts.dryRun) {
-    let mode: UpdateRunResult["mode"] = "unknown";
-    if (updateInstallKind === "git") {
-      mode = "git";
-    } else if (updateInstallKind === "package") {
-      mode = await resolveGlobalManager({
-        root,
-        installKind,
-        timeoutMs: updateStepTimeoutMs,
-      });
-    }
-
-    const actions: string[] = [];
-    if (requestedChannel && requestedChannel !== storedChannel) {
-      actions.push(`Persist update.channel=${requestedChannel} in config`);
-    }
-    if (switchToGit) {
-      actions.push("Switch install mode from package to git checkout (dev channel)");
-    } else if (switchToPackage) {
-      actions.push(`Switch install mode from git to package manager (${mode})`);
-    } else if (updateInstallKind === "git") {
-      actions.push(`Run git update flow on channel ${channel} (fetch/rebase/build/doctor)`);
-    } else if (packageAlreadyCurrent) {
-      actions.push(
-        `Refresh package install with spec ${packageInstallSpec ?? tag}; current version already matches ${targetVersion}`,
-      );
-    } else {
-      actions.push(`Run global package manager update with spec ${packageInstallSpec ?? tag}`);
-    }
-    actions.push("Run plugin update sync after core update");
-    actions.push("Refresh shell completion cache (if needed)");
-    actions.push(
-      shouldRestart
-        ? "Restart gateway service and run doctor checks"
-        : "Skip restart (because --no-restart is set)",
-    );
-
-    const notes: string[] = [];
-    if (opts.tag && updateInstallKind === "git") {
-      notes.push("--tag applies to npm installs only; git updates ignore it.");
-    }
-    if (fallbackToLatest) {
-      notes.push("Beta channel resolves to latest for this run (fallback).");
-    }
-    if (managedServiceRootRedirect) {
-      notes.push(
-        `Package update targets managed service root ${managedServiceRootRedirect.root} instead of invoking root ${managedServiceRootRedirect.previousRoot}.`,
-      );
-    }
-    if (explicitTag && !canResolveRegistryVersionForPackageTarget(tag)) {
-      notes.push("Non-registry package specs skip npm version lookup and downgrade previews.");
-    }
-    if (hasSchemaRefusal(packageSchemaPreflight)) {
-      notes.push(...formatSchemaRefusalLines(packageSchemaPreflight, true));
-    }
-    if (updateInstallKind === "git") {
-      // The git target revision is resolved inside the real update run, so its
-      // schema support cannot be previewed here without duplicating that flow.
-      notes.push(
-        "Database schema compatibility of the git target is verified during the real update; this preview does not check it.",
-      );
-    }
-
-    printDryRunPreview(
-      {
-        dryRun: true,
-        root,
-        installKind,
-        mode,
-        updateInstallKind,
-        switchToGit,
-        switchToPackage,
-        restart: shouldRestart,
-        requestedChannel,
-        storedChannel,
-        effectiveChannel: channel,
-        tag: packageInstallSpec ?? tag,
-        currentVersion,
-        targetVersion,
-        downgradeRisk,
-        actions,
-        notes,
-      },
-      Boolean(opts.json),
-    );
+    await printUpdateDryRun({
+      root,
+      installKind,
+      updateInstallKind,
+      switchToGit,
+      switchToPackage,
+      shouldRestart,
+      requestedChannel,
+      storedChannel,
+      channel,
+      tag,
+      packageInstallSpec,
+      currentVersion,
+      targetVersion,
+      downgradeRisk,
+      packageAlreadyCurrent,
+      fallbackToLatest,
+      managedServiceRootRedirect,
+      explicitTag,
+      packageSchemaPreflight,
+      timeoutMs: updateStepTimeoutMs,
+      opts,
+    });
     return;
   }
 
@@ -1141,553 +537,54 @@ async function updateCommandInternal(
   const startedAt = Date.now();
   const preUpdatePluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
 
-  let preManagedServiceStop: PreManagedServiceStop | undefined;
-  let schemaRefusalAfterStop = false;
-  const gitMutationRoots =
-    updateInstallKind === "git" ? (switchToGit ? [root, resolveGitInstallDir()] : [root]) : null;
-  const stopManagedServiceBeforeMutableUpdate = async (
-    mutationRoots: readonly string[] = [root],
-  ) => {
-    if (updateInstallKind !== "package" && updateInstallKind !== "git") {
-      return;
-    }
-    try {
-      const uniqueMutationRoots = Array.from(new Set(mutationRoots));
-      for (const mutationRoot of uniqueMutationRoots) {
-        preManagedServiceStop = await maybeStopManagedServiceBeforeMutableUpdate({
-          updateInstallKind,
-          root: mutationRoot,
-          shouldRestart,
-          jsonMode: Boolean(opts.json),
-        });
-        if (preManagedServiceStop.windowsTaskAutoStartRecovery) {
-          recoveryState.windowsTaskAutoStartRecovery =
-            preManagedServiceStop.windowsTaskAutoStartRecovery;
-        }
-        if (
-          preManagedServiceStop.stopped ||
-          preManagedServiceStop.blockMessage ||
-          shouldBlockMutableUpdateFromGatewayServiceEnv({ preManagedServiceStop }) ||
-          !preManagedServiceStop.inspected ||
-          !preManagedServiceStop.running ||
-          !shouldRestart
-        ) {
-          break;
-        }
-      }
-    } catch (err) {
-      if (err instanceof UpdateCommandAbort) {
-        throw err;
-      }
-      stop();
-      defaultRuntime.error(`Failed to stop managed gateway service before update: ${String(err)}`);
-      defaultRuntime.exit(1);
-      throw new UpdateCommandAbort();
-    }
-
-    if (preManagedServiceStop?.blockMessage) {
-      stop();
-      defaultRuntime.error(preManagedServiceStop.blockMessage);
-      defaultRuntime.exit(1);
-      throw new UpdateCommandAbort();
-    }
-
-    if (shouldBlockMutableUpdateFromGatewayServiceEnv({ preManagedServiceStop })) {
-      stop();
-      const updateLabel = updateInstallKind === "git" ? "Git updates" : "Package updates";
-      defaultRuntime.error(
-        [
-          `${updateLabel} cannot run from inside the gateway service process.`,
-          "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
-          `Run \`${replaceCliName(formatCliCommand("openclaw update"), CLI_NAME)}\` from a shell outside the gateway service, or stop the gateway service first and then update.`,
-        ].join("\n"),
-      );
-      defaultRuntime.exit(1);
-      throw new UpdateCommandAbort();
-    }
-  };
-
-  if (updateInstallKind === "package") {
-    try {
-      await stopManagedServiceBeforeMutableUpdate();
-    } catch (err) {
-      if (err instanceof UpdateCommandAbort) {
-        return;
-      }
-      throw err;
-    }
-  }
-
-  const postStopPackageSchemaPreflight =
-    updateInstallKind === "package"
-      ? checkTargetDatabaseSchemas(
-          packageTargetSchemaVersions,
-          preManagedServiceStop?.serviceEnv ?? process.env,
-        )
-      : { incompatible: [], indeterminate: [] };
-  if (hasSchemaRefusal(postStopPackageSchemaPreflight)) {
-    schemaRefusalAfterStop = true;
-    defaultRuntime.error(formatSchemaRefusalLines(postStopPackageSchemaPreflight).join("\n"));
-  }
-
-  let result: UpdateRunResult;
-  try {
-    result =
-      updateInstallKind === "package" && hasSchemaRefusal(postStopPackageSchemaPreflight)
-        ? {
-            status: "error",
-            mode: packageInstallTarget?.manager ?? "unknown",
-            root,
-            reason: "database-schema-preflight",
-            steps: [],
-            durationMs: Date.now() - startedAt,
-          }
-        : updateInstallKind === "package"
-          ? await runPackageInstallUpdate({
-              root,
-              installKind,
-              tag,
-              installSpec: packageInstallSpec ?? undefined,
-              timeoutMs: updateStepTimeoutMs,
-              startedAt,
-              progress,
-              jsonMode: Boolean(opts.json),
-              allowGatewayServiceRepair: preManagedServiceStop?.serviceMatchesMutationRoot === true,
-              allowGatewayActivation:
-                shouldRestart &&
-                preManagedServiceStop?.stopped === true &&
-                preManagedServiceStop.serviceMatchesMutationRoot === true,
-              managedServiceEnv: preManagedServiceStop?.serviceEnv,
-              invocationCwd,
-              honorPackageRoot:
-                managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
-              nodeRunner: packageUpdateNodeRunner,
-              installEnv: packageInstallEnv,
-              installTarget: packageInstallTarget,
-            })
-          : await runGitUpdate({
-              root,
-              switchToGit,
-              installKind,
-              timeoutMs,
-              startedAt,
-              progress,
-              channel,
-              tag,
-              showProgress,
-              opts,
-              stop,
-              devTargetRef,
-              beforeGitMutation:
-                updateInstallKind === "git"
-                  ? async (target) => {
-                      if (target?.metadataUnreadable) {
-                        defaultRuntime.error(
-                          `Update refused: could not inspect the target's schema support (${target.metadataUnreadable}). Retry, or see ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
-                        );
-                        defaultRuntime.exit(1);
-                        throw new UpdateCommandAbort();
-                      }
-                      const preStopSchemas = checkTargetDatabaseSchemas(target?.schemaVersions);
-                      if (hasSchemaRefusal(preStopSchemas)) {
-                        defaultRuntime.error(formatSchemaRefusalLines(preStopSchemas).join("\n"));
-                        defaultRuntime.exit(1);
-                        throw new UpdateCommandAbort();
-                      }
-                      await stopManagedServiceBeforeMutableUpdate(gitMutationRoots ?? [root]);
-                      const postStopSchemas = checkTargetDatabaseSchemas(
-                        target?.schemaVersions,
-                        preManagedServiceStop?.serviceEnv ?? process.env,
-                      );
-                      if (hasSchemaRefusal(postStopSchemas)) {
-                        schemaRefusalAfterStop = true;
-                        defaultRuntime.error(formatSchemaRefusalLines(postStopSchemas).join("\n"));
-                        throw new UpdateCommandAbort();
-                      }
-                      return {
-                        // Only a positively owned service may be rewritten. Activation
-                        // additionally requires this update to have stopped it.
-                        allowGatewayServiceRepair:
-                          preManagedServiceStop?.serviceMatchesMutationRoot === true,
-                        allowGatewayActivation:
-                          shouldRestart &&
-                          preManagedServiceStop?.stopped === true &&
-                          preManagedServiceStop.serviceMatchesMutationRoot === true,
-                      };
-                    }
-                  : undefined,
-              allowGatewayServiceRepair: false,
-              allowGatewayActivation: false,
-            });
-  } catch (err) {
-    stop();
-    if (err instanceof UpdateCommandAbort) {
-      if (schemaRefusalAfterStop) {
-        if (preManagedServiceStop?.stopped === true) {
-          await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop).catch(
-            () => undefined,
-          );
-          await maybeRestartServiceAfterFailedMutableUpdate({
-            preManagedServiceStop,
-            jsonMode: Boolean(opts.json),
-          });
-        }
-        defaultRuntime.exit(1);
-      }
-      return;
-    }
-    try {
-      await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop);
-    } catch (resumeErr) {
-      recoveryState.windowsTaskAutoStartRecovery?.complete();
-      recoveryState.windowsTaskAutoStartRecovery = undefined;
-      throw createAggregateErrorWithCause(
-        [err, resumeErr],
-        `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
-        err,
-      );
-    }
-    await maybeRestartServiceAfterFailedMutableUpdate({
-      preManagedServiceStop,
-      jsonMode: Boolean(opts.json),
-    });
-    throw err;
-  }
-
-  stop();
-  if (!opts.json || result.status !== "ok") {
-    printResult(result, { ...opts, hideSteps: showProgress });
-  }
-
-  if (result.status === "error") {
-    if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
-      return;
-    }
-    await writeControlPlaneUpdateRestartSentinelBestEffort({
-      meta: controlPlaneUpdateSentinelMeta,
-      result,
-      jsonMode: Boolean(opts.json),
-    });
-    await maybeRestartServiceAfterFailedMutableUpdate({
-      preManagedServiceStop,
-      jsonMode: Boolean(opts.json),
-    });
-    defaultRuntime.exit(1);
-    return;
-  }
-
-  if (result.status === "skipped") {
-    if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
-      return;
-    }
-    await writeControlPlaneUpdateRestartSentinelBestEffort({
-      meta: controlPlaneUpdateSentinelMeta,
-      result,
-      jsonMode: Boolean(opts.json),
-    });
-    await maybeRestartServiceAfterFailedMutableUpdate({
-      preManagedServiceStop,
-      jsonMode: Boolean(opts.json),
-    });
-    if (result.reason === "dirty") {
-      defaultRuntime.error(theme.error("Update blocked: local files are edited in this checkout."));
-      defaultRuntime.log(
-        theme.warn(
-          "Git-based updates need a clean working tree before they can switch commits, fetch, or rebase.",
-        ),
-      );
-      defaultRuntime.log(
-        theme.muted("Commit, stash, or discard the local changes, then rerun `openclaw update`."),
-      );
-    }
-    if (result.reason === "not-git-install") {
-      defaultRuntime.log(
-        theme.warn(
-          `Skipped: this OpenClaw install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run \`${replaceCliName(formatCliCommand("openclaw doctor"), CLI_NAME)}\` and \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\`.`,
-        ),
-      );
-      defaultRuntime.log(
-        theme.muted(
-          `Examples: \`${replaceCliName("npm i -g openclaw@latest", CLI_NAME)}\` or \`${replaceCliName("pnpm add -g openclaw@latest", CLI_NAME)}\``,
-        ),
-      );
-    }
-    defaultRuntime.exit(0);
-    return;
-  }
-
-  const shouldResumePostCoreInFreshProcess = shouldResumePostCoreUpdateInFreshProcess({
-    result,
-    downgradeRisk,
-  });
-
-  let postUpdateConfigSnapshot =
-    result.status === "ok" && !opts.dryRun
-      ? await readConfigFileSnapshot({
-          skipPluginValidation: true,
-          suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
-        })
-      : configSnapshot;
-  if (!shouldResumePostCoreInFreshProcess) {
-    postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
-      configSnapshot: postUpdateConfigSnapshot,
-      requestedChannel,
-    });
-  }
-  if (
-    requestedChannel &&
-    configSnapshot.valid &&
-    requestedChannel !== storedChannel &&
-    !shouldResumePostCoreInFreshProcess &&
-    !opts.json
-  ) {
-    defaultRuntime.log(theme.muted(`Update channel set to ${requestedChannel}.`));
-  } else if (
-    requestedChannel &&
-    configSnapshot.valid &&
-    requestedChannel !== storedChannel &&
-    shouldResumePostCoreInFreshProcess &&
-    !opts.json
-  ) {
-    defaultRuntime.log(theme.muted(`Update channel will be set to ${requestedChannel}.`));
-  }
-
-  const postUpdateRoot = result.root ?? root;
-
-  let postCorePluginUpdate: PostCorePluginUpdateResult | undefined;
-  let pluginsUpdatedInFreshProcess = false;
-  if (shouldResumePostCoreInFreshProcess) {
-    const freshProcessResult = await continuePostCoreUpdateInFreshProcess({
-      root: postUpdateRoot,
-      channel,
-      requestedChannel,
-      opts,
-      pluginInstallRecords: preUpdatePluginInstallRecords,
-      updateStartedAtMs: startedAt,
-      nodeRunner: packageUpdateNodeRunner,
-      preUpdateConfig: configSnapshot.valid
-        ? {
-            sourceConfig: configSnapshot.sourceConfig,
-            authoredConfig: isRecord(configSnapshot.parsed)
-              ? (configSnapshot.parsed as OpenClawConfig)
-              : configSnapshot.sourceConfig,
-          }
-        : undefined,
-    });
-    if (freshProcessResult.exitCode !== undefined) {
-      if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
-        return;
-      }
-      defaultRuntime.exit(freshProcessResult.exitCode);
-      throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
-    }
-    pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
-    postCorePluginUpdate = freshProcessResult.pluginUpdate;
-  }
-
-  if (!pluginsUpdatedInFreshProcess) {
-    if (shouldResumePostCoreInFreshProcess) {
-      postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
-        configSnapshot: postUpdateConfigSnapshot,
-        requestedChannel,
-      });
-    }
-    const restoredConfig = restoreDroppedPreUpdateChannels(
-      postUpdateConfigSnapshot,
-      configSnapshot.valid
-        ? {
-            sourceConfig: configSnapshot.sourceConfig,
-            authoredConfig: isRecord(configSnapshot.parsed)
-              ? (configSnapshot.parsed as OpenClawConfig)
-              : configSnapshot.sourceConfig,
-          }
-        : undefined,
-    );
-    postUpdateConfigSnapshot = restoredConfig.snapshot;
-    // Current-process post-core convergence still reports the pre-update
-    // VERSION. During downgrades, pin compatibility checks to the installed
-    // target so incompatible newer plugins are disabled before restart.
-    const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
-    const versionComparison =
-      postUpdateInstalledVersion && VERSION
-        ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
-        : null;
-    const compatibilityDowngradeTarget =
-      versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
-    const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-    if (compatibilityDowngradeTarget) {
-      process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
-    }
-    try {
-      postCorePluginUpdate = await updatePluginsAfterCoreUpdate({
-        root: postUpdateRoot,
-        channel,
-        configSnapshot: postUpdateConfigSnapshot,
-        configChanged: restoredConfig.changed,
-        restoredAuthoredChannels: restoredConfig.authoredChannels,
-        opts,
-        timeoutMs: updateStepTimeoutMs,
-        pluginInstallRecords: preUpdatePluginInstallRecords,
-      });
-    } finally {
-      if (compatibilityDowngradeTarget) {
-        if (previousCompatibilityHostVersion === undefined) {
-          delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-        } else {
-          process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
-        }
-      }
-    }
-  }
-
-  const resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate
-    ? {
-        ...result,
-        status: postCorePluginUpdate.status === "error" ? "error" : result.status,
-        ...(postCorePluginUpdate.status === "error" ? { reason: "post-update-plugins" } : {}),
-        postUpdate: {
-          ...result.postUpdate,
-          plugins: postCorePluginUpdate,
-        },
-      }
-    : result;
-
-  if (postCorePluginUpdate?.status === "error") {
-    if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
-      return;
-    }
-    await writeControlPlaneUpdateRestartSentinelBestEffort({
-      meta: controlPlaneUpdateSentinelMeta,
-      result: resultWithPostUpdate,
-      jsonMode: Boolean(opts.json),
-    });
-    if (opts.json) {
-      defaultRuntime.writeJson(resultWithPostUpdate);
-    } else {
-      defaultRuntime.error(theme.error("Update failed during plugin post-update sync."));
-    }
-    defaultRuntime.exit(1);
-    return;
-  }
-
-  let restartScriptPath: string | null = null;
-  let refreshGatewayServiceEnvLocal = false;
-  let gatewayServiceEnv: NodeJS.ProcessEnv | undefined;
-  let skipLegacyServiceRestart = false;
-  let gatewayPort = resolveUpdatedGatewayRestartPort({
-    config: postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
-    processEnv: process.env,
-  });
-  if (shouldRestart) {
-    try {
-      const serviceState = await readGatewayServiceState(resolveGatewayService(), {
-        env: resolvePostUpdateServiceStateReadEnv({
-          updateMode: resultWithPostUpdate.mode,
-          processEnv: process.env,
-          preManagedServiceEnv: preManagedServiceStop?.serviceEnv,
-        }),
-      });
-      const serviceMatchesUpdateRoot =
-        (await gatewayServiceCommandUsesRoot({
-          root: postUpdateRoot,
-          command: serviceState.command,
-        })) ?? undefined;
-      const serviceOwnershipConfirmed =
-        preManagedServiceStop?.serviceMatchesMutationRoot === true ||
-        serviceMatchesUpdateRoot === true;
-      const knownForeignService =
-        preManagedServiceStop?.serviceMatchesMutationRoot === false &&
-        serviceMatchesUpdateRoot !== true;
-      skipLegacyServiceRestart =
-        knownForeignService ||
-        (resultWithPostUpdate.mode === "git" &&
-          serviceState.installed &&
-          serviceState.loaded &&
-          preManagedServiceStop?.stopped !== true &&
-          serviceMatchesUpdateRoot === false);
-      if (
-        !knownForeignService &&
-        shouldPrepareUpdatedInstallRestart({
-          updateMode: resultWithPostUpdate.mode,
-          serviceInstalled: serviceState.installed,
-          serviceLoaded: serviceState.loaded,
-          serviceStoppedForUpdate: preManagedServiceStop?.stopped,
-          serviceMatchesMutationRoot: serviceOwnershipConfirmed
-            ? true
-            : preManagedServiceStop?.serviceMatchesMutationRoot,
-          serviceMatchesUpdateRoot,
-        })
-      ) {
-        gatewayServiceEnv = serviceState.env;
-        gatewayPort = resolveUpdatedGatewayRestartPort({
-          config: postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
-          processEnv: process.env,
-          serviceEnv: gatewayServiceEnv,
-        });
-        restartScriptPath = await prepareRestartScript(
-          serviceState.env,
-          gatewayPort,
-          serviceOwnershipConfirmed ? serviceState.command?.programArguments : undefined,
-        );
-        // An ambiguous wrapper may be stopped and restored, but only proven
-        // ownership authorizes rewriting the service definition.
-        refreshGatewayServiceEnvLocal = serviceOwnershipConfirmed;
-      }
-    } catch {
-      // Ignore errors during pre-check; fallback to standard restart
-    }
-  }
-
-  await tryWriteCompletionCache(postUpdateRoot, Boolean(opts.json));
-  await tryInstallShellCompletion({
-    jsonMode: Boolean(opts.json),
-    skipPrompt: Boolean(opts.yes),
-  });
-
-  await writeControlPlaneUpdateRestartSentinelBestEffort({
-    meta: controlPlaneUpdateSentinelMeta,
-    result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
-    jsonMode: Boolean(opts.json),
-  });
-
-  if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
-    return;
-  }
-  const restartOk = await maybeRestartService({
-    shouldRestart,
-    result: resultWithPostUpdate,
+  const execution = await executeMutableUpdate({
+    root,
+    installKind,
+    updateInstallKind,
+    switchToGit,
+    timeoutMs,
+    updateStepTimeoutMs,
+    startedAt,
+    progress,
+    stop,
+    channel,
+    tag,
+    showProgress,
     opts,
-    refreshServiceEnv: refreshGatewayServiceEnvLocal,
-    serviceEnv: gatewayServiceEnv,
-    gatewayPort,
-    restartScriptPath,
+    shouldRestart,
+    devTargetRef,
+    packageInstallSpec,
+    packageInstallEnv,
+    packageInstallTarget,
+    packageTargetSchemaVersions,
+    packageUpdateNodeRunner,
+    managedServiceNodeRunner,
+    managedServiceRootRedirect,
     invocationCwd,
-    nodeRunner: packageUpdateNodeRunner,
-    skipLegacyServiceRestart,
-    requireRunningServiceAfterRestart:
-      resultWithPostUpdate.mode === "git" && preManagedServiceStop?.stopped === true,
-    timeoutMs: updateStepTimeoutMs,
+    recoveryState,
   });
-  if (!restartOk) {
-    await markControlPlaneUpdateRestartSentinelFailureBestEffort({
-      meta: controlPlaneUpdateSentinelMeta,
-      reason: "restart-unhealthy",
-      jsonMode: Boolean(opts.json),
-    });
-    defaultRuntime.exit(1);
+  if (!execution) {
     return;
   }
-
-  await writeControlPlaneUpdateRestartSentinelBestEffort({
-    meta: controlPlaneUpdateSentinelMeta,
-    result: resultWithPostUpdate,
-    jsonMode: Boolean(opts.json),
+  const { result, preManagedServiceStop } = execution;
+  stop();
+  await finishUpdate({
+    result,
+    root,
+    configSnapshot,
+    requestedChannel,
+    storedChannel,
+    channel,
+    downgradeRisk,
+    shouldRestart,
+    opts,
+    showProgress,
+    preManagedServiceStop,
+    controlPlaneUpdateSentinelMeta,
+    preUpdatePluginInstallRecords,
+    startedAt,
+    packageUpdateNodeRunner,
+    updateStepTimeoutMs,
+    invocationCwd,
   });
-
-  if (!opts.json) {
-    defaultRuntime.log(theme.muted(pickUpdateQuip()));
-  } else {
-    defaultRuntime.writeJson(resultWithPostUpdate);
-  }
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`src/cli/update-cli/update-command.ts` was 1693 lines with a grandfathered `max-lines` suppression - the largest and most change-prone of the update surfaces (three separate feature rounds landed in it this week alone). Repo policy treats those suppressions as TODOs: split the file, remove the entry.

## Why This Change Was Made

Behavior-preserving split into focused siblings, each owning one phase of the update flow: `update-command-dry-run.ts` (179, preview assembly), `update-command-git.ts` (219, git flow + schema guards), `update-command-package.ts` (208, package install/doctor pipeline), `update-command-execution.ts` (255, mutable-update/service-stop orchestration), `update-command-post-update.ts` (427, plugin convergence/restart/final output), `update-command-resume.ts` (106, fresh-process post-core resume), with `update-command.ts` (590) as the public entry and orchestrator. The suppression is removed and the `config/max-lines-baseline.txt` entry deleted (ratchet shrinks). No behavior, output text, or exit-code changes.

## User Impact

None - pure refactor of internal module layout.

## Evidence

- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/infra/update-check.test.ts src/infra/update-runner.test.ts`: 288 passed, unchanged assertions (imports/mock targets follow moved code only).
- Max-lines ratchet passes with the removed entry; oxlint clean on all touched files; no new suppressions.
- `node scripts/check-deadcode-exports.mjs` 0 findings; `pnpm check:test-types` green (Blacksmith Testbox); `git diff --check` clean.
- Structured Codex autoreview (gpt-5.6-sol, xhigh): clean - "behavior-preserving split... flows remain equivalent", 0.98.
