### PR TITLE
fix(ui): exception-only sidebar connection state

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { state } from "lit/decorators.js";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import { pathForRoute } from "../app-route-paths.ts";
@@ -34,14 +34,50 @@ import {
 const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
   ? "⌘K"
   : "Ctrl K";
+const OFFLINE_INDICATOR_DELAY_MS = 2_000;
 
 class AppSidebar extends AppSidebarSessionListElement {
   @state() private logoVisit: LobsterLogoVisitDetail | null = null;
+  @state() private debouncedDisconnected = false;
+
+  private offlineIndicatorTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   constructor() {
     super();
     // The footer pet announces logo stand-in phases through this bubbling event.
     this.addEventListener(LOBSTER_LOGO_VISIT_EVENT, this.handleLogoVisit as EventListener);
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.syncOfflineIndicator();
+  }
+
+  override disconnectedCallback() {
+    this.syncOfflineIndicator(false);
+    super.disconnectedCallback();
+  }
+
+  protected override willUpdate(changed: PropertyValues<this>) {
+    if (changed.has("connected")) {
+      this.syncOfflineIndicator();
+    }
+  }
+
+  private syncOfflineIndicator(schedule = !this.connected) {
+    if (this.offlineIndicatorTimer !== null) {
+      globalThis.clearTimeout(this.offlineIndicatorTimer);
+      this.offlineIndicatorTimer = null;
+    }
+    this.debouncedDisconnected = false;
+    if (!schedule) {
+      return;
+    }
+    // Both sidebar signals share one grace window so brief transport blips stay quiet.
+    this.offlineIndicatorTimer = globalThis.setTimeout(() => {
+      this.offlineIndicatorTimer = null;
+      this.debouncedDisconnected = true;
+    }, OFFLINE_INDICATOR_DELAY_MS);
   }
 
   private readonly handleLogoVisit = (event: Event) => {
@@ -99,7 +135,7 @@ class AppSidebar extends AppSidebarSessionListElement {
           .agentName=${cardName}
           .avatarUrl=${cardAgent ? resolveAgentAvatarUrl(cardAgent) : null}
           .avatarText=${cardAvatarText}
-          .connected=${this.connected}
+          .offline=${this.debouncedDisconnected}
           .statusLabel=${gatewayStatus}
           .subtitle=${this.agentChipSubtitle(cardAgentId)}
           .menuOpen=${this.agentMenuPosition !== null}
@@ -209,15 +245,17 @@ class AppSidebar extends AppSidebarSessionListElement {
           .gatewayVersion=${this.gatewayVersion}
           .onNavigate=${(routeId: "about") => this.onNavigate?.(routeId)}
         ></openclaw-sidebar-build-chip>
-        <span
-          class="sidebar-footer-bar__status ${this.connected
-            ? "sidebar-connection-status--online"
-            : "sidebar-connection-status--offline"}"
-          role="img"
-          aria-live="polite"
-          aria-label=${gatewayStatus}
-          title=${gatewayStatus}
-        ></span>
+        ${this.debouncedDisconnected
+          ? html`<span
+              class="sidebar-footer-bar__status"
+              role="status"
+              aria-live="polite"
+              title=${gatewayStatus}
+              ><span class="sidebar-footer-bar__status-dot" aria-hidden="true"></span>${t(
+                "common.offline",
+              )}</span
+            >`
+          : nothing}
         <openclaw-tooltip .content=${t("nav.settings")}>
           <button
             type="button"

--- a/ui/src/components/sidebar-agent-card.ts
+++ b/ui/src/components/sidebar-agent-card.ts
@@ -12,7 +12,7 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) agentName = "";
   @property({ attribute: false }) avatarUrl: string | null = null;
   @property({ attribute: false }) avatarText = "";
-  @property({ attribute: false }) connected = false;
+  @property({ attribute: false }) offline = false;
   @property({ attribute: false }) statusLabel = "";
   @property({ attribute: false }) subtitle = "";
   @property({ attribute: false }) menuOpen = false;
@@ -33,7 +33,7 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
           class="sidebar-agent-card__main"
           aria-haspopup="menu"
           aria-expanded=${String(this.menuOpen)}
-          aria-label="${this.agentName} · ${menuLabel}"
+          aria-label="${this.agentName} · ${menuLabel} · ${this.statusLabel}"
           @click=${(event: MouseEvent) => this.onToggleMenu?.(event.currentTarget as HTMLElement)}
         >
           <span class="sidebar-agent-card__avatar">
@@ -48,15 +48,14 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
               : html`<span class="sidebar-agent-card__avatar-text" aria-hidden="true"
                   >${this.avatarText}</span
                 >`}
-            <span
-              class="sidebar-agent-card__presence ${this.connected
-                ? "sidebar-connection-status--online"
-                : "sidebar-connection-status--offline"}"
-              role="img"
-              aria-live="polite"
-              aria-label=${this.statusLabel}
-              title=${this.statusLabel}
-            ></span>
+            ${this.offline
+              ? html`<span
+                  class="sidebar-agent-card__presence"
+                  role="img"
+                  aria-label=${this.statusLabel}
+                  title=${this.statusLabel}
+                ></span>`
+              : nothing}
           </span>
           <span class="sidebar-agent-card__text">
             <span class="sidebar-agent-card__name">

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2339,7 +2339,6 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   object-fit: cover;
 }
 
-/* Presence fuses connection state into the identity: no separate online dot. */
 .sidebar-agent-card__presence {
   position: absolute;
   right: -1px;
@@ -2348,13 +2347,6 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   height: 10px;
   border-radius: var(--radius-full);
   border: 2px solid var(--sidebar-bg);
-}
-
-.sidebar-agent-card__presence.sidebar-connection-status--online {
-  background: var(--ok);
-}
-
-.sidebar-agent-card__presence.sidebar-connection-status--offline {
   background: var(--danger);
 }
 
@@ -2485,17 +2477,23 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 }
 
 .sidebar-footer-bar__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   flex: none;
-  width: 8px;
-  height: 8px;
+  padding: 3px 7px;
   border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
 }
 
-.sidebar-footer-bar__status.sidebar-connection-status--online {
-  background: var(--ok);
-}
-
-.sidebar-footer-bar__status.sidebar-connection-status--offline {
+.sidebar-footer-bar__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
   background: var(--danger);
 }
 

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -146,15 +146,52 @@ describe("AppSidebar agent chip", () => {
     expect(onNavigate).not.toHaveBeenCalledWith("config");
   });
 
-  it("shows offline in the chip subtitle when disconnected", async () => {
+  it("shows connection exceptions only after a sustained disconnect", async () => {
+    vi.useFakeTimers();
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    sidebar.connected = false;
+    const presence = () => sidebar.querySelector(".sidebar-agent-card__presence");
+    const offlinePill = () => sidebar.querySelector(".sidebar-footer-bar__status");
+    const expectQuiet = () => {
+      expect(presence()).toBeNull();
+      expect(offlinePill()).toBeNull();
+    };
+    sidebar.connected = true;
     await sidebar.updateComplete;
 
+    expectQuiet();
+    expect(
+      sidebar.querySelector(".sidebar-agent-card__main")?.getAttribute("aria-label"),
+    ).toContain("Online");
+
+    sidebar.connected = false;
+    await sidebar.updateComplete;
     expect(sidebar.querySelector(".sidebar-agent-card__subtitle")?.textContent?.trim()).toBe(
       "Offline",
     );
+    await vi.advanceTimersByTimeAsync(1_999);
+    expectQuiet();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await sidebar.updateComplete;
+    const pill = offlinePill();
+    expect(pill?.textContent?.trim()).toBe("Offline");
+    expect(pill?.getAttribute("aria-live")).toBe("polite");
+    expect(pill?.getAttribute("title")).toContain("Offline");
+    expect(pill?.querySelector(".sidebar-footer-bar__status-dot")).not.toBeNull();
+    expect(presence()).not.toBeNull();
+
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+    expectQuiet();
+
+    sidebar.connected = false;
+    await sidebar.updateComplete;
+    await vi.advanceTimersByTimeAsync(1_000);
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+    await vi.advanceTimersByTimeAsync(2_000);
+    expectQuiet();
   });
 
   it("shows a working subtitle while the agent has an active run", async () => {

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -351,6 +351,7 @@ export function setupSidebarTest() {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     document.body.replaceChildren();
     if (originalLocalStorage) {
       Object.defineProperty(globalThis, "localStorage", originalLocalStorage);


### PR DESCRIPTION
## What Problem This Solves

The sidebar showed two permanent green "online" dots — on the agent card avatar and in the footer bar. Steady-state "everything is fine" indicators are noise; connection state only carries information when something is wrong. Part of the sidebar quieting series (#110448/#110459/#110470/#110524).

## Why This Change Was Made

Maintainer decision: connection state becomes exception-only. Nothing renders while connected; a single clear treatment appears only after a sustained disconnect.

## User Impact

- Connected: no presence dot on the agent card, no status dot in the footer — the footer is just build number + settings.
- Disconnected for ~2s (debounced so reconnect blips and initial page load never flash): the agent card shows the red presence dot and the footer shows a compact danger "Offline" pill; both clear immediately on reconnect.
- Screen readers keep the gateway status: it is announced via the agent-card button's aria-label while connected, and via the aria-live pill when offline. The chip subtitle still flips to "Offline" text immediately (unchanged behavior).
- The Settings sidebar's own status dot is untouched; only the main sidebar header/footer changed. Reused existing i18n keys; no new ones.

| Connected (quiet) | Offline (debounced) |
| --- | --- |
| ![online](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/quiet-sidebar/conn-online.png) | ![offline](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/quiet-sidebar/conn-offline.png) |

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 107 tests pass (rerun after rebase onto current main), including a new fake-timer test: nothing before 2s, pill + presence after, reconnect clears, and a 1s blip never shows anything.
- Live-verified in the Control UI mock harness (screenshots above; offline captured by flipping `connected` and waiting out the debounce).
- Codex autoreview (gpt-5.6-sol) clean: no accepted/actionable findings.
