### PR TITLE
Bound trajectory pointer file read with size cap

### DIFF
--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -59,7 +59,11 @@ function readTrajectoryPointerFile(
     return null;
   }
   try {
-    const parsed: unknown = JSON.parse(readRegularFileSync({ filePath: pointerPath, maxBytes: TRAJECTORY_POINTER_MAX_BYTES }));
+    const { buffer } = readRegularFileSync({
+      filePath: pointerPath,
+      maxBytes: TRAJECTORY_POINTER_MAX_BYTES,
+    });
+    const parsed: unknown = JSON.parse(buffer.toString("utf8"));
     if (!isRecord(parsed)) {
       return null;
     }

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -6,11 +6,14 @@ import { resolveSessionFilePath } from "../config/sessions/paths.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import { readFileWindowFullySync } from "../infra/file-read.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
   safeTrajectorySessionFileName,
 } from "./paths.js";
+
+const TRAJECTORY_POINTER_MAX_BYTES = 1 * 1024 * 1024;
 
 type RemovedTrajectoryArtifact = {
   kind: "pointer" | "runtime";
@@ -56,7 +59,7 @@ function readTrajectoryPointerFile(
     return null;
   }
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(pointerPath, "utf8"));
+    const parsed: unknown = JSON.parse(readRegularFileSync({ filePath: pointerPath, maxBytes: TRAJECTORY_POINTER_MAX_BYTES }));
     if (!isRecord(parsed)) {
       return null;
     }


### PR DESCRIPTION
## What Problem This Solves

readTrajectoryPointerFile calls fs.readFileSync(pointerPath, "utf8") on session trajectory pointer files with no size limit. A corrupted or malicious pointer file can OOM the process during session cleanup.

## Why This Change Was Made

PR #101472 established readRegularFileSync with maxBytes as the standard bounded-read primitive. This applies the same pattern to trajectory pointer files.

## User Impact

No user-visible change. Trajectory pointer files are typically <1 KB. A 1 MB cap is more than sufficient. An oversized pointer file gracefully returns null.

## Evidence

### Code Change
**src/trajectory/cleanup.ts** — readTrajectoryPointerFile
- Added: import { readRegularFileSync } from "../infra/regular-file.js"
- Added: const TRAJECTORY_POINTER_MAX_BYTES = 1 * 1024 * 1024
- Old: JSON.parse(fs.readFileSync(pointerPath, "utf8"))
- New: const { buffer } = readRegularFileSync({ filePath: pointerPath, maxBytes: TRAJECTORY_POINTER_MAX_BYTES }); JSON.parse(buffer.toString("utf8"))
- Error handling: existing try-catch returns null on any error including RangeError

### Fix Applied
- **2026-07-18**: Fixed ClawSweeper P1 finding — now correctly destructures { buffer } from readRegularFileSync result
- Branch rebased onto current main

### Provenance
Follows the same pattern as PR #101472 (merged) and PR #110516 (sibling PR).