### PR TITLE
fix(agents): report agent-delete cleanup failures instead of silent success

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8679,21 +8679,29 @@ public struct AgentsDeleteResult: Codable, Sendable {
     public let ok: Bool
     public let agentid: String
     public let removedbindings: Int
+    public let removed: [[String: AnyCodable]]?
+    public let failed: [[String: AnyCodable]]?
 
     public init(
         ok: Bool,
         agentid: String,
-        removedbindings: Int)
+        removedbindings: Int,
+        removed: [[String: AnyCodable]]? = nil,
+        failed: [[String: AnyCodable]]? = nil)
     {
         self.ok = ok
         self.agentid = agentid
         self.removedbindings = removedbindings
+        self.removed = removed
+        self.failed = failed
     }
 
     private enum CodingKeys: String, CodingKey {
         case ok
         case agentid = "agentId"
         case removedbindings = "removedBindings"
+        case removed
+        case failed
     }
 }
 

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -68,7 +68,7 @@ Options: `--force`, `--json`.
 
 - `main` cannot be deleted.
 - Without `--force`, interactive confirmation is required (fails in a non-TTY session; re-run with `--force`).
-- Workspace, agent state, and session transcript directories move to Trash, not hard-deleted.
+- Workspace, agent state, and session transcript directories move to Trash, not hard-deleted. If Trash is unavailable, agent config deletion still succeeds and reports paths requiring manual cleanup.
 - When the Gateway is reachable, deletion routes through the Gateway so config and session-store cleanup share the same writer as runtime traffic. If the Gateway is unreachable, the CLI falls back to the offline local path.
 - If another agent's workspace is the same path, inside this workspace, or contains this workspace, the workspace is retained, and `--json` reports `workspaceRetained`, `workspaceRetainedReason`, and `workspaceSharedWith`.
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -2,6 +2,7 @@
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
+  AgentsDeleteResultSchema,
   AgentsListResultSchema,
   AgentsUpdateParamsSchema,
   ModelsListParamsSchema,
@@ -14,6 +15,20 @@ import {
   ToolsEffectiveResultSchema,
   ToolsInvokeParamsSchema,
 } from "./agents-models-skills.js";
+
+describe("AgentsDeleteResultSchema", () => {
+  it("accepts per-path cleanup outcomes", () => {
+    expect(
+      Value.Check(AgentsDeleteResultSchema, {
+        ok: true,
+        agentId: "ops",
+        removedBindings: 1,
+        removed: [{ path: "/state/agents/ops/agent", method: "trash" }],
+        failed: [{ path: "/state/workspace-ops", reason: "trash unavailable" }],
+      }),
+    ).toBe(true);
+  });
+});
 
 /**
  * Schema regression tests for agent metadata, skill proposals, and effective

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -142,6 +142,22 @@ export const AgentsDeleteResultSchema = closedObject({
   ok: Type.Literal(true),
   agentId: NonEmptyString,
   removedBindings: Type.Integer({ minimum: 0 }),
+  removed: Type.Optional(
+    Type.Array(
+      closedObject({
+        path: NonEmptyString,
+        method: Type.Union([Type.Literal("trash"), Type.Literal("missing")]),
+      }),
+    ),
+  ),
+  failed: Type.Optional(
+    Type.Array(
+      closedObject({
+        path: NonEmptyString,
+        reason: NonEmptyString,
+      }),
+    ),
+  ),
 });
 
 /** File metadata and optional content for agent-local editable files. */

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -40,6 +40,8 @@ type AgentsDeleteGatewayResult = {
   ok: true;
   agentId: string;
   removedBindings: number;
+  removed?: Array<{ path: string; method: "trash" | "missing" }>;
+  failed?: Array<{ path: string; reason: string }>;
 };
 
 async function maybeDeleteAgentThroughGateway(params: {
@@ -144,10 +146,17 @@ export async function agentsDeleteCommand(
         sessionsDir,
         removedBindings: gatewayResult.removedBindings,
         removedAllow: result.removedAllow,
+        removed: gatewayResult.removed,
+        failed: gatewayResult.failed,
         transport: "gateway",
       });
     } else {
       runtime.log(`Deleted agent: ${agentId}`);
+      for (const failure of gatewayResult.failed ?? []) {
+        runtime.error(
+          `Warning: path could not be moved to Trash: ${failure.reason}; remove it manually at ${failure.path}`,
+        );
+      }
     }
     return;
   }

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -181,7 +181,28 @@ export function pruneAgentConfig(
 } {
   const id = normalizeAgentId(agentId);
   const agents = listAgentEntries(cfg);
-  const nextAgentsList = agents.filter((entry) => normalizeAgentId(entry.id) !== id);
+  const pruneAllowAgents = (allowAgents: string[] | undefined) =>
+    allowAgents?.filter((entry) => {
+      const trimmed = entry.trim();
+      return !trimmed || trimmed === "*" || normalizeAgentId(trimmed) !== id;
+    });
+  const nextAgentsList = [];
+  for (const entry of agents) {
+    if (normalizeAgentId(entry.id) === id) {
+      continue;
+    }
+    nextAgentsList.push(
+      entry.subagents?.allowAgents
+        ? {
+            ...entry,
+            subagents: {
+              ...entry.subagents,
+              allowAgents: pruneAllowAgents(entry.subagents.allowAgents),
+            },
+          }
+        : entry,
+    );
+  }
   const nextAgents = nextAgentsList.length > 0 ? nextAgentsList : undefined;
 
   const bindings = cfg.bindings ?? [];
@@ -190,8 +211,17 @@ export function pruneAgentConfig(
   const allow = cfg.tools?.agentToAgent?.allow ?? [];
   const filteredAllow = allow.filter((entry) => entry !== id);
 
+  const nextDefaults = cfg.agents?.defaults?.subagents?.allowAgents
+    ? {
+        ...cfg.agents.defaults,
+        subagents: {
+          ...cfg.agents.defaults.subagents,
+          allowAgents: pruneAllowAgents(cfg.agents.defaults.subagents.allowAgents),
+        },
+      }
+    : cfg.agents?.defaults;
   const nextAgentsConfig = cfg.agents
-    ? { ...cfg.agents, list: nextAgents }
+    ? { ...cfg.agents, defaults: nextDefaults, list: nextAgents }
     : nextAgents
       ? { list: nextAgents }
       : undefined;

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -179,6 +179,8 @@ describe("agents delete command", () => {
         ok: true,
         agentId: "ops",
         removedBindings: 0,
+        removed: [{ path: path.join(stateDir, "agents", "ops", "agent"), method: "trash" }],
+        failed: [{ path: path.join(stateDir, "workspace-ops"), reason: "trash unavailable" }],
       });
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
@@ -193,7 +195,38 @@ describe("agents delete command", () => {
       const output = readJsonLogs()[0];
       expect(output?.agentId).toBe("ops");
       expect(output?.removedBindings).toBe(0);
+      expect(output?.removed).toEqual([
+        { path: path.join(stateDir, "agents", "ops", "agent"), method: "trash" },
+      ]);
+      expect(output?.failed).toEqual([
+        { path: path.join(stateDir, "workspace-ops"), reason: "trash unavailable" },
+      ]);
       expect(output?.transport).toBe("gateway");
+    });
+  });
+
+  it("warns about Gateway cleanup failures without failing committed deletion", async () => {
+    await withStateDirEnv("openclaw-agents-delete-gateway-warning-", async ({ stateDir }) => {
+      const workspace = path.join(stateDir, "workspace-ops");
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main" }, { id: "ops", workspace }] },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+      gatewayMocks.callGateway.mockResolvedValue({
+        ok: true,
+        agentId: "ops",
+        removedBindings: 0,
+        removed: [],
+        failed: [{ path: workspace, reason: "trash unavailable" }],
+      });
+
+      await agentsDeleteCommand({ id: "ops", force: true }, runtime);
+
+      expect(runtime.log).toHaveBeenCalledWith("Deleted agent: ops");
+      expect(runtime.error).toHaveBeenCalledWith(
+        `Warning: path could not be moved to Trash: trash unavailable; remove it manually at ${workspace}`,
+      );
+      expect(runtime.exit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -414,9 +414,14 @@ describe("agents helpers", () => {
   it("pruneAgentConfig removes agent, bindings, and allowlist entries", () => {
     const cfg: OpenClawConfig = {
       agents: {
+        defaults: { subagents: { allowAgents: ["work", "home"] } },
         list: [
           { id: "work", default: true, workspace: "/work-ws" },
-          { id: "home", workspace: "/home-ws" },
+          {
+            id: "home",
+            workspace: "/home-ws",
+            subagents: { allowAgents: ["WORK", "home"] },
+          },
         ],
       },
       bindings: [
@@ -435,6 +440,8 @@ describe("agents helpers", () => {
       { agentId: "home", match: { channel: "telegram" } },
     ]);
     expect(result.config.tools?.agentToAgent?.allow).toEqual(["home"]);
+    expect(result.config.agents?.defaults?.subagents?.allowAgents).toEqual(["home"]);
+    expect(result.config.agents?.list?.[0]?.subagents?.allowAgents).toEqual(["home"]);
     expect(result.removedBindings).toBe(1);
     expect(result.removedAllow).toBe(1);
   });

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1,6 +1,8 @@
 // Agent mutation tests cover create/update/delete handlers, safe workspace file
 // access, config preconditions, trash cleanup, and workspace-state handling.
 
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { FsSafeError } from "../../infra/fs-safe.js";
@@ -44,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   fsLstat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
   fsRealpath: vi.fn(async (p: string) => p),
   fsReadlink: vi.fn(async () => ""),
+  fsRm: vi.fn(async () => undefined),
   fsOpen: vi.fn(async () => ({}) as unknown),
   rootRead: vi.fn(async (_params?: unknown) => ({
     buffer: Buffer.from(""),
@@ -197,6 +200,7 @@ vi.mock("node:fs/promises", async () => {
     lstat: mocks.fsLstat,
     realpath: mocks.fsRealpath,
     readlink: mocks.fsReadlink,
+    rm: mocks.fsRm,
     open: mocks.fsOpen,
   };
   return { ...patched, default: patched };
@@ -1169,11 +1173,20 @@ describe("agents.delete", () => {
 
     expect(respond).toHaveBeenCalledWith(
       true,
-      { ok: true, agentId: "test-agent", removedBindings: 2 },
+      {
+        ok: true,
+        agentId: "test-agent",
+        removedBindings: 2,
+        removed: [
+          { path: "/workspace/test-agent", method: "trash" },
+          { path: "/agents/test-agent", method: "trash" },
+          { path: "/transcripts/test-agent", method: "trash" },
+        ],
+        failed: [],
+      },
       undefined,
     );
     expect(mocks.writeConfigFile).toHaveBeenCalled();
-    // moveToTrashBestEffort calls fs.lstat then movePathToTrash for each dir
     expect(mocks.movePathToTrash).toHaveBeenCalled();
   });
 
@@ -1221,16 +1234,55 @@ describe("agents.delete", () => {
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/workspace/test-agent");
   });
 
-  it("retains workspace state when best-effort workspace trash fails", async () => {
-    mocks.movePathToTrash.mockRejectedValueOnce(new Error("trash unavailable"));
+  it("reports trash failures without deleting the retained directory", async () => {
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const workspaceDir = await actualFs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-agent-delete-trash-failure-"),
+    );
+    mocks.resolveAgentWorkspaceDir.mockReturnValueOnce(workspaceDir);
+    mocks.movePathToTrash.mockRejectedValueOnce(
+      Object.assign(new Error("trash destination missing"), { code: "ENOENT" }),
+    );
+
+    try {
+      const { respond, promise } = makeCall("agents.delete", {
+        agentId: "test-agent",
+      });
+      await promise;
+
+      expectRespondOk(respond, {
+        removed: [
+          { path: "/agents/test-agent", method: "trash" },
+          { path: "/transcripts/test-agent", method: "trash" },
+        ],
+        failed: [{ path: workspaceDir, reason: "trash destination missing" }],
+      });
+      await expect(actualFs.stat(workspaceDir)).resolves.toBeDefined();
+      expect(mocks.fsRm).not.toHaveBeenCalled();
+      expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
+    } finally {
+      await actualFs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an absent source without invoking the trash backend", async () => {
+    mocks.fsLstat.mockRejectedValueOnce(createEnoentError());
 
     const { respond, promise } = makeCall("agents.delete", {
       agentId: "test-agent",
     });
     await promise;
 
-    expectRespondOk(respond, { ok: true });
-    expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
+    expectRespondOk(respond, {
+      removed: [
+        { path: "/workspace/test-agent", method: "missing" },
+        { path: "/agents/test-agent", method: "trash" },
+        { path: "/transcripts/test-agent", method: "trash" },
+      ],
+      failed: [],
+    });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/workspace/test-agent");
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalled();
   });
 
   it("retains workspace state when workspace presence cannot be checked", async () => {
@@ -1243,12 +1295,15 @@ describe("agents.delete", () => {
     });
     await promise;
 
-    expectRespondOk(respond, { ok: true });
+    expectRespondOk(respond, {
+      failed: [{ path: "/workspace/test-agent", reason: "permission denied" }],
+    });
     expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
   });
 
   it("skips file deletion when deleteFiles is false", async () => {
     mocks.fsLstat.mockClear();
+    mocks.movePathToTrash.mockClear();
 
     const { respond, promise } = makeCall("agents.delete", {
       agentId: "test-agent",
@@ -1257,8 +1312,9 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    // moveToTrashBestEffort should not be called at all
+    // No filesystem cleanup should run.
     expect(mocks.fsLstat).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
     expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -319,21 +319,38 @@ function respondAgentConfigPreconditionError(
   );
 }
 
-async function moveToTrashBestEffort(pathname: string): Promise<boolean> {
-  if (!pathname) {
-    return false;
-  }
+type AgentDeleteRemovedPath = {
+  path: string;
+  method: "trash" | "missing";
+};
+
+type AgentDeleteFailedPath = {
+  path: string;
+  reason: string;
+};
+
+type AgentDeletePathOutcome =
+  | { removed: AgentDeleteRemovedPath }
+  | { failed: AgentDeleteFailedPath };
+
+function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcome {
+  const reason = error instanceof Error && error.message ? error.message : String(error);
+  return { failed: { path: pathname, reason: reason || "unknown error" } };
+}
+
+async function removeAgentPath(pathname: string): Promise<AgentDeletePathOutcome> {
   try {
     await fs.lstat(pathname);
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT";
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+      ? { removed: { path: pathname, method: "missing" } }
+      : cleanupFailure(pathname, error);
   }
   try {
     await movePathToTrash(pathname);
-    return true;
-  } catch {
-    // Best-effort: path may already be gone or trash unavailable.
-    return false;
+    return { removed: { path: pathname, method: "trash" } };
+  } catch (error) {
+    return cleanupFailure(pathname, error);
   }
 }
 
@@ -742,6 +759,16 @@ export const agentsHandlers: GatewayRequestHandlers = {
     // Purge session store entries so orphaned sessions cannot be targeted (#65524).
     await purgeAgentSessionStoreEntries(cfg, agentId);
 
+    const removed: AgentDeleteRemovedPath[] = [];
+    const failed: AgentDeleteFailedPath[] = [];
+    const recordOutcome = (outcome: AgentDeletePathOutcome) => {
+      if ("removed" in outcome) {
+        removed.push(outcome.removed);
+      } else {
+        failed.push(outcome.failed);
+      }
+    };
+
     if (deleteFiles) {
       const workspaceSharedWith = findOverlappingWorkspaceAgentIds(
         committed.nextConfig,
@@ -749,12 +776,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
         deleteResult.workspaceDir,
       );
       const deleteWorkspace = workspaceSharedWith.length === 0;
-      const pathsToTrash = [deleteResult.agentDir, deleteResult.sessionsDir];
       if (deleteWorkspace) {
         const legacyPlan = prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir);
         const statePlan = prepareWorkspaceStateDeletion(deleteResult.workspaceDir);
-        const workspaceRemoved = await moveToTrashBestEffort(deleteResult.workspaceDir);
-        if (workspaceRemoved) {
+        const workspaceOutcome = await removeAgentPath(deleteResult.workspaceDir);
+        recordOutcome(workspaceOutcome);
+        if ("removed" in workspaceOutcome) {
           try {
             await removeLegacyWorkspaceStateForReset(legacyPlan);
             deleteWorkspaceState(statePlan);
@@ -763,10 +790,17 @@ export const agentsHandlers: GatewayRequestHandlers = {
           }
         }
       }
-      await Promise.all(pathsToTrash.map((pathname) => moveToTrashBestEffort(pathname)));
+      const stateOutcomes = await Promise.all(
+        [deleteResult.agentDir, deleteResult.sessionsDir].map(removeAgentPath),
+      );
+      stateOutcomes.forEach(recordOutcome);
     }
 
-    respond(true, { ok: true, agentId, removedBindings: deleteResult.removedBindings }, undefined);
+    respond(
+      true,
+      { ok: true, agentId, removedBindings: deleteResult.removedBindings, removed, failed },
+      undefined,
+    );
   },
   "agents.files.list": async ({ params, respond, context }) => {
     if (!validateAgentsFilesListParams(params)) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw agents delete <id>` reported `ok:true` (and printed the removed directory paths) even when it could not actually remove the agent's on-disk state — when the Trash move failed, the agent's `agents/<id>/agent/` state and its `workspace-<id>/` directory were silently left behind. In headless/server environments where Trash is unavailable this happened on every delete: the operator saw success while orphaned state accumulated. A deleted agent id was also left dangling in `agents.defaults.subagents.allowAgents`.

## Why This Change Was Made

Found by the R5 QA campaign (skills/MCP/multi-agent lane, live repro). The delete path used a best-effort trash move that swallowed all failures and returned unconditional success.

## User Impact

`agents delete` now reports honest per-path cleanup outcomes: the response carries `removed: [{path, method}]` and `failed: [{path, reason}]`. The agent is still removed from config (exit 0 — the config mutation is authoritative), but text mode prints a warning for any path that could not be moved to Trash (with the path + reason so the operator can clean it up), and JSON exposes the outcomes. Deleted agent ids are pruned from default and per-agent `subagents.allowAgents`. No behavior change when Trash works.

Design note: this deliberately does NOT hard-delete on Trash failure. An earlier iteration added an `fs.rm` fallback; review surfaced multiple ways an irreversible recursive delete could hit unintended data (user-configured agent dirs, cross-agent overlapping workspaces, retained orphans, create/delete races). Since the reported bug is "stop lying about success," honest reporting is the correct, safe fix — no user data is ever deleted that Trash didn't already move.

## Evidence

- Protocol schema extended with `removed`/`failed` (`packages/gateway-protocol/src/schema/agents-models-skills.ts`); CLI handles new + older gateway responses via optional fields.
- Tests cover trash-success (reports removed), trash-failure (reports `failed`, directory left in place, no deletion attempted), source-missing (lstat pre-check → `method:"missing"`), and allowAgents pruning.
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.9)". Small, boring diff (agents.ts +47/−18).
