### PR TITLE
fix(sqlite): normalize BLOB-stored text during STRICT migration

### DIFF
--- a/src/infra/sqlite-strict.test.ts
+++ b/src/infra/sqlite-strict.test.ts
@@ -414,4 +414,535 @@ describe("migrateSqliteSchemaToStrict", () => {
       value: null,
     });
   });
+
+  it("normalizes BLOB values in TEXT columns during STRICT migration", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE entries (id TEXT PRIMARY KEY, value TEXT NOT NULL)");
+    database.prepare("INSERT INTO entries (id, value) VALUES (?, ?)").run("key1", "normal-text");
+    database
+      .prepare("INSERT INTO entries (id, value) VALUES (?, ?)")
+      .run("key2", Buffer.from("blob-as-text"));
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, value TEXT NOT NULL) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "entries")).toBe(1);
+    expect(
+      database
+        .prepare("SELECT id, typeof(value) AS vtype, value FROM entries WHERE id = 'key1'")
+        .get(),
+    ).toEqual({ id: "key1", vtype: "text", value: "normal-text" });
+    expect(
+      database
+        .prepare("SELECT id, typeof(value) AS vtype, value FROM entries WHERE id = 'key2'")
+        .get(),
+    ).toEqual({ id: "key2", vtype: "text", value: "blob-as-text" });
+  });
+
+  it("normalizes TEXT values in BLOB columns during STRICT migration", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE blobs (id INTEGER PRIMARY KEY, data BLOB NOT NULL)");
+    database.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(1, "text-as-blob");
+    database.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(2, Buffer.from("real-blob"));
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS blobs (id INTEGER PRIMARY KEY, data BLOB NOT NULL) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "blobs")).toBe(1);
+    expect(
+      database.prepare("SELECT id, typeof(data) AS dtype FROM blobs ORDER BY id").all(),
+    ).toEqual([
+      { id: 1, dtype: "blob" },
+      { id: 2, dtype: "blob" },
+    ]);
+  });
+
+  it("normalizes mixed-type rows in TEXT columns without losing values", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE mixed (id INTEGER PRIMARY KEY, name TEXT, note TEXT)");
+    database
+      .prepare("INSERT INTO mixed (id, name, note) VALUES (?, ?, ?)")
+      .run(1, "text-name", "text-note");
+    database
+      .prepare("INSERT INTO mixed (id, name, note) VALUES (?, ?, ?)")
+      .run(2, Buffer.from("blob-name"), null);
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS mixed (id INTEGER PRIMARY KEY, name TEXT, note TEXT) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "mixed")).toBe(1);
+    expect(
+      database
+        .prepare(
+          "SELECT id, typeof(name) AS ntype, name, typeof(note) AS nntype, note FROM mixed ORDER BY id",
+        )
+        .all(),
+    ).toEqual([
+      { id: 1, ntype: "text", name: "text-name", nntype: "text", note: "text-note" },
+      { id: 2, ntype: "text", name: "blob-name", nntype: "null", note: null },
+    ]);
+  });
+
+  it("rejects STRICT migration when BLOB and TEXT primary key rows collide after CAST", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE entries (id TEXT PRIMARY KEY, value TEXT NOT NULL)");
+    database.prepare("INSERT INTO entries (id, value) VALUES (?, ?)").run("key-a", "text-value");
+    database
+      .prepare("INSERT INTO entries (id, value) VALUES (?, ?)")
+      .run(Buffer.from("key-a"), "blob-value");
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, value TEXT NOT NULL) STRICT;",
+      ),
+    ).toThrow(/primary-key collision.*collide/);
+
+    expect(readStrictFlag(database, "entries")).toBe(0);
+  });
+
+  it("preserves BLOB primary key rows when no TEXT collision exists", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE entries (id TEXT PRIMARY KEY, value TEXT NOT NULL)");
+    database
+      .prepare("INSERT INTO entries (id, value) VALUES (?, ?)")
+      .run(Buffer.from("blob-key"), "blob-value");
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, value TEXT NOT NULL) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "entries")).toBe(1);
+    expect(
+      database
+        .prepare("SELECT id, typeof(id) AS idtype, value, typeof(value) AS vtype FROM entries")
+        .get(),
+    ).toEqual({ id: "blob-key", idtype: "text", value: "blob-value", vtype: "text" });
+  });
+
+  it("normalizes non-UTF-8 BLOB bytes in TEXT columns during STRICT migration", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE entries (id INTEGER PRIMARY KEY, data TEXT NOT NULL)");
+    const nonUtf8Blob = Buffer.from([0x80, 0x81, 0xfe, 0xff]);
+    database.prepare("INSERT INTO entries (id, data) VALUES (?, ?)").run(1, nonUtf8Blob);
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY, data TEXT NOT NULL) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "entries")).toBe(1);
+    expect(
+      database.prepare("SELECT id, typeof(data) AS dtype, hex(data) AS hexdata FROM entries").get(),
+    ).toEqual({ id: 1, dtype: "text", hexdata: "8081FEFF" });
+  });
+
+  it("allows composite-key rows when BLOB component matches but full tuple is unique", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE kv (scope TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY (scope, key))",
+    );
+    database
+      .prepare("INSERT INTO kv (scope, key, value) VALUES (?, ?, ?)")
+      .run("scope-a", "key-one", "text-value");
+    database
+      .prepare("INSERT INTO kv (scope, key, value) VALUES (?, ?, ?)")
+      .run(Buffer.from("scope-a"), "key-two", "blob-value");
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS kv (scope TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY (scope, key)) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "kv")).toBe(1);
+    expect(database.prepare("SELECT COUNT(*) AS cnt FROM kv").get()).toEqual({ cnt: 2 });
+    expect(
+      database
+        .prepare("SELECT scope, typeof(scope) AS stype, key, value FROM kv ORDER BY key")
+        .all(),
+    ).toEqual([
+      { scope: "scope-a", stype: "text", key: "key-one", value: "text-value" },
+      { scope: "scope-a", stype: "text", key: "key-two", value: "blob-value" },
+    ]);
+  });
+
+  it("rejects composite-key rows when full tuple collides after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE kv (scope TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY (scope, key))",
+    );
+    database
+      .prepare("INSERT INTO kv (scope, key, value) VALUES (?, ?, ?)")
+      .run("scope-a", "key-one", "text-value");
+    database
+      .prepare("INSERT INTO kv (scope, key, value) VALUES (?, ?, ?)")
+      .run(Buffer.from("scope-a"), Buffer.from("key-one"), "blob-value");
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS kv (scope TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY (scope, key)) STRICT;",
+      ),
+    ).toThrow(/primary-key collision.*collide/);
+
+    expect(readStrictFlag(database, "kv")).toBe(0);
+  });
+
+  it("allows composite-key rows when BLOB sits in a TEXT component paired with a distinct INTEGER component", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE versions (name TEXT NOT NULL, version INTEGER NOT NULL, value TEXT, PRIMARY KEY (name, version))",
+    );
+    database
+      .prepare("INSERT INTO versions (name, version, value) VALUES (?, ?, ?)")
+      .run("alice", 1, "text-value");
+    database
+      .prepare("INSERT INTO versions (name, version, value) VALUES (?, ?, ?)")
+      .run(Buffer.from("alice"), 2, "blob-value");
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS versions (name TEXT NOT NULL, version INTEGER NOT NULL, value TEXT, PRIMARY KEY (name, version)) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "versions")).toBe(1);
+    expect(
+      database
+        .prepare(
+          "SELECT name, typeof(name) AS ntype, version, value FROM versions ORDER BY version",
+        )
+        .all(),
+    ).toEqual([
+      { name: "alice", ntype: "text", version: 1, value: "text-value" },
+      { name: "alice", ntype: "text", version: 2, value: "blob-value" },
+    ]);
+  });
+
+  it("rejects composite-key rows when distributed BLOB components collide after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE kv (scope TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY (scope, key))",
+    );
+    database
+      .prepare("INSERT INTO kv (scope, key, value) VALUES (?, ?, ?)")
+      .run(Buffer.from("scope-a"), "key-one", "blob-scope");
+    database
+      .prepare("INSERT INTO kv (scope, key, value) VALUES (?, ?, ?)")
+      .run("scope-a", Buffer.from("key-one"), "blob-key");
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS kv (scope TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY (scope, key)) STRICT;",
+      ),
+    ).toThrow(/primary-key collision.*collide/);
+
+    expect(readStrictFlag(database, "kv")).toBe(0);
+  });
+
+  it("rejects secondary UNIQUE column collisions after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE events (id INTEGER PRIMARY KEY, event_id TEXT NOT NULL UNIQUE, payload TEXT)",
+    );
+    database
+      .prepare("INSERT INTO events (id, event_id, payload) VALUES (?, ?, ?)")
+      .run(1, "evt-1", "text-payload");
+    database
+      .prepare("INSERT INTO events (id, event_id, payload) VALUES (?, ?, ?)")
+      .run(2, Buffer.from("evt-1"), "blob-payload");
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY, event_id TEXT NOT NULL UNIQUE, payload TEXT) STRICT;",
+      ),
+    ).toThrow(/unique collision.*collide/);
+
+    expect(readStrictFlag(database, "events")).toBe(0);
+  });
+
+  it("rejects composite UNIQUE constraint collisions after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE ledger (id INTEGER PRIMARY KEY, occurred_at TEXT NOT NULL, receipt_id TEXT NOT NULL, UNIQUE (occurred_at, receipt_id))",
+    );
+    database
+      .prepare("INSERT INTO ledger (id, occurred_at, receipt_id) VALUES (?, ?, ?)")
+      .run(1, "100", "r-1");
+    database
+      .prepare("INSERT INTO ledger (id, occurred_at, receipt_id) VALUES (?, ?, ?)")
+      .run(2, "100", Buffer.from("r-1"));
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS ledger (id INTEGER PRIMARY KEY, occurred_at TEXT NOT NULL, receipt_id TEXT NOT NULL, UNIQUE (occurred_at, receipt_id)) STRICT;",
+      ),
+    ).toThrow(/unique collision.*collide/);
+
+    expect(readStrictFlag(database, "ledger")).toBe(0);
+  });
+
+  it("rejects CREATE UNIQUE INDEX collisions after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE approvals (approval_id TEXT NOT NULL PRIMARY KEY, resolution_ref TEXT NOT NULL);",
+    );
+    database.exec(
+      "CREATE UNIQUE INDEX idx_approvals_resolution_ref ON approvals (resolution_ref);",
+    );
+    database
+      .prepare("INSERT INTO approvals (approval_id, resolution_ref) VALUES (?, ?)")
+      .run("apr-1", "ref-1");
+    database
+      .prepare("INSERT INTO approvals (approval_id, resolution_ref) VALUES (?, ?)")
+      .run("apr-2", Buffer.from("ref-1"));
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS approvals (approval_id TEXT NOT NULL PRIMARY KEY, resolution_ref TEXT NOT NULL) STRICT; CREATE UNIQUE INDEX IF NOT EXISTS idx_approvals_resolution_ref ON approvals (resolution_ref);",
+      ),
+    ).toThrow(/unique collision.*collide/);
+
+    expect(readStrictFlag(database, "approvals")).toBe(0);
+  });
+
+  it("rejects COLLATE NOCASE unique index collisions after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE approvals (approval_id TEXT NOT NULL PRIMARY KEY, resolution_ref TEXT NOT NULL);",
+    );
+    database.exec(
+      "CREATE UNIQUE INDEX idx_approvals_resolution_ref_nocase ON approvals (resolution_ref COLLATE NOCASE);",
+    );
+    database
+      .prepare("INSERT INTO approvals (approval_id, resolution_ref) VALUES (?, ?)")
+      .run("apr-1", "REF-1");
+    database
+      .prepare("INSERT INTO approvals (approval_id, resolution_ref) VALUES (?, ?)")
+      .run("apr-2", Buffer.from("ref-1"));
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS approvals (approval_id TEXT NOT NULL PRIMARY KEY, resolution_ref TEXT NOT NULL) STRICT; CREATE UNIQUE INDEX IF NOT EXISTS idx_approvals_resolution_ref_nocase ON approvals (resolution_ref COLLATE NOCASE);",
+      ),
+    ).toThrow(/unique collision.*collide/);
+
+    expect(readStrictFlag(database, "approvals")).toBe(0);
+  });
+
+  it("rejects same-type BLOB collisions under a NOCASE unique index after CAST", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE approvals (approval_id TEXT NOT NULL PRIMARY KEY, resolution_ref TEXT NOT NULL);",
+    );
+    database.exec(
+      "CREATE UNIQUE INDEX idx_approvals_resolution_ref_nocase ON approvals (resolution_ref COLLATE NOCASE);",
+    );
+    database
+      .prepare("INSERT INTO approvals (approval_id, resolution_ref) VALUES (?, ?)")
+      .run("apr-1", Buffer.from([0x41]));
+    database
+      .prepare("INSERT INTO approvals (approval_id, resolution_ref) VALUES (?, ?)")
+      .run("apr-2", Buffer.from([0x61]));
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS approvals (approval_id TEXT NOT NULL PRIMARY KEY, resolution_ref TEXT NOT NULL) STRICT; CREATE UNIQUE INDEX IF NOT EXISTS idx_approvals_resolution_ref_nocase ON approvals (resolution_ref COLLATE NOCASE);",
+      ),
+    ).toThrow(/unique collision.*collide/);
+
+    expect(readStrictFlag(database, "approvals")).toBe(0);
+  });
+
+  it("does not falsely reject distinct BLOB values under a BLOB-column unique index", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE blobs (id INTEGER PRIMARY KEY, data BLOB NOT NULL);");
+    database.exec("CREATE UNIQUE INDEX idx_blobs_data_nocase ON blobs (data COLLATE NOCASE);");
+    database.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(1, Buffer.from([0x41]));
+    database.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(2, "a");
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS blobs (id INTEGER PRIMARY KEY, data BLOB NOT NULL) STRICT; CREATE UNIQUE INDEX IF NOT EXISTS idx_blobs_data_nocase ON blobs (data COLLATE NOCASE);",
+    );
+
+    expect(readStrictFlag(database, "blobs")).toBe(1);
+    expect(
+      database
+        .prepare("SELECT id, typeof(data) AS dtype, hex(data) AS hexdata FROM blobs ORDER BY id")
+        .all(),
+    ).toEqual([
+      { id: 1, dtype: "blob", hexdata: "41" },
+      { id: 2, dtype: "blob", hexdata: "61" },
+    ]);
+  });
+
+  it("does not reject valid rows under an expression unique index", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE conversations (" +
+        "conversation_id TEXT NOT NULL PRIMARY KEY, " +
+        "channel TEXT NOT NULL, " +
+        "account_id TEXT NOT NULL, " +
+        "kind TEXT NOT NULL, " +
+        "peer_id TEXT, " +
+        "parent_conversation_id TEXT, " +
+        "thread_id TEXT" +
+        ");",
+    );
+    database.exec(
+      "CREATE UNIQUE INDEX idx_conversations_identity ON conversations(" +
+        "channel, account_id, kind, peer_id, " +
+        "IFNULL(parent_conversation_id, ''), IFNULL(thread_id, '')" +
+        ");",
+    );
+    database
+      .prepare(
+        "INSERT INTO conversations (conversation_id, channel, account_id, kind, peer_id, parent_conversation_id, thread_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run("c1", "tg", "acct-1", "dm", "peer-1", null, null);
+    database
+      .prepare(
+        "INSERT INTO conversations (conversation_id, channel, account_id, kind, peer_id, parent_conversation_id, thread_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run("c2", "tg", "acct-1", "dm", "peer-1", Buffer.from("parent-1"), null);
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS conversations (" +
+        "conversation_id TEXT NOT NULL PRIMARY KEY, " +
+        "channel TEXT NOT NULL, " +
+        "account_id TEXT NOT NULL, " +
+        "kind TEXT NOT NULL, " +
+        "peer_id TEXT, " +
+        "parent_conversation_id TEXT, " +
+        "thread_id TEXT" +
+        ") STRICT; " +
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_identity ON conversations(" +
+        "channel, account_id, kind, peer_id, " +
+        "IFNULL(parent_conversation_id, ''), IFNULL(thread_id, '')" +
+        ");",
+    );
+
+    expect(readStrictFlag(database, "conversations")).toBe(1);
+    expect(database.prepare("SELECT COUNT(*) AS cnt FROM conversations").get()).toEqual({
+      cnt: 2,
+    });
+  });
+
+  it("does not reject valid rows under a partial unique index", () => {
+    const database = createDatabase();
+    database.exec(
+      "CREATE TABLE session_conversations (" +
+        "session_id TEXT NOT NULL, " +
+        "conversation_id TEXT NOT NULL, " +
+        "role TEXT NOT NULL DEFAULT 'primary', " +
+        "PRIMARY KEY (session_id, conversation_id, role)" +
+        ");",
+    );
+    database.exec(
+      "CREATE UNIQUE INDEX idx_session_conversations_primary ON session_conversations(session_id) WHERE role = 'primary';",
+    );
+    database
+      .prepare(
+        "INSERT INTO session_conversations (session_id, conversation_id, role) VALUES (?, ?, ?)",
+      )
+      .run("s1", "c1", "primary");
+    database
+      .prepare(
+        "INSERT INTO session_conversations (session_id, conversation_id, role) VALUES (?, ?, ?)",
+      )
+      .run("s1", "c2", "participant");
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS session_conversations (" +
+        "session_id TEXT NOT NULL, " +
+        "conversation_id TEXT NOT NULL, " +
+        "role TEXT NOT NULL DEFAULT 'primary', " +
+        "PRIMARY KEY (session_id, conversation_id, role)" +
+        ") STRICT; " +
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_session_conversations_primary ON session_conversations(session_id) WHERE role = 'primary';",
+    );
+
+    expect(readStrictFlag(database, "session_conversations")).toBe(1);
+    expect(
+      database
+        .prepare(
+          "SELECT session_id, conversation_id, role FROM session_conversations ORDER BY conversation_id",
+        )
+        .all(),
+    ).toEqual([
+      { session_id: "s1", conversation_id: "c1", role: "primary" },
+      { session_id: "s1", conversation_id: "c2", role: "participant" },
+    ]);
+  });
+
+  it("does not preflight UNIQUE constraints with non-TEXT/BLOB key columns", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE counters (id INTEGER PRIMARY KEY, key TEXT NOT NULL UNIQUE);");
+    database.prepare("INSERT INTO counters (id, key) VALUES (?, ?)").run(1, "1");
+    database.prepare("INSERT INTO counters (id, key) VALUES (?, ?)").run(2, "01");
+
+    expect(() =>
+      migrateSqliteSchemaToStrict(
+        database,
+        "CREATE TABLE IF NOT EXISTS counters (id INTEGER PRIMARY KEY, key INTEGER NOT NULL UNIQUE) STRICT;",
+      ),
+    ).toThrow("Failed migrating SQLite table counters to STRICT");
+
+    expect(readStrictFlag(database, "counters")).toBe(0);
+  });
+
+  it("does not preflight UNIQUE constraints when the table declares ON CONFLICT REPLACE", () => {
+    const database = createDatabase();
+    database.exec("CREATE TABLE dedupe (id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
+    database.prepare("INSERT INTO dedupe (id, key) VALUES (?, ?)").run(1, "dup");
+    database.prepare("INSERT INTO dedupe (id, key) VALUES (?, ?)").run(2, "dup");
+
+    migrateSqliteSchemaToStrict(
+      database,
+      "CREATE TABLE IF NOT EXISTS dedupe (id INTEGER PRIMARY KEY, key TEXT NOT NULL UNIQUE ON CONFLICT REPLACE) STRICT;",
+    );
+
+    expect(readStrictFlag(database, "dedupe")).toBe(1);
+    expect(database.prepare("SELECT id, key FROM dedupe ORDER BY id").all()).toEqual([
+      { id: 2, key: "dup" },
+    ]);
+  });
+
+  it("normalizes BLOB values in TEXT columns whose identifier contains a double quote", () => {
+    const database = createDatabase();
+    database.exec('CREATE TABLE entries (id INTEGER PRIMARY KEY, "na""me" TEXT NOT NULL)');
+    database.prepare('INSERT INTO entries (id, "na""me") VALUES (?, ?)').run(1, "text-value");
+    database
+      .prepare('INSERT INTO entries (id, "na""me") VALUES (?, ?)')
+      .run(2, Buffer.from("blob-as-text"));
+
+    migrateSqliteSchemaToStrict(
+      database,
+      'CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY, "na""me" TEXT NOT NULL) STRICT;',
+    );
+
+    expect(readStrictFlag(database, "entries")).toBe(1);
+    expect(
+      database
+        .prepare(
+          'SELECT id, typeof("na""me") AS vtype, "na""me" AS value FROM entries WHERE id = 2',
+        )
+        .get(),
+    ).toEqual({ id: 2, vtype: "text", value: "blob-as-text" });
+  });
 });

--- a/src/infra/sqlite-strict.ts
+++ b/src/infra/sqlite-strict.ts
@@ -33,9 +33,11 @@ type PreservedSchemaObject = {
 };
 
 type CanonicalStrictTable = {
+  columnTypes: Map<string, string>;
   columns: string[];
   createSql: string;
   name: string;
+  uniqueConstraints: UniqueConstraint[];
   rowidAlias: string | null;
   rowidStorage: TableRowidStorage;
   usesAutoincrement: boolean;
@@ -46,6 +48,17 @@ type TableRowidStorage = "implicit" | "integer-primary-key" | "without-rowid";
 type TableRowidModel = {
   alias: string | null;
   storage: TableRowidStorage;
+};
+
+// A unique constraint discovered on the canonical STRICT schema. `origin`
+// distinguishes PRIMARY KEY autoindexes from secondary UNIQUE constraints
+// (table-level UNIQUE or CREATE UNIQUE INDEX), so error messages stay accurate
+// when a non-PK collision is the blocker.
+type UniqueConstraint = {
+  columns: string[];
+  collations: string[];
+  name: string;
+  origin: "primary-key" | "unique";
 };
 
 export type SqliteStrictMigrationOptions = {
@@ -125,6 +138,100 @@ function readTableRowidModel(
   return { alias, storage: "implicit" };
 }
 
+type IndexListRow = {
+  name?: unknown;
+  origin?: unknown;
+  partial?: unknown;
+  unique?: unknown;
+};
+
+type IndexXInfoRow = {
+  cid?: unknown;
+  coll?: unknown;
+  desc?: unknown;
+  key?: unknown;
+  name?: unknown;
+  seqno?: unknown;
+};
+
+// Reads UNIQUE constraints whose canonical SQLite semantics the preflight can
+// model exactly: PRIMARY KEY (origin='pk'), table-level UNIQUE (origin='u'),
+// and CREATE UNIQUE INDEX (origin='c') over plain TEXT/BLOB columns only. The
+// preflight groups rows by CAST(col AS TEXT/BLOB) matching the final copy, so
+// constraints with INTEGER/REAL/ANY key columns are skipped — their STRICT
+// destination affinity cannot be reproduced by CAST (e.g. legacy TEXT '1' and
+// '01' both become integer 1 under INTEGER affinity, but CAST AS INTEGER
+// accepts 'abc' as 0 while STRICT affinity rejects it). Expression indexes
+// (index_xinfo returns cid=-2/name=null for IFNULL() and similar terms) and
+// partial indexes (index_list returns partial=1) are also omitted. ON CONFLICT
+// IGNORE/REPLACE policies cannot be read from PRAGMA index_list (REPLACE,
+// IGNORE, and ABORT all look identical), so any table whose CREATE statement
+// declares a non-ABORT conflict policy skips all its UNIQUE constraints — the
+// migration transaction's INSERT remains the authoritative enforcement.
+function readUniqueConstraints(db: DatabaseSync, table: CanonicalStrictTable): UniqueConstraint[] {
+  const tableName = table.name;
+  if (/\bON\s+CONFLICT\s+(IGNORE|REPLACE)\b/iu.test(table.createSql)) {
+    return [];
+  }
+  const indexes = db
+    .prepare(`PRAGMA index_list(${quoteSqliteIdentifier(tableName)})`)
+    .all() as IndexListRow[];
+  const constraints: UniqueConstraint[] = [];
+  for (const index of indexes) {
+    if (Number(index.unique ?? 0) !== 1 || typeof index.name !== "string") {
+      continue;
+    }
+    if (Number(index.partial ?? 0) === 1) {
+      continue;
+    }
+    // index_xinfo exposes per-term collation (BINARY/NOCASE/RTRIM) that
+    // index_info omits, plus auxiliary non-key columns (key=0, e.g. the
+    // trailing rowid). Filter to key=1 so auxiliary rows with name=null do
+    // not trigger the expression-index skip, and capture each term's
+    // collation so the preflight matches the index's canonical comparison.
+    const terms = (
+      db
+        .prepare(`PRAGMA index_xinfo(${quoteSqliteIdentifier(index.name)})`)
+        .all() as IndexXInfoRow[]
+    ).toSorted((left, right) => Number(left.seqno ?? 0) - Number(right.seqno ?? 0));
+    const columns: string[] = [];
+    const collations: string[] = [];
+    let hasExpressionTerm = false;
+    let hasUnsupportedType = false;
+    for (const term of terms) {
+      if (Number(term.key ?? 0) !== 1) {
+        continue;
+      }
+      if (typeof term.name !== "string") {
+        // Expression index term (cid=-2); the preflight cannot model its
+        // semantics, so skip the whole constraint.
+        hasExpressionTerm = true;
+        break;
+      }
+      const declaredType = table.columnTypes.get(term.name);
+      if (declaredType !== "TEXT" && declaredType !== "BLOB") {
+        // Non-TEXT/BLOB key column: the preflight's CAST-based grouping
+        // cannot reproduce STRICT destination affinity, so skip the whole
+        // constraint and let the final INSERT enforce it.
+        hasUnsupportedType = true;
+        break;
+      }
+      columns.push(term.name);
+      collations.push(typeof term.coll === "string" ? term.coll : "BINARY");
+    }
+    if (hasExpressionTerm || hasUnsupportedType || columns.length === 0) {
+      continue;
+    }
+    constraints.push({
+      columns,
+      collations,
+      name: index.name,
+      origin: index.origin === "pk" ? "primary-key" : "unique",
+    });
+  }
+  return constraints;
+}
+
 function readCanonicalStrictTables(schemaSql: string): CanonicalStrictTable[] {
   const canonical = openNodeSqliteDatabase(":memory:");
   try {
@@ -143,21 +250,42 @@ function readCanonicalStrictTables(schemaSql: string): CanonicalStrictTable[] {
         if (typeof row.name !== "string") {
           throw new Error("Canonical SQLite schema contains an unnamed table");
         }
+        const tableName = row.name;
         const schemaRow = canonical
           .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
-          .get(row.name) as { sql?: unknown } | undefined;
+          .get(tableName) as { sql?: unknown } | undefined;
         if (typeof schemaRow?.sql !== "string") {
-          throw new Error(`Canonical SQLite table ${row.name} has no CREATE statement`);
+          throw new Error(`Canonical SQLite table ${tableName} has no CREATE statement`);
         }
-        const rowidModel = readTableRowidModel(canonical, row.name, row);
-        return {
-          columns: readVisibleColumns(canonical, row.name),
+        const rowidModel = readTableRowidModel(canonical, tableName, row);
+        const visibleColumns = readTableColumns(canonical, tableName).filter(
+          (column) => Number(column.hidden ?? 0) === 0,
+        );
+        const columnTypes = new Map<string, string>();
+        for (const column of visibleColumns) {
+          if (typeof column.name === "string" && typeof column.type === "string") {
+            columnTypes.set(column.name, column.type.toUpperCase());
+          }
+        }
+        const columnList = visibleColumns.map((column) => {
+          if (typeof column.name !== "string" || column.name.length === 0) {
+            throw new Error(`Canonical SQLite table ${tableName} has an invalid column name`);
+          }
+          return column.name;
+        });
+        const usesAutoincrement = /\bAUTOINCREMENT\b/iu.test(schemaRow.sql);
+        const result: CanonicalStrictTable = {
+          columnTypes,
+          columns: columnList,
           createSql: schemaRow.sql,
-          name: row.name,
+          name: tableName,
+          uniqueConstraints: [],
           rowidAlias: rowidModel.alias,
           rowidStorage: rowidModel.storage,
-          usesAutoincrement: /\bAUTOINCREMENT\b/iu.test(schemaRow.sql),
+          usesAutoincrement,
         };
+        result.uniqueConstraints = readUniqueConstraints(canonical, result);
+        return result;
       })
       .toSorted((left, right) => left.name.localeCompare(right.name));
   } finally {
@@ -337,15 +465,88 @@ export function migrateSqliteSchemaToStrictInTransaction(
       ? readAutoincrementHighWater(db, table.name)
       : null;
     db.exec(rewriteCreateTableName(table.createSql, migrationTable));
-    const columns = table.columns.map(quoteSqliteIdentifier);
-    if (table.rowidAlias) {
-      columns.unshift(quoteSqliteIdentifier(table.rowidAlias));
+    // Preflight every UNIQUE constraint (PRIMARY KEY, table-level UNIQUE,
+    // CREATE UNIQUE INDEX) for normalized-key collisions. Legacy non-STRICT
+    // tables allow BLOB and TEXT values to coexist as distinct keys; after
+    // CAST they may collapse onto the same canonical row and surface as a
+    // generic INSERT failure. Detecting the collision here yields a targeted
+    // diagnosis with the constraint name and lets the operator resolve the
+    // duplicate rows before retrying the upgrade. The migration transaction
+    // remains the final enforcement.
+    for (const constraint of table.uniqueConstraints) {
+      // Group by the normalized key tuple so SQLite performs a single sorted
+      // scan instead of a correlated EXISTS self-join, which scans both
+      // aliases per row (O(rows²)) since CAST on both operands prevents the
+      // unique index from being used. The group expressions must mirror the
+      // final copy's per-column conversion: TEXT columns are CAST AS TEXT,
+      // BLOB columns are CAST AS BLOB, and other types pass through. A BLOB
+      // column stores distinct X'41' and X'61' under a NOCASE index because
+      // BLOB comparison is always BINARY; CAST AS TEXT would falsely collapse
+      // them, while CAST AS BLOB matches what the final INSERT stores.
+      // SQLite allows multiple NULLs under a UNIQUE constraint, so groups
+      // with any NULL constraint term are excluded via MIN(col IS NOT NULL).
+      const groupTerms = constraint.columns.map((column, termIndex) => {
+        const quoted = quoteSqliteIdentifier(column);
+        const declaredType = table.columnTypes.get(column);
+        const converted =
+          declaredType === "TEXT"
+            ? `CAST(${quoted} AS TEXT)`
+            : declaredType === "BLOB"
+              ? `CAST(${quoted} AS BLOB)`
+              : quoted;
+        return `${converted} COLLATE ${constraint.collations[termIndex]}`;
+      });
+      const nonNullGuards = constraint.columns.map(
+        (column) => `MIN(${quoteSqliteIdentifier(column)} IS NOT NULL) = 1`,
+      );
+      const collisionCount = db
+        .prepare(
+          `SELECT COUNT(*) AS cnt FROM (` +
+            `SELECT 1 FROM ${quoteSqliteIdentifier(table.name)} ` +
+            `GROUP BY ${groupTerms.join(", ")} ` +
+            `HAVING COUNT(*) > 1 AND ${nonNullGuards.join(" AND ")}` +
+            `);`,
+        )
+        .get() as { cnt?: unknown } | undefined;
+      if (Number(collisionCount?.cnt ?? 0) > 0) {
+        throw new Error(
+          `SQLite table ${table.name} has ${String(collisionCount?.cnt)} ${constraint.origin} collision group(s) whose values would collide after CAST (constraint: ${constraint.name}); remove the duplicate rows manually before upgrading`,
+        );
+      }
     }
-    const copyColumns = columns.join(", ");
+    const insertColumns = table.columns.map(quoteSqliteIdentifier);
+    if (table.rowidAlias) {
+      insertColumns.unshift(quoteSqliteIdentifier(table.rowidAlias));
+    }
+    const insertColumnList = insertColumns.join(", ");
+    // Build SELECT expressions from the original column names so embedded
+    // double quotes (e.g. a column named na"me) survive the type lookup.
+    // Reconstructing the name from the quoted identifier via replaceAll
+    // collapses "" back to ", losing the original name and skipping the CAST.
+    const selectColumns: string[] = [];
+    if (table.rowidAlias) {
+      selectColumns.push(quoteSqliteIdentifier(table.rowidAlias));
+    }
+    for (const column of table.columns) {
+      const quoted = quoteSqliteIdentifier(column);
+      if (column === table.rowidAlias) {
+        selectColumns.push(quoted);
+        continue;
+      }
+      const declaredType = table.columnTypes.get(column);
+      if (declaredType === "TEXT") {
+        selectColumns.push(`CAST(${quoted} AS TEXT)`);
+      } else if (declaredType === "BLOB") {
+        selectColumns.push(`CAST(${quoted} AS BLOB)`);
+      } else {
+        selectColumns.push(quoted);
+      }
+    }
+    const selectExpressions = selectColumns;
     try {
       db.exec(
-        `INSERT INTO ${quoteSqliteIdentifier(migrationTable)} (${copyColumns}) ` +
-          `SELECT ${copyColumns} FROM ${quoteSqliteIdentifier(table.name)};`,
+        `INSERT INTO ${quoteSqliteIdentifier(migrationTable)} (${insertColumnList}) ` +
+          `SELECT ${selectExpressions.join(", ")} FROM ${quoteSqliteIdentifier(table.name)};`,
       );
     } catch (error) {
       throw new Error(`Failed migrating SQLite table ${table.name} to STRICT`, { cause: error });


### PR DESCRIPTION
Closes #110186

## What Problem This Solves

OpenClaw rebuilds legacy SQLite tables as STRICT tables during shared-state, agent-state, and plugin-store upgrades. The migration copied source values unchanged. A legacy BLOB value stored in a declared TEXT column therefore reached the STRICT destination as BLOB and stopped startup or Doctor with `cannot store BLOB value in TEXT column`.

The earlier version of this PR also added a separate unique-index preflight. That duplicate policy became large and still allowed `ON CONFLICT REPLACE` to discard rows after conversion.

## Why This Change Was Made

`src/infra/sqlite-strict.ts` is the one migration owner used by runtime open, Doctor repair, agent databases, memory, proxy capture, Logbook, Workboard, and plugin state.

The owner now carries each canonical column's declared type into the copy and applies `CAST(... AS TEXT)` only to TEXT destinations. The copy uses `INSERT OR ABORT`, which overrides table conflict policies so a normalized key collision rolls back the whole transaction instead of deleting a row.

The redundant unique-index introspection and its 20 implementation-specific tests are removed. SQLite's destination INSERT remains the authoritative constraint check.

## User Impact

- Databases with valid legacy BLOB-stored TEXT values upgrade to canonical STRICT TEXT storage.
- A conversion collision fails atomically and preserves all legacy rows.
- No schema version, configuration, protocol, or public API changes.

## Evidence

### Current-main red

Baseline `107a39797825e93e4021329f92e4057ed53bc2f9` was current `origin/main` when captured. Later main movement did not touch the migration owner or its test.

Product command: `pnpm test src/commands/doctor.strict-sqlite-migration.test.ts`

Blacksmith Testbox `tbx_01m1dqa899s8z5898mczahzdpp`, [Actions run 33474045433](https://github.com/openclaw/openclaw/actions/runs/33474045433): **RED**.

Observed Doctor result: `Failed migrating shared state database schema ... Failed migrating SQLite table workspace_path_aliases to STRICT`.

Owner-boundary command: `pnpm test src/infra/sqlite-strict-blob-text-upgrade.proof.test.ts`

Blacksmith Testbox `tbx_01m1dnr4xzpmye30d2herw02ex`, [Actions run 33472292698](https://github.com/openclaw/openclaw/actions/runs/33472292698): **RED**.

Observed cause: `cannot store BLOB value in TEXT column __openclaw_strict_migration_0_entries.value`.

### Contributor-head safety red

Untouched contributor head `cfc78fcba3dcc79b14fb4fed9278e507212c8a14` was tested with two legacy rows that collide after TEXT conversion under `UNIQUE ON CONFLICT REPLACE`.

Blacksmith Testbox `tbx_01m1dnwss9vtm6em7qsxm9efre`, [Actions run 33472451779](https://github.com/openclaw/openclaw/actions/runs/33472451779): **RED**. The migration returned successfully instead of rolling back, and its existing test expected one of the two rows to disappear.

### Repaired-head green

Head `2d10bb5dbf1dda78544d532d168511e56ccda8bf`:

- `pnpm test src/commands/doctor.strict-sqlite-migration.test.ts src/infra/sqlite-strict.test.ts`: **17/17 passed** on Testbox `tbx_01m1dqjfqapzjf5c517n3sex79`, [Actions run 33474334890](https://github.com/openclaw/openclaw/actions/runs/33474334890).
- Targeted `oxfmt`: **passed**.
- Targeted `oxlint`: **0 warnings, 0 errors** on the same Testbox.
- Pre-commit Codex Sol Autoreview after the product-path repair: **no P0 findings**, confidence `0.99`.

The branch-only changed gate stopped on eight expired compatibility records outside this PR. The same plugin-boundary gate passed on the current-main baseline with zero eligible records on Testbox `tbx_01m1dpgge87ej4w1hvxq3kvpvw`, [Actions run 33473143480](https://github.com/openclaw/openclaw/actions/runs/33473143480). Pull-request CI validates the current-main merge tree.

## Attribution

Original repair and reproduction: @wangyan2026. Maintainer simplification and landing: @obviyus.
