### PR TITLE
feat(ui): merge voice and video talk into one button with in-call camera toggle

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -143,6 +143,9 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect.poll(() => camera.isVisible()).toBe(false);
       await expect.poll(() => voice.isVisible()).toBe(true);
       await expect
+        .poll(() => page.getByRole("button", { name: "Start video talk" }).count())
+        .toBe(0);
+      await expect
         .poll(() =>
           attach.evaluate((node) => node.closest(".agent-chat__composer-input-row") != null),
         )

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3858,10 +3858,11 @@ export const en: TranslationMap = {
         limitHours: "{hours}-hour limit",
       },
       takePhoto: "Take photo",
+      cameraAccessFailed: "Unable to access the camera.",
       cameraBusy: "The camera is busy or unavailable to the browser.",
       cameraNoneFound: "No camera was found.",
       cameraPermissionBlocked:
-        "Camera access is blocked. Allow camera and microphone access in browser site settings.",
+        "Camera access is blocked. Allow camera access in browser site settings.",
       cameraPreview: "Camera preview",
       dismissVoiceInputError: "Dismiss voice input error",
       microphoneAccessFailed: "Unable to access microphone inputs.",
@@ -3878,10 +3879,11 @@ export const en: TranslationMap = {
       selectedMicrophoneUnavailable:
         "The selected microphone is unavailable. Choose another input or System default.",
       startVoiceInput: "Start voice input",
-      startVideoTalk: "Start video talk",
       stillListening: "Still listening",
       stopVoiceInput: "Stop voice input",
       systemDefaultMicrophone: "System default",
+      turnCameraOff: "Turn camera off",
+      turnCameraOn: "Turn camera on",
       voiceTranscript: "Voice transcript",
     },
     selectors: {

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -86,6 +86,7 @@ describe("renderChatComposer controls", () => {
     let view = renderComposer({ onToggleRealtimeTalk });
     button(view.container, t("chat.composer.startVoiceInput")).click();
     expect(onToggleRealtimeTalk).toHaveBeenCalledOnce();
+    expect(view.container.querySelector('[aria-label="Start video talk"]')).toBeNull();
 
     const onSend = vi.fn();
     view = renderComposer({ draft: "Send this", onSend });
@@ -121,6 +122,30 @@ describe("renderChatComposer controls", () => {
       onAbort,
     });
     expect(button(view.container, t("chat.runControls.sendMessage")).disabled).toBe(false);
+  });
+
+  it("offers camera only inside a video-capable active talk session", () => {
+    const onToggleRealtimeCamera = vi.fn();
+    const { container } = renderComposer({
+      onToggleRealtimeTalk: vi.fn(),
+      onToggleRealtimeCamera,
+      realtimeTalkActive: true,
+      realtimeTalkStatus: "listening",
+      realtimeTalkVideoCapable: true,
+    });
+
+    button(container, t("chat.composer.turnCameraOn")).click();
+    expect(onToggleRealtimeCamera).toHaveBeenCalledOnce();
+    expect(container.querySelector('[aria-label="Start video talk"]')).toBeNull();
+
+    const failed = renderComposer({
+      onToggleRealtimeTalk: vi.fn(),
+      onToggleRealtimeCamera,
+      realtimeTalkActive: true,
+      realtimeTalkStatus: "error",
+      realtimeTalkVideoCapable: true,
+    });
+    expect(button(failed.container, t("chat.composer.turnCameraOn")).disabled).toBe(true);
   });
 
   it("sends attachment-only drafts instead of starting voice", () => {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1861,6 +1861,9 @@ class ChatPane extends OpenClawLightDomElement {
       state.realtimeTalkSession = null;
       state.realtimeTalkActive = false;
       state.realtimeTalkVideoStream = null;
+      state.realtimeTalkVideoCapable = false;
+      state.realtimeTalkVideoPending = false;
+      state.realtimeTalkCameraError = false;
       state.realtimeTalkStatus = "idle";
       state.realtimeTalkInputLevel.set(0);
       state.resetToolStream();
@@ -2334,6 +2337,9 @@ class ChatPane extends OpenClawLightDomElement {
       realtimeTalkInputLevel: state.realtimeTalkInputLevel,
       realtimeTalkConversation: state.realtimeTalkConversation,
       realtimeTalkVideoStream: state.realtimeTalkVideoStream,
+      realtimeTalkVideoCapable: state.realtimeTalkVideoCapable,
+      realtimeTalkVideoPending: state.realtimeTalkVideoPending,
+      realtimeTalkCameraError: state.realtimeTalkCameraError,
       connected: state.connected,
       canSend: catalogKey ? this.catalogSession?.canContinue === true : !selectedSessionArchived,
       disabledReason: catalogDisabledReason ?? disabledReason,
@@ -2451,7 +2457,7 @@ class ChatPane extends OpenClawLightDomElement {
         this.context.navigate("sessions", { search: `?${search.toString()}` });
       },
       onToggleRealtimeTalk: () => void state.toggleRealtimeTalk(),
-      onToggleRealtimeVideo: () => void state.toggleRealtimeTalk({ video: true }),
+      onToggleRealtimeCamera: () => void state.toggleRealtimeTalkCamera(),
       onDismissError: () => {
         dismissChatError(state as never);
         state.requestUpdate?.();

--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { loadSettings, saveSettings } from "../../app/settings.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
   attachChatRealtimeActions,
   createInitialChatRealtimeState,
@@ -11,8 +12,8 @@ import { RealtimeTalkSession } from "./realtime-talk.ts";
 
 type InspectableRealtimeTalkSession = {
   callbacks: RealtimeTalkCallbacks;
-  options: { provider?: string; transport?: string; capabilities?: string[] };
-  localOptions: { inputDeviceId?: string; videoEnabled?: boolean };
+  options: { provider?: string; transport?: string };
+  localOptions: { inputDeviceId?: string };
 };
 
 function inspectSession(state: ChatRealtimeState): InspectableRealtimeTalkSession {
@@ -44,8 +45,7 @@ describe("chat realtime actions", () => {
   let startSpy: MockInstance<RealtimeTalkSession["start"]>;
 
   beforeEach(() => {
-    vi.stubGlobal("localStorage", window.localStorage);
-    localStorage.clear();
+    vi.stubGlobal("localStorage", createStorageMock());
     startSpy = vi.spyOn(RealtimeTalkSession.prototype, "start").mockResolvedValue(undefined);
     vi.spyOn(RealtimeTalkSession.prototype, "stop").mockImplementation(() => undefined);
   });
@@ -67,22 +67,117 @@ describe("chat realtime actions", () => {
     expect(startSpy).toHaveBeenCalledOnce();
   });
 
-  it("launches video talk through the configured provider and owns the preview stream", async () => {
+  it("enables camera only after a video-capable voice session starts", async () => {
     const state = createState();
+    const setVideoEnabled = vi
+      .spyOn(RealtimeTalkSession.prototype, "setVideoEnabled")
+      .mockResolvedValue(undefined);
 
-    await state.toggleRealtimeTalk({ video: true });
+    await state.toggleRealtimeTalk();
     const session = inspectSession(state);
     const stream = {} as MediaStream;
+    session.callbacks.onVideoCapability?.(true);
+    await state.toggleRealtimeTalkCamera();
     session.callbacks.onVideoStream?.(stream);
 
     expect(session.options.provider).toBeUndefined();
     expect(session.options.transport).toBeUndefined();
-    expect(session.options.capabilities).toEqual(["camera-frame"]);
-    expect(session.localOptions.videoEnabled).toBe(true);
+    expect(setVideoEnabled).toHaveBeenCalledWith(true);
     expect(state.realtimeTalkVideoStream).toBe(stream);
 
-    await state.toggleRealtimeTalk();
+    await state.toggleRealtimeTalkCamera();
+    expect(setVideoEnabled).toHaveBeenLastCalledWith(false);
+    session.callbacks.onVideoStream?.(null);
     expect(state.realtimeTalkVideoStream).toBeNull();
+  });
+
+  it("keeps voice active and surfaces a non-fatal camera error", async () => {
+    const state = createState();
+    vi.spyOn(RealtimeTalkSession.prototype, "setVideoEnabled").mockRejectedValue(
+      new Error("Camera access is blocked"),
+    );
+
+    await state.toggleRealtimeTalk();
+    const session = inspectSession(state);
+    session.callbacks.onVideoCapability?.(true);
+    session.callbacks.onStatus?.("listening");
+    await state.toggleRealtimeTalkCamera();
+
+    expect(state.realtimeTalkSession).not.toBeNull();
+    expect(state.realtimeTalkActive).toBe(true);
+    expect(state.realtimeTalkStatus).toBe("listening");
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkDetail).toBe("Camera access is blocked");
+    expect(state.realtimeTalkCameraError).toBe(true);
+  });
+
+  it("keeps the connection error when camera toggle is requested after failure", async () => {
+    const state = createState();
+    const setVideoEnabled = vi
+      .spyOn(RealtimeTalkSession.prototype, "setVideoEnabled")
+      .mockResolvedValue(undefined);
+
+    await state.toggleRealtimeTalk();
+    const session = inspectSession(state);
+    session.callbacks.onVideoCapability?.(true);
+    session.callbacks.onStatus?.("error", "Realtime connection closed");
+    await state.toggleRealtimeTalkCamera();
+
+    expect(setVideoEnabled).not.toHaveBeenCalled();
+    expect(state.realtimeTalkDetail).toBe("Realtime connection closed");
+    expect(state.realtimeTalkCameraError).toBe(false);
+  });
+
+  it("keeps a connection error authoritative over an in-flight camera rejection", async () => {
+    const state = createState();
+    let rejectCamera: (error: Error) => void = () => undefined;
+    vi.spyOn(RealtimeTalkSession.prototype, "setVideoEnabled").mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectCamera = reject;
+        }),
+    );
+
+    await state.toggleRealtimeTalk();
+    const session = inspectSession(state);
+    session.callbacks.onVideoCapability?.(true);
+    session.callbacks.onStatus?.("listening");
+    const toggling = state.toggleRealtimeTalkCamera();
+    session.callbacks.onStatus?.("error", "Realtime connection closed");
+    rejectCamera(new Error("Camera access is blocked"));
+    await toggling;
+
+    expect(state.realtimeTalkDetail).toBe("Realtime connection closed");
+    expect(state.realtimeTalkCameraError).toBe(false);
+  });
+
+  it("releases a camera stream that arrives after a connection error", async () => {
+    const state = createState();
+    let resolveCamera: () => void = () => undefined;
+    const setVideoEnabled = vi
+      .spyOn(RealtimeTalkSession.prototype, "setVideoEnabled")
+      .mockImplementation((enabled) =>
+        enabled
+          ? new Promise<void>((resolve) => {
+              resolveCamera = resolve;
+            })
+          : Promise.resolve(),
+      );
+
+    await state.toggleRealtimeTalk();
+    const session = inspectSession(state);
+    session.callbacks.onVideoCapability?.(true);
+    session.callbacks.onStatus?.("listening");
+    const toggling = state.toggleRealtimeTalkCamera();
+    session.callbacks.onStatus?.("error", "Realtime connection closed");
+    session.callbacks.onVideoStream?.({} as MediaStream);
+    resolveCamera();
+    await toggling;
+
+    expect(setVideoEnabled).toHaveBeenLastCalledWith(false);
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkDetail).toBe("Realtime connection closed");
+    expect(state.realtimeTalkCameraError).toBe(false);
   });
 
   it("re-reads the persisted microphone on every launch instead of caching it", async () => {
@@ -100,7 +195,7 @@ describe("chat realtime actions", () => {
   });
 
   it("keeps a microphone picked while storage is blocked for the next launch", async () => {
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new DOMException("blocked", "SecurityError");
     });
     saveSettings({ ...loadSettings(), realtimeTalkInputDeviceId: "usb-mic" });

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -188,13 +188,16 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
       state.requestUpdate();
     }
   };
+  // Reads through a call so TS does not keep the early-guard narrowing across the
+  // await below; the status can legitimately become "error" while acquiring the camera.
+  const talkStatusIsError = () => state.realtimeTalkStatus === "error";
   state.toggleRealtimeTalkCamera = async () => {
     const session = state.realtimeTalkSession;
     if (
       !session ||
       !state.realtimeTalkVideoCapable ||
       state.realtimeTalkVideoPending ||
-      state.realtimeTalkStatus === "error"
+      talkStatusIsError()
     ) {
       return;
     }
@@ -206,7 +209,7 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
     try {
       await session.setVideoEnabled(enabled);
     } catch (error) {
-      if (state.realtimeTalkSession !== session || state.realtimeTalkStatus === "error") {
+      if (state.realtimeTalkSession !== session || talkStatusIsError()) {
         return;
       }
       state.realtimeTalkVideoStream = null;

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -22,11 +22,15 @@ export type ChatRealtimeState = {
   realtimeTalkInputLevel: RealtimeTalkLevelSignal;
   realtimeTalkConversation: RealtimeTalkConversationEntry[];
   realtimeTalkVideoStream: MediaStream | null;
+  realtimeTalkVideoCapable: boolean;
+  realtimeTalkVideoPending: boolean;
+  realtimeTalkCameraError: boolean;
   realtimeTalkSession: RealtimeTalkSession | null;
   realtimeTalkConversationState: RealtimeTalkConversationState;
   requestUpdate: () => void;
   resetRealtimeTalkConversation: () => void;
-  toggleRealtimeTalk: (options?: { video?: boolean }) => Promise<void>;
+  toggleRealtimeTalk: () => Promise<void>;
+  toggleRealtimeTalkCamera: () => Promise<void>;
 };
 
 export function createInitialChatRealtimeState() {
@@ -37,6 +41,9 @@ export function createInitialChatRealtimeState() {
     realtimeTalkInputLevel: new RealtimeTalkLevelSignal(),
     realtimeTalkConversation: [],
     realtimeTalkVideoStream: null,
+    realtimeTalkVideoCapable: false,
+    realtimeTalkVideoPending: false,
+    realtimeTalkCameraError: false,
     realtimeTalkSession: null,
     realtimeTalkConversationState: createRealtimeTalkConversationState(),
   };
@@ -58,6 +65,9 @@ export function dismissRealtimeTalkError(state: ChatRealtimeState) {
   state.realtimeTalkDetail = null;
   state.realtimeTalkInputLevel.set(0);
   state.realtimeTalkVideoStream = null;
+  state.realtimeTalkVideoCapable = false;
+  state.realtimeTalkVideoPending = false;
+  state.realtimeTalkCameraError = false;
   state.resetRealtimeTalkConversation();
 }
 
@@ -65,7 +75,7 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
   state.resetRealtimeTalkConversation = () => {
     resetChatRealtimeConversation(state);
   };
-  state.toggleRealtimeTalk = async (options = {}) => {
+  state.toggleRealtimeTalk = async () => {
     if (state.realtimeTalkSession) {
       state.realtimeTalkSession.stop();
       state.realtimeTalkSession = null;
@@ -74,6 +84,9 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
       state.realtimeTalkDetail = null;
       state.realtimeTalkInputLevel.set(0);
       state.realtimeTalkVideoStream = null;
+      state.realtimeTalkVideoCapable = false;
+      state.realtimeTalkVideoPending = false;
+      state.realtimeTalkCameraError = false;
       state.resetRealtimeTalkConversation();
       state.requestUpdate();
       return;
@@ -90,6 +103,9 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
     state.realtimeTalkActive = true;
     state.realtimeTalkStatus = "connecting";
     state.realtimeTalkDetail = null;
+    state.realtimeTalkVideoCapable = false;
+    state.realtimeTalkVideoPending = false;
+    state.realtimeTalkCameraError = false;
     state.realtimeTalkInputLevel.set(0);
     state.resetRealtimeTalkConversation();
     const session = new RealtimeTalkSession(
@@ -102,10 +118,18 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
           }
           state.realtimeTalkStatus = status;
           state.realtimeTalkDetail = detail ?? null;
+          state.realtimeTalkCameraError = false;
           state.realtimeTalkActive = status !== "idle";
           if (status === "idle" || status === "error") {
             state.realtimeTalkInputLevel.set(0);
           }
+          state.requestUpdate();
+        },
+        onVideoCapability: (capable) => {
+          if (state.realtimeTalkSession !== session) {
+            return;
+          }
+          state.realtimeTalkVideoCapable = capable;
           state.requestUpdate();
         },
         onInputLevel: (level) => {
@@ -129,12 +153,20 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
           if (state.realtimeTalkSession !== session) {
             return;
           }
+          if (stream && state.realtimeTalkStatus === "error") {
+            void session.setVideoEnabled(false).catch(() => undefined);
+            return;
+          }
           state.realtimeTalkVideoStream = stream;
+          if (stream) {
+            state.realtimeTalkDetail = null;
+            state.realtimeTalkCameraError = false;
+          }
           state.requestUpdate();
         },
       },
-      options.video ? { capabilities: ["camera-frame"] } : {},
-      { inputDeviceId, videoEnabled: options.video },
+      {},
+      { inputDeviceId },
     );
     state.realtimeTalkSession = session;
     try {
@@ -150,7 +182,41 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
       state.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
       state.realtimeTalkInputLevel.set(0);
       state.realtimeTalkVideoStream = null;
+      state.realtimeTalkVideoCapable = false;
+      state.realtimeTalkVideoPending = false;
+      state.realtimeTalkCameraError = false;
       state.requestUpdate();
+    }
+  };
+  state.toggleRealtimeTalkCamera = async () => {
+    const session = state.realtimeTalkSession;
+    if (
+      !session ||
+      !state.realtimeTalkVideoCapable ||
+      state.realtimeTalkVideoPending ||
+      state.realtimeTalkStatus === "error"
+    ) {
+      return;
+    }
+    const enabled = state.realtimeTalkVideoStream === null;
+    state.realtimeTalkVideoPending = true;
+    state.realtimeTalkCameraError = false;
+    state.realtimeTalkDetail = null;
+    state.requestUpdate();
+    try {
+      await session.setVideoEnabled(enabled);
+    } catch (error) {
+      if (state.realtimeTalkSession !== session || state.realtimeTalkStatus === "error") {
+        return;
+      }
+      state.realtimeTalkVideoStream = null;
+      state.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
+      state.realtimeTalkCameraError = true;
+    } finally {
+      if (state.realtimeTalkSession === session) {
+        state.realtimeTalkVideoPending = false;
+        state.requestUpdate();
+      }
     }
   };
 }

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1966,6 +1966,9 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     if (state) {
       state.realtimeTalkSession = null;
       state.realtimeTalkVideoStream = null;
+      state.realtimeTalkVideoCapable = false;
+      state.realtimeTalkVideoPending = false;
+      state.realtimeTalkCameraError = false;
       state.resetToolStream?.();
     }
   }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -646,7 +646,7 @@ function createChatProps(
     onSend: () => undefined,
     onCompact: () => undefined,
     onToggleRealtimeTalk: () => undefined,
-    onToggleRealtimeVideo: () => undefined,
+    onToggleRealtimeCamera: () => undefined,
     onDismissError: () => undefined,
     onAbort: () => undefined,
     onQueueRemove: () => undefined,
@@ -2158,23 +2158,37 @@ describe("chat voice controls", () => {
     await i18n.setLocale("en");
   });
 
-  it("keeps voice input visible without a second dictation control", () => {
+  it("shows one mic button for starting realtime talk", () => {
     const container = renderChatView();
 
     requireElement(container, '[aria-label="Start voice input"]', "voice input button");
-    requireElement(container, '[aria-label="Start video talk"]', "video talk button");
+    expect(container.querySelector('[aria-label="Start video talk"]')).toBeNull();
     expect(container.querySelector('[aria-label="Voice input"]')).toBeNull();
   });
 
-  it("starts Video Talk separately and renders the live camera preview", () => {
-    const onToggleRealtimeVideo = vi.fn();
+  it("toggles camera inside a video-capable voice session and renders the preview", () => {
+    const onToggleRealtimeCamera = vi.fn();
     const stream = {} as MediaStream;
-    const container = renderChatView({
-      onToggleRealtimeVideo,
-      realtimeTalkVideoStream: stream,
+    let container = renderChatView({
+      realtimeTalkActive: true,
+      realtimeTalkStatus: "listening",
+      realtimeTalkVideoCapable: true,
+      onToggleRealtimeCamera,
     });
 
-    requireElement(container, '[aria-label="Start video talk"]', "video talk button").dispatchEvent(
+    requireElement(container, '[aria-label="Turn camera on"]', "camera on button").dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
+    expect(onToggleRealtimeCamera).toHaveBeenCalledOnce();
+
+    container = renderChatView({
+      realtimeTalkActive: true,
+      realtimeTalkStatus: "listening",
+      realtimeTalkVideoCapable: true,
+      realtimeTalkVideoStream: stream,
+      onToggleRealtimeCamera,
+    });
+    requireElement(container, '[aria-label="Turn camera off"]', "camera off button").dispatchEvent(
       new MouseEvent("click", { bubbles: true }),
     );
     const preview = requireElement(
@@ -2183,7 +2197,7 @@ describe("chat voice controls", () => {
       "camera preview",
     ) as HTMLVideoElement;
 
-    expect(onToggleRealtimeVideo).toHaveBeenCalledOnce();
+    expect(onToggleRealtimeCamera).toHaveBeenCalledTimes(2);
     expect(preview.srcObject).toBe(stream);
     expect(preview.autoplay).toBe(true);
     expect(preview.muted).toBe(true);

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -106,6 +106,9 @@ export type ChatProps = {
   realtimeTalkInputLevel?: RealtimeTalkLevelSignal;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
   realtimeTalkVideoStream?: MediaStream | null;
+  realtimeTalkVideoCapable?: boolean;
+  realtimeTalkVideoPending?: boolean;
+  realtimeTalkCameraError?: boolean;
   connected: boolean;
   canSend: boolean;
   disabledReason: string | null;
@@ -154,7 +157,7 @@ export type ChatProps = {
   onCompact?: () => void | Promise<void>;
   onOpenSessionCheckpoints?: () => void | Promise<void>;
   onToggleRealtimeTalk?: () => void;
-  onToggleRealtimeVideo?: () => void;
+  onToggleRealtimeCamera?: () => void;
   onDismissError?: () => void;
   onDismissRealtimeTalkError?: () => void;
   onAbort?: () => void;
@@ -352,6 +355,9 @@ export function renderChat(props: ChatProps) {
     realtimeTalkInputLevel: props.realtimeTalkInputLevel,
     realtimeTalkConversation: props.realtimeTalkConversation,
     realtimeTalkVideoStream: props.realtimeTalkVideoStream,
+    realtimeTalkVideoCapable: props.realtimeTalkVideoCapable,
+    realtimeTalkVideoPending: props.realtimeTalkVideoPending,
+    realtimeTalkCameraError: props.realtimeTalkCameraError,
     composerControls: props.composerControls,
     getDraft: props.getDraft,
     onDraftChange: props.onDraftChange,
@@ -361,7 +367,7 @@ export function renderChat(props: ChatProps) {
     onSend: props.onSend,
     onCompact: props.onCompact,
     onToggleRealtimeTalk: props.onToggleRealtimeTalk,
-    onToggleRealtimeVideo: props.onToggleRealtimeVideo,
+    onToggleRealtimeCamera: props.onToggleRealtimeCamera,
     onDismissRealtimeTalkError: props.onDismissRealtimeTalkError,
     onAbort: props.onAbort,
     onQueueRemove: props.onQueueRemove,

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -113,6 +113,9 @@ type ChatComposerProps = {
   realtimeTalkInputLevel?: RealtimeTalkLevelSignal;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
   realtimeTalkVideoStream?: MediaStream | null;
+  realtimeTalkVideoCapable?: boolean;
+  realtimeTalkVideoPending?: boolean;
+  realtimeTalkCameraError?: boolean;
   composerControls?: TemplateResult | typeof nothing;
   getDraft?: () => string;
   onDraftChange: (next: string) => void;
@@ -122,7 +125,7 @@ type ChatComposerProps = {
   onSend: () => void;
   onCompact?: () => void | Promise<void>;
   onToggleRealtimeTalk?: () => void;
-  onToggleRealtimeVideo?: () => void;
+  onToggleRealtimeCamera?: () => void;
   onDismissRealtimeTalkError?: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
@@ -1721,13 +1724,16 @@ type ChatRunControlsProps = {
   voiceStatus?: RealtimeTalkStatus;
   voiceDetail?: string | null;
   voiceInputLevel?: RealtimeTalkLevelSignal;
+  voiceVideoCapable?: boolean;
+  voiceVideoEnabled?: boolean;
+  voiceVideoPending?: boolean;
   onAbort?: () => void;
   onExport: () => void;
   onNewSession: () => void;
   onSend: () => void;
   onStoreDraft: (draft: string) => void;
   onToggleVoice?: () => void;
-  onToggleVideo?: () => void;
+  onToggleCamera?: () => void;
   showPrimary?: boolean;
   showSecondary?: boolean;
 };
@@ -1809,6 +1815,34 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
                   >${voiceStatusLabel(props.voiceStatus, props.voiceDetail)}</span
                 >
               `}
+          ${props.voiceVideoCapable && props.onToggleCamera
+            ? html`
+                <openclaw-tooltip
+                  .content=${props.voiceVideoEnabled
+                    ? t("chat.composer.turnCameraOff")
+                    : t("chat.composer.turnCameraOn")}
+                >
+                  <button
+                    class="chat-send-btn chat-send-btn--voice"
+                    @click=${props.onToggleCamera}
+                    ?disabled=${props.voiceVideoPending ||
+                    props.voiceStatus === "connecting" ||
+                    props.voiceStatus === "error"}
+                    aria-label=${props.voiceVideoEnabled
+                      ? t("chat.composer.turnCameraOff")
+                      : t("chat.composer.turnCameraOn")}
+                    aria-pressed=${props.voiceVideoEnabled ? "true" : "false"}
+                  >
+                    ${icons.camera}
+                    <span class="agent-chat__control-label"
+                      >${props.voiceVideoEnabled
+                        ? t("chat.composer.turnCameraOff")
+                        : t("chat.composer.turnCameraOn")}</span
+                    >
+                  </button>
+                </openclaw-tooltip>
+              `
+            : nothing}
           ${abortAction}
         `
       : props.canAbort
@@ -1875,23 +1909,6 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
                   >
                 </button>
               </openclaw-tooltip>
-              ${props.onToggleVideo
-                ? html`
-                    <openclaw-tooltip .content=${t("chat.composer.startVideoTalk")}>
-                      <button
-                        class="chat-send-btn chat-send-btn--voice"
-                        @click=${props.onToggleVideo}
-                        ?disabled=${!props.connected || props.sending || props.isBusy}
-                        aria-label=${t("chat.composer.startVideoTalk")}
-                      >
-                        ${icons.camera}
-                        <span class="agent-chat__control-label"
-                          >${t("chat.composer.startVideoTalk")}</span
-                        >
-                      </button>
-                    </openclaw-tooltip>
-                  `
-                : nothing}
             `}
   `;
 }
@@ -2271,13 +2288,16 @@ export function renderChatComposer(props: ChatComposerProps) {
     voiceStatus: props.realtimeTalkStatus,
     voiceDetail: props.realtimeTalkDetail,
     voiceInputLevel: props.realtimeTalkInputLevel,
+    voiceVideoCapable: props.realtimeTalkVideoCapable,
+    voiceVideoEnabled: Boolean(props.realtimeTalkVideoStream),
+    voiceVideoPending: props.realtimeTalkVideoPending,
     onAbort: props.onAbort,
     onExport: () => exportMarkdown(props),
     onNewSession: props.onNewSession,
     onSend: handleSend,
     onStoreDraft: () => {},
     onToggleVoice: props.onToggleRealtimeTalk ? handleVoicePrimaryAction : undefined,
-    onToggleVideo: props.onToggleRealtimeVideo,
+    onToggleCamera: props.onToggleRealtimeCamera,
   };
   const slashMenuVisible = props.connected && canCompose && isSlashMenuVisible(state);
   const activeSlashMenuOptionId = getActiveSlashMenuOptionId(state, props.paneId);
@@ -2367,9 +2387,11 @@ export function renderChatComposer(props: ChatComposerProps) {
 
         ${renderChatAttachmentInputs({ ...props, disabled: !canCompose })}
         ${renderChatVoiceError({
-          status: props.realtimeTalkStatus,
+          status: props.realtimeTalkCameraError ? "error" : props.realtimeTalkStatus,
           detail: props.realtimeTalkDetail,
-          onDismissError: props.onDismissRealtimeTalkError,
+          onDismissError: props.realtimeTalkCameraError
+            ? undefined
+            : props.onDismissRealtimeTalkError,
         })}
         ${props.realtimeTalkVideoStream
           ? html`

--- a/ui/src/pages/chat/realtime-talk-google-live-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-video.test.ts
@@ -79,7 +79,6 @@ function createTransport(callbacks: RealtimeTalkCallbacks) {
       callbacks,
       client: { request: vi.fn(), addEventListener: vi.fn() } as never,
       sessionKey: "main",
-      videoEnabled: true,
     },
   );
 }
@@ -102,12 +101,12 @@ describe("Google Live Video Talk", () => {
     const audioStop = vi.fn();
     const videoStop = vi.fn();
     const audioTrack = { stop: audioStop } as unknown as MediaStreamTrack;
-    const videoTrack = {
+    const videoTrack = Object.assign(new EventTarget(), {
       stop: videoStop,
       readyState: "live",
       enabled: true,
       muted: false,
-    } as unknown as MediaStreamTrack;
+    }) as unknown as MediaStreamTrack;
     const audio = {
       getAudioTracks: () => [audioTrack],
       getTracks: () => [audioTrack],
@@ -116,21 +115,8 @@ describe("Google Live Video Talk", () => {
       getVideoTracks: () => [videoTrack],
       getTracks: () => [videoTrack],
     } as unknown as MediaStream;
-    class TestMediaStream {
-      constructor(readonly tracks: MediaStreamTrack[]) {}
-      getAudioTracks() {
-        return [audioTrack];
-      }
-      getVideoTracks() {
-        return [videoTrack];
-      }
-      getTracks() {
-        return this.tracks;
-      }
-    }
     const getUserMedia = vi.fn().mockResolvedValueOnce(audio).mockResolvedValueOnce(camera);
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
-    vi.stubGlobal("MediaStream", TestMediaStream);
 
     const originalCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
@@ -156,6 +142,9 @@ describe("Google Live Video Talk", () => {
     const transport = createTransport({ onStatus, onVideoStream });
 
     await transport.start();
+    expect(getUserMedia).toHaveBeenCalledOnce();
+    expect(onVideoStream).not.toHaveBeenCalled();
+    await transport.setVideoEnabled(true);
     const ws = FakeGoogleLiveWebSocket.instance;
     if (!ws) {
       throw new Error("missing Google Live WebSocket");
@@ -201,7 +190,7 @@ describe("Google Live Video Talk", () => {
       },
     });
     expect(getUserMedia).toHaveBeenNthCalledWith(2, { video: true });
-    expect(onVideoStream).toHaveBeenCalledWith(expect.any(TestMediaStream));
+    expect(onVideoStream).toHaveBeenCalledWith(camera);
     expect(onStatus).toHaveBeenCalledWith("listening");
 
     const countVideoMessages = () =>
@@ -212,9 +201,9 @@ describe("Google Live Video Talk", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(countVideoMessages()).toBe(2);
 
-    (videoTrack as { readyState: MediaStreamTrackState }).readyState = "ended";
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(countVideoMessages()).toBe(2);
+    await transport.setVideoEnabled(false);
+    expect(videoStop).toHaveBeenCalledOnce();
+    expect(audioStop).not.toHaveBeenCalled();
     ws.emitMessage({
       toolCall: {
         functionCalls: [
@@ -231,8 +220,7 @@ describe("Google Live Video Talk", () => {
             name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME,
             response: {
               ok: false,
-              cameraStreamActive: false,
-              error: "Camera stream is unavailable",
+              error: "camera is off",
             },
           },
         ],
@@ -246,6 +234,54 @@ describe("Google Live Video Talk", () => {
     expect(onVideoStream).toHaveBeenLastCalledWith(null);
     expect(audioStop).toHaveBeenCalledOnce();
     expect(videoStop).toHaveBeenCalledOnce();
+  });
+
+  it("clears ended camera state and reacquires on the next enable", async () => {
+    const audioTrack = { stop: vi.fn() } as unknown as MediaStreamTrack;
+    const firstVideoTrack = Object.assign(new EventTarget(), {
+      stop: vi.fn(),
+      readyState: "live",
+      enabled: true,
+      muted: false,
+    }) as unknown as MediaStreamTrack;
+    const secondVideoTrack = Object.assign(new EventTarget(), {
+      stop: vi.fn(),
+      readyState: "live",
+      enabled: true,
+      muted: false,
+    }) as unknown as MediaStreamTrack;
+    const audio = {
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [audioTrack],
+    } as unknown as MediaStream;
+    const firstCamera = {
+      getVideoTracks: () => [firstVideoTrack],
+      getTracks: () => [firstVideoTrack],
+    } as unknown as MediaStream;
+    const secondCamera = {
+      getVideoTracks: () => [secondVideoTrack],
+      getTracks: () => [secondVideoTrack],
+    } as unknown as MediaStream;
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(audio)
+      .mockResolvedValueOnce(firstCamera)
+      .mockResolvedValueOnce(secondCamera);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const onVideoStream = vi.fn();
+    const transport = createTransport({ onVideoStream });
+
+    await transport.start();
+    await transport.setVideoEnabled(true);
+    firstVideoTrack.dispatchEvent(new Event("ended"));
+
+    expect(onVideoStream).toHaveBeenLastCalledWith(null);
+    await transport.setVideoEnabled(true);
+    expect(getUserMedia).toHaveBeenNthCalledWith(3, { video: true });
+    expect(onVideoStream).toHaveBeenLastCalledWith(secondCamera);
+
+    transport.stop();
   });
 
   it("releases acquired media when stopped during the camera prompt", async () => {
@@ -267,14 +303,15 @@ describe("Google Live Video Talk", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
     const transport = createTransport({});
 
-    const start = transport.start();
-    await Promise.resolve();
+    await transport.start();
+    const enabling = transport.setVideoEnabled(true);
+    await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
     transport.stop();
     resolveCamera(camera);
-    await start;
+    await enabling;
 
     expect(audioStop).toHaveBeenCalledOnce();
     expect(videoStop).toHaveBeenCalledOnce();
-    expect(FakeGoogleLiveWebSocket.instance).toBeUndefined();
+    expect(FakeGoogleLiveWebSocket.instance?.readyState).toBe(3);
   });
 });

--- a/ui/src/pages/chat/realtime-talk-google-live.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.ts
@@ -8,7 +8,7 @@ import {
   RealtimeTalkPcmInputPump,
   RealtimeTalkPcmOutputQueue,
 } from "./realtime-talk-audio.ts";
-import { openRealtimeTalkInput } from "./realtime-talk-input.ts";
+import { openRealtimeTalkCamera, openRealtimeTalkInput } from "./realtime-talk-input.ts";
 import type { RealtimeTalkJsonPcmWebSocketSessionResult } from "./realtime-talk-shared.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -106,6 +106,7 @@ function buildGoogleLiveUrl(session: RealtimeTalkJsonPcmWebSocketSessionResult):
 export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   private ws: WebSocket | null = null;
   private media: MediaStream | null = null;
+  private cameraMedia: MediaStream | null = null;
   private captureVideo: HTMLVideoElement | null = null;
   private inputContext: AudioContext | null = null;
   private outputContext: AudioContext | null = null;
@@ -113,6 +114,9 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   private readonly inputPump = new RealtimeTalkPcmInputPump();
   private closed = false;
   private mediaSetupController: AbortController | null = null;
+  private cameraSetupController: AbortController | null = null;
+  private readonly handleCameraTrackEnded = () => this.releaseCamera();
+  private setupComplete = false;
   private videoFramesActive = false;
   private hasSentVideoFrame = false;
   private videoFrameTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -143,7 +147,6 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     let media: MediaStream;
     try {
       media = await openRealtimeTalkInput(this.ctx.inputDeviceId, {
-        video: this.ctx.videoEnabled,
         signal: mediaSetupController.signal,
       });
     } catch (error) {
@@ -161,16 +164,6 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
       return;
     }
     this.media = media;
-    if (this.ctx.videoEnabled) {
-      const captureVideo = document.createElement("video");
-      captureVideo.autoplay = true;
-      captureVideo.muted = true;
-      captureVideo.playsInline = true;
-      captureVideo.srcObject = media;
-      this.captureVideo = captureVideo;
-      this.ctx.callbacks.onVideoStream?.(media);
-      void captureVideo.play().catch(() => undefined);
-    }
     this.inputContext = new AudioContext({ sampleRate: this.session.audio.inputSampleRateHz });
     this.outputContext = new AudioContext({ sampleRate: this.session.audio.outputSampleRateHz });
     if (this.ctx.callbacks.onInputLevel) {
@@ -201,6 +194,57 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     });
   }
 
+  async setVideoEnabled(enabled: boolean): Promise<void> {
+    if (!enabled) {
+      this.releaseCamera();
+      return;
+    }
+    if (this.closed) {
+      throw new Error("Realtime Talk session is closed");
+    }
+    if (this.cameraMedia?.getVideoTracks().some((track) => track.readyState === "live")) {
+      return;
+    }
+    this.cameraSetupController?.abort();
+    const controller = new AbortController();
+    this.cameraSetupController = controller;
+    let camera: MediaStream;
+    try {
+      camera = await openRealtimeTalkCamera(controller.signal);
+    } catch (error) {
+      if (this.closed || controller.signal.aborted) {
+        return;
+      }
+      throw error;
+    } finally {
+      if (this.cameraSetupController === controller) {
+        this.cameraSetupController = null;
+      }
+    }
+    if (this.closed || controller.signal.aborted) {
+      camera.getTracks().forEach((track) => track.stop());
+      return;
+    }
+    this.cameraMedia = camera;
+    // External track loss clears preview state so the next toggle reacquires the camera.
+    camera
+      .getVideoTracks()
+      .forEach((track) =>
+        track.addEventListener("ended", this.handleCameraTrackEnded, { once: true }),
+      );
+    const captureVideo = document.createElement("video");
+    captureVideo.autoplay = true;
+    captureVideo.muted = true;
+    captureVideo.playsInline = true;
+    captureVideo.srcObject = camera;
+    this.captureVideo = captureVideo;
+    this.ctx.callbacks.onVideoStream?.(camera);
+    void captureVideo.play().catch(() => undefined);
+    if (this.setupComplete) {
+      this.startVideoFrames();
+    }
+  }
+
   stop(): void {
     if (!this.closed) {
       this.emitTalkEvent({ type: "session.closed", final: true });
@@ -208,7 +252,9 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     this.closed = true;
     this.mediaSetupController?.abort();
     this.mediaSetupController = null;
-    this.stopVideoFrames();
+    this.cameraSetupController?.abort();
+    this.cameraSetupController = null;
+    this.setupComplete = false;
     for (const controller of this.consultAbortControllers) {
       controller.abort();
     }
@@ -219,11 +265,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     this.inputMeter = null;
     this.media?.getTracks().forEach((track) => track.stop());
     this.media = null;
-    if (this.captureVideo) {
-      this.captureVideo.srcObject = null;
-      this.captureVideo = null;
-    }
-    this.ctx.callbacks.onVideoStream?.(null);
+    this.releaseCamera();
     this.stopOutput();
     void this.inputContext?.close();
     this.inputContext = null;
@@ -275,6 +317,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
       return;
     }
     if (message.setupComplete) {
+      this.setupComplete = true;
       this.ctx.callbacks.onStatus?.("listening");
       this.emitTalkEvent({ type: "session.ready" });
       this.startVideoFrames();
@@ -395,11 +438,10 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     }
     if (name === REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME) {
       const active = this.videoFramesActive && this.hasSentVideoFrame && this.isCameraTrackUsable();
-      this.submitToolResult(callId, {
-        ok: active,
-        cameraStreamActive: active,
-        ...(!active ? { error: "Camera stream is unavailable" } : {}),
-      });
+      this.submitToolResult(
+        callId,
+        active ? { ok: true, cameraStreamActive: true } : { ok: false, error: "camera is off" },
+      );
       this.emitTalkEvent({
         type: active ? "tool.result" : "tool.error",
         callId,
@@ -488,7 +530,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   }
 
   private startVideoFrames(): void {
-    if (!this.ctx.videoEnabled || !this.captureVideo || this.videoFramesActive || this.closed) {
+    if (!this.captureVideo || this.videoFramesActive || this.closed) {
       return;
     }
     this.videoFramesActive = true;
@@ -547,15 +589,31 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   }
 
   private hasLiveCameraTrack(): boolean {
-    return this.media?.getVideoTracks().some((track) => track.readyState === "live") === true;
+    return this.cameraMedia?.getVideoTracks().some((track) => track.readyState === "live") === true;
   }
 
   private isCameraTrackUsable(): boolean {
     return (
-      this.media
+      this.cameraMedia
         ?.getVideoTracks()
         .some((track) => track.readyState === "live" && track.enabled && !track.muted) === true
     );
+  }
+
+  private releaseCamera(): void {
+    this.cameraSetupController?.abort();
+    this.cameraSetupController = null;
+    this.stopVideoFrames();
+    this.cameraMedia?.getVideoTracks().forEach((track) => {
+      track.removeEventListener("ended", this.handleCameraTrackEnded);
+      track.stop();
+    });
+    this.cameraMedia = null;
+    if (this.captureVideo) {
+      this.captureVideo.srcObject = null;
+      this.captureVideo = null;
+    }
+    this.ctx.callbacks.onVideoStream?.(null);
   }
 
   private sendControlSpeechMessage(message: string): void {

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { discoverRealtimeTalkInputs, openRealtimeTalkInput } from "./realtime-talk-input.ts";
+import {
+  discoverRealtimeTalkInputs,
+  openRealtimeTalkCamera,
+  openRealtimeTalkInput,
+} from "./realtime-talk-input.ts";
 
 function mediaDevice(kind: MediaDeviceKind, deviceId: string, label: string): MediaDeviceInfo {
   return { kind, deviceId, label, groupId: "", toJSON: () => ({}) } as MediaDeviceInfo;
@@ -115,23 +119,14 @@ describe("realtime Talk microphone inputs", () => {
     });
   });
 
-  it("acquires camera separately so video errors do not mask microphone errors", async () => {
-    const audioTrack = {} as MediaStreamTrack;
-    const videoTrack = {} as MediaStreamTrack;
-    const audio = {
-      getAudioTracks: () => [audioTrack],
-      getTracks: () => [audioTrack],
-    } as unknown as MediaStream;
-    const camera = { getVideoTracks: () => [videoTrack] } as unknown as MediaStream;
-    class TestMediaStream {
-      constructor(readonly tracks: MediaStreamTrack[]) {}
-    }
+  it("acquires camera separately so camera errors cannot stop microphone input", async () => {
+    const audio = { getTracks: () => [] } as unknown as MediaStream;
+    const camera = { getTracks: () => [] } as unknown as MediaStream;
     const getUserMedia = vi.fn().mockResolvedValueOnce(audio).mockResolvedValueOnce(camera);
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
-    vi.stubGlobal("MediaStream", TestMediaStream);
 
-    const combined = await openRealtimeTalkInput("usb-mic", { video: true });
-    expect(combined).toBeInstanceOf(TestMediaStream);
+    await expect(openRealtimeTalkInput("usb-mic")).resolves.toBe(audio);
+    await expect(openRealtimeTalkCamera()).resolves.toBe(camera);
     expect(getUserMedia).toHaveBeenNthCalledWith(1, {
       audio: {
         autoGainControl: true,
@@ -141,65 +136,38 @@ describe("realtime Talk microphone inputs", () => {
       },
     });
     expect(getUserMedia).toHaveBeenNthCalledWith(2, { video: true });
-    expect((combined as unknown as TestMediaStream).tracks).toEqual([audioTrack, videoTrack]);
   });
 
   it("reports camera permission denial with actionable guidance", async () => {
-    const stop = vi.fn();
-    const audio = { getTracks: () => [{ stop }] } as unknown as MediaStream;
-    const getUserMedia = vi
-      .fn()
-      .mockResolvedValueOnce(audio)
-      .mockRejectedValueOnce(new DOMException("denied", "NotAllowedError"));
+    const getUserMedia = vi.fn().mockRejectedValue(new DOMException("denied", "NotAllowedError"));
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
-    await expect(openRealtimeTalkInput(undefined, { video: true })).rejects.toThrow(
-      "Camera access is blocked",
-    );
-    expect(stop).toHaveBeenCalledOnce();
+    await expect(openRealtimeTalkCamera()).rejects.toThrow("Camera access is blocked");
   });
 
-  it("reports a missing camera when an exact microphone is selected", async () => {
-    const stop = vi.fn();
-    const audio = { getTracks: () => [{ stop }] } as unknown as MediaStream;
-    const getUserMedia = vi
-      .fn()
-      .mockResolvedValueOnce(audio)
-      .mockRejectedValueOnce(new DOMException("missing", "NotFoundError"));
+  it("reports a missing camera", async () => {
+    const getUserMedia = vi.fn().mockRejectedValue(new DOMException("missing", "NotFoundError"));
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
-    await expect(openRealtimeTalkInput("usb-mic", { video: true })).rejects.toThrow(
-      "No camera was found",
-    );
-    expect(stop).toHaveBeenCalledOnce();
+    await expect(openRealtimeTalkCamera()).rejects.toThrow("No camera was found");
   });
 
-  it("releases partial media when video acquisition is cancelled", async () => {
-    const audioStop = vi.fn();
+  it("releases camera media when acquisition is cancelled", async () => {
     const videoStop = vi.fn();
-    const audio = {
-      getAudioTracks: () => [{} as MediaStreamTrack],
-      getTracks: () => [{ stop: audioStop }],
-    } as unknown as MediaStream;
     const camera = {
-      getVideoTracks: () => [{} as MediaStreamTrack],
       getTracks: () => [{ stop: videoStop }],
     } as unknown as MediaStream;
     let resolveCamera: (stream: MediaStream) => void = () => undefined;
     const cameraPending = new Promise<MediaStream>((resolve) => {
       resolveCamera = resolve;
     });
-    const getUserMedia = vi.fn().mockResolvedValueOnce(audio).mockReturnValueOnce(cameraPending);
+    const getUserMedia = vi.fn().mockReturnValue(cameraPending);
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
     const controller = new AbortController();
 
-    const opening = openRealtimeTalkInput(undefined, {
-      video: true,
-      signal: controller.signal,
-    });
-    await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+    const opening = openRealtimeTalkCamera(controller.signal);
+    await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
     controller.abort();
-    expect(audioStop).toHaveBeenCalledOnce();
     resolveCamera(camera);
 
     await expect(opening).rejects.toMatchObject({ name: "AbortError" });

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -105,7 +105,7 @@ function realtimeTalkAbortReason(signal: AbortSignal): Error {
 
 export async function openRealtimeTalkInput(
   inputDeviceId: string | undefined,
-  options: { video?: boolean; signal?: AbortSignal } = {},
+  options: { signal?: AbortSignal } = {},
 ): Promise<MediaStream> {
   const devices = globalThis.navigator?.mediaDevices;
   if (!devices?.getUserMedia) {
@@ -130,31 +130,25 @@ export async function openRealtimeTalkInput(
     audio.getTracks().forEach((track) => track.stop());
     throw realtimeTalkAbortReason(options.signal);
   }
-  if (!options.video) {
-    return audio;
-  }
+  return audio;
+}
 
-  let audioStopped = false;
-  const stopAudio = () => {
-    if (audioStopped) {
-      return;
-    }
-    audioStopped = true;
-    audio.getTracks().forEach((track) => track.stop());
-  };
-  options.signal?.addEventListener("abort", stopAudio, { once: true });
-  let camera: MediaStream | undefined;
+export async function openRealtimeTalkCamera(signal?: AbortSignal): Promise<MediaStream> {
+  const devices = globalThis.navigator?.mediaDevices;
+  if (!devices?.getUserMedia) {
+    throw new Error(t("chat.composer.cameraAccessFailed"));
+  }
+  let camera: MediaStream;
   try {
     camera = await devices.getUserMedia({ video: true });
-    if (options.signal?.aborted) {
-      throw realtimeTalkAbortReason(options.signal);
+    if (signal?.aborted) {
+      camera.getTracks().forEach((track) => track.stop());
+      throw realtimeTalkAbortReason(signal);
     }
-    return new MediaStream([...audio.getAudioTracks(), ...camera.getVideoTracks()]);
+    return camera;
   } catch (error) {
-    camera?.getTracks().forEach((track) => track.stop());
-    stopAudio();
-    if (options.signal?.aborted) {
-      throw realtimeTalkAbortReason(options.signal);
+    if (signal?.aborted) {
+      throw realtimeTalkAbortReason(signal);
     }
     if (error instanceof DOMException && error.name === "NotAllowedError") {
       throw new Error(t("chat.composer.cameraPermissionBlocked"), { cause: error });
@@ -165,8 +159,6 @@ export async function openRealtimeTalkInput(
     if (error instanceof DOMException && error.name === "NotReadableError") {
       throw new Error(t("chat.composer.cameraBusy"), { cause: error });
     }
-    throw error;
-  } finally {
-    options.signal?.removeEventListener("abort", stopAudio);
+    throw new Error(t("chat.composer.cameraAccessFailed"), { cause: error });
   }
 }

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -16,6 +16,7 @@ export type RealtimeTalkEvent = TalkEvent;
 
 export type RealtimeTalkCallbacks = {
   onStatus?: (status: RealtimeTalkStatus, detail?: string) => void;
+  onVideoCapability?: (capable: boolean) => void;
   onInputLevel?: (level: number) => void;
   onTranscript?: (entry: { role: "user" | "assistant"; text: string; final: boolean }) => void;
   onTalkEvent?: (event: RealtimeTalkEvent) => void;
@@ -101,6 +102,7 @@ export type RealtimeTalkSessionResult =
 export type RealtimeTalkTransport = {
   start(): Promise<void>;
   stop(): void;
+  setVideoEnabled?: (enabled: boolean) => Promise<void>;
 };
 
 export type RealtimeTalkTransportContext = {
@@ -108,7 +110,6 @@ export type RealtimeTalkTransportContext = {
   sessionKey: string;
   callbacks: RealtimeTalkCallbacks;
   inputDeviceId?: string;
-  videoEnabled?: boolean;
   consultThinkingLevel?: string;
   consultFastMode?: boolean;
 };

--- a/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
@@ -67,33 +67,24 @@ describe("OpenAI Realtime Video Talk", () => {
     vi.restoreAllMocks();
   });
 
-  it("keeps camera local, bounds the frame event, and releases both tracks", async () => {
+  it("starts audio-only, toggles local camera, and reports camera-off tool calls", async () => {
     const audioStop = vi.fn();
     const videoStop = vi.fn();
     const audioTrack = { stop: audioStop } as unknown as MediaStreamTrack;
-    const videoTrack = { stop: videoStop } as unknown as MediaStreamTrack;
+    const videoTrack = Object.assign(new EventTarget(), {
+      stop: videoStop,
+      readyState: "live",
+    }) as unknown as MediaStreamTrack;
     const audio = {
       getAudioTracks: () => [audioTrack],
       getTracks: () => [audioTrack],
     } as unknown as MediaStream;
     const camera = {
       getVideoTracks: () => [videoTrack],
+      getTracks: () => [videoTrack],
     } as unknown as MediaStream;
-    class TestMediaStream {
-      constructor(readonly tracks: MediaStreamTrack[]) {}
-      getAudioTracks() {
-        return [audioTrack];
-      }
-      getVideoTracks() {
-        return [videoTrack];
-      }
-      getTracks() {
-        return this.tracks;
-      }
-    }
     const getUserMedia = vi.fn().mockResolvedValueOnce(audio).mockResolvedValueOnce(camera);
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
-    vi.stubGlobal("MediaStream", TestMediaStream);
 
     const originalCreateElement = document.createElement.bind(document);
     let videoReadyState: number = HTMLMediaElement.HAVE_METADATA;
@@ -129,13 +120,17 @@ describe("OpenAI Realtime Video Talk", () => {
         client: {} as never,
         sessionKey: "main",
         callbacks: { onStatus, onTalkEvent, onVideoStream },
-        videoEnabled: true,
       },
     );
 
     await transport.start();
     const peer = FakePeerConnection.instance;
-    const combined = onVideoStream.mock.calls[0]?.[0] as MediaStream;
+    expect(getUserMedia).toHaveBeenCalledOnce();
+    expect(peer?.addTrack).toHaveBeenCalledWith(audioTrack, audio);
+    expect(onVideoStream).not.toHaveBeenCalled();
+
+    await transport.setVideoEnabled(true);
+    expect(onVideoStream).toHaveBeenCalledWith(camera);
     peer?.channel.dispatchEvent(
       new MessageEvent("message", {
         data: JSON.stringify({
@@ -184,24 +179,129 @@ describe("OpenAI Realtime Video Talk", () => {
     });
     expect(getUserMedia).toHaveBeenNthCalledWith(2, { video: true });
     expect(peer?.addTrack).toHaveBeenCalledOnce();
-    expect(peer?.addTrack).toHaveBeenCalledWith(audioTrack, combined);
-    expect(combined).toBeInstanceOf(TestMediaStream);
-    expect(onVideoStream).toHaveBeenCalledWith(combined);
     expect(drawImage).toHaveBeenCalledTimes(2);
     expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toContain("tool.result");
     for (const [payload] of peer?.channel.send.mock.calls ?? []) {
       expect(new TextEncoder().encode(String(payload)).length).toBeLessThanOrEqual(512);
     }
 
-    peer!.connectionState = "failed";
-    peer!.dispatchEvent(new Event("connectionstatechange"));
-    expect(onStatus).toHaveBeenLastCalledWith("error", "Realtime connection closed");
+    await transport.setVideoEnabled(false);
     expect(onVideoStream).toHaveBeenLastCalledWith(null);
-    expect(audioStop).toHaveBeenCalledOnce();
     expect(videoStop).toHaveBeenCalledOnce();
+    expect(audioStop).not.toHaveBeenCalled();
+
+    peer?.channel.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "item-camera-off",
+          call_id: "call-camera-off",
+          name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME,
+          arguments: "{}",
+        }),
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(sentRealtimeEvents()).toContainEqual({
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call-camera-off",
+          output: JSON.stringify({ ok: false, error: "camera is off" }),
+        },
+      }),
+    );
+    expect(onStatus).not.toHaveBeenCalledWith("error", expect.anything());
+
+    transport.stop();
+    expect(audioStop).toHaveBeenCalledOnce();
   });
 
-  it("releases the microphone when stopped during the camera prompt", async () => {
+  it("clears ended camera state and reacquires on the next enable", async () => {
+    const audioTrack = { stop: vi.fn() } as unknown as MediaStreamTrack;
+    const firstVideoTrack = Object.assign(new EventTarget(), {
+      stop: vi.fn(),
+      readyState: "live",
+    }) as unknown as MediaStreamTrack;
+    const secondVideoTrack = Object.assign(new EventTarget(), {
+      stop: vi.fn(),
+      readyState: "live",
+    }) as unknown as MediaStreamTrack;
+    const audio = {
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [audioTrack],
+    } as unknown as MediaStream;
+    const firstCamera = {
+      getVideoTracks: () => [firstVideoTrack],
+      getTracks: () => [firstVideoTrack],
+    } as unknown as MediaStream;
+    const secondCamera = {
+      getVideoTracks: () => [secondVideoTrack],
+      getTracks: () => [secondVideoTrack],
+    } as unknown as MediaStream;
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(audio)
+      .mockResolvedValueOnce(firstCamera)
+      .mockResolvedValueOnce(secondCamera);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const onVideoStream = vi.fn();
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
+      {
+        client: {} as never,
+        sessionKey: "main",
+        callbacks: { onVideoStream },
+      },
+    );
+
+    await transport.start();
+    await transport.setVideoEnabled(true);
+    firstVideoTrack.dispatchEvent(new Event("ended"));
+
+    expect(onVideoStream).toHaveBeenLastCalledWith(null);
+    await transport.setVideoEnabled(true);
+    expect(getUserMedia).toHaveBeenNthCalledWith(3, { video: true });
+    expect(onVideoStream).toHaveBeenLastCalledWith(secondCamera);
+
+    transport.stop();
+  });
+
+  it("keeps voice alive when lazy camera acquisition fails", async () => {
+    const audioStop = vi.fn();
+    const audioTrack = { stop: audioStop } as unknown as MediaStreamTrack;
+    const audio = {
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [audioTrack],
+    } as unknown as MediaStream;
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(audio)
+      .mockRejectedValueOnce(new DOMException("denied", "NotAllowedError"));
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStatus = vi.fn();
+    const onVideoStream = vi.fn();
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
+      {
+        client: {} as never,
+        sessionKey: "main",
+        callbacks: { onStatus, onVideoStream },
+      },
+    );
+
+    await transport.start();
+    await expect(transport.setVideoEnabled(true)).rejects.toThrow("Camera access is blocked");
+
+    expect(audioStop).not.toHaveBeenCalled();
+    expect(onVideoStream).not.toHaveBeenCalled();
+    expect(onStatus).not.toHaveBeenCalledWith("error", expect.anything());
+    transport.stop();
+    expect(audioStop).toHaveBeenCalledOnce();
+  });
+
+  it("releases acquired media when stopped during the camera prompt", async () => {
     const audioStop = vi.fn();
     const videoStop = vi.fn();
     const audio = {
@@ -228,17 +328,17 @@ describe("OpenAI Realtime Video Talk", () => {
         client: {} as never,
         sessionKey: "main",
         callbacks: {},
-        videoEnabled: true,
       },
     );
 
-    const starting = transport.start();
+    await transport.start();
+    const enabling = transport.setVideoEnabled(true);
     await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
     transport.stop();
     expect(audioStop).toHaveBeenCalledOnce();
     resolveCamera(camera);
 
-    await expect(starting).resolves.toBeUndefined();
+    await expect(enabling).resolves.toBeUndefined();
     expect(videoStop).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -84,7 +84,6 @@ function createOpenAiTransport(
   client: Record<string, unknown> = {},
   callbacks: Record<string, unknown> = {},
   inputDeviceId?: string,
-  videoEnabled?: boolean,
 ): WebRtcSdpRealtimeTalkTransport {
   return new WebRtcSdpRealtimeTalkTransport(
     {
@@ -97,7 +96,6 @@ function createOpenAiTransport(
       sessionKey: "main",
       callbacks: callbacks as never,
       inputDeviceId,
-      videoEnabled,
     },
   );
 }

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -1,7 +1,7 @@
 // Control UI chat module implements realtime talk webrtc behavior.
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
 import { RealtimeTalkMediaStreamMeter } from "./realtime-talk-audio.ts";
-import { openRealtimeTalkInput } from "./realtime-talk-input.ts";
+import { openRealtimeTalkCamera, openRealtimeTalkInput } from "./realtime-talk-input.ts";
 import type { RealtimeTalkWebRtcSdpSessionResult } from "./realtime-talk-shared.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -53,6 +53,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private peer: RTCPeerConnection | null = null;
   private channel: RTCDataChannel | null = null;
   private media: MediaStream | null = null;
+  private cameraMedia: MediaStream | null = null;
   private audio: HTMLAudioElement | null = null;
   private captureVideo: HTMLVideoElement | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
@@ -63,6 +64,8 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private toolBuffers = new Map<string, ToolBuffer>();
   private pendingOfferRequest: PendingOfferRequest | null = null;
   private mediaSetupController: AbortController | null = null;
+  private cameraSetupController: AbortController | null = null;
+  private readonly handleCameraTrackEnded = () => this.releaseCamera();
   private readonly consultAbortControllers = new Set<AbortController>();
   private readonly emitTalkEvent: ReturnType<typeof createRealtimeTalkEventEmitter>;
 
@@ -98,7 +101,6 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       media = await this.awaitSetupStep(
         peer,
         openRealtimeTalkInput(this.ctx.inputDeviceId, {
-          video: this.ctx.videoEnabled,
           signal: mediaSetupController.signal,
         }),
       );
@@ -115,16 +117,6 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       return;
     }
     this.media = media;
-    if (this.ctx.videoEnabled) {
-      const captureVideo = document.createElement("video");
-      captureVideo.autoplay = true;
-      captureVideo.muted = true;
-      captureVideo.playsInline = true;
-      captureVideo.srcObject = media;
-      this.captureVideo = captureVideo;
-      this.ctx.callbacks.onVideoStream?.(media);
-      void captureVideo.play().catch(() => undefined);
-    }
     if (this.ctx.callbacks.onInputLevel) {
       this.inputMeter = new RealtimeTalkMediaStreamMeter(this.ctx.callbacks.onInputLevel);
       this.inputMeter.start(media);
@@ -182,6 +174,54 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         sdp: answerSdp,
       }),
     );
+  }
+
+  async setVideoEnabled(enabled: boolean): Promise<void> {
+    if (!enabled) {
+      this.releaseCamera();
+      return;
+    }
+    if (this.closed) {
+      throw new Error("Realtime Talk session is closed");
+    }
+    if (this.cameraMedia?.getVideoTracks().some((track) => track.readyState === "live")) {
+      return;
+    }
+    this.cameraSetupController?.abort();
+    const controller = new AbortController();
+    this.cameraSetupController = controller;
+    let camera: MediaStream;
+    try {
+      camera = await openRealtimeTalkCamera(controller.signal);
+    } catch (error) {
+      if (this.closed || controller.signal.aborted) {
+        return;
+      }
+      throw error;
+    } finally {
+      if (this.cameraSetupController === controller) {
+        this.cameraSetupController = null;
+      }
+    }
+    if (this.closed || controller.signal.aborted) {
+      camera.getTracks().forEach((track) => track.stop());
+      return;
+    }
+    this.cameraMedia = camera;
+    // External track loss clears preview state so the next toggle reacquires the camera.
+    camera
+      .getVideoTracks()
+      .forEach((track) =>
+        track.addEventListener("ended", this.handleCameraTrackEnded, { once: true }),
+      );
+    const captureVideo = document.createElement("video");
+    captureVideo.autoplay = true;
+    captureVideo.muted = true;
+    captureVideo.playsInline = true;
+    captureVideo.srcObject = camera;
+    this.captureVideo = captureVideo;
+    this.ctx.callbacks.onVideoStream?.(camera);
+    void captureVideo.play().catch(() => undefined);
   }
 
   private async readOfferAnswer(
@@ -286,6 +326,8 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     this.closed = true;
     this.mediaSetupController?.abort();
     this.mediaSetupController = null;
+    this.cameraSetupController?.abort();
+    this.cameraSetupController = null;
     this.abortOfferRequest();
     this.channel?.close();
     this.channel = null;
@@ -293,11 +335,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     this.peer = null;
     this.media?.getTracks().forEach((track) => track.stop());
     this.media = null;
-    if (this.captureVideo) {
-      this.captureVideo.srcObject = null;
-      this.captureVideo = null;
-    }
-    this.ctx.callbacks.onVideoStream?.(null);
+    this.releaseCamera();
     this.inputMeter?.stop();
     this.inputMeter = null;
     this.audio?.remove();
@@ -526,6 +564,17 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       itemId,
       payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME },
     });
+    if (!this.cameraMedia?.getVideoTracks().some((track) => track.readyState === "live")) {
+      this.submitToolResult(callId, { ok: false, error: "camera is off" });
+      this.emitTalkEvent({
+        type: "tool.error",
+        callId,
+        itemId,
+        final: true,
+        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, message: "camera is off" },
+      });
+      return;
+    }
     try {
       const frame = await captureRealtimeTalkVideoFrame(
         this.captureVideo,
@@ -564,6 +613,21 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       },
     });
     this.requestResponseCreate();
+  }
+
+  private releaseCamera(): void {
+    this.cameraSetupController?.abort();
+    this.cameraSetupController = null;
+    this.cameraMedia?.getVideoTracks().forEach((track) => {
+      track.removeEventListener("ended", this.handleCameraTrackEnded);
+      track.stop();
+    });
+    this.cameraMedia = null;
+    if (this.captureVideo) {
+      this.captureVideo.srcObject = null;
+      this.captureVideo = null;
+    }
+    this.ctx.callbacks.onVideoStream?.(null);
   }
 
   private reportToolResultSubmissionError(error: unknown): void {

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -8,6 +8,8 @@ const {
   relayStop,
   webRtcStart,
   webRtcStop,
+  googleSetVideoEnabled,
+  webRtcSetVideoEnabled,
   googleCtor,
   relayCtor,
   webRtcCtor,
@@ -18,14 +20,16 @@ const {
   relayStop: vi.fn(),
   webRtcStart: vi.fn(async () => undefined),
   webRtcStop: vi.fn(),
+  googleSetVideoEnabled: vi.fn(async () => undefined),
+  webRtcSetVideoEnabled: vi.fn(async () => undefined),
   googleCtor: vi.fn(function () {
-    return { start: googleStart, stop: googleStop };
+    return { start: googleStart, stop: googleStop, setVideoEnabled: googleSetVideoEnabled };
   }),
   relayCtor: vi.fn(function () {
     return { start: relayStart, stop: relayStop };
   }),
   webRtcCtor: vi.fn(function () {
-    return { start: webRtcStart, stop: webRtcStop };
+    return { start: webRtcStart, stop: webRtcStop, setVideoEnabled: webRtcSetVideoEnabled };
   }),
 }));
 
@@ -51,6 +55,8 @@ describe("RealtimeTalkSession", () => {
     relayStop.mockClear();
     webRtcStart.mockClear();
     webRtcStop.mockClear();
+    googleSetVideoEnabled.mockClear();
+    webRtcSetVideoEnabled.mockClear();
     googleCtor.mockClear();
     relayCtor.mockClear();
     webRtcCtor.mockClear();
@@ -199,6 +205,62 @@ describe("RealtimeTalkSession", () => {
     expect(relayStart).toHaveBeenCalledTimes(1);
   });
 
+  it("strips browser capabilities and hides camera when falling back to Gateway relay", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.catalog") {
+        return {
+          realtime: {
+            activeProvider: "openai",
+            providers: [{ id: "openai", label: "OpenAI", supportsVideoFrames: true }],
+          },
+        };
+      }
+      if (method === "talk.client.create") {
+        throw new Error("browser session unavailable");
+      }
+      if (method === "talk.session.create") {
+        return {
+          provider: "openai",
+          transport: "gateway-relay",
+          relaySessionId: "relay-1",
+          audio: {
+            inputEncoding: "pcm16",
+            inputSampleRateHz: 24000,
+            outputEncoding: "pcm16",
+            outputSampleRateHz: 24000,
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const onVideoCapability = vi.fn();
+    const session = new RealtimeTalkSession(
+      { request } as never,
+      "main",
+      { onVideoCapability },
+      { provider: "openai", transport: "gateway-relay" },
+    );
+
+    await session.start();
+
+    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", {
+      sessionKey: "main",
+      provider: "openai",
+      transport: "gateway-relay",
+      capabilities: ["camera-frame"],
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "talk.session.create", {
+      sessionKey: "main",
+      provider: "openai",
+      transport: "gateway-relay",
+      mode: "realtime",
+      brain: "agent-consult",
+    });
+    expect(onVideoCapability).toHaveBeenCalledOnce();
+    expect(onVideoCapability).toHaveBeenCalledWith(false);
+    expect(relayCtor).toHaveBeenCalledTimes(1);
+  });
+
   it("starts the WebRTC transport for canonical WebRTC sessions", async () => {
     const request = vi.fn(async () => ({
       provider: "openai",
@@ -257,6 +319,71 @@ describe("RealtimeTalkSession", () => {
       expect.any(Object),
       expect.objectContaining({ inputDeviceId: "usb-mic" }),
     );
+  });
+
+  it("requests camera-frame for the active video-capable provider without enabling camera", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.catalog") {
+        return {
+          realtime: {
+            activeProvider: "openai",
+            providers: [{ id: "openai", label: "OpenAI", supportsVideoFrames: true }],
+          },
+        };
+      }
+      return {
+        provider: "openai",
+        transport: "webrtc",
+        clientSecret: "secret",
+      };
+    });
+    const onVideoCapability = vi.fn();
+    const session = new RealtimeTalkSession({ request } as never, "main", {
+      onVideoCapability,
+    });
+
+    await session.start();
+
+    expect(request).toHaveBeenNthCalledWith(1, "talk.catalog", {});
+    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", {
+      sessionKey: "main",
+      capabilities: ["camera-frame"],
+    });
+    expect(onVideoCapability).toHaveBeenCalledWith(true);
+    expect(webRtcCtor).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.not.objectContaining({ videoEnabled: expect.anything() }),
+    );
+
+    await session.setVideoEnabled(true);
+    expect(webRtcSetVideoEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("does not request camera-frame for a provider without video-frame support", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.catalog") {
+        return {
+          realtime: {
+            activeProvider: "openai",
+            providers: [{ id: "openai", label: "OpenAI", supportsVideoFrames: false }],
+          },
+        };
+      }
+      return {
+        provider: "openai",
+        transport: "webrtc",
+        clientSecret: "secret",
+      };
+    });
+    const onVideoCapability = vi.fn();
+    const session = new RealtimeTalkSession({ request } as never, "main", {
+      onVideoCapability,
+    });
+
+    await session.start();
+
+    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", { sessionKey: "main" });
+    expect(onVideoCapability).toHaveBeenCalledWith(false);
   });
 
   it("does not fall back to Gateway relay when config selects a client transport", async () => {

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -1,4 +1,5 @@
 // Control UI chat module implements realtime talk behavior.
+import type { TalkCatalogResult } from "@openclaw/gateway-protocol";
 import { normalizeTalkTransport } from "../../../../src/talk/talk-session-controller.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
@@ -26,12 +27,10 @@ type RealtimeTalkLaunchOptions = {
   silenceDurationMs?: number;
   prefixPaddingMs?: number;
   reasoningEffort?: string;
-  capabilities?: Array<"camera-frame">;
 };
 
 type RealtimeTalkLocalOptions = {
   inputDeviceId?: string;
-  videoEnabled?: boolean;
 };
 
 type RealtimeTalkLaunchTransport = NonNullable<RealtimeTalkLaunchOptions["transport"]>;
@@ -114,7 +113,13 @@ export class RealtimeTalkSession {
   async start(): Promise<void> {
     this.closed = false;
     this.callbacks.onStatus?.("connecting");
-    const session = await this.createSession();
+    const providerVideoCapable = await this.resolveVideoCapability();
+    if (this.closed) {
+      return;
+    }
+    const session = await this.createSession(
+      providerVideoCapable ? { ...this.options, capabilities: ["camera-frame"] } : this.options,
+    );
     if (this.closed) {
       return;
     }
@@ -123,24 +128,49 @@ export class RealtimeTalkSession {
       sessionKey: this.sessionKey,
       callbacks: this.callbacks,
       inputDeviceId: this.localOptions.inputDeviceId,
-      videoEnabled: this.localOptions.videoEnabled,
       consultThinkingLevel: session.consultThinkingLevel,
       consultFastMode: session.consultFastMode,
     });
+    this.callbacks.onVideoCapability?.(
+      providerVideoCapable && typeof this.transport.setVideoEnabled === "function",
+    );
     await this.transport.start();
   }
 
-  private async createSession(): Promise<RealtimeTalkSessionResult> {
+  private async resolveVideoCapability(): Promise<boolean> {
+    if (!this.callbacks.onVideoCapability) {
+      return false;
+    }
+    try {
+      const catalog = await this.client.request<TalkCatalogResult>("talk.catalog", {});
+      const selectedProvider = this.options.provider ?? catalog.realtime.activeProvider;
+      if (!selectedProvider) {
+        return false;
+      }
+      return (
+        catalog.realtime.providers.find(
+          (provider) =>
+            provider.id === selectedProvider || provider.aliases?.includes(selectedProvider),
+        )?.supportsVideoFrames === true
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private async createSession(
+    options: RealtimeTalkLaunchOptions & { capabilities?: Array<"camera-frame"> },
+  ): Promise<RealtimeTalkSessionResult> {
     try {
       return await this.client.request<RealtimeTalkSessionResult>(
         "talk.client.create",
         compactLaunchParams({
           sessionKey: this.sessionKey,
-          ...this.options,
+          ...options,
         }),
       );
     } catch (error) {
-      let transport = this.options.transport;
+      let transport = options.transport;
       if (!transport) {
         let result: RealtimeTalkConfigResult;
         try {
@@ -162,12 +192,14 @@ export class RealtimeTalkSession {
       if (transport && transport !== "gateway-relay") {
         throw error;
       }
+      const gatewayOptions = { ...options };
+      delete gatewayOptions.capabilities;
       try {
         return await this.client.request<RealtimeTalkSessionResult>(
           "talk.session.create",
           compactLaunchParams({
             sessionKey: this.sessionKey,
-            ...this.options,
+            ...gatewayOptions,
             mode: "realtime",
             transport: transport ?? "gateway-relay",
             brain: "agent-consult",
@@ -184,5 +216,12 @@ export class RealtimeTalkSession {
     this.callbacks.onStatus?.("idle");
     this.transport?.stop();
     this.transport = null;
+  }
+
+  async setVideoEnabled(enabled: boolean): Promise<void> {
+    if (this.closed || !this.transport?.setVideoEnabled) {
+      throw new Error("Camera is unavailable for this realtime session");
+    }
+    await this.transport.setVideoEnabled(enabled);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The empty composer showed two round talk buttons: a mic (start voice talk) and a camera (start video talk). The camera glyph collided with the plus-menu's "Take photo" attachment action, and the voice/video mode decision was forced up front — before the call — where it is not reversible without hanging up.

## Why This Change Was Made

Video never rides the WebRTC peer connection in this architecture; camera frames travel only as on-demand `describe_view` snapshots over the data channel. That makes an in-call camera upgrade nearly free, so the mode decision can move into the call where it is reversible:

- One round mic button starts voice talk. The start-video button and its `onToggleRealtimeVideo` plumbing are deleted.
- When the active realtime provider reports `supportsVideoFrames` (via the existing `talk.catalog`), the session requests `capabilities: ["camera-frame"]` up front so `describe_view` is registered — but the camera hardware is NOT acquired at start.
- The in-call HUD gains a camera toggle (shown only for video-capable sessions on transports implementing the new `setVideoEnabled`). Toggling on lazily runs `getUserMedia({video})`, wires the hidden capture element, and shows the local self-preview; toggling off stops video tracks only. Voice is never interrupted.
- `describe_view` with the camera off returns `{ ok: false, error: "camera is off" }` so the model can ask the user to enable it instead of erroring.
- `getUserMedia` denial or camera loss mid-call (unplug, permission revoked — track `ended` listeners) reverts the toggle non-fatally; terminal session errors block and release late-arriving camera streams.
- Gateway-relay fallback: `capabilities` is stripped before `talk.session.create` (its closed schema has no such key — sending it broke relay fallback), and camera capability is reported only after transport construction confirms `setVideoEnabled` support.
- Google Live transport gets the same lazy toggle semantics while keeping its existing bounded continuous-frame upload once enabled.

No gateway/protocol/schema changes; no new config surface.

## User Impact

One talk button instead of two; video becomes an in-call upgrade with a self-preview, matching how the feature actually works (snapshots on model request, no continuous upload). The camera/"Take photo" icon ambiguity in the composer is gone.

## Evidence

- Focused suites green: `realtime-talk-webrtc{,-video}`, `realtime-talk-google-live{,-video}`, `realtime-talk-input`, `realtime-talk`, `chat-realtime`, `chat-composer`, `chat-view`, `chat-composer-redesign.e2e` (100+ tests, `node scripts/run-vitest.mjs`).
- New coverage: lazy start without camera, toggle acquire/release, camera-off `describe_view`, `getUserMedia` rejection, track-`ended` reacquisition, relay-fallback capability stripping, capability-false on relay transport.
- `pnpm ui:i18n:baseline` clean; non-English locales untouched.
- Autoreview (Codex, gpt-5.6-sol): initial P2 (stale camera state on track end) fixed; final run clean.
