### PR TITLE
fix: preserve same-session hook bursts

### DIFF
--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -220,7 +220,7 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
     expect(runCronIsolatedAgentTurnMock.mock.calls[0]?.[0]).toMatchObject({
       message: "first",
-      sessionKey: "agent:main:main",
+      sessionKey: "main",
     });
 
     firstGate.resolve();
@@ -269,7 +269,7 @@ describe("dispatchAgentHook trust handling", () => {
     }
   });
 
-  it("uses fresh config while retaining the session accepted before reload", async () => {
+  it("uses fresh config when a queued hook starts after reload", async () => {
     const dispatch = resolveDispatchAgentHook();
     let currentConfig: { session?: { mainKey?: string } } = {};
     loadConfigMock.mockImplementation(() => currentConfig);
@@ -293,9 +293,10 @@ describe("dispatchAgentHook trust handling", () => {
 
     await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
     expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
+      agentId: "main",
       cfg: currentConfig,
       message: "second",
-      sessionKey: "agent:main:main",
+      sessionKey: "main",
     });
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
@@ -331,7 +332,7 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
     expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
       message: "second",
-      sessionKey: "agent:main:shared-session",
+      sessionKey: "shared-session",
     });
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -151,6 +151,7 @@ describe("dispatchAgentHook trust handling", () => {
   beforeEach(() => {
     resetGatewayWorkAdmission();
     vi.clearAllMocks();
+    loadConfigMock.mockImplementation(() => ({}));
     capturedDispatchAgentHook = undefined;
     createGatewayHooksRequestHandler(buildMinimalParams());
   });
@@ -192,7 +193,7 @@ describe("dispatchAgentHook trust handling", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
-  it("serializes same-session agent hook runs in dispatch order", async () => {
+  it("serializes canonical aliases for the same session in dispatch order", async () => {
     const dispatch = resolveDispatchAgentHook();
     const firstGate = createDeferred();
     runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
@@ -208,18 +209,18 @@ describe("dispatchAgentHook trust handling", () => {
     dispatch({
       ...buildAgentPayload("First"),
       message: "first",
-      sessionKey: "shared-session",
+      sessionKey: "main",
     });
     dispatch({
       ...buildAgentPayload("Second"),
       message: "second",
-      sessionKey: "shared-session",
+      sessionKey: "agent:main:main",
     });
 
     await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
     expect(runCronIsolatedAgentTurnMock.mock.calls[0]?.[0]).toMatchObject({
       message: "first",
-      sessionKey: "shared-session",
+      sessionKey: "agent:main:main",
     });
 
     firstGate.resolve();
@@ -227,8 +228,76 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
     expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
       message: "second",
-      sessionKey: "shared-session",
+      sessionKey: "agent:main:main",
     });
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+  });
+
+  it("runs different sessions in parallel", async () => {
+    const dispatch = resolveDispatchAgentHook();
+    const firstGate = createDeferred();
+    const secondGate = createDeferred();
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await firstGate.promise;
+      return { status: "ok", summary: "first done", delivered: false };
+    });
+
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await secondGate.promise;
+      return { status: "ok", summary: "second done", delivered: false };
+    });
+
+    dispatch({
+      ...buildAgentPayload("First"),
+      message: "first",
+      sessionKey: "agent:main:session-a",
+    });
+    dispatch({
+      ...buildAgentPayload("Second"),
+      message: "second",
+      sessionKey: "agent:main:session-b",
+    });
+
+    expect(getActiveGatewayRootWorkCount()).toBe(2);
+
+    try {
+      await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+    } finally {
+      firstGate.resolve();
+      secondGate.resolve();
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    }
+  });
+
+  it("uses fresh config while retaining the session accepted before reload", async () => {
+    const dispatch = resolveDispatchAgentHook();
+    let currentConfig: { session?: { mainKey?: string } } = {};
+    loadConfigMock.mockImplementation(() => currentConfig);
+    const firstGate = createDeferred();
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await firstGate.promise;
+      return { status: "ok", summary: "first done", delivered: false };
+    });
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "second done",
+      delivered: false,
+    });
+
+    dispatch({ ...buildAgentPayload("First"), message: "first", sessionKey: "main" });
+    dispatch({ ...buildAgentPayload("Second"), message: "second", sessionKey: "main" });
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+
+    currentConfig = { session: { mainKey: "reloaded" } };
+    firstGate.resolve();
+
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+    expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
+      cfg: currentConfig,
+      message: "second",
+      sessionKey: "agent:main:main",
+    });
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("continues a same-session hook queue after a failed run", async () => {
@@ -262,8 +331,26 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
     expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
       message: "second",
-      sessionKey: "shared-session",
+      sessionKey: "agent:main:shared-session",
     });
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+  });
+
+  it("reports runtime-config failures after returning a run id", async () => {
+    loadConfigMock.mockImplementationOnce(() => {
+      throw new Error("config exploded");
+    });
+
+    const runId = dispatchAgentHook(buildAgentPayload("Config"));
+
+    expect(runId).toEqual(expect.any(String));
+    await waitForFast(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+        "Hook Config (error): Error: config exploded",
+        { sessionKey: "main-session" },
+      ),
+    );
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("does not announce successful deliver:false hook results", async () => {

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -95,10 +95,22 @@ function buildAgentPayload(name: string, agentId?: string) {
 }
 
 function dispatchAgentHook(payload: unknown): unknown {
+  return resolveDispatchAgentHook()(payload);
+}
+
+function resolveDispatchAgentHook(): (...args: unknown[]) => unknown {
   if (!capturedDispatchAgentHook) {
     throw new Error("dispatchAgentHook missing");
   }
-  return capturedDispatchAgentHook(payload);
+  return capturedDispatchAgentHook;
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
 }
 
 type HookLogMeta = {
@@ -178,6 +190,80 @@ describe("dispatchAgentHook trust handling", () => {
     );
     expect(subordinateAdmissionClosed).toBe(false);
     expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("serializes same-session agent hook runs in dispatch order", async () => {
+    const dispatch = resolveDispatchAgentHook();
+    const firstGate = createDeferred();
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await firstGate.promise;
+      return { status: "ok", summary: "first done", delivered: false };
+    });
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "second done",
+      delivered: false,
+    });
+
+    dispatch({
+      ...buildAgentPayload("First"),
+      message: "first",
+      sessionKey: "shared-session",
+    });
+    dispatch({
+      ...buildAgentPayload("Second"),
+      message: "second",
+      sessionKey: "shared-session",
+    });
+
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+    expect(runCronIsolatedAgentTurnMock.mock.calls[0]?.[0]).toMatchObject({
+      message: "first",
+      sessionKey: "shared-session",
+    });
+
+    firstGate.resolve();
+
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+    expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
+      message: "second",
+      sessionKey: "shared-session",
+    });
+  });
+
+  it("continues a same-session hook queue after a failed run", async () => {
+    const dispatch = resolveDispatchAgentHook();
+    runCronIsolatedAgentTurnMock.mockRejectedValueOnce(new Error("agent exploded"));
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "second done",
+      delivered: false,
+    });
+
+    dispatch({
+      ...buildAgentPayload("First"),
+      message: "first",
+      sessionKey: "shared-session",
+    });
+    dispatch({
+      ...buildAgentPayload("Second"),
+      message: "second",
+      sessionKey: "shared-session",
+    });
+
+    await waitForFast(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+        "Hook First (error): Error: agent exploded",
+        {
+          sessionKey: "agent:main:main",
+        },
+      ),
+    );
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+    expect(runCronIsolatedAgentTurnMock.mock.calls[1]?.[0]).toMatchObject({
+      message: "second",
+      sessionKey: "shared-session",
+    });
   });
 
   it("does not announce successful deliver:false hook results", async () => {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -209,9 +209,8 @@ export function createGatewayHooksRequestHandler(params: {
       mainKey: dispatchCfg.session?.mainKey,
       cfg: dispatchCfg,
     });
-    // Acceptance fixes the target identity; queued execution still reads fresh
-    // settings. Otherwise reload can move one FIFO entry to another session.
-    job.agentId = agentId;
+    // Queue identity is fixed when accepted; the isolated runner still receives
+    // the original session expression and fresh config, preserving hook routing.
     void runWithGatewayIndependentRootWorkContinuation(() =>
       enqueueHookAgentDispatch(queueKey, async () => {
         try {
@@ -220,7 +219,7 @@ export function createGatewayHooksRequestHandler(params: {
           const cfg = getRuntimeConfig();
           hookEventSessionKey = resolveHookEventSessionKey({
             cfg,
-            agentId,
+            agentId: value.agentId,
           });
           const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
           const result = await runCronIsolatedAgentTurn({
@@ -228,7 +227,8 @@ export function createGatewayHooksRequestHandler(params: {
             deps,
             job,
             message: value.message,
-            sessionKey: queueKey,
+            sessionKey,
+            agentId,
             lane: "cron",
           });
           const summary = resolveHookRunSummary(result);

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -217,6 +217,8 @@ export function createGatewayHooksRequestHandler(params: {
           // Agent hooks run after the HTTP response path has returned, so failure
           // handling must record a system event instead of throwing to the caller.
           const cfg = getRuntimeConfig();
+          // Keep an omitted agent omitted for event routing so global session scope
+          // stays global; runner identity is frozen separately via accepted agentId.
           hookEventSessionKey = resolveHookEventSessionKey({
             cfg,
             agentId: value.agentId,
@@ -228,6 +230,8 @@ export function createGatewayHooksRequestHandler(params: {
             job,
             message: value.message,
             sessionKey,
+            // Isolated runs derive their lifecycle key from random jobId (or an
+            // already-stable cron: key), so accepted agentId closes reload drift.
             agentId,
             lane: "cron",
           });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -93,6 +93,28 @@ function formatHookRunWarningConsoleMessage(params: {
   return parts.join(" ");
 }
 
+function createSessionKeyedHookDispatchQueue() {
+  const hookAgentDispatchTails = new Map<string, Promise<void>>();
+
+  return (sessionKey: string, operation: () => Promise<void>) => {
+    const previousTail = hookAgentDispatchTails.get(sessionKey);
+    const run = previousTail ? previousTail.catch(() => undefined).then(operation) : operation();
+    const tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    hookAgentDispatchTails.set(sessionKey, tail);
+    // Same-session hook agent runs append to one Codex session. Serializing avoids
+    // optimistic lifecycle-claim races while preserving parallelism across sessions.
+    void tail.finally(() => {
+      if (hookAgentDispatchTails.get(sessionKey) === tail) {
+        hookAgentDispatchTails.delete(sessionKey);
+      }
+    });
+    return run;
+  };
+}
+
 /** Creates the HTTP handler used by gateway hook endpoints. */
 export function createGatewayHooksRequestHandler(params: {
   deps: CliDeps;
@@ -103,6 +125,7 @@ export function createGatewayHooksRequestHandler(params: {
   logHooks: SubsystemLogger;
 }) {
   const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
+  const enqueueHookAgentDispatch = createSessionKeyedHookDispatchQueue();
 
   const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
@@ -151,79 +174,81 @@ export function createGatewayHooksRequestHandler(params: {
     };
 
     let hookEventSessionKey: string | undefined;
-    void runWithGatewayIndependentRootWorkContinuation(async () => {
-      try {
-        // Agent hooks run after the HTTP response path has returned, so failure
-        // handling must record a system event instead of throwing to the caller.
-        const cfg = getRuntimeConfig();
-        hookEventSessionKey = resolveHookEventSessionKey({
-          cfg,
-          agentId: value.agentId,
-        });
-        const { runCronIsolatedAgentTurn } = await import("../../cron/isolated-agent.js");
-        const result = await runCronIsolatedAgentTurn({
-          cfg,
-          deps,
-          job,
-          message: value.message,
-          sessionKey,
-          lane: "cron",
-        });
-        const summary = resolveHookRunSummary(result);
-        const prefix =
-          result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
-        const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
-        if (result.status !== "ok") {
-          logHooks.warn("hook agent run returned non-ok status", {
-            sourcePath: value.sourcePath,
-            name: safeName,
-            runId,
-            jobId,
+    void runWithGatewayIndependentRootWorkContinuation(() =>
+      enqueueHookAgentDispatch(sessionKey, async () => {
+        try {
+          // Agent hooks run after the HTTP response path has returned, so failure
+          // handling must record a system event instead of throwing to the caller.
+          const cfg = getRuntimeConfig();
+          hookEventSessionKey = resolveHookEventSessionKey({
+            cfg,
             agentId: value.agentId,
+          });
+          const { runCronIsolatedAgentTurn } = await import("../../cron/isolated-agent.js");
+          const result = await runCronIsolatedAgentTurn({
+            cfg,
+            deps,
+            job,
+            message: value.message,
             sessionKey,
-            status: result.status,
-            model: value.model,
-            summary,
-            consoleMessage: formatHookRunWarningConsoleMessage({
+            lane: "cron",
+          });
+          const summary = resolveHookRunSummary(result);
+          const prefix =
+            result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
+          const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
+          if (result.status !== "ok") {
+            logHooks.warn("hook agent run returned non-ok status", {
+              sourcePath: value.sourcePath,
+              name: safeName,
+              runId,
+              jobId,
+              agentId: value.agentId,
+              sessionKey,
               status: result.status,
               model: value.model,
               summary,
-            }),
-          });
-        }
-        if (shouldAnnounce) {
-          const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
-          enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
-            sessionKey: eventSessionKey,
+              consoleMessage: formatHookRunWarningConsoleMessage({
+                status: result.status,
+                model: value.model,
+                summary,
+              }),
+            });
+          }
+          if (shouldAnnounce) {
+            const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
+            enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
+              sessionKey: eventSessionKey,
+            });
+            if (value.wakeMode === "now") {
+              requestHeartbeat({ source: "hook", intent: "immediate", reason: `hook:${jobId}` });
+            }
+          } else if (result.status === "ok" && !value.deliver) {
+            logHooks.info("hook agent run completed without announcement", {
+              sourcePath: value.sourcePath,
+              name: safeName,
+              runId,
+              jobId,
+              agentId: value.agentId,
+              sessionKey,
+              completedAt: new Date().toISOString(),
+            });
+          }
+        } catch (err) {
+          logHooks.warn(`hook agent failed: ${String(err)}`);
+          enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
+            sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
           });
           if (value.wakeMode === "now") {
-            requestHeartbeat({ source: "hook", intent: "immediate", reason: `hook:${jobId}` });
+            requestHeartbeat({
+              source: "hook",
+              intent: "immediate",
+              reason: `hook:${jobId}:error`,
+            });
           }
-        } else if (result.status === "ok" && !value.deliver) {
-          logHooks.info("hook agent run completed without announcement", {
-            sourcePath: value.sourcePath,
-            name: safeName,
-            runId,
-            jobId,
-            agentId: value.agentId,
-            sessionKey,
-            completedAt: new Date().toISOString(),
-          });
         }
-      } catch (err) {
-        logHooks.warn(`hook agent failed: ${String(err)}`);
-        enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
-          sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
-        });
-        if (value.wakeMode === "now") {
-          requestHeartbeat({
-            source: "hook",
-            intent: "immediate",
-            reason: `hook:${jobId}:error`,
-          });
-        }
-      }
-    });
+      }),
+    );
 
     return runId;
   };

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { sanitizeInboundSystemTags } from "../../auto-reply/reply/inbound-text.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -16,6 +17,7 @@ import {
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RunCronAgentTurnResult } from "../../cron/isolated-agent/run.types.js";
+import { resolveCronAgentSessionKey } from "../../cron/isolated-agent/session-key.js";
 import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeat } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -104,7 +106,7 @@ function createSessionKeyedHookDispatchQueue() {
       () => undefined,
     );
     hookAgentDispatchTails.set(sessionKey, tail);
-    // Same-session hook agent runs append to one Codex session. Serializing avoids
+    // Same-session hook agent runs append to one agent session. Serializing avoids
     // optimistic lifecycle-claim races while preserving parallelism across sessions.
     void tail.finally(() => {
       if (hookAgentDispatchTails.get(sessionKey) === tail) {
@@ -126,6 +128,11 @@ export function createGatewayHooksRequestHandler(params: {
 }) {
   const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
   const enqueueHookAgentDispatch = createSessionKeyedHookDispatchQueue();
+  let isolatedAgentModulePromise:
+    | Promise<typeof import("../../cron/isolated-agent.js")>
+    | undefined;
+  const loadIsolatedAgentModule = () =>
+    (isolatedAgentModulePromise ??= import("../../cron/isolated-agent.js"));
 
   const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
@@ -172,25 +179,56 @@ export function createGatewayHooksRequestHandler(params: {
       delivery,
       state: { nextRunAtMs: nowMs },
     };
-
     let hookEventSessionKey: string | undefined;
+    const reportHookFailure = (err: unknown) => {
+      logHooks.warn(`hook agent failed: ${String(err)}`);
+      enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
+        sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
+      });
+      if (value.wakeMode === "now") {
+        requestHeartbeat({
+          source: "hook",
+          intent: "immediate",
+          reason: `hook:${jobId}:error`,
+        });
+      }
+    };
+    let dispatchCfg: OpenClawConfig;
+    try {
+      dispatchCfg = getRuntimeConfig();
+    } catch (err) {
+      // Config resolution historically failed after the hook response returned.
+      // Preserve that detached failure contract while queue keys stay canonical.
+      void runWithGatewayIndependentRootWorkContinuation(async () => reportHookFailure(err));
+      return runId;
+    }
+    const agentId = value.agentId ?? resolveDefaultAgentId(dispatchCfg);
+    const queueKey = resolveCronAgentSessionKey({
+      sessionKey,
+      agentId,
+      mainKey: dispatchCfg.session?.mainKey,
+      cfg: dispatchCfg,
+    });
+    // Acceptance fixes the target identity; queued execution still reads fresh
+    // settings. Otherwise reload can move one FIFO entry to another session.
+    job.agentId = agentId;
     void runWithGatewayIndependentRootWorkContinuation(() =>
-      enqueueHookAgentDispatch(sessionKey, async () => {
+      enqueueHookAgentDispatch(queueKey, async () => {
         try {
           // Agent hooks run after the HTTP response path has returned, so failure
           // handling must record a system event instead of throwing to the caller.
           const cfg = getRuntimeConfig();
           hookEventSessionKey = resolveHookEventSessionKey({
             cfg,
-            agentId: value.agentId,
+            agentId,
           });
-          const { runCronIsolatedAgentTurn } = await import("../../cron/isolated-agent.js");
+          const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
           const result = await runCronIsolatedAgentTurn({
             cfg,
             deps,
             job,
             message: value.message,
-            sessionKey,
+            sessionKey: queueKey,
             lane: "cron",
           });
           const summary = resolveHookRunSummary(result);
@@ -235,17 +273,7 @@ export function createGatewayHooksRequestHandler(params: {
             });
           }
         } catch (err) {
-          logHooks.warn(`hook agent failed: ${String(err)}`);
-          enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
-            sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
-          });
-          if (value.wakeMode === "now") {
-            requestHeartbeat({
-              source: "hook",
-              intent: "immediate",
-              reason: `hook:${jobId}:error`,
-            });
-          }
+          reportHookFailure(err);
         }
       }),
     );


### PR DESCRIPTION
Closes #110109

## What Problem This Solves

Fixes an issue where multiple `/hooks/agent` events targeting the same underlying agent session could race the cron session lifecycle claim and lose later events.

## Why This Change Was Made

Agent hook dispatch now canonicalizes the target agent and session when the hook is accepted, then uses a per-session FIFO inside tracked detached gateway work. Alias forms such as `main` and `agent:main:main` share one queue. Different sessions remain parallel. Runtime settings are refreshed when queued work starts, while the accepted target identity remains stable across config reloads. Failed runs and config-load failures preserve detached error reporting and do not block later queue entries.

The isolated-agent module load is shared so independent session queues can start concurrently.

AI-assisted maintainer fix.

## User Impact

Webhook bursts for one session no longer drop loser events as non-retryable `CronSessionLifecycleClaimError` failures. Operators retain normal parallelism across unrelated sessions without lowering global cron concurrency.

## Evidence

- `corepack pnpm test src/gateway/server/hooks.agent-trust.test.ts` — 15/15 passed on Blacksmith Testbox `tbx_01kxv49hrwfwb5jr1xx0cqdj1t`.
- `corepack pnpm test src/gateway/server/hooks.agent-trust.test.ts src/gateway/server.hooks.test.ts` — 40/40 unit and HTTP integration tests passed on fresh Testbox `tbx_01kxv6v2pjbwmgd48atbwh8y7x`.
- Same focused suite repeated 50 consecutive times — all passed (650 test executions at that revision).
- `corepack pnpm check:changed -- src/gateway/server/hooks.ts src/gateway/server/hooks.agent-trust.test.ts` — passed, including core/core-test typechecks, lint, format, boundaries, import cycles, and gateway guards.
- Live OpenAI QA scenario `cron-model-created-one-shot-recurring` passed in 4m42s with an isolated random-port gateway: model-authored one-shot ran once and was deleted; recurring ran repeatedly, survived restart, and retained a future next run.
- `$autoreview --mode branch --base origin/main` plus focused follow-up reviews — no accepted/actionable findings.
- PR head: `249ca7e62727`.
