### PR TITLE
fix(ui): make mock sessions archive flow usable

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1378,6 +1378,7 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
       },
     },
     models: modelProviders.models,
+    sessionArchiveFiltering: true,
     sessionKey: "agent:main:main",
   };
 }

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1013,6 +1013,23 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
       labelPrefix: "Long running session",
     }),
   ];
+  const archivedSessions = [
+    sessionRow("agent:main:archived-launch-notes", "Archived launch notes", baseTime - 86_400_000, {
+      archived: true,
+      totalTokens: 42_000,
+    }),
+    sessionRow(
+      "agent:main:discord:channel:archived-lounge",
+      "#archived-lounge",
+      baseTime - 172_800_000,
+      {
+        archived: true,
+        channel: "discord",
+        kind: "group",
+        totalTokens: 18_000,
+      },
+    ),
+  ];
   const telegramSessions = buildSessionRows({
     baseTime: baseTime - 30_000,
     count: TOTAL_TELEGRAM_SESSIONS,
@@ -1046,6 +1063,7 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
       // (raw persists, hash advances) because config.get ships a raw fixture.
       "config.get": configMocks.get,
       "config.schema": configMocks.schema,
+      "sessions.patch": { ok: true },
       "sessions.diff": buildSessionDiffMock(),
       "plugins.list": buildPluginCatalogMock(),
       "channels.status": buildChannelsStatusMock(baseTime),
@@ -1355,7 +1373,7 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
             ...searchPrefixes("claude-sonnet-4-6"),
             ...searchPrefixes("anthropic"),
           ]),
-          ...buildSessionListCases(sessions),
+          ...buildSessionListCases([...sessions, ...archivedSessions]),
         ],
       },
     },

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -151,6 +151,49 @@ describe("mock gateway stateful config", () => {
 });
 
 describe("mock gateway stateful sessions", () => {
+  it("keeps archive filtering opt-in for static session fixtures", async () => {
+    const script = createControlUiMockGatewayInitScript({
+      methodResponses: {
+        "sessions.list": {
+          count: 1,
+          defaults: {},
+          path: "",
+          sessions: [{ key: "agent:main:research", archived: false }],
+          ts: 0,
+        },
+        "sessions.patch": { ok: true },
+      },
+    });
+    window.sessionStorage.clear();
+    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
+    new Function(script)();
+
+    const socket = new WebSocket("ws://mock-gateway");
+    const frames: ResponseFrame[] = [];
+    socket.addEventListener("message", (event) => {
+      frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
+    });
+    await flushMockTimers();
+
+    socket.send(
+      JSON.stringify({
+        type: "req",
+        id: "patch-1",
+        method: "sessions.patch",
+        params: { key: "agent:main:research", archived: true },
+      }),
+    );
+    await flushMockTimers();
+    socket.send(JSON.stringify({ type: "req", id: "list-1", method: "sessions.list", params: {} }));
+    await flushMockTimers();
+
+    expect(frames.find((frame) => frame.id === "list-1")?.payload).toMatchObject({
+      count: 1,
+      sessions: [{ key: "agent:main:research", archived: false }],
+    });
+    socket.close();
+  });
+
   it("moves archive patches between active and archived session lists", async () => {
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -166,6 +209,7 @@ describe("mock gateway stateful sessions", () => {
         },
         "sessions.patch": { ok: true },
       },
+      sessionArchiveFiltering: true,
     });
     window.sessionStorage.clear();
     // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -149,3 +149,71 @@ describe("mock gateway stateful config", () => {
     socket.close();
   });
 });
+
+describe("mock gateway stateful sessions", () => {
+  it("moves archive patches between active and archived session lists", async () => {
+    const script = createControlUiMockGatewayInitScript({
+      methodResponses: {
+        "sessions.list": {
+          count: 2,
+          defaults: {},
+          path: "",
+          sessions: [
+            { key: "agent:main:research", archived: false },
+            { key: "agent:main:launch-notes", archived: true },
+          ],
+          ts: 0,
+        },
+        "sessions.patch": { ok: true },
+      },
+    });
+    window.sessionStorage.clear();
+    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
+    new Function(script)();
+
+    const socket = new WebSocket("ws://mock-gateway");
+    const frames: ResponseFrame[] = [];
+    socket.addEventListener("message", (event) => {
+      frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
+    });
+    await flushMockTimers();
+
+    const request = async (id: string, method: string, params: unknown) => {
+      socket.send(JSON.stringify({ type: "req", id, method, params }));
+      await flushMockTimers();
+      const response = frames.find((frame) => frame.type === "res" && frame.id === id);
+      if (!response) {
+        throw new Error(`No mock response for ${method}`);
+      }
+      return response.payload as Record<string, unknown>;
+    };
+    const keys = (payload: Record<string, unknown>) =>
+      (payload.sessions as Array<{ key: string }>).map((row) => row.key);
+
+    expect(keys(await request("list-1", "sessions.list", {}))).toEqual(["agent:main:research"]);
+    expect(keys(await request("list-2", "sessions.list", { archived: true }))).toEqual([
+      "agent:main:launch-notes",
+    ]);
+    expect(
+      await request("patch-3", "sessions.patch", {
+        key: "agent:main:research",
+        archived: true,
+      }),
+    ).toEqual({ ok: true });
+    expect(keys(await request("list-4", "sessions.list", {}))).toEqual([]);
+    expect(keys(await request("list-5", "sessions.list", { archived: true }))).toEqual([
+      "agent:main:research",
+      "agent:main:launch-notes",
+    ]);
+
+    await request("patch-6", "sessions.patch", {
+      key: "agent:main:launch-notes",
+      archived: false,
+    });
+    expect(keys(await request("list-7", "sessions.list", {}))).toEqual(["agent:main:launch-notes"]);
+    expect(keys(await request("list-8", "sessions.list", { archived: true }))).toEqual([
+      "agent:main:research",
+    ]);
+    socket.close();
+  });
+});

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -573,7 +573,14 @@ function installControlUiMockGateway(input: {
       return;
     }
     const patch = { ...sessionPatches.get(params.key) };
-    for (const key of ["model", "thinkingLevel", "fastMode", "category", "pinned"] as const) {
+    for (const key of [
+      "model",
+      "thinkingLevel",
+      "fastMode",
+      "category",
+      "pinned",
+      "archived",
+    ] as const) {
       if (hasOwn(params, key)) {
         patch[key] = params[key];
       }
@@ -581,13 +588,13 @@ function installControlUiMockGateway(input: {
     sessionPatches.set(params.key, patch);
   }
 
-  function applySessionPatches(response: unknown): unknown {
+  function applySessionPatches(response: unknown, params: unknown): unknown {
     if (!isRecord(response) || !Array.isArray(response.sessions)) {
       return response;
     }
-    return {
-      ...response,
-      sessions: response.sessions.map((row) => {
+    const showArchived = isRecord(params) && params.archived === true;
+    const sessions = response.sessions
+      .map((row) => {
         if (!isRecord(row) || typeof row.key !== "string") {
           return row;
         }
@@ -607,7 +614,12 @@ function installControlUiMockGateway(input: {
           next.category = category;
         }
         return next;
-      }),
+      })
+      .filter((row) => isRecord(row) && (row.archived === true) === showArchived);
+    return {
+      ...response,
+      count: sessions.length,
+      sessions,
     };
   }
 
@@ -700,7 +712,9 @@ function installControlUiMockGateway(input: {
     }
     const configured = configuredResponse(method, params);
     if (configured.found) {
-      return method === "sessions.list" ? applySessionPatches(configured.value) : configured.value;
+      return method === "sessions.list"
+        ? applySessionPatches(configured.value, params)
+        : configured.value;
     }
     switch (method) {
       case "connect":
@@ -841,17 +855,20 @@ function installControlUiMockGateway(input: {
       case "models.list":
         return { models: scenario.models };
       case "sessions.list":
-        return applySessionPatches({
-          count: 1,
-          defaults: {
-            contextTokens: null,
-            model: "gpt-5.5",
-            modelProvider: "openai",
+        return applySessionPatches(
+          {
+            count: 1,
+            defaults: {
+              contextTokens: null,
+              model: "gpt-5.5",
+              modelProvider: "openai",
+            },
+            path: "",
+            sessions: [sessionRow()],
+            ts: Date.now(),
           },
-          path: "",
-          sessions: [sessionRow()],
-          ts: Date.now(),
-        });
+          params,
+        );
       case "sessions.groups.list":
         return groupsPayload();
       case "sessions.groups.put": {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -67,6 +67,8 @@ export type ControlUiMockGatewayScenario = {
   inFlightRun?: { runId: string; text?: string; plan?: unknown } | null;
   /** Session run state served alongside history (hasActiveRun/activeRunIds). */
   sessionInfo?: Record<string, unknown> | null;
+  /** Partition sessions.list fixtures by archived state after applying patches. */
+  sessionArchiveFiltering?: boolean;
   models?: Array<{
     id: string;
     name: string;
@@ -260,6 +262,7 @@ function normalizeScenario(
     inFlightRun: scenario.inFlightRun ?? null,
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
     sessionInfo: scenario.sessionInfo ?? null,
+    sessionArchiveFiltering: scenario.sessionArchiveFiltering ?? false,
     sessionKey,
     sessionGroups: scenario.sessionGroups ?? [],
     terminalEnabled: scenario.terminalEnabled ?? false,
@@ -573,17 +576,13 @@ function installControlUiMockGateway(input: {
       return;
     }
     const patch = { ...sessionPatches.get(params.key) };
-    for (const key of [
-      "model",
-      "thinkingLevel",
-      "fastMode",
-      "category",
-      "pinned",
-      "archived",
-    ] as const) {
+    for (const key of ["model", "thinkingLevel", "fastMode", "category", "pinned"] as const) {
       if (hasOwn(params, key)) {
         patch[key] = params[key];
       }
+    }
+    if (scenario.sessionArchiveFiltering && hasOwn(params, "archived")) {
+      patch.archived = params.archived;
     }
     sessionPatches.set(params.key, patch);
   }
@@ -593,33 +592,37 @@ function installControlUiMockGateway(input: {
       return response;
     }
     const showArchived = isRecord(params) && params.archived === true;
-    const sessions = response.sessions
-      .map((row) => {
-        if (!isRecord(row) || typeof row.key !== "string") {
-          return row;
+    const sessions = response.sessions.map((row) => {
+      if (!isRecord(row) || typeof row.key !== "string") {
+        return row;
+      }
+      const patch = sessionPatches.get(row.key);
+      const next = patch ? { ...row, ...patch } : { ...row };
+      // Replay group renames/deletes over static fixtures: the real gateway
+      // rewrites member categories server-side before the next sessions.list.
+      let category = typeof next.category === "string" ? next.category : undefined;
+      for (const rename of groupsState.renames) {
+        if (category === rename.from) {
+          category = rename.to ?? undefined;
         }
-        const patch = sessionPatches.get(row.key);
-        const next = patch ? { ...row, ...patch } : { ...row };
-        // Replay group renames/deletes over static fixtures: the real gateway
-        // rewrites member categories server-side before the next sessions.list.
-        let category = typeof next.category === "string" ? next.category : undefined;
-        for (const rename of groupsState.renames) {
-          if (category === rename.from) {
-            category = rename.to ?? undefined;
-          }
-        }
-        if (category === undefined) {
-          delete next.category;
-        } else {
-          next.category = category;
-        }
-        return next;
-      })
-      .filter((row) => isRecord(row) && (row.archived === true) === showArchived);
+      }
+      if (category === undefined) {
+        delete next.category;
+      } else {
+        next.category = category;
+      }
+      return next;
+    });
+    if (!scenario.sessionArchiveFiltering) {
+      return { ...response, sessions };
+    }
+    const filteredSessions = sessions.filter(
+      (row) => isRecord(row) && (row.archived === true) === showArchived,
+    );
     return {
       ...response,
-      count: sessions.length,
-      sessions,
+      count: filteredSessions.length,
+      sessions: filteredSessions,
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers using `pnpm dev:ui:mock` could not exercise the archived Sessions view or round-trip archive and restore state with realistic fixture rows.

The reported indefinite loader on `/settings/sessions` was not reproducible on current `main`: a fresh browser trace showed both awaited route requests, `config.get` and `sessions.list`, resolving. The mock dispatcher also responds to unmatched non-deferred methods. This keeps the fix at the fixture/mock-state boundary instead of adding a loader workaround.

## Why This Change Was Made

The mock harness now serves active and archived rows from one canonical fixture set, partitions `sessions.list` results using the request's archived mode after applying stateful patches, and returns an explicit successful `sessions.patch` response. Two archived fixtures make the existing archive/restore UI directly demoable.

## User Impact

Developers can open the Sessions panel in the mock UI, switch to Archived only, see realistic archived rows, restore one, refresh, and find it in the active list.

Release-note context: the Control UI mock development harness now demonstrates archived Sessions and archive/restore round trips.

AI-assisted implementation; reviewed and understood by the author.

## Evidence

- Blacksmith Testbox browser proof against the real mock-dev Vite entry: `/settings/sessions` rendered ten active rows; Archived only rendered two archived fixtures; Restore plus Refresh moved the selected row back to Active.
- `pnpm test ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts`: 1 file, 4 tests passed.
- `pnpm check:changed`: core-test, UI, scripts, and tooling lanes passed, including formatting, three `tsgo` lanes, UI i18n verification, and oxlint.
- Fresh `autoreview --mode uncommitted`: no accepted or actionable findings.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29636332907
- Visual captures were inspected from the Testbox run. The local `gh image` uploader is unavailable, so they are not attached to this description.
