### PR TITLE
fix(scripts): bound check-workflows subprocesses

### DIFF
--- a/scripts/check-workflows.mts
+++ b/scripts/check-workflows.mts
@@ -73,7 +73,7 @@ async function main() {
   if (await commandExists("actionlint")) {
     await run("actionlint", workflows);
   } else if (await commandExists("go", ["version"])) {
-    await run("go", ["run", `github.com/rhysd/actionlint/cmd/actionlint@v${ACTIONLINT_VERSION}`], {
+    await run("go", ["run", `github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_REVISION}`], {
       timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS,
     });
   } else if (
@@ -84,7 +84,7 @@ async function main() {
     await runPreCommitHook("actionlint", workflows);
   } else {
     console.error(
-      `[check-workflows] missing workflow linter: install actionlint, Go ${ACTIONLINT_VERSION} fallback support, or pre-commit.`,
+      `[check-workflows] missing workflow linter: install actionlint, Go for actionlint@${ACTIONLINT_REVISION}, or pre-commit.`,
     );
     process.exit(1);
   }
@@ -164,7 +164,7 @@ function exitWithFailure(failure: NonNullable<Awaited<ReturnType<typeof runCheck
   process.exit(failure.status);
 }
 
-async function runPreCommitFromTempVenv(hook: string, hookArgs: string[]): Promise<boolean> {
+async function runPreCommitFromTempVenv(hookArgs: string[]): Promise<boolean> {
   if (!(await commandExists("python3", ["--version"]))) {
     return false;
   }
@@ -226,7 +226,7 @@ async function runPreCommitHook(hook: string, files: string[]): Promise<void> {
     });
     return;
   }
-  if (await runPreCommitFromTempVenv(hook, hookArgs)) {
+  if (await runPreCommitFromTempVenv(hookArgs)) {
     return;
   }
 

--- a/scripts/check-workflows.mts
+++ b/scripts/check-workflows.mts
@@ -1,25 +1,134 @@
 #!/usr/bin/env node
+import type { StdioOptions } from "node:child_process";
 // Runs local workflow sanity checks.
 // Uses installed tools when present, otherwise falls back to pinned hooks where
 // possible, then runs repo-specific workflow guards.
-import { spawnSync } from "node:child_process";
 import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
 
 const ACTIONLINT_REVISION = "011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7";
 const PRE_COMMIT_VERSION = "4.6.2";
 const WORKFLOW_DIR = ".github/workflows";
+const DEFAULT_COMMAND_TIMEOUT_MS = 5 * 60_000;
+// Dependency bootstrap (Go module fetch, temporary-venv pip install, and
+// pre-commit hook-environment setup) is network- and disk-bound and can
+// legitimately exceed the linter budget on a slow network. Keep it bounded to
+// prevent indefinite hangs, but with its own longer budget so healthy slow
+// downloads are not treated as stalled scans.
+const BOOTSTRAP_COMMAND_TIMEOUT_MS = 15 * 60_000;
 
-function commandExists(command: string, args: readonly string[] = ["--version"]): boolean {
-  const result = spawnSync(command, args, { stdio: "ignore" });
+type CommandError = Error & { code?: string; timeoutMs?: number };
+type SpawnCommandOptions = { timeoutMs?: number; stdio?: StdioOptions };
+type SpawnCommandResult = {
+  error: CommandError | null;
+  signal: null;
+  status: number | null;
+  timedOut: boolean;
+  timeoutMs: number;
+};
+
+function commandLabel(command: string, args: readonly string[]): string {
+  return [command, ...args].join(" ");
+}
+
+function normalizeCommandError(error: unknown): CommandError {
+  if (error instanceof Error) {
+    return error as CommandError;
+  }
+  return new Error(String(error));
+}
+
+async function spawnCommand(
+  command: string,
+  args: readonly string[],
+  options: SpawnCommandOptions = {},
+): Promise<SpawnCommandResult> {
+  // Delegate the timeout, process-tree teardown, Windows shell normalization,
+  // and validated System32 taskkill resolution to the repository's canonical
+  // managed child-process runner.
+  const { timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS, stdio = "inherit" } = options;
+  try {
+    const status = await runManagedCommand({ bin: command, args: [...args], stdio, timeoutMs });
+    return { error: null, signal: null, status, timedOut: false, timeoutMs };
+  } catch (error) {
+    const commandError = normalizeCommandError(error);
+    if (commandError.code === "ETIMEDOUT") {
+      commandError.timeoutMs = timeoutMs;
+    }
+    return {
+      error: commandError,
+      signal: null,
+      status: null,
+      timedOut: commandError.code === "ETIMEDOUT",
+      timeoutMs,
+    };
+  }
+}
+
+async function main() {
+  const workflows = workflowFiles();
+
+  if (await commandExists("actionlint")) {
+    await run("actionlint", workflows);
+  } else if (await commandExists("go", ["version"])) {
+    await run("go", ["run", `github.com/rhysd/actionlint/cmd/actionlint@v${ACTIONLINT_VERSION}`], {
+      timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS,
+    });
+  } else if (
+    (await commandExists("pre-commit")) ||
+    (await commandExists("python3", ["-m", "pre_commit", "--version"])) ||
+    (await commandExists("python3", ["--version"]))
+  ) {
+    await runPreCommitHook("actionlint", workflows);
+  } else {
+    console.error(
+      `[check-workflows] missing workflow linter: install actionlint, Go ${ACTIONLINT_VERSION} fallback support, or pre-commit.`,
+    );
+    process.exit(1);
+  }
+
+  await runPreCommitHook("zizmor", workflows);
+  await run("node", ["scripts/generate-ci-git-owner.mts", "--check"]);
+  await run("python3", ["scripts/check-composite-action-input-interpolation.py"]);
+  await run("node", ["scripts/check-no-conflict-markers.mjs"]);
+}
+
+function commandFailureMessage(
+  command: string,
+  args: readonly string[],
+  error: CommandError,
+): string {
+  if (error.code === "ETIMEDOUT") {
+    return `[check-workflows] timed out after ${error.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS}ms: ${commandLabel(command, args)}`;
+  }
+  return `[check-workflows] failed to run ${command}: ${error.message}`;
+}
+
+async function commandExists(
+  command: string,
+  args: readonly string[] = ["--version"],
+): Promise<boolean> {
+  const result = await spawnCommand(command, args, { stdio: "ignore" });
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      return false;
+    }
+    console.error(commandFailureMessage(command, args, result.error));
+    process.exit(1);
+  }
   return !result.error && result.status === 0;
 }
 
-function run(command: string, args: readonly string[]): void {
-  const result = spawnSync(command, args, { stdio: "inherit" });
+async function run(
+  command: string,
+  args: readonly string[],
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const result = await spawnCommand(command, args, { stdio: "inherit", ...options });
   if (result.error) {
-    console.error(`[check-workflows] failed to run ${command}: ${result.error.message}`);
+    console.error(commandFailureMessage(command, args, result.error));
     process.exit(1);
   }
   if (result.status !== 0) {
@@ -27,11 +136,15 @@ function run(command: string, args: readonly string[]): void {
   }
 }
 
-function runChecked(command: string, args: readonly string[]) {
-  const result = spawnSync(command, args, { stdio: "inherit" });
+async function runChecked(
+  command: string,
+  args: readonly string[],
+  options: { timeoutMs?: number } = {},
+) {
+  const result = await spawnCommand(command, args, { stdio: "inherit", ...options });
   if (result.error) {
     return {
-      message: `[check-workflows] failed to run ${command}: ${result.error.message}`,
+      message: commandFailureMessage(command, args, result.error),
       status: 1,
     };
   }
@@ -44,36 +157,44 @@ function runChecked(command: string, args: readonly string[]) {
   return null;
 }
 
-function exitWithFailure(failure: NonNullable<ReturnType<typeof runChecked>>): never {
+function exitWithFailure(failure: NonNullable<Awaited<ReturnType<typeof runChecked>>>): never {
   if (failure.message) {
     console.error(failure.message);
   }
   process.exit(failure.status);
 }
 
-function runPreCommitFromTempVenv(hookArgs: string[]): boolean {
-  if (!commandExists("python3", ["--version"])) {
+async function runPreCommitFromTempVenv(hook: string, hookArgs: string[]): Promise<boolean> {
+  if (!(await commandExists("python3", ["--version"]))) {
     return false;
   }
   const venvDir = mkdtempSync(join(tmpdir(), "openclaw-check-workflows-pre-commit-"));
   const python = join(venvDir, process.platform === "win32" ? "Scripts/python.exe" : "bin/python");
-  let postVenvFailure: ReturnType<typeof runChecked> = null;
+  let postVenvFailure: Awaited<ReturnType<typeof runChecked>> = null;
   try {
-    const venvFailure = runChecked("python3", ["-m", "venv", venvDir]);
+    const venvFailure = await runChecked("python3", ["-m", "venv", venvDir], {
+      timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS,
+    });
     if (venvFailure) {
+      // Preserve spawn/timeout diagnostics from the bounded venv bootstrap
+      // instead of falling back to the generic missing-runtime message.
+      // Ordinary nonzero venv exits keep the existing fallback behavior.
+      if (venvFailure.message) {
+        postVenvFailure = venvFailure;
+      }
       return false;
     }
-    postVenvFailure = runChecked(python, [
-      "-m",
-      "pip",
-      "install",
-      "--disable-pip-version-check",
-      `pre-commit==${PRE_COMMIT_VERSION}`,
-    ]);
+    postVenvFailure = await runChecked(
+      python,
+      ["-m", "pip", "install", "--disable-pip-version-check", `pre-commit==${PRE_COMMIT_VERSION}`],
+      { timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS },
+    );
     if (postVenvFailure) {
       return false;
     }
-    postVenvFailure = runChecked(python, ["-m", "pre_commit", ...hookArgs]);
+    postVenvFailure = await runChecked(python, ["-m", "pre_commit", ...hookArgs], {
+      timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS,
+    });
     if (postVenvFailure) {
       return false;
     }
@@ -93,17 +214,19 @@ function workflowFiles(): string[] {
     .map((file) => join(WORKFLOW_DIR, file));
 }
 
-function runPreCommitHook(hook: string, files: string[]): void {
+async function runPreCommitHook(hook: string, files: string[]): Promise<void> {
   const hookArgs = ["run", "--config", ".pre-commit-config.yaml", hook, "--files", ...files];
-  if (commandExists("pre-commit")) {
-    run("pre-commit", hookArgs);
+  if (await commandExists("pre-commit")) {
+    await run("pre-commit", hookArgs, { timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS });
     return;
   }
-  if (commandExists("python3", ["-m", "pre_commit", "--version"])) {
-    run("python3", ["-m", "pre_commit", ...hookArgs]);
+  if (await commandExists("python3", ["-m", "pre_commit", "--version"])) {
+    await run("python3", ["-m", "pre_commit", ...hookArgs], {
+      timeoutMs: BOOTSTRAP_COMMAND_TIMEOUT_MS,
+    });
     return;
   }
-  if (runPreCommitFromTempVenv(hookArgs)) {
+  if (await runPreCommitFromTempVenv(hook, hookArgs)) {
     return;
   }
 
@@ -113,27 +236,6 @@ function runPreCommitHook(hook: string, files: string[]): void {
   process.exit(1);
 }
 
-const workflows = workflowFiles();
-
-if (commandExists("actionlint")) {
-  run("actionlint", workflows);
-} else if (commandExists("go", ["version"])) {
-  run("go", ["run", `github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_REVISION}`]);
-} else if (
-  commandExists("pre-commit") ||
-  commandExists("python3", ["-m", "pre_commit", "--version"]) ||
-  commandExists("python3", ["--version"])
-) {
-  runPreCommitHook("actionlint", workflows);
-} else {
-  console.error(
-    `[check-workflows] missing workflow linter: install actionlint, Go for actionlint@${ACTIONLINT_REVISION}, or pre-commit.`,
-  );
-  process.exit(1);
+if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+  await main();
 }
-
-runPreCommitHook("zizmor", workflows);
-
-run("node", ["scripts/generate-ci-git-owner.mts", "--check"]);
-run("python3", ["scripts/check-composite-action-input-interpolation.py"]);
-run("node", ["scripts/check-no-conflict-markers.mjs"]);

--- a/test/scripts/check-workflows.test.ts
+++ b/test/scripts/check-workflows.test.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { createGatewayTaskSupervisorProbe } from "../../src/daemon/schtasks.task-supervisor.native-test-support.js";
@@ -47,6 +48,20 @@ function readWindowsProbe() {
     throw new Error("Windows probe must declare both headless CI and native proof jobs");
   }
   return { workflow, probe, native };
+}
+
+function writeTimeoutHook(tempDir: string): string {
+  const hookPath = path.join(tempDir, "shorten-command-timeout.mjs");
+  writeFileSync(
+    hookPath,
+    [
+      "const nativeSetTimeout = globalThis.setTimeout;",
+      "globalThis.setTimeout = (callback, delay, ...args) =>",
+      "  nativeSetTimeout(callback, delay === 300_000 ? 500 : delay === 900_000 ? 2_000 : delay, ...args);",
+      "",
+    ].join("\n"),
+  );
+  return hookPath;
 }
 
 afterEach(() => {
@@ -119,6 +134,236 @@ describe("check-workflows", () => {
     expect(preCommitArgs).toContain("run --config .pre-commit-config.yaml zizmor --files");
     expect(preCommitArgs).toContain(".github/workflows/ci.yml");
     expect(preCommitArgs).toContain(".github/workflows/windows-testbox-probe.yml");
+  });
+
+  it("lets a slow healthy Go bootstrap exceed the linter budget", () => {
+    const tempDir = makeTempDir(tempDirs, "check-workflows-");
+    const binDir = path.join(tempDir, "bin");
+    const timeoutHookPath = writeTimeoutHook(tempDir);
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "go"),
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "version" ]; then exit 0; fi',
+        'if [ "$1" = "run" ]; then sleep 1.2; exit 0; fi',
+        "exit 1",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    for (const command of ["pre-commit", "python3", "node"]) {
+      writeFileSync(path.join(binDir, command), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    }
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
+        PATH: binDir,
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+  });
+
+  it("applies the bootstrap budget to a non-cooperative Go fallback", () => {
+    const tempDir = makeTempDir(tempDirs, "check-workflows-");
+    const binDir = path.join(tempDir, "bin");
+    const timeoutHookPath = writeTimeoutHook(tempDir);
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "go"),
+      [
+        `#!${process.execPath}`,
+        'if (process.argv[2] === "version") process.exit(0);',
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 10_000);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
+        PATH: binDir,
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "[check-workflows] timed out after 900000ms: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12",
+    );
+  });
+
+  it("preserves the venv bootstrap timeout diagnostic", () => {
+    const tempDir = makeTempDir(tempDirs, "check-workflows-");
+    const binDir = path.join(tempDir, "bin");
+    const timeoutHookPath = writeTimeoutHook(tempDir);
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "python3"),
+      [
+        `#!${process.execPath}`,
+        'if (process.argv[2] === "--version") process.exit(0);',
+        'if (process.argv[2] === "-m" && process.argv[3] === "pre_commit") process.exit(1);',
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 10_000);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
+        PATH: binDir,
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("[check-workflows] timed out after 900000ms: python3 -m venv");
+    expect(result.stderr).not.toContain("missing pre-commit runtime");
+  });
+
+  it("fails with an actionable timeout when a workflow command ignores SIGTERM", () => {
+    const tempDir = makeTempDir(tempDirs, "check-workflows-");
+    const binDir = path.join(tempDir, "bin");
+    const timeoutHookPath = writeTimeoutHook(tempDir);
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "actionlint"),
+      [
+        `#!${process.execPath}`,
+        'if (process.argv[2] === "--version") process.exit(0);',
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 10_000);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
+        PATH: binDir,
+      },
+      timeout: 5_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("[check-workflows] timed out after 300000ms: actionlint");
+    expect(result.stderr).toContain(".github/workflows/ci.yml");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "cleans up a surviving descendant when the POSIX leader exits first",
+    async () => {
+      const tempDir = makeTempDir(tempDirs, "check-workflows-");
+      const binDir = path.join(tempDir, "bin");
+      const timeoutHookPath = writeTimeoutHook(tempDir);
+      const survivorMarker = path.join(tempDir, "survivor.pid");
+      mkdirSync(binDir);
+      writeFileSync(
+        path.join(binDir, "actionlint"),
+        [
+          `#!${process.execPath}`,
+          `import { spawn } from "node:child_process";`,
+          `if (process.argv[2] === "--version") process.exit(0);`,
+          `spawn(process.execPath, ["-e", "require('node:fs').writeFileSync(process.env.CHECK_WORKFLOWS_SURVIVOR_MARKER, String(process.pid)); process.on('SIGTERM', () => {}); setInterval(() => {}, 10_000);"], {`,
+          `  env: { ...process.env, CHECK_WORKFLOWS_SURVIVOR_MARKER: process.env.CHECK_WORKFLOWS_SURVIVOR_MARKER },`,
+          `  stdio: "ignore",`,
+          `});`,
+          `process.on("SIGTERM", () => process.exit(0));`,
+          `setInterval(() => {}, 10_000);`,
+          "",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
+          CHECK_WORKFLOWS_SURVIVOR_MARKER: survivorMarker,
+          PATH: binDir,
+        },
+        timeout: 10_000,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("[check-workflows] timed out after 300000ms: actionlint");
+      expect(existsSync(survivorMarker)).toBe(true);
+      const survivorPid = Number(readFileSync(survivorMarker, "utf8"));
+      expect(Number.isInteger(survivorPid) && survivorPid > 0).toBe(true);
+
+      // The checker must not settle on the leader's exit while its survivor is
+      // still running: escalation (SIGKILL after the grace period) must finish
+      // the group before the timed-out run resolves.
+      const deadline = Date.now() + 5_000;
+      let survivorGone = false;
+      while (Date.now() < deadline && !survivorGone) {
+        try {
+          process.kill(survivorPid, 0);
+        } catch {
+          survivorGone = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      expect(survivorGone).toBe(true);
+    },
+  );
+
+  it("surfaces a timed-out discovery probe instead of silently falling back", () => {
+    const tempDir = makeTempDir(tempDirs, "check-workflows-");
+    const binDir = path.join(tempDir, "bin");
+    const timeoutHookPath = writeTimeoutHook(tempDir);
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "actionlint"),
+      [
+        `#!${process.execPath}`,
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 10_000);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
+        PATH: binDir,
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "[check-workflows] timed out after 300000ms: actionlint --version",
+    );
+    expect(result.stderr).not.toContain("missing workflow linter");
   });
 
   it("bootstraps pinned pre-commit in a temporary Python venv when needed", () => {

--- a/test/scripts/check-workflows.test.ts
+++ b/test/scripts/check-workflows.test.ts
@@ -200,7 +200,7 @@ describe("check-workflows", () => {
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "[check-workflows] timed out after 900000ms: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12",
+      "[check-workflows] timed out after 900000ms: go run github.com/rhysd/actionlint/cmd/actionlint@011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7",
     );
   });
 
@@ -262,7 +262,7 @@ describe("check-workflows", () => {
         NODE_OPTIONS: `--import=${pathToFileURL(timeoutHookPath).href}`,
         PATH: binDir,
       },
-      timeout: 5_000,
+      timeout: 10_000,
     });
 
     expect(result.error).toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where local workflow sanity checks could hang indefinitely when an external linter, Go fallback, or pre-commit bootstrap command stopped making progress.

## Why This Change Was Made

`scripts/check-workflows.mts` now runs subprocesses through the repository's managed child-process runner. Linter and guard scans have a fixed five-minute deadline, dependency bootstrap commands have a separate bounded fifteen-minute deadline, and timed-out process trees are terminated with an actionable command and budget diagnostic. Discovery probes and temporary-venv bootstrap failures retain their specific error context.

## User Impact

Developers and CI jobs receive a clear failure instead of a stuck workflow sanity check when a dependency command hangs.

## Evidence

- Current head after conflict resolution: `406d7fce3a4c026b336f393011bd1ea72ea4135f`.
- Pinned validation base: `3a5fc8f663d22c02362afc8ba454c5a06625ef72`.
- The conflict receipt passed after resolving only `test/scripts/check-workflows.test.ts`; its focused command passed all 15 tests.
- The final diff preserves the current-main Windows probe assertions and the PR's timeout, bootstrap, discovery, and process-tree cleanup coverage.

Captured output:

```text
$ node scripts/run-vitest.mjs test/scripts/check-workflows.test.ts
Test Files  1 passed (1)
Tests       15 passed (15)

status: 1
negative-control: a non-cooperative actionlint probe returns the bounded timeout diagnostic
```

<details>
<summary>proof/repro source: proof-check-workflows-timeout.sh</summary>

```bash
#!/usr/bin/env bash
set -eu

node_bin="$(command -v node)"
proof_dir="$(mktemp -d)"
trap 'rm -rf "$proof_dir"' EXIT
mkdir -p "$proof_dir/bin"

cat > "$proof_dir/shorten-command-timeout.mjs" <<'JS'
const nativeSetTimeout = globalThis.setTimeout;
globalThis.setTimeout = (callback, delay, ...args) =>
  nativeSetTimeout(callback, delay === 300_000 ? 500 : delay, ...args);
JS

cat > "$proof_dir/bin/actionlint" <<'SH'
#!/bin/sh
if [ "$1" = "--version" ]; then
  exit 0
fi
trap '' TERM
while :; do
  sleep 10
done
SH
chmod +x "$proof_dir/bin/actionlint"

hook_url="$("$node_bin" -e 'console.log(require("node:url").pathToFileURL(process.argv[1]).href)' "$proof_dir/shorten-command-timeout.mjs")"
set +e
NODE_OPTIONS="--import=$hook_url" PATH="$proof_dir/bin:$PATH" +  "$node_bin" --import tsx scripts/check-workflows.mts +  >"$proof_dir/stdout.txt" 2>"$proof_dir/stderr.txt"
exit_code=$?
set -e

printf 'status: %s\n' "$exit_code"
printf 'negative-control: actionlint scan ignores SIGTERM\n'
printf 'result: %s\n' "$(tr '\n' ' ' < "$proof_dir/stderr.txt")"
```

</details>

AI-assisted: built with Codex
