### PR TITLE
test: add subagent handoff failure diagnostics

### DIFF
--- a/qa/scenarios/agents/subagent-handoff.yaml
+++ b/qa/scenarios/agents/subagent-handoff.yaml
@@ -29,24 +29,33 @@ flow:
     - name: delegates a bounded task and reports the result
       actions:
         - call: reset
-        - call: runAgentPrompt
-          args:
-            - ref: env
-            - sessionKey: agent:qa:subagent
-              message:
-                expr: config.prompt
-              timeoutMs:
-                expr: liveTurnTimeoutMs(env, 90000)
-        - call: waitForAgentHistoryReply
-          saveAs: outbound
-          args:
-            - ref: env
-            - agent:qa:subagent
-            - lambda:
-                params: [text]
-                expr: "(() => { const lower = normalizeLowercaseStringOrEmpty(text); return lower.includes('delegated task') && lower.includes('result') && lower.includes('evidence') && !lower.includes('waiting'); })()"
-            - expr: liveTurnTimeoutMs(env, 45000)
-            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - try:
+            actions:
+              - call: runAgentPrompt
+                args:
+                  - ref: env
+                  - sessionKey: agent:qa:subagent
+                    message:
+                      expr: config.prompt
+                    timeoutMs:
+                      expr: liveTurnTimeoutMs(env, 90000)
+              - call: waitForAgentHistoryReply
+                saveAs: outbound
+                args:
+                  - ref: env
+                  - agent:qa:subagent
+                  - lambda:
+                      params: [text]
+                      expr: "(() => { const lower = normalizeLowercaseStringOrEmpty(text); return lower.includes('delegated task') && lower.includes('result') && lower.includes('evidence') && !lower.includes('waiting'); })()"
+                  - expr: liveTurnTimeoutMs(env, 45000)
+                  - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+            catchAs: handoffError
+            catch:
+              - set: handoffTasks
+                value:
+                  expr: "await runQaCli(env, ['tasks', 'list', '--json', '--runtime', 'subagent'], { timeoutMs: liveTurnTimeoutMs(env, 60000), json: true }).catch((error) => ({ error: formatErrorMessage(error) }))"
+              - throw:
+                  expr: "`subagent handoff stalled: ${formatErrorMessage(handoffError)}; outbound=${recentOutboundSummary(state, 8)} tasks=${JSON.stringify(handoffTasks)}`"
         - assert:
             expr: "!['failed to delegate','could not delegate','subagent unavailable'].some((needle) => normalizeLowercaseStringOrEmpty(outbound.text).includes(needle))"
             message:


### PR DESCRIPTION
Related: #110572

## What Problem This Solves

Resolves a problem where the `subagent-handoff` QA scenario timed out with only a generic wait failure, leaving maintainers unable to tell whether the child failed, delivery failed, or requester synthesis failed.

## Why This Change Was Made

The scenario now wraps the prompt/run wait in a bounded diagnostic block. On failure, it captures recent outbound messages and the current subagent task list before rethrowing the original failure with that context.

## User Impact

No end-user behavior change. QA failures for subagent handoff now point directly at child task status and delivery state, which makes live and mock stress failures triageable.

## Evidence

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` — 46 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings
- Diagnostic repro artifact after the change: `.artifacts/qa-e2e/subagent-handoff-mock-diagnostics/qa-suite-report.md` showed child `status=succeeded`, `deliveryStatus=delivered`, `progressSummary=ok`, proving issue #110572 is requester synthesis/wake rather than child execution.
