### PR TITLE
fix(gateway): trim whitespace in audit.list cursor parsing

### DIFF
--- a/src/gateway/server-methods/audit.test.ts
+++ b/src/gateway/server-methods/audit.test.ts
@@ -199,4 +199,13 @@ describe("audit gateway methods", () => {
       expect(listAuditEvents).not.toHaveBeenCalled();
     },
   );
+
+  it.each(["audit.list", "audit.activity.list"] as const)(
+    "trims whitespace around cursor digits for %s",
+    async (method) => {
+      const respond = await runAuditHandler(method, { cursor: "  11  " });
+      expect(respond).toHaveBeenCalledWith(true, expect.anything());
+      expect(listAuditEvents).toHaveBeenCalledWith(expect.objectContaining({ cursor: 11 }));
+    },
+  );
 });

--- a/src/gateway/server-methods/audit.ts
+++ b/src/gateway/server-methods/audit.ts
@@ -23,10 +23,11 @@ function parseAuditCursor(cursor: string | undefined): number | undefined | null
   if (cursor === undefined) {
     return undefined;
   }
-  if (!/^\d+$/.test(cursor)) {
+  const trimmed = cursor.trim();
+  if (!/^\d+$/.test(trimmed)) {
     return null;
   }
-  const parsed = Number(cursor);
+  const parsed = Number(trimmed);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 


### PR DESCRIPTION
## What Problem This Solves

`parseAuditCursor` in `src/gateway/server-methods/audit.ts` did not trim whitespace before running the digit regex, while the parallel `parseCursor` in `src/gateway/server-methods/tasks.ts` did. A client passing `"  11  "` (e.g. URL-decoded from query strings, or copy-pasted by a user) would get a `400 INVALID_REQUEST` from `audit.list` / `audit.activity.list` instead of the correct page. The two gateway cursor parsers should behave identically.

## Fix

Trim the cursor before the digit regex so behavior matches `tasks.list` and the gateway cursor contract.

```diff
 function parseAuditCursor(cursor: string | undefined): number | undefined | null {
   if (cursor === undefined) {
     return undefined;
   }
+  const trimmed = cursor.trim();
     return null;
   }
-  const parsed = Number(cursor);
+  const parsed = Number(trimmed);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
```

## Evidence

New regression test covers the whitespace case for both `audit.list` and `audit.activity.list`:

```
src/gateway/server-methods/audit.test.ts
  ✓ trims whitespace around cursor digits for audit.list
  ✓ trims whitespace around cursor digits for audit.activity.list
```

Full test run for `audit.test.ts`:

```
Test Files  2 passed (2)
Tests  16 passed (16)
Duration  10.33s
```

Existing `rejects malformed cursors and inverted ranges` test continues to pass, confirming non-numeric cursors are still rejected.

Co-authored-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>