### PR TITLE
refactor(exec): remove duplicate task session detail

### DIFF
--- a/src/agents/bash-tools.exec-task-tracking.test.ts
+++ b/src/agents/bash-tools.exec-task-tracking.test.ts
@@ -51,7 +51,6 @@ describe("background exec task tracking", () => {
       startedAt: 100,
       lastEventAt: 100,
       progressSummary: "Command running",
-      detail: { processSessionId: "amber-reef" },
     });
   });
 
@@ -137,6 +136,9 @@ describe("background exec task tracking", () => {
       );
       expect(JSON.stringify(taskRuntime.finalizeTaskRunByRunId.mock.calls)).not.toContain(
         "secret output",
+      );
+      expect(JSON.stringify(taskRuntime.finalizeTaskRunByRunId.mock.calls)).not.toContain(
+        "processSessionId",
       );
     },
   );

--- a/src/agents/bash-tools.exec-task-tracking.ts
+++ b/src/agents/bash-tools.exec-task-tracking.ts
@@ -41,7 +41,6 @@ export function createBackgroundExecTask(params: {
       startedAt: params.startedAt,
       lastEventAt: params.startedAt,
       progressSummary: "Command running",
-      detail: { processSessionId: params.processSessionId },
     });
     if (!task) {
       return null;
@@ -90,7 +89,6 @@ export function finalizeBackgroundExecTask(params: {
             : "Command stopped",
       ...(status === "succeeded" ? { clearError: true } : { error: execTaskError(params.outcome) }),
       detail: {
-        processSessionId: params.handle.runId.slice("exec:".length),
         exitCode: params.outcome.exitCode,
         ...(params.outcome.exitSignal != null
           ? { exitSignal: String(params.outcome.exitSignal) }


### PR DESCRIPTION
Related: #110468

## What Problem This Solves

Background CLI task records stored the process session identity in both the canonical `sourceId` field and an untyped `detail.processSessionId` field. Keeping the same identity twice adds drift risk and unnecessary persisted metadata.

## Why This Change Was Made

Keep `sourceId` as the single process-session identity. Preserve only exit diagnostics in task detail, and remove the finalization-time run ID string slicing that existed solely to reconstruct the duplicate field.

## User Impact

No user-visible behavior change. Background-task display, cancellation, completion, and wake-up behavior remain unchanged; the persisted record has one canonical identity field.

Release note: none — internal metadata cleanup.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/bash-tools.exec-task-tracking.test.ts src/agents/bash-tools.exec-task-wiring.test.ts` — 2 files, 6 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- Autoreview (`--mode branch --base origin/main`) — clean, no accepted/actionable findings.

AI-assisted. I reviewed the final diff and understand the change.
