### PR TITLE
fix(zalo): journal polled inbound updates across restarts

### DIFF
--- a/extensions/zalo/src/monitor-ingress.test.ts
+++ b/extensions/zalo/src/monitor-ingress.test.ts
@@ -1,0 +1,245 @@
+// Zalo tests cover durable ingress journaling, replay, and dedupe.
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ZaloUpdate } from "./api.js";
+import {
+  createZaloIngressSpool,
+  type ZaloIngressSpool,
+  type ZaloIngressTurnLifecycle,
+} from "./monitor-ingress.js";
+
+type ZaloIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  update: ZaloUpdate;
+};
+
+type ZaloIngressDispatch = (
+  update: ZaloUpdate,
+  lifecycle: ZaloIngressTurnLifecycle,
+) => Promise<void>;
+
+const stateDirs: string[] = [];
+const disposers: Array<() => void> = [];
+
+async function createStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-ingress-"));
+  const resolved = await realpath(created);
+  stateDirs.push(resolved);
+  return resolved;
+}
+
+function createQueue(stateDir: string) {
+  return createChannelIngressQueueForTests<ZaloIngressPayload>({
+    channelId: "zalo",
+    accountId: "default",
+    stateDir,
+  });
+}
+
+function createTextUpdate(params?: { messageId?: string; chatId?: string; userId?: string }) {
+  return {
+    event_name: "message.text.received",
+    message: {
+      message_id: params?.messageId ?? "msg-1",
+      from: { id: params?.userId ?? "user-1", name: "Test User" },
+      chat: { id: params?.chatId ?? "chat-1", chat_type: "PRIVATE" as const },
+      date: 1_774_080_000,
+      text: "hello from zalo",
+    },
+  } satisfies ZaloUpdate;
+}
+
+function createSpool(params: {
+  stateDir: string;
+  dispatch: ZaloIngressDispatch;
+  retryPolicy?: Parameters<typeof createZaloIngressSpool>[0]["retryPolicy"];
+}): ZaloIngressSpool {
+  const spool = createZaloIngressSpool({
+    accountId: "default",
+    abortSignal: new AbortController().signal,
+    queue: createQueue(params.stateDir),
+    dispatch: params.dispatch,
+    ...(params.retryPolicy ? { retryPolicy: params.retryPolicy } : {}),
+  });
+  disposers.push(spool.dispose);
+  return spool;
+}
+
+async function drainSpool(spool: ZaloIngressSpool): Promise<void> {
+  await spool.drainOnce();
+  await spool.waitForIdle();
+}
+
+afterEach(async () => {
+  for (const dispose of disposers.splice(0).toReversed()) {
+    dispose();
+  }
+  for (const stateDir of stateDirs.splice(0).toReversed()) {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+describe("createZaloIngressSpool", () => {
+  it("replays a journaled update after a crash before dispatch", async () => {
+    // Loss window: the Bot API consumes the update on response, then the process
+    // dies before processUpdate runs. The journaled row must survive and replay.
+    const stateDir = await createStateDir();
+    const crashed = createSpool({
+      stateDir,
+      dispatch: vi.fn<ZaloIngressDispatch>(async () => {
+        throw new Error("must never dispatch before the crash");
+      }),
+    });
+    await crashed.enqueue(createTextUpdate({ messageId: "msg-crash-window" }));
+    crashed.dispose();
+
+    const dispatch = vi.fn<ZaloIngressDispatch>(async (_update, lifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const recovered = createSpool({ stateDir, dispatch });
+    await drainSpool(recovered);
+
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(dispatch.mock.calls[0]?.[0].message?.message_id).toBe("msg-crash-window");
+  });
+
+  it("tombstones after dispatch so a redelivered update never dispatches twice", async () => {
+    const stateDir = await createStateDir();
+    const dispatch = vi.fn<ZaloIngressDispatch>(async (_update, lifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const spool = createSpool({ stateDir, dispatch });
+
+    expect(await spool.enqueue(createTextUpdate())).toEqual({ kind: "accepted" });
+    await drainSpool(spool);
+    expect(await spool.enqueue(createTextUpdate())).toEqual({ kind: "duplicate" });
+    await drainSpool(spool);
+
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("completes at dispatch return when the turn never adopts", async () => {
+    // Sticker/unsupported events and pre-dispatch drops (unauthorized, empty text)
+    // never reach the turn lifecycle; they must still tombstone at dispatch return.
+    const stateDir = await createStateDir();
+    const dispatch = vi.fn<ZaloIngressDispatch>(async () => undefined);
+    const spool = createSpool({ stateDir, dispatch });
+
+    await spool.enqueue(createTextUpdate());
+    await drainSpool(spool);
+    expect(await spool.enqueue(createTextUpdate())).toEqual({ kind: "duplicate" });
+
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("retries a failed dispatch instead of dropping the update", async () => {
+    const stateDir = await createStateDir();
+    let attempts = 0;
+    const dispatch = vi.fn<ZaloIngressDispatch>(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("dispatch boom");
+      }
+    });
+    const spool = createSpool({
+      stateDir,
+      dispatch,
+      retryPolicy: { baseMs: 1, maxMs: 5 },
+    });
+
+    await spool.enqueue(createTextUpdate());
+    await drainSpool(spool);
+    expect(dispatch).toHaveBeenCalledOnce();
+
+    await vi.waitFor(async () => {
+      await spool.drainOnce();
+      await spool.waitForIdle();
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    });
+    expect(await spool.enqueue(createTextUpdate())).toEqual({ kind: "duplicate" });
+  });
+
+  it("dead-letters a permanently invalid payload instead of retrying forever", async () => {
+    const stateDir = await createStateDir();
+    const queue = createQueue(stateDir);
+    const dispatch = vi.fn<ZaloIngressDispatch>(async () => undefined);
+    const spool = createSpool({ stateDir, dispatch });
+
+    const eventId = JSON.stringify(["chat-1", "user-1", "msg-corrupt"]);
+    await queue.enqueue(
+      eventId,
+      {
+        version: 99,
+        receivedAt: Date.now(),
+        update: createTextUpdate(),
+      } as unknown as ZaloIngressPayload,
+      { receivedAt: Date.now(), laneKey: "chat:chat-1" },
+    );
+    await drainSpool(spool);
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(await queue.listPending()).toEqual([]);
+  });
+
+  it("ignores updates that cannot be journaled", async () => {
+    const stateDir = await createStateDir();
+    const queue = createQueue(stateDir);
+    const dispatch = vi.fn<ZaloIngressDispatch>(async () => undefined);
+    const spool = createZaloIngressSpool({
+      accountId: "default",
+      abortSignal: new AbortController().signal,
+      queue,
+      dispatch,
+    });
+    disposers.push(spool.dispose);
+
+    expect(await spool.enqueue({ event_name: "message.text.received" })).toEqual({
+      kind: "ignored",
+    });
+    expect(await queue.listPending()).toEqual([]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the same message id in different chats distinct", async () => {
+    const stateDir = await createStateDir();
+    const queue = createQueue(stateDir);
+    const dispatch = vi.fn<ZaloIngressDispatch>(async () => undefined);
+    const spool = createZaloIngressSpool({
+      accountId: "default",
+      abortSignal: new AbortController().signal,
+      queue,
+      dispatch,
+    });
+    disposers.push(spool.dispose);
+
+    expect(await spool.enqueue(createTextUpdate({ chatId: "chat-a" }))).toEqual({
+      kind: "accepted",
+    });
+    expect(await spool.enqueue(createTextUpdate({ chatId: "chat-b" }))).toEqual({
+      kind: "accepted",
+    });
+    expect(await queue.listPending()).toHaveLength(2);
+  });
+
+  it("serializes one lane per chat", async () => {
+    const stateDir = await createStateDir();
+    const queue = createQueue(stateDir);
+    const spool = createZaloIngressSpool({
+      accountId: "default",
+      abortSignal: new AbortController().signal,
+      queue,
+      dispatch: vi.fn<ZaloIngressDispatch>(async () => undefined),
+    });
+    disposers.push(spool.dispose);
+
+    await spool.enqueue(createTextUpdate({ chatId: "group-9", messageId: "msg-lane" }));
+
+    expect(await queue.listPending()).toEqual([
+      expect.objectContaining({ laneKey: "chat:group-9" }),
+    ]);
+  });
+});

--- a/extensions/zalo/src/monitor-ingress.ts
+++ b/extensions/zalo/src/monitor-ingress.ts
@@ -1,0 +1,152 @@
+// Zalo plugin module owns durable ingress enqueue + drain for inbound updates.
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import type { ZaloUpdate } from "./api.js";
+import { getZaloRuntime } from "./runtime.js";
+
+const ZALO_INGRESS_PAYLOAD_VERSION = 1;
+// Tombstones dominate the retired 5-minute in-memory webhook replay guard.
+const ZALO_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const ZALO_INGRESS_COMPLETED_MAX_ENTRIES = 20_000;
+const ZALO_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const ZALO_INGRESS_FAILED_MAX_ENTRIES = 1_000;
+// Short backoff against transient SQLite contention before failing closed.
+const ZALO_INGRESS_ENQUEUE_RETRY_DELAYS_MS = [250, 750] as const;
+
+type ZaloIngressPayload = {
+  version: typeof ZALO_INGRESS_PAYLOAD_VERSION;
+  receivedAt: number;
+  update: ZaloUpdate;
+};
+
+/** Turn adoption lifecycle the drain binds into the channel turn (adoption tombstones the claim). */
+export type ZaloIngressTurnLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
+
+export type ZaloIngressEnqueueResult =
+  | { kind: "accepted" }
+  | { kind: "duplicate" }
+  | { kind: "ignored" };
+
+class ZaloIngressPermanentError extends Error {}
+
+function parseZaloIngressPayload(payload: ZaloIngressPayload): ZaloUpdate {
+  if (payload.version !== ZALO_INGRESS_PAYLOAD_VERSION || !payload.update.message) {
+    throw new ZaloIngressPermanentError("Zalo ingress payload is invalid.");
+  }
+  return payload.update;
+}
+
+/** Stable dedupe id + serialized lane for one delivered update; null when it cannot be journaled. */
+function resolveZaloUpdateIngressFacts(update: ZaloUpdate): {
+  eventId: string;
+  laneKey: string;
+} | null {
+  const message = update.message;
+  const messageId = message?.message_id?.trim();
+  if (!message || !messageId) {
+    return null;
+  }
+  // JSON encoding keeps ids unambiguous when chat/sender values contain separators.
+  return {
+    eventId: JSON.stringify([message.chat.id, message.from.id, messageId]),
+    laneKey: `chat:${message.chat.id}`,
+  };
+}
+
+export function createZaloIngressSpool(params: {
+  accountId: string;
+  abortSignal: AbortSignal;
+  queue?: ChannelIngressQueue<ZaloIngressPayload>;
+  retryPolicy?: {
+    maxAttempts?: number;
+    deadLetterMinAgeMs?: number;
+    baseMs?: number;
+    maxMs?: number;
+  };
+  onLog?: (message: string) => void;
+  dispatch: (update: ZaloUpdate, lifecycle: ZaloIngressTurnLifecycle) => Promise<void>;
+}) {
+  const queue =
+    params.queue ??
+    getZaloRuntime().state.openChannelIngressQueue<ZaloIngressPayload>({
+      accountId: params.accountId,
+    });
+  const drain = createChannelIngressDrain<ZaloIngressPayload>({
+    queue,
+    abortSignal: params.abortSignal,
+    retryPolicy: {
+      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      ...params.retryPolicy,
+    },
+    resolveNonRetryableFailure: (error) =>
+      error instanceof ZaloIngressPermanentError
+        ? { reason: "invalid-payload", message: error.message }
+        : null,
+    ...(params.onLog ? { onLog: params.onLog } : {}),
+    dispatchClaimedEvent: async (record, lifecycle) => {
+      const update = parseZaloIngressPayload(record.payload);
+      await params.dispatch(
+        update,
+        bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
+      );
+    },
+  });
+
+  return {
+    /** Journal one update durably before dispatch; the Bot API consumes updates on response. */
+    enqueue: async (update: ZaloUpdate): Promise<ZaloIngressEnqueueResult> => {
+      const facts = resolveZaloUpdateIngressFacts(update);
+      if (!facts) {
+        // Updates without a message are no-ops downstream; a message without the
+        // contract-required message_id can be neither deduped nor replayed.
+        if (update.message) {
+          params.onLog?.("zalo ingress: dropping update with message but no message_id");
+        }
+        return { kind: "ignored" };
+      }
+      const receivedAt = Date.now();
+      await queue.prune({
+        completedTtlMs: ZALO_INGRESS_COMPLETED_TTL_MS,
+        completedMaxEntries: ZALO_INGRESS_COMPLETED_MAX_ENTRIES,
+        failedTtlMs: ZALO_INGRESS_FAILED_TTL_MS,
+        failedMaxEntries: ZALO_INGRESS_FAILED_MAX_ENTRIES,
+      });
+      let lastError: unknown;
+      for (let attempt = 0; ; attempt += 1) {
+        try {
+          const result = await queue.enqueue(
+            facts.eventId,
+            { version: ZALO_INGRESS_PAYLOAD_VERSION, receivedAt, update },
+            { receivedAt, laneKey: facts.laneKey },
+          );
+          return result.kind === "accepted" ? { kind: "accepted" } : { kind: "duplicate" };
+        } catch (error) {
+          lastError = error;
+          const delay = ZALO_INGRESS_ENQUEUE_RETRY_DELAYS_MS[attempt];
+          if (delay === undefined || params.abortSignal.aborted) {
+            break;
+          }
+          await sleepWithAbort(delay, params.abortSignal).catch(() => undefined);
+        }
+      }
+      // Fail closed: dispatching an unjournaled update would bypass dedupe and die with the process.
+      throw lastError;
+    },
+    drainOnce: async () => {
+      await drain.drainOnce();
+    },
+    waitForIdle: drain.waitForIdle,
+    dispose: () => drain.dispose(),
+  };
+}
+
+export type ZaloIngressSpool = ReturnType<typeof createZaloIngressSpool>;

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -24,13 +24,28 @@ vi.mock("./api.js", async () => {
   };
 });
 
-vi.mock("./runtime.js", () => ({
-  getZaloRuntime: () => ({
-    logging: {
-      shouldLogVerbose: () => false,
-    },
-  }),
-}));
+vi.mock("./runtime.js", async () => {
+  const { createChannelIngressQueueForTests } =
+    await import("openclaw/plugin-sdk/plugin-state-test-runtime");
+  const { mkdtempSync } = await import("node:fs");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  return {
+    getZaloRuntime: () => ({
+      logging: {
+        shouldLogVerbose: () => false,
+      },
+      state: {
+        openChannelIngressQueue: (options?: { accountId?: string; stateDir?: string }) =>
+          createChannelIngressQueueForTests({
+            channelId: "zalo",
+            stateDir: mkdtempSync(path.join(os.tmpdir(), "openclaw-zalo-lifecycle-ingress-")),
+            ...options,
+          }),
+      },
+    }),
+  };
+});
 
 const TEST_ACCOUNT = {
   accountId: "default",
@@ -116,12 +131,16 @@ describe("monitorZaloProvider lifecycle", () => {
         expect.stringContaining("zalo poll transport failed"),
       );
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);
-      expect(vi.getTimerCount()).toBe(1);
+      // The 5s backoff sleep must be pending; the ingress journal's first DB use may
+      // hold an additional unref'd timer, so only assert the backoff exists.
+      expect(vi.getTimerCount()).toBeGreaterThanOrEqual(1);
 
       abort.abort();
       await run;
 
-      expect(vi.getTimerCount()).toBe(0);
+      // The journal's SQLite WAL maintenance interval (unref'd) outlives the provider,
+      // so prove the backoff timer was cleared behaviorally: advancing past the 5s
+      // backoff must not schedule another poll.
       await vi.advanceTimersByTimeAsync(5_000);
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);
       expect(started.runtime.log).toHaveBeenCalledWith(

--- a/extensions/zalo/src/monitor.reply-once.lifecycle.test-support.ts
+++ b/extensions/zalo/src/monitor.reply-once.lifecycle.test-support.ts
@@ -173,8 +173,10 @@ describe("Zalo reply-once lifecycle", () => {
 
       expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
       expect(sendMessageMock).toHaveBeenCalledTimes(1);
+      // The durable journal keeps the failed dispatch for retry (drain backoff) instead
+      // of the old commit-and-drop; the replayed POST dedupes against the pending row.
       expect(monitor.runtime.error).toHaveBeenCalledWith(
-        "[acct-zalo-lifecycle] Zalo webhook failed: Error: post-send failure",
+        expect.stringContaining("failed; keeping for retry: post-send failure"),
       );
     } finally {
       await monitor.stop();

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -40,6 +40,11 @@ import {
   prepareZaloDurableReplyPayload,
   resolveZaloDurableReplyOptions,
 } from "./monitor-durable.js";
+import {
+  createZaloIngressSpool,
+  type ZaloIngressSpool,
+  type ZaloIngressTurnLifecycle,
+} from "./monitor-ingress.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
 import {
   prepareHostedZaloMediaUrl,
@@ -93,9 +98,11 @@ type ZaloProcessingContext = {
 type ZaloPollingLoopParams = ZaloProcessingContext & {
   abortSignal: AbortSignal;
   isStopped: () => boolean;
+  ingress: ZaloIngressSpool;
 };
 type ZaloUpdateProcessingParams = ZaloProcessingContext & {
   update: ZaloUpdate;
+  turnAdoptionLifecycle?: ZaloIngressTurnLifecycle;
 };
 const hostedMediaRouteRefs = new Map<string, { count: number; unregisters: Array<() => void> }>();
 
@@ -164,9 +171,11 @@ type ZaloMessagePipelineParams = ZaloProcessingContext & {
   mediaPath?: string;
   mediaType?: string;
   authorization?: ZaloMessageAuthorizationResult;
+  turnAdoptionLifecycle?: ZaloIngressTurnLifecycle;
 };
 type ZaloImageMessageParams = ZaloProcessingContext & {
   message: ZaloMessage;
+  turnAdoptionLifecycle?: ZaloIngressTurnLifecycle;
 };
 type ZaloMessageAuthorizationResult = {
   chatId: string;
@@ -210,54 +219,12 @@ async function handleZaloWebhookRequest(
 ): Promise<boolean> {
   const { handleZaloWebhookRequest: handleZaloWebhookRequestInternal } =
     await loadZaloWebhookModule();
-  return await handleZaloWebhookRequestInternal(req, res, async ({ update, target }) => {
-    await processUpdate({
-      update,
-      token: target.token,
-      account: target.account,
-      config: target.config,
-      runtime: target.runtime,
-      core: target.core as ZaloCoreRuntime,
-      mediaMaxMb: target.mediaMaxMb,
-      canHostMedia: target.canHostMedia,
-      webhookUrl: target.webhookUrl,
-      webhookPath: target.webhookPath,
-      statusSink: target.statusSink,
-      fetcher: target.fetcher,
-    });
-  });
+  return await handleZaloWebhookRequestInternal(req, res);
 }
 
 function startPollingLoop(params: ZaloPollingLoopParams) {
-  const {
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    mediaMaxMb,
-    canHostMedia,
-    webhookUrl,
-    webhookPath,
-    abortSignal,
-    isStopped,
-    statusSink,
-    fetcher,
-  } = params;
+  const { token, account, runtime, abortSignal, isStopped, statusSink, fetcher, ingress } = params;
   const pollTimeout = 30;
-  const processingContext = {
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    mediaMaxMb,
-    canHostMedia,
-    webhookUrl,
-    webhookPath,
-    statusSink,
-    fetcher,
-  };
 
   runtime.log?.(`[${account.accountId}] Zalo polling loop started timeout=${String(pollTimeout)}s`);
 
@@ -273,11 +240,14 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
       }
       if (response.ok && response.result) {
         statusSink?.({ lastInboundAt: Date.now() });
-        await processUpdate({
-          update: response.result,
-          ...processingContext,
-        });
+        // The Bot API consumes each polled update on response (there is no offset or
+        // confirm parameter), so journal durably before dispatch: an unjournaled
+        // update is permanently lost if the process dies before dispatch completes.
+        await ingress.enqueue(response.result);
       }
+      // Pump every cycle so released retries drain even when this poll returned nothing.
+      await ingress.drainOnce();
+      await ingress.waitForIdle();
     } catch (err) {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
@@ -299,7 +269,18 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
 }
 
 async function processUpdate(params: ZaloUpdateProcessingParams): Promise<void> {
-  const { update, token, account, config, runtime, core, mediaMaxMb, statusSink, fetcher } = params;
+  const {
+    update,
+    token,
+    account,
+    config,
+    runtime,
+    core,
+    mediaMaxMb,
+    statusSink,
+    fetcher,
+    turnAdoptionLifecycle,
+  } = params;
   const { event_name, message } = update;
   const sharedContext = {
     token,
@@ -313,6 +294,7 @@ async function processUpdate(params: ZaloUpdateProcessingParams): Promise<void> 
     webhookPath: params.webhookPath,
     statusSink,
     fetcher,
+    turnAdoptionLifecycle,
   };
   if (!message) {
     return undefined;
@@ -346,7 +328,10 @@ async function processUpdate(params: ZaloUpdateProcessingParams): Promise<void> 
 }
 
 async function handleTextMessage(
-  params: ZaloProcessingContext & { message: ZaloMessage },
+  params: ZaloProcessingContext & {
+    message: ZaloMessage;
+    turnAdoptionLifecycle?: ZaloIngressTurnLifecycle;
+  },
 ): Promise<void> {
   const { message } = params;
   const { text } = message;
@@ -680,6 +665,9 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
     accountId: account.accountId,
     route: { agentId: route.agentId, dmScope: route.dmScope, sessionKey: route.sessionKey },
     ctxPayload,
+    ...(params.turnAdoptionLifecycle
+      ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+      : {}),
     delivery: {
       preparePayload: (payload) =>
         prepareZaloDurableReplyPayload({
@@ -842,6 +830,29 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
   const stopHandlers: Array<() => void> = [];
   let cleanupWebhook: (() => Promise<void>) | undefined;
 
+  const ingress = createZaloIngressSpool({
+    accountId: account.accountId,
+    abortSignal,
+    onLog: (message) => runtime.error?.(`[${account.accountId}] ${message}`),
+    dispatch: async (update, turnAdoptionLifecycle) => {
+      await processUpdate({
+        update,
+        token,
+        account,
+        config,
+        runtime,
+        core,
+        mediaMaxMb: effectiveMediaMaxMb,
+        canHostMedia,
+        webhookUrl: effectiveWebhookUrl,
+        webhookPath: effectiveWebhookPath,
+        statusSink,
+        fetcher,
+        turnAdoptionLifecycle,
+      });
+    },
+  });
+
   const stop = () => {
     if (stopped) {
       return;
@@ -864,6 +875,9 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
   );
 
   try {
+    // Replay updates journaled before a previous crash or shutdown before new inbound work.
+    await ingress.drainOnce();
+
     if (hostedMediaRoutePath) {
       const unregisterHostedMediaRoute = registerSharedHostedMediaRoute({
         path: hostedMediaRoutePath,
@@ -930,6 +944,7 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
           mediaMaxMb: effectiveMediaMaxMb,
           canHostMedia,
           fetcher,
+          ingress,
         },
         {
           route: {
@@ -1000,6 +1015,7 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       mediaMaxMb: effectiveMediaMaxMb,
       statusSink,
       fetcher,
+      ingress,
     });
 
     await waitForAbortSignal(abortSignal);
@@ -1012,6 +1028,8 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
     abortSignal.removeEventListener("abort", stopOnAbort);
     await cleanupWebhook?.();
     stop();
+    // Dispose leaves undispatched claims for the next start to recover and replay.
+    ingress.dispose();
     runtime.log?.(`[${account.accountId}] Zalo provider stopped mode=${mode}`);
   }
 }

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
 // Zalo tests cover monitor.webhook plugin behavior.
 import type { RequestListener } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   createEmptyPluginRegistry,
   setActivePluginRegistry,
@@ -7,6 +11,8 @@ import {
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+import type { ZaloUpdate } from "./api.js";
+import { createZaloIngressSpool, type ZaloIngressSpool } from "./monitor-ingress.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
 import {
   clearZaloWebhookSecurityStateForTest,
@@ -14,8 +20,7 @@ import {
   getZaloWebhookStatusCounterSizeForTest,
   handleZaloWebhookRequest as handleZaloWebhookRequestInternal,
   registerZaloWebhookTarget,
-  type ZaloWebhookProcessUpdate,
-  ZaloRetryableWebhookError,
+  type ZaloWebhookIngress,
 } from "./monitor.webhook.js";
 import { createTextUpdate, postWebhookReplay } from "./test-support/lifecycle-test-support.js";
 import type { ResolvedZaloAccount } from "./types.js";
@@ -36,12 +41,18 @@ const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   config: {},
 };
 
-function createWebhookRequestHandler(
-  processUpdate: ZaloWebhookProcessUpdate = async () => {},
-): RequestListener {
+function createFakeIngress(overrides?: Partial<ZaloWebhookIngress>): ZaloWebhookIngress {
+  return {
+    enqueue: vi.fn(async () => ({ kind: "accepted" }) as const),
+    drainOnce: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function createWebhookRequestHandler(): RequestListener {
   return (req, res) => {
     void (async () => {
-      const handled = await handleZaloWebhookRequestInternal(req, res, processUpdate);
+      const handled = await handleZaloWebhookRequestInternal(req, res);
       if (!handled) {
         res.statusCode = 404;
         res.end("not found");
@@ -60,6 +71,7 @@ function registerTarget(params: {
   config?: OpenClawConfig;
   core?: PluginRuntime;
   runtime?: Partial<ZaloRuntimeEnv>;
+  ingress?: ZaloWebhookIngress;
 }): () => void {
   return registerZaloWebhookTarget({
     token: "tok",
@@ -74,7 +86,37 @@ function registerTarget(params: {
     mediaMaxMb: 5,
     canHostMedia: true,
     statusSink: params.statusSink,
+    ingress: params.ingress ?? createFakeIngress(),
   });
+}
+
+const ingressStateDirs: string[] = [];
+const ingressDisposers: Array<() => void> = [];
+
+async function createIngressStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-webhook-ingress-"));
+  const resolved = await realpath(created);
+  ingressStateDirs.push(resolved);
+  return resolved;
+}
+
+async function createRealIngress(params: {
+  accountId: string;
+  dispatch: (update: ZaloUpdate) => Promise<void>;
+}): Promise<ZaloIngressSpool> {
+  const stateDir = await createIngressStateDir();
+  const spool = createZaloIngressSpool({
+    accountId: params.accountId,
+    abortSignal: new AbortController().signal,
+    queue: createChannelIngressQueueForTests({
+      channelId: "zalo",
+      accountId: params.accountId,
+      stateDir,
+    }),
+    dispatch: params.dispatch,
+  });
+  ingressDisposers.push(spool.dispose);
+  return spool;
 }
 
 async function postUntilRateLimited(params: {
@@ -143,9 +185,15 @@ async function expectTwoWebhookPostsOk(params: {
 }
 
 describe("handleZaloWebhookRequest", () => {
-  afterEach(() => {
+  afterEach(async () => {
     clearZaloWebhookSecurityStateForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());
+    for (const dispose of ingressDisposers.splice(0).toReversed()) {
+      dispose();
+    }
+    for (const stateDir of ingressStateDirs.splice(0).toReversed()) {
+      await rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("returns 400 for non-object payloads", async () => {
@@ -218,10 +266,43 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
-  it("deduplicates webhook replay for the same event origin", async () => {
+  it("journals the update before ack and drains it detached", async () => {
+    const dispatch = vi.fn(async (_update: ZaloUpdate) => undefined);
+    const ingress = await createRealIngress({ accountId: "default", dispatch });
+    const unregister = registerTarget({ path: "/hook-durable", ingress });
+    const payload = createTextUpdate({
+      messageId: "msg-durable-1",
+      userId: "123",
+      userName: "",
+      chatId: "123",
+      text: "hello",
+    });
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const response = await postWebhookJson({
+          baseUrl,
+          path: "/hook-durable",
+          secret: "secret",
+          payload,
+        });
+
+        expect(response.status).toBe(200);
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledOnce();
+        expect(dispatch.mock.calls[0]?.[0].message?.message_id).toBe("msg-durable-1");
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  it("deduplicates webhook replay through the durable journal", async () => {
     runDetachedWebhookWork.mockClear();
+    const dispatch = vi.fn(async (_update: ZaloUpdate) => undefined);
+    const ingress = await createRealIngress({ accountId: "default", dispatch });
     const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay", statusSink: sink });
+    const unregister = registerTarget({ path: "/hook-replay", statusSink: sink, ingress });
     const payload = createTextUpdate({
       messageId: "msg-replay-1",
       userId: "123",
@@ -241,7 +322,10 @@ describe("handleZaloWebhookRequest", () => {
 
         expect(first.status).toBe(200);
         expect(replay.status).toBe(200);
-        expect(sink).toHaveBeenCalledTimes(1);
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledOnce();
+        // Admission is acknowledged per delivery; the journal dedupes dispatch.
+        expect(sink).toHaveBeenCalledTimes(2);
         expect(runDetachedWebhookWork).toHaveBeenCalledTimes(2);
       });
     } finally {
@@ -249,48 +333,40 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
-  it("allows a retry after processUpdate throws a retryable replay error", async () => {
+  it("responds 500 when the ingress append fails so Zalo redelivers", async () => {
     const error = vi.fn();
+    const ingress = createFakeIngress({
+      enqueue: vi.fn(async () => {
+        throw new Error("sqlite wedged");
+      }),
+    });
     const unregister = registerTarget({
-      path: "/hook-retry-after-failure",
+      path: "/hook-append-failure",
       runtime: { error },
+      ingress,
     });
     const payload = createTextUpdate({
-      messageId: "msg-retry-after-failure-1",
+      messageId: "msg-append-failure-1",
       userId: "123",
       userName: "",
       chatId: "123",
       text: "hello",
     });
-    let attempts = 0;
-    const processUpdate = vi.fn<ZaloWebhookProcessUpdate>(async () => {
-      attempts += 1;
-      if (attempts === 1) {
-        throw new ZaloRetryableWebhookError("boom");
-      }
-    });
 
     try {
-      await withServer(createWebhookRequestHandler(processUpdate), async (baseUrl) => {
-        const first = await postWebhookJson({
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const response = await postWebhookJson({
           baseUrl,
-          path: "/hook-retry-after-failure",
+          path: "/hook-append-failure",
           secret: "secret",
           payload,
         });
 
-        expect(first.status).toBe(200);
-        await vi.waitFor(() => expect(error).toHaveBeenCalledTimes(1));
-
-        const second = await postWebhookJson({
-          baseUrl,
-          path: "/hook-retry-after-failure",
-          secret: "secret",
-          payload,
-        });
-
-        expect(second.status).toBe(200);
-        await vi.waitFor(() => expect(processUpdate).toHaveBeenCalledTimes(2));
+        expect(response.status).toBe(500);
+        expect(error).toHaveBeenCalledWith(
+          expect.stringContaining("Zalo webhook ingress append failed"),
+        );
+        expect(ingress.drainOnce).not.toHaveBeenCalled();
       });
     } finally {
       unregister();
@@ -300,10 +376,13 @@ describe("handleZaloWebhookRequest", () => {
   it("keeps replay dedupe isolated per authenticated target", async () => {
     const sinkA = vi.fn();
     const sinkB = vi.fn();
+    const ingressA = createFakeIngress();
+    const ingressB = createFakeIngress();
     const unregisterA = registerTarget({
       path: "/hook-replay-scope",
       secret: "secret-a",
       statusSink: sinkA,
+      ingress: ingressA,
     });
     const unregisterB = registerTarget({
       path: "/hook-replay-scope",
@@ -313,6 +392,7 @@ describe("handleZaloWebhookRequest", () => {
         ...DEFAULT_ACCOUNT,
         accountId: "work",
       },
+      ingress: ingressB,
     });
     const payload = createTextUpdate({
       messageId: "msg-replay-scope-1",
@@ -331,77 +411,14 @@ describe("handleZaloWebhookRequest", () => {
         });
       });
 
+      // Each account owns its journal, so the same update is admitted once per target.
+      expect(ingressA.enqueue).toHaveBeenCalledTimes(1);
+      expect(ingressB.enqueue).toHaveBeenCalledTimes(1);
       expect(sinkA).toHaveBeenCalledTimes(1);
       expect(sinkB).toHaveBeenCalledTimes(1);
     } finally {
       unregisterA();
       unregisterB();
-    }
-  });
-
-  it("does not collide replay dedupe across different chats", async () => {
-    const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay-chat-scope", statusSink: sink });
-    const firstPayload = createTextUpdate({
-      messageId: "msg-replay-chat-1",
-      userId: "123",
-      userName: "",
-      chatId: "chat-a",
-      text: "hello from a",
-    });
-    const secondPayload = createTextUpdate({
-      messageId: "msg-replay-chat-1",
-      userId: "123",
-      userName: "",
-      chatId: "chat-b",
-      text: "hello from b",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-chat-scope", secret: "secret", payload: firstPayload },
-          second: { path: "/hook-replay-chat-scope", secret: "secret", payload: secondPayload },
-        });
-      });
-
-      expect(sink).toHaveBeenCalledTimes(2);
-    } finally {
-      unregister();
-    }
-  });
-
-  it("does not collide replay dedupe across different senders in the same chat", async () => {
-    const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay-sender-scope", statusSink: sink });
-    const firstPayload = createTextUpdate({
-      messageId: "msg-replay-sender-1",
-      userId: "user-a",
-      userName: "",
-      chatId: "chat-shared",
-      text: "hello from user a",
-    });
-    const secondPayload = createTextUpdate({
-      messageId: "msg-replay-sender-1",
-      userId: "user-b",
-      userName: "",
-      chatId: "chat-shared",
-      text: "hello from user b",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-sender-scope", secret: "secret", payload: firstPayload },
-          second: { path: "/hook-replay-sender-scope", secret: "secret", payload: secondPayload },
-        });
-      });
-
-      expect(sink).toHaveBeenCalledTimes(2);
-    } finally {
-      unregister();
     }
   });
 
@@ -434,92 +451,6 @@ describe("handleZaloWebhookRequest", () => {
       expect(sink).toHaveBeenCalledTimes(1);
     } finally {
       unregister();
-    }
-  });
-
-  it("keeps replay dedupe isolated when path/account values collide under colon-joined keys", async () => {
-    const sinkA = vi.fn();
-    const sinkB = vi.fn();
-    // Old key format `${path}:${accountId}:${event_name}:${messageId}` would collide for these two targets.
-    const unregisterA = registerTarget({
-      path: "/hook-replay-collision:a",
-      secret: "secret-a",
-      statusSink: sinkA,
-      account: {
-        ...DEFAULT_ACCOUNT,
-        accountId: "team",
-      },
-    });
-    const unregisterB = registerTarget({
-      path: "/hook-replay-collision",
-      secret: "secret-b",
-      statusSink: sinkB,
-      account: {
-        ...DEFAULT_ACCOUNT,
-        accountId: "a:team",
-      },
-    });
-    const payload = createTextUpdate({
-      messageId: "msg-replay-collision-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-collision:a", secret: "secret-a", payload },
-          second: { path: "/hook-replay-collision", secret: "secret-b", payload },
-        });
-      });
-
-      expect(sinkA).toHaveBeenCalledTimes(1);
-      expect(sinkB).toHaveBeenCalledTimes(1);
-    } finally {
-      unregisterA();
-      unregisterB();
-    }
-  });
-
-  it("keeps replay dedupe isolated across different webhook paths", async () => {
-    const sinkA = vi.fn();
-    const sinkB = vi.fn();
-    const sharedSecret = "secret";
-    const unregisterA = registerTarget({
-      path: "/hook-replay-scope-a",
-      secret: sharedSecret,
-      statusSink: sinkA,
-    });
-    const unregisterB = registerTarget({
-      path: "/hook-replay-scope-b",
-      secret: sharedSecret,
-      statusSink: sinkB,
-    });
-    const payload = createTextUpdate({
-      messageId: "msg-replay-cross-path-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-scope-a", secret: sharedSecret, payload },
-          second: { path: "/hook-replay-scope-b", secret: sharedSecret, payload },
-        });
-      });
-
-      expect(sinkA).toHaveBeenCalledTimes(1);
-      expect(sinkB).toHaveBeenCalledTimes(1);
-    } finally {
-      unregisterA();
-      unregisterB();
     }
   });
 

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -1,10 +1,10 @@
 // Zalo plugin module implements monitor.webhook behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { ResolvedZaloAccount } from "./accounts.js";
 import type { ZaloFetch, ZaloUpdate } from "./api.js";
+import type { ZaloIngressEnqueueResult } from "./monitor-ingress.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
 import {
   createFixedWindowRateLimiter,
@@ -23,7 +23,11 @@ import {
   type OpenClawConfig,
 } from "./runtime-api.js";
 
-const ZALO_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
+/** Minimal durable-ingress surface the webhook admission path needs. */
+export type ZaloWebhookIngress = {
+  enqueue: (update: ZaloUpdate) => Promise<ZaloIngressEnqueueResult>;
+  drainOnce: () => Promise<void>;
+};
 
 type ZaloWebhookTarget = {
   token: string;
@@ -39,12 +43,8 @@ type ZaloWebhookTarget = {
   canHostMedia: boolean;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   fetcher?: ZaloFetch;
+  ingress: ZaloWebhookIngress;
 };
-
-export type ZaloWebhookProcessUpdate = (params: {
-  update: ZaloUpdate;
-  target: ZaloWebhookTarget;
-}) => Promise<void>;
 
 const webhookTargets = new Map<string, ZaloWebhookTarget[]>();
 const webhookRateLimiter = createFixedWindowRateLimiter({
@@ -60,7 +60,6 @@ const webhookAnomalyTracker = createWebhookAnomalyTracker({
 
 export function clearZaloWebhookSecurityStateForTest(): void {
   webhookRateLimiter.clear();
-  recentWebhookEvents.clearMemory();
   webhookAnomalyTracker.clear();
 }
 
@@ -70,62 +69,6 @@ export function getZaloWebhookRateLimitStateSizeForTest(): number {
 
 export function getZaloWebhookStatusCounterSizeForTest(): number {
   return webhookAnomalyTracker.size();
-}
-
-function buildReplayEventCacheKey(target: ZaloWebhookTarget, update: ZaloUpdate): string | null {
-  const messageId = update.message?.message_id;
-  if (!messageId) {
-    return null;
-  }
-  const chatId = update.message?.chat?.id ?? "";
-  const senderId = update.message?.from?.id ?? "";
-  return JSON.stringify([
-    target.path,
-    target.account.accountId,
-    update.event_name,
-    chatId,
-    senderId,
-    messageId,
-  ]);
-}
-
-const recentWebhookEvents = createChannelReplayGuard<{
-  target: ZaloWebhookTarget;
-  update: ZaloUpdate;
-}>({
-  dedupe: {
-    ttlMs: ZALO_WEBHOOK_REPLAY_WINDOW_MS,
-    memoryMaxSize: 5000,
-  },
-  buildReplayKey: ({ target, update }) => buildReplayEventCacheKey(target, update),
-});
-
-export class ZaloRetryableWebhookError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "ZaloRetryableWebhookError";
-  }
-}
-
-async function processZaloReplayGuardedUpdate(params: {
-  target: ZaloWebhookTarget;
-  update: ZaloUpdate;
-  processUpdate: ZaloWebhookProcessUpdate;
-  nowMs?: number;
-}): Promise<"processed" | "duplicate"> {
-  const event = { target: params.target, update: params.update };
-  const result = await recentWebhookEvents.processGuarded(
-    event,
-    async () => {
-      params.target.statusSink?.({ lastInboundAt: Date.now() });
-      await params.processUpdate(event);
-    },
-    {
-      dedupe: { now: params.nowMs },
-      onError: (error) => (error instanceof ZaloRetryableWebhookError ? "release" : "commit"),
-    },
-  );
-  return result.kind === "processed" ? "processed" : "duplicate";
 }
 
 function recordWebhookStatus(
@@ -169,7 +112,6 @@ export function registerZaloWebhookTarget(
 export async function handleZaloWebhookRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  processUpdate: ZaloWebhookProcessUpdate,
 ): Promise<boolean> {
   return await withResolvedWebhookRequestPipeline({
     req,
@@ -254,18 +196,30 @@ export async function handleZaloWebhookRequest(
         return true;
       }
 
-      // Reserve the detached task before the HTTP admission is released;
-      // otherwise later queue work inherits a released admission root.
-      void runDetachedWebhookWork(() =>
-        processZaloReplayGuardedUpdate({
-          target,
-          update,
-          processUpdate,
-          nowMs,
-        }),
-      ).catch((err: unknown) => {
-        target.runtime.error?.(`[${target.account.accountId}] Zalo webhook failed: ${String(err)}`);
-      });
+      target.statusSink?.({ lastInboundAt: nowMs });
+      let accepted: ZaloIngressEnqueueResult;
+      try {
+        // Durable-before-ack: respond 200 only after the update is journaled, so a
+        // failed append keeps Zalo's webhook redelivery contract alive.
+        accepted = await target.ingress.enqueue(update);
+      } catch (error) {
+        target.runtime.error?.(
+          `[${target.account.accountId}] Zalo webhook ingress append failed: ${String(error)}`,
+        );
+        res.statusCode = 500;
+        res.end("Ingress Unavailable");
+        recordWebhookStatus(target.runtime, path, res.statusCode);
+        return true;
+      }
+      if (accepted.kind !== "ignored") {
+        // Reserve the detached task before the HTTP admission is released;
+        // otherwise later queue work inherits a released admission root.
+        void runDetachedWebhookWork(() => target.ingress.drainOnce()).catch((err: unknown) => {
+          target.runtime.error?.(
+            `[${target.account.accountId}] Zalo ingress drain failed: ${String(err)}`,
+          );
+        });
+      }
 
       res.statusCode = 200;
       res.end("ok");

--- a/extensions/zalo/src/test-support/lifecycle-test-support.ts
+++ b/extensions/zalo/src/test-support/lifecycle-test-support.ts
@@ -7,6 +7,7 @@ import {
 import { expect, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "../types.js";
+import { openLifecycleIngressQueueForTest } from "./monitor-mocks-test-support.js";
 
 function resolveLifecycleAllowFrom(params: {
   dmPolicy: "open" | "pairing";
@@ -199,6 +200,10 @@ export function createImageLifecycleCore() {
       shouldLogVerbose: vi.fn(
         () => false,
       ) as unknown as PluginRuntime["logging"]["shouldLogVerbose"],
+    },
+    state: {
+      openChannelIngressQueue:
+        openLifecycleIngressQueueForTest as unknown as PluginRuntime["state"]["openChannelIngressQueue"],
     },
     channel: {
       pairing: {

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -1,13 +1,17 @@
 // Zalo plugin module implements monitor mocks test support behavior.
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   createEmptyPluginRegistry,
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi, type Mock } from "vitest";
-import type { OpenClawConfig } from "../runtime-api.js";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "../types.js";
 
 type MonitorModule = typeof import("../monitor.js");
@@ -110,6 +114,18 @@ export async function resetLifecycleTestState() {
   setActivePluginRegistry(createEmptyPluginRegistry());
 }
 
+/** Fresh SQLite state per queue open keeps journaled updates isolated per test run. */
+export function openLifecycleIngressQueueForTest(options?: {
+  accountId?: string;
+  stateDir?: string;
+}) {
+  return createChannelIngressQueueForTests({
+    channelId: "zalo",
+    stateDir: mkdtempSync(path.join(os.tmpdir(), "openclaw-zalo-test-ingress-")),
+    ...options,
+  });
+}
+
 export function setLifecycleRuntimeCore(
   channel: NonNullable<NonNullable<Parameters<typeof createPluginRuntimeMock>[0]>["channel"]>,
   state?: NonNullable<Parameters<typeof createPluginRuntimeMock>[0]>["state"],
@@ -117,7 +133,11 @@ export function setLifecycleRuntimeCore(
   getZaloRuntimeMock.mockReturnValue(
     createPluginRuntimeMock({
       channel,
-      ...(state ? { state } : {}),
+      state: {
+        openChannelIngressQueue:
+          openLifecycleIngressQueueForTest as unknown as PluginRuntime["state"]["openChannelIngressQueue"],
+        ...state,
+      },
     }),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Zalo long-polling — the default inbound mode when no webhook is configured — loses messages permanently in two windows:

1. **Crash window.** `getUpdates` (`extensions/zalo/src/api.ts:249-258`) sends only `{timeout}`; no offset parameter exists and `ZaloUpdate` (`api.ts:51-58`) carries no update id, so the client can never confirm or replay — the server consumes each update on response. In the poll loop (`monitor.ts`), a crash between the `getUpdates` response and `processUpdate` completion destroys the only copy of the message. It is never redelivered.
2. **Dispatch-error window.** Before this change the poll loop called `await processUpdate(...)` directly and the surrounding `catch` only logged `Zalo polling error` and polled on — any handler failure silently dropped the consumed update.

The webhook sibling had the weaker form of the same bug: detached processing with an immediate 200 and a memory-only replay guard (5 min TTL), so a restart forgot recent deliveries and a post-ack handler failure was committed-and-dropped.

## Why This Change Was Made

This mirrors the maintainer-blessed "inbound durability across restart" wave that landed on `main` in the last 24h — #110418 whatsapp, #110409 imessage, #110386 mattermost, #110357 msteams, #110274 discord, #109910 slack, #109866 sms, #109907 signal, line webhook-spool (#109655/#109819) — all built on the core durable ingress drain (`src/channels/message/ingress-drain.ts`, #108656 lineage). Zalo adopts the same mechanism through the same SDK seam (`openclaw/plugin-sdk/channel-outbound`: `createChannelIngressDrain`, `bindIngressLifecycleToReplyOptions`), storing rows in the existing `channel_ingress_events` table of the shared state DB — **no schema change**.

Design (closest template: `extensions/sms/src/ingress-spool.ts`, mapped to Zalo's polling chokepoint):

- New `extensions/zalo/src/monitor-ingress.ts`: `createZaloIngressSpool` journals each inbound update **before** it can be lost. Event id = `JSON.stringify([chatId, senderId, messageId])` (JSON encoding keeps ids unambiguous; `message_id` is contract-required per `api.ts:31`), lane = one per chat for per-conversation serialization.
- Polling loop: enqueue first, then `drainOnce()` + `waitForIdle()` each cycle (preserves the old one-at-a-time backpressure), pumping retries even on empty polls. Dispatch errors are now drain-owned: retry with backoff (8 attempts / 24h dead-letter gate) instead of silent drop.
- Webhook: 200 only **after** the journal append (durable-before-ack); an append failure answers 500 so Zalo redelivers. The retired memory-only replay guard is deleted; 30d/20k tombstones dominate its 5min/5k window.
- Adoption lifecycle is threaded into `core.channel.inbound.dispatch` (`turnAdoptionLifecycle`) so claims tombstone when recovery-relevant turn state is durable; events dropped pre-dispatch (unauthorized, sticker/unsupported, empty text) complete at dispatch return.
- Fail closed: the append retries transient SQLite errors (250/750ms) then throws loudly — no unjournaled live dispatch fallback (the whatsapp landed-autoreview lesson).

Honest note: Zalo's server-side consume-on-response semantics are code-inferred — no offset/id field exists in the client contract, so the journal is correct under any server semantics (worst case it dedupes a redelivery).

## User Impact

- Polling mode (default): a gateway crash/restart no longer loses the in-flight Zalo message; it replays on startup. Handler failures retry with backoff instead of vanishing.
- Webhook mode: deliveries survive restarts; replays dedupe durably (30d) instead of 5 minutes in memory; failed appends get a 500 so Zalo redelivers.
- No config/schema changes; journal rows live in the existing shared state DB table already used by telegram/sms/signal/whatsapp.
- Updates without a `message` (no-ops downstream) and malformed messages missing the contract-required `message_id` are acknowledged without journaling (logged), since they can be neither deduped nor replayed.

## Evidence

- New `extensions/zalo/src/monitor-ingress.test.ts` (8 tests, real SQLite queues in temp dirs via `createChannelIngressQueueForTests`): crash-window replay (journal → dispose without dispatch → fresh spool replays exactly once), tombstone dedupe, complete-at-dispatch-return, retryable-failure retry, permanent-failure dead-letter, ignore-without-message, per-chat event-id scoping, per-chat lane.
- `monitor.webhook.test.ts` (14 tests): real-spool journal-before-ack + detached drain over HTTP, durable replay dedupe, 500-on-append-failure redelivery contract, plus retained rate-limit/auth guards.
- Reverse verification: with the durable append in `enqueue` removed, 6/8 spool tests go red (crash replay, dedupe, complete-at-return, retry, scoping, lane); restored, all 8 pass.
- Full zalo suite: 126/127 pass. The single failure (`setup-surface.test.ts` wizard prompt, locale-dependent) fails identically on an untouched `main` checkout — pre-existing, unrelated.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json`: zero errors in touched files (only the 3 pre-existing `packages/net-policy/src/ip.ts` errors from stale worktree `ipaddr.js` types).
- Existing end-to-end lifecycle tests (polling image, pairing, reply-once) run the real monitor through the journal and stay green, proving no regression in the happy path.
