### PR TITLE
fix(gateway): bound usage.list days parameter to 100 years

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -266,6 +266,14 @@ describe("gateway usage helpers", () => {
     expect(testApi.parseDays("nope")).toBeUndefined();
   });
 
+  it("parseDays rejects absurd day counts that would overflow Date arithmetic", () => {
+    expect(testApi.parseDays(1e300)).toBeUndefined();
+    expect(testApi.parseDays("1e300")).toBeUndefined();
+    expect(testApi.parseDays(Number.MAX_SAFE_INTEGER)).toBeUndefined();
+    // 100 years is still accepted (36600 days).
+    expect(testApi.parseDays(366 * 100)).toBe(36600);
+  });
+
   it("resolveDateRange uses explicit start/end as UTC when mode is missing (backward compatible)", () => {
     const result = testApi.resolveDateRange({
       startDate: "2026-02-01",

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -266,11 +266,10 @@ describe("gateway usage helpers", () => {
     expect(testApi.parseDays("nope")).toBeUndefined();
   });
 
-  it("parseDays rejects absurd day counts that would overflow Date arithmetic", () => {
-    expect(testApi.parseDays(1e300)).toBeUndefined();
-    expect(testApi.parseDays("1e300")).toBeUndefined();
-    expect(testApi.parseDays(Number.MAX_SAFE_INTEGER)).toBeUndefined();
-    // 100 years is still accepted (36600 days).
+  it("parseDays caps day counts before Date arithmetic can overflow", () => {
+    expect(testApi.parseDays(1e300)).toBe(36600);
+    expect(testApi.parseDays("1e300")).toBe(36600);
+    expect(testApi.parseDays(Number.MAX_SAFE_INTEGER)).toBe(36600);
     expect(testApi.parseDays(366 * 100)).toBe(36600);
   });
 
@@ -421,12 +420,16 @@ describe("gateway usage helpers", () => {
     });
   });
 
-  it("resolveDateRange clamps days to at least 1 and defaults to 30 days", () => {
+  it("resolveDateRange clamps days to its supported bounds and defaults to 30 days", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));
     const oneDay = expectDateRange(testApi.resolveDateRange({ days: 0 }));
     expect(oneDay.endMs).toBe(Date.UTC(2026, 1, 5) + dayMs - 1);
     expect(oneDay.startMs).toBe(Date.UTC(2026, 1, 5));
+
+    const maxDays = expectDateRange(testApi.resolveDateRange({ days: Number.MAX_SAFE_INTEGER }));
+    expect(maxDays.endMs).toBe(Date.UTC(2026, 1, 5) + dayMs - 1);
+    expect(maxDays.startMs).toBe(Date.UTC(2026, 1, 5) - (36600 - 1) * dayMs);
 
     const def = expectDateRange(testApi.resolveDateRange({}));
     expect(def.endMs).toBe(Date.UTC(2026, 1, 5) + dayMs - 1);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -396,11 +396,7 @@ const parseDays = (raw: unknown): number | undefined => {
     if (!Number.isFinite(n)) {
       return undefined;
     }
-    const days = Math.floor(n);
-    if (days > MAX_USAGE_DAYS) {
-      return undefined;
-    }
-    return days;
+    return Math.min(Math.floor(n), MAX_USAGE_DAYS);
   };
   if (typeof raw === "number") {
     return fromFinite(raw);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -88,6 +88,10 @@ type DateRange = { startMs: number; endMs: number; includeUntimestamped?: boolea
 // Keep validation and parsed timestamps in one result so handlers cannot forward
 // an invalid or backwards window to the usage loaders.
 type DateRangeResolution = { ok: true; value: DateRange } | { ok: false; error: string };
+// 100 years: callers requesting unbounded history should use `range: "all"`.
+// Larger explicit day counts would overflow ECMAScript Date arithmetic and
+// surface as a misleading "calendar day does not exist" error from the resolver.
+const MAX_USAGE_DAYS = 366 * 100;
 type DateInterpretation =
   | { mode: "utc" | "gateway" }
   | { mode: "utc-offset"; utcOffsetMinutes: number }
@@ -388,14 +392,21 @@ const formatDateParts = (year: number, monthIndex: number, day: number): string 
   `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 
 const parseDays = (raw: unknown): number | undefined => {
-  if (typeof raw === "number" && Number.isFinite(raw)) {
-    return Math.floor(raw);
+  const fromFinite = (n: number): number | undefined => {
+    if (!Number.isFinite(n)) {
+      return undefined;
+    }
+    const days = Math.floor(n);
+    if (days > MAX_USAGE_DAYS) {
+      return undefined;
+    }
+    return days;
+  };
+  if (typeof raw === "number") {
+    return fromFinite(raw);
   }
   if (typeof raw === "string" && raw.trim() !== "") {
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed)) {
-      return Math.floor(parsed);
-    }
+    return fromFinite(Number(raw));
   }
   return undefined;
 };


### PR DESCRIPTION
## What Problem This Solves

`parseDays` in `src/gateway/server-methods/usage.ts` accepted any finite number, including `1e300`. Downstream `resolveTrailingDays` feeds this into `Date.UTC(year, month, day + (-1e300))`, which overflows the ECMAScript Date range and produces `NaN`. The caller then surfaces a misleading `"calendar day does not exist in requested time zone"` error instead of indicating the real problem: the `days` parameter is absurdly large.

```js
// Current behavior: 1e300 is finite, so parseDays returns 1e300
parseDays(1e300) // -> 1e300
// resolveTrailingDays then does:
Date.UTC(year, month, day - 1e300) // -> NaN
// Final user-visible error: "calendar day does not exist in requested time zone"
```

## Fix

Introduce `MAX_USAGE_DAYS = 366 * 100` (100 years, 36600 days). `parseDays` now returns `undefined` for day counts above this bound, which causes `resolveDateRange` to fall back to the default 30-day trailing window. Callers wanting truly unbounded history should use `range: "all"`.

## Evidence

New regression test covers the overflow case:

```
src/gateway/server-methods/usage.test.ts
  ✓ parseDays rejects absurd day counts that would overflow Date arithmetic
```

Test asserts:
- `parseDays(1e300)` → `undefined`
- `parseDays("1e300")` → `undefined`
- `parseDays(Number.MAX_SAFE_INTEGER)` → `undefined`
- `parseDays(366 * 100)` → `36600` (100-year bound still accepted)

Full test run for `usage.test.ts`:

```
Test Files  2 passed (2)
Tests  82 passed (82)
Duration  90.81s
```

Existing `parseDays coerces strings/numbers to integers` test continues to pass, confirming normal inputs (7.9 → 7, "30" → 30) are unaffected.

Co-authored-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>