### PR TITLE
ci(ui): raise startup JS gzip budget to 375 KiB

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -12,7 +12,7 @@ const KIB = 1024;
 export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze({
   startupJsRequests: 28,
   startupCssRequests: 1,
-  startupJsGzipBytes: 370 * KIB,
+  startupJsGzipBytes: 375 * KIB,
   startupCssGzipBytes: 42 * KIB,
   largestJsGzipBytes: 215 * KIB,
   largestCssGzipBytes: 42 * KIB,


### PR DESCRIPTION
## What Problem This Solves

Control UI startup JS on current `main` sits at exactly the 370.0 KiB gzip budget, so every PR's QA Smoke CI profile now fails with `startup JS gzip: 370.0 KiB exceeds 370.0 KiB` regardless of content - PRs #110532 and #110550 (zero UI changes) are blocked, and every other open PR will hit the same wall.

## Why This Change Was Made

Raise `startupJsGzipBytes` from 370 to 375 KiB, following the existing precedent for boundary crossings on main (`a3804782dc9` raised the startup request budget the same way). The last budget-value change was #106865; main crossed the line through the accumulation of normally-sized merges, not one offender. 5 KiB of headroom unblocks CI while keeping the creep guard tight.

## User Impact

CI-only. QA Smoke bundle checks pass again for all PRs.

## Evidence

- Violation reproduced in QA Smoke logs on two unrelated PRs (runs 29636183787, 29636584490): all four profiles fail at the bundle-budget step with the exact-boundary message.
- One-line budget constant change; `git diff --check` clean.
