### PR TITLE
fix(telegram): keep commands responsive during Codex login

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -32,6 +32,7 @@ import {
   createTelegramMessageProcessor,
   resolveTelegramMessageTurnSettings,
 } from "./bot-message.js";
+import { defaultTelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import {
   ensureTelegramMessageProcessingResult,
@@ -389,7 +390,10 @@ export function createTelegramBotCore(
     resolveTelegramGroupConfig,
     shouldSkipUpdate,
     opts,
-    telegramDeps,
+    telegramDeps: {
+      ...telegramDeps,
+      sendMessageTelegram: defaultTelegramNativeCommandDeps.sendMessageTelegram,
+    },
   });
 
   registerTelegramHandlers({

--- a/extensions/telegram/src/bot-native-command-deps.runtime.ts
+++ b/extensions/telegram/src/bot-native-command-deps.runtime.ts
@@ -23,6 +23,7 @@ export type TelegramNativeCommandDeps = Pick<
   dispatchChannelInboundTurn?: typeof dispatchChannelInboundTurn;
   getPluginCommandSpecs?: typeof getPluginCommandSpecs;
   runModelsAuthLoginFlow?: (opts: ModelsAuthLoginFlowOptions) => Promise<ModelsAuthLoginFlowResult>;
+  sendMessageTelegram: typeof import("./send.js").sendMessageTelegram;
 };
 
 export const defaultTelegramNativeCommandDeps: TelegramNativeCommandDeps & {
@@ -54,5 +55,9 @@ export const defaultTelegramNativeCommandDeps: TelegramNativeCommandDeps & {
   async editMessageTelegram(...args) {
     const { editMessageTelegram } = await loadTelegramSendModule();
     return await editMessageTelegram(...args);
+  },
+  async sendMessageTelegram(...args) {
+    const { sendMessageTelegram } = await loadTelegramSendModule();
+    return await sendMessageTelegram(...args);
   },
 };

--- a/extensions/telegram/src/bot-native-commands.login.test.ts
+++ b/extensions/telegram/src/bot-native-commands.login.test.ts
@@ -1,7 +1,12 @@
 // Tests Telegram native Codex login command behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ModelsAuthLoginFlowOptions } from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createTelegramGroupCommandContext } from "./bot-native-commands.fixture-test-support.js";
+import {
+  createDeferred,
+  createTelegramGroupCommandContext,
+} from "./bot-native-commands.fixture-test-support.js";
 import {
   createCommandBot,
   createNativeCommandTestParams,
@@ -20,17 +25,33 @@ function registerLoginCommand(params: {
   cfg: OpenClawConfig;
   loginFlow: LoginFlowMock;
   allowFrom?: string[];
+  abortSignal?: AbortSignal;
+  runtime?: RuntimeEnv;
 }) {
   const botHarness = createCommandBot();
   const nativeParams = createNativeCommandTestParams(params.cfg, {
     bot: botHarness.bot,
     allowFrom: params.allowFrom ?? ["200"],
+    ...(params.abortSignal
+      ? {
+          opts: {
+            token: "token",
+            accountAbortSignal: params.abortSignal,
+          },
+        }
+      : {}),
+    ...(params.runtime ? { runtime: params.runtime } : {}),
+  });
+  const sendMessageTelegram = vi.fn(async (_to, text) => {
+    const result = await botHarness.bot.api.sendMessage(100, text, {});
+    return { messageId: String(result.message_id), chatId: "100" };
   });
   registerTelegramNativeCommands({
     ...nativeParams,
     telegramDeps: {
       ...nativeParams.telegramDeps,
       runModelsAuthLoginFlow: params.loginFlow,
+      sendMessageTelegram,
     } as never,
   });
   const handler = botHarness.commandHandlers.get("login");
@@ -40,15 +61,8 @@ function registerLoginCommand(params: {
   return {
     ...botHarness,
     handler,
+    sendMessageTelegram,
   };
-}
-
-function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
 }
 
 describe("registerTelegramNativeCommands /login", () => {
@@ -63,39 +77,25 @@ describe("registerTelegramNativeCommands /login", () => {
   });
 
   it("handles /login codex by sending the device code before login completes", async () => {
-    const loginFlow = vi.fn(
-      async (params: {
-        provider?: string;
-        method?: string;
-        agent?: string;
-        prompter: {
-          deviceCode?: (params: {
-            title: string;
-            code: string;
-            expiresInMinutes?: number;
-            message?: string;
-          }) => Promise<void>;
-        };
-      }) => {
-        expect(params.provider).toBe("openai");
-        expect(params.method).toBe("device-code");
-        expect(params.agent).toBe("main");
-        await params.prompter.deviceCode?.({
-          title: "OpenAI Codex device code",
-          code: "ABCD-EFGH",
-          expiresInMinutes: 15,
-          message: [
-            "Open this URL in your LOCAL browser and enter the code below.",
-            "URL: https://auth.openai.com/codex/device",
-          ].join("\n"),
-        });
-        return {
-          providerId: "openai",
-          methodId: "device-code",
-          profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
-        };
-      },
-    );
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      expect(params.provider).toBe("openai");
+      expect(params.method).toBe("device-code");
+      expect(params.agent).toBe("main");
+      await params.prompter.deviceCode?.({
+        title: "OpenAI Codex device code",
+        code: "ABCD-EFGH",
+        expiresInMinutes: 15,
+        message: [
+          "Open this URL in your LOCAL browser and enter the code below.",
+          "URL: https://auth.openai.com/codex/device",
+        ].join("\n"),
+      });
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      };
+    });
     const { handler, sendMessage, setMyCommands } = registerLoginCommand({
       cfg: {
         commands: {
@@ -114,6 +114,11 @@ describe("registerTelegramNativeCommands /login", () => {
     });
 
     await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+    await vi.waitFor(() =>
+      expect(sendMessage.mock.calls.map((call) => String(call[1]))).toContain(
+        "Codex login complete. Try your request again now.",
+      ),
+    );
 
     const texts = sendMessage.mock.calls.map((call) => String(call[1]));
     expect(texts[0]).toContain("URL: https://auth.openai.com/codex/device");
@@ -123,19 +128,82 @@ describe("registerTelegramNativeCommands /login", () => {
     expect(texts.at(-1)).toContain("Codex login complete. Try your request again now.");
   });
 
-  it("rejects group /login codex without sending the device code publicly", async () => {
-    const loginFlow = vi.fn(
-      async (params: {
-        prompter: { note: (message: string, title?: string) => Promise<void> };
-      }) => {
-        await params.prompter.note("URL: https://auth.openai.com/codex/device\nCode: SECRET");
-        return {
-          providerId: "openai",
-          methodId: "device-code",
-          profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
-        };
+  it("releases the chat lane only after structured device-code delivery", async () => {
+    const allowDeviceCode = createDeferred<void>();
+    const finishLogin = createDeferred<void>();
+    let loginCompleted = false;
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      await params.prompter.note("Preparing Codex login…");
+      await allowDeviceCode.promise;
+      if (!params.prompter.deviceCode) {
+        throw new Error("expected structured device-code delivery");
+      }
+      await params.prompter.deviceCode({
+        title: "OpenAI Codex device code",
+        code: "PENDING-CODE",
+        expiresInMinutes: 15,
+        message: "URL: https://auth.openai.com/codex/device",
+      });
+      await finishLogin.promise;
+      loginCompleted = true;
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      };
+    });
+    const { handler, sendMessage } = registerLoginCommand({
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig,
+      loginFlow,
+    });
+
+    let handlerReturned = false;
+    const handlerTask = handler(createPrivateCommandContext({ match: "codex", userId: 200 })).then(
+      () => {
+        handlerReturned = true;
       },
     );
+    await vi.waitFor(() =>
+      expect(sendMessage.mock.calls.map((call) => String(call[1]))).toContain(
+        "Preparing Codex login…",
+      ),
+    );
+    expect(handlerReturned).toBe(false);
+
+    allowDeviceCode.resolve();
+    await handlerTask;
+
+    expect(loginCompleted).toBe(false);
+    expect(sendMessage).toHaveBeenCalledWith(
+      100,
+      expect.stringContaining("Code: <code>PENDING-CODE</code>"),
+      expect.objectContaining({ parse_mode: "HTML" }),
+    );
+    expect(sendMessage.mock.calls.map((call) => String(call[1]))).not.toContain(
+      "Codex login complete. Try your request again now.",
+    );
+
+    finishLogin.resolve();
+    await vi.waitFor(() => expect(loginCompleted).toBe(true));
+    await vi.waitFor(() =>
+      expect(sendMessage.mock.calls.map((call) => String(call[1]))).toContain(
+        "Codex login complete. Try your request again now.",
+      ),
+    );
+  });
+
+  it("rejects group /login codex without sending the device code publicly", async () => {
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      await params.prompter.note("URL: https://auth.openai.com/codex/device\nCode: SECRET");
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      };
+    });
     const { handler, sendMessage } = registerLoginCommand({
       cfg: {
         commands: {
@@ -186,27 +254,20 @@ describe("registerTelegramNativeCommands /login", () => {
 
   it("dedupes active /login flows for the same Telegram thread", async () => {
     const deferred = createDeferred<void>();
-    const loginFlow = vi.fn(
-      async (params: {
-        prompter: { note: (message: string, title?: string) => Promise<void> };
-      }) => {
-        await params.prompter.note(
-          [
-            "Open this URL in your LOCAL browser and enter the code below.",
-            "URL: https://auth.openai.com/codex/device",
-            "Code: FIRST-CODE",
-            "Code expires in 15 minutes. Never share it.",
-          ].join("\n"),
-          "OpenAI Codex device code",
-        );
-        await deferred.promise;
-        return {
-          providerId: "openai",
-          methodId: "device-code",
-          profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
-        };
-      },
-    );
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      await params.prompter.deviceCode?.({
+        title: "OpenAI Codex device code",
+        code: "FIRST-CODE",
+        expiresInMinutes: 15,
+        message: "URL: https://auth.openai.com/codex/device",
+      });
+      await deferred.promise;
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      };
+    });
     const { handler, sendMessage } = registerLoginCommand({
       cfg: {
         commands: {
@@ -218,15 +279,161 @@ describe("registerTelegramNativeCommands /login", () => {
       loginFlow,
     });
 
-    const first = handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
-    await vi.waitFor(() => expect(loginFlow).toHaveBeenCalledTimes(1));
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
     await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
     deferred.resolve();
-    await first;
+    await vi.waitFor(() =>
+      expect(sendMessage.mock.calls.map((call) => String(call[1]))).toContain(
+        "Codex login complete. Try your request again now.",
+      ),
+    );
 
     expect(loginFlow).toHaveBeenCalledTimes(1);
     expect(sendMessage.mock.calls.map((call) => String(call[1]))).toContain(
       "A Codex login code is already active for this Telegram chat. Complete it, or wait for it to expire before requesting a new one.",
     );
+  });
+
+  it("releases a failed flow before any device code is delivered", async () => {
+    const loginFlow = vi.fn(async () => {
+      throw new Error("device-code request failed");
+    });
+    const { handler, sendMessage } = registerLoginCommand({
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig,
+      loginFlow,
+    });
+
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+
+    expect(loginFlow).toHaveBeenCalledTimes(2);
+    expect(
+      sendMessage.mock.calls.filter(
+        (call) =>
+          call[1] === "Codex login did not complete. Send `/login codex` to request a new code.",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("does not report auth failure when only the terminal notification fails", async () => {
+    const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      await params.prompter.deviceCode?.({ title: "Codex login", code: "SUCCESS-CODE" });
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      };
+    });
+    const { handler, sendMessage } = registerLoginCommand({
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig,
+      loginFlow,
+      runtime,
+    });
+    sendMessage.mockResolvedValueOnce({ message_id: 999 });
+    sendMessage.mockRejectedValueOnce(new Error("Telegram unavailable"));
+
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+    await vi.waitFor(() =>
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("result notification failed"),
+      ),
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls.map((call) => String(call[1]))).not.toContain(
+      "Codex login did not complete. Send `/login codex` to request a new code.",
+    );
+  });
+
+  it("blocks provider prompts and terminal messages after Telegram stops", async () => {
+    const shutdown = new AbortController();
+    let loginSettled = false;
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      await params.prompter.deviceCode?.({ title: "Codex login", code: "ABORT-CODE" });
+      if (!params.signal) {
+        throw new Error("expected login owner signal");
+      }
+      const signal = params.signal;
+      try {
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                signal.reason instanceof Error ? signal.reason : new Error("Telegram stopped"),
+              ),
+            { once: true },
+          );
+        });
+        throw new Error("unreachable");
+      } catch {
+        await params.prompter.note("Trouble with device code login?", "OAuth help");
+      } finally {
+        loginSettled = true;
+      }
+    });
+    const { handler, sendMessage } = registerLoginCommand({
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig,
+      loginFlow,
+      abortSignal: shutdown.signal,
+    });
+
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+    shutdown.abort(new Error("Telegram stopped"));
+    await vi.waitFor(() => expect(loginSettled).toBe(true));
+
+    expect(sendMessage.mock.calls.map((call) => String(call[1]))).toHaveLength(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toContain("ABORT-CODE");
+  });
+
+  it("keeps pending login alive across a polling-cycle restart", async () => {
+    const account = new AbortController();
+    const pollingCycle = new AbortController();
+    const finishLogin = createDeferred<void>();
+    let loginSignal: AbortSignal | undefined;
+    const loginFlow = vi.fn(async (params: ModelsAuthLoginFlowOptions) => {
+      loginSignal = params.signal;
+      await params.prompter.deviceCode?.({ title: "Codex login", code: "RESTART-CODE" });
+      await finishLogin.promise;
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:codex", provider: "openai", mode: "oauth" }],
+      };
+    });
+    const { handler, sendMessage, sendMessageTelegram } = registerLoginCommand({
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig,
+      loginFlow,
+      abortSignal: account.signal,
+    });
+
+    await handler(createPrivateCommandContext({ match: "codex", userId: 200 }));
+    pollingCycle.abort(new Error("recoverable polling restart"));
+    sendMessage.mockRejectedValue(new Error("retired polling bot"));
+    sendMessageTelegram.mockResolvedValueOnce({ messageId: "1000", chatId: "100" });
+
+    expect(loginSignal?.aborted).toBe(false);
+    finishLogin.resolve();
+    await vi.waitFor(() =>
+      expect(sendMessageTelegram).toHaveBeenCalledWith(
+        "telegram:100",
+        "Codex login complete. Try your request again now.",
+        expect.objectContaining({ accountId: "default", token: "token" }),
+      ),
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -117,6 +117,7 @@ export function createNativeCommandTestParams(
       return bot.api.setMyCommands(commandsToRegister);
     }) as TelegramNativeCommandDeps["syncTelegramMenuCommands"],
     editMessageTelegram,
+    sendMessageTelegram: vi.fn(async () => ({ messageId: "999", chatId: "100" })),
   };
   return createBaseNativeCommandTestParams({
     cfg,

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -4,6 +4,7 @@ import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import {
@@ -389,6 +390,10 @@ function registerAndResolveCommandHandlerBase(params: {
     getPluginCommandSpecs: vi.fn(() => pluginCommandSpecs ?? []),
     listSkillCommandsForAgents: vi.fn(() => []),
     syncTelegramMenuCommands: vi.fn(),
+    sendMessageTelegram: vi.fn(async (_to, text) => {
+      await sendMessage(100, text, {});
+      return { messageId: "999", chatId: "100" };
+    }),
     ...(runModelsAuthLoginFlow ? { runModelsAuthLoginFlow } : {}),
   };
   registerTelegramNativeCommands({
@@ -1838,6 +1843,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
   });
 
   it("moves the target session to the profile returned by Telegram /login codex", async () => {
+    const finishLogin = createDeferred<void>();
     sessionMocks.loadSessionStore.mockReturnValue({
       "agent:main:main": {
         authProfileOverride: "openai:owner@example.com",
@@ -1846,10 +1852,13 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       },
     });
     const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async (opts) => {
-      await opts.prompter.note?.(
-        "URL: https://auth.openai.com/codex/device\nCode: ABCD-EFGH",
-        "OpenAI Codex device code",
-      );
+      await opts.prompter.deviceCode?.({
+        title: "OpenAI Codex device code",
+        code: "ABCD-EFGH",
+        expiresInMinutes: 15,
+        message: "URL: https://auth.openai.com/codex/device",
+      });
+      await finishLogin.promise;
       return {
         providerId: "openai",
         methodId: "device-code",
@@ -1869,6 +1878,8 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     });
 
     await handler(createTelegramPrivateCommandContext({ match: "codex", userId: 200 }));
+    expect(sessionMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    finishLogin.resolve();
 
     expect(runModelsAuthLoginFlow).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1880,13 +1891,15 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(
       (runModelsAuthLoginFlow.mock.calls[0]?.[0] as { profileId?: string } | undefined)?.profileId,
     ).toBeUndefined();
-    expect(sessionMocks.updateSessionStoreEntry).toHaveBeenCalledWith({
-      sessionKey: "agent:main:main",
-      storePath: "/tmp/openclaw-sessions.json",
-      requireWriteSuccess: true,
-      skipMaintenance: true,
-      update: expect.any(Function),
-    });
+    await vi.waitFor(() =>
+      expect(sessionMocks.updateSessionStoreEntry).toHaveBeenCalledWith({
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
+        requireWriteSuccess: true,
+        skipMaintenance: true,
+        update: expect.any(Function),
+      }),
+    );
     const patchUpdate = (
       sessionMocks.updateSessionStoreEntry.mock.calls[0]?.[0] as {
         update?: (entry: Record<string, unknown>) => Record<string, unknown>;
@@ -1901,6 +1914,118 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       authProfileOverrideSource: "user",
       authProfileOverrideCompactionCount: undefined,
     });
+  });
+
+  it("moves a session created while Telegram login is pending to the returned profile", async () => {
+    const finishLogin = createDeferred<void>();
+    let sessionStore: Record<string, SessionEntry> = {};
+    sessionMocks.loadSessionStore.mockImplementation(() => sessionStore);
+    const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async (opts) => {
+      await opts.prompter.deviceCode?.({
+        title: "OpenAI Codex device code",
+        code: "NEW-SESSION",
+      });
+      await finishLogin.promise;
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [
+          { profileId: "openai:new-owner@example.com", provider: "openai", mode: "oauth" },
+        ],
+      };
+    });
+    const { handler, sendMessage } = registerAndResolveCommandHandler({
+      commandName: "login",
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+      } as OpenClawConfig,
+      allowFrom: ["200"],
+      runModelsAuthLoginFlow,
+    });
+
+    await handler(createTelegramPrivateCommandContext({ match: "codex", userId: 200 }));
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "sess-created-during-login",
+        updatedAt: 2,
+      },
+    };
+    finishLogin.resolve();
+
+    await vi.waitFor(() => expect(sessionMocks.updateSessionStoreEntry).toHaveBeenCalledTimes(1));
+    const update = (
+      sessionMocks.updateSessionStoreEntry.mock.calls[0]?.[0] as {
+        update?: (entry: SessionEntry) => Partial<SessionEntry> | null;
+      }
+    )?.update;
+    expect(
+      update?.({
+        sessionId: "sess-created-during-login",
+        updatedAt: 2,
+      }),
+    ).toEqual({
+      authProfileOverride: "openai:new-owner@example.com",
+      authProfileOverrideSource: "user",
+      authProfileOverrideCompactionCount: undefined,
+    });
+    await vi.waitFor(() =>
+      expect(sendMessage).toHaveBeenCalledWith(
+        100,
+        "Codex login complete. Try your request again now.",
+        {},
+      ),
+    );
+  });
+
+  it("preserves a later user-selected profile on a session created during Telegram login", async () => {
+    const finishLogin = createDeferred<void>();
+    let sessionStore: Record<string, SessionEntry> = {};
+    sessionMocks.loadSessionStore.mockImplementation(() => sessionStore);
+    const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async (opts) => {
+      await opts.prompter.deviceCode?.({
+        title: "OpenAI Codex device code",
+        code: "LATER-USER-SELECTION",
+      });
+      await finishLogin.promise;
+      return {
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [{ profileId: "openai:login-profile", provider: "openai", mode: "oauth" }],
+      };
+    });
+    const { handler, sendMessage } = registerAndResolveCommandHandler({
+      commandName: "login",
+      cfg: {
+        commands: { native: true, ownerAllowFrom: ["200"] },
+      } as OpenClawConfig,
+      allowFrom: ["200"],
+      runModelsAuthLoginFlow,
+    });
+
+    await handler(createTelegramPrivateCommandContext({ match: "codex", userId: 200 }));
+    sessionStore = {
+      "agent:main:main": {
+        authProfileOverride: "openai:later-user-profile",
+        authProfileOverrideSource: "user",
+        sessionId: "sess-created-during-login",
+        updatedAt: 2,
+      },
+    };
+    finishLogin.resolve();
+
+    await vi.waitFor(() =>
+      expect(sendMessage).toHaveBeenCalledWith(
+        100,
+        "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
+        {},
+      ),
+    );
+    expect(sessionStore["agent:main:main"]?.authProfileOverride).toBe("openai:later-user-profile");
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      100,
+      "Codex login complete. Try your request again now.",
+      expect.any(Object),
+    );
   });
 
   it("marks a same-profile Telegram login as user-selected", async () => {

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -180,6 +180,10 @@ export function createNativeCommandsHarness(params?: {
     getPluginCommandSpecs: pluginCommandMocks.getPluginCommandSpecs,
     listSkillCommandsForAgents: vi.fn(() => []),
     syncTelegramMenuCommands: vi.fn(),
+    sendMessageTelegram: vi.fn(async (_to, text) => {
+      await sendMessage(100, text, {});
+      return { messageId: "999", chatId: "100" };
+    }),
   };
   const bot = {
     api: {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -34,6 +34,7 @@ import type {
   TelegramGroupConfig,
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { codexChannelLoginRuntime } from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
@@ -119,7 +120,7 @@ import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js"
 export { parseTelegramNativeCommandCallbackData } from "./native-command-callback-data.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
-const activeTelegramCodexLoginFlows = new Map<string, { expiresAt: number }>();
+const activeTelegramCodexLoginFlows = codexChannelLoginRuntime.createFlowRegistry();
 
 type TelegramNativeCommandContext = Context & { match?: string };
 
@@ -675,7 +676,10 @@ type RegisterTelegramNativeCommandsParams = {
   ) => TelegramResolvedGroupConfig;
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   telegramDeps?: TelegramNativeCommandDeps;
-  opts: Pick<TelegramBotOptions, "token" | "allowFrom" | "groupAllowFrom" | "replyToMode">;
+  opts: Pick<
+    TelegramBotOptions,
+    "token" | "allowFrom" | "groupAllowFrom" | "replyToMode" | "accountAbortSignal"
+  >;
 };
 
 async function resolveTelegramCommandAuth(params: {
@@ -1302,6 +1306,17 @@ export const registerTelegramNativeCommands = ({
                 }),
             });
           };
+          const sendLoginResultMessage = async (text: string) => {
+            await telegramDeps.sendMessageTelegram(
+              buildTelegramRoutingTarget(chatId, threadSpec),
+              text,
+              {
+                cfg: runtimeCfg,
+                token: opts.token,
+                accountId: route.accountId,
+              },
+            );
+          };
           if (
             !senderIsOwner ||
             !codexChannelLoginRuntime.hasConfiguredCommandOwnerAllowlist(runtimeCfg)
@@ -1341,124 +1356,158 @@ export const registerTelegramNativeCommands = ({
             );
             return;
           }
-          try {
+          const flowSignal = opts.accountAbortSignal
+            ? AbortSignal.any([reservation.record.signal, opts.accountAbortSignal])
+            : reservation.record.signal;
+          const deviceCodeDelivered = createDeferred<void>();
+          // Device-code delivery releases Telegram's serialized chat lane. The
+          // reservation and account signal still own polling through completion.
+          const completion = (async () => {
+            const sessionSwitchFailedMessage =
+              "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.";
+            let terminalMessage: string;
             const loginFlow =
               telegramDeps.runModelsAuthLoginFlow ??
               defaultTelegramNativeCommandDeps.runModelsAuthLoginFlow;
-            if (!loginFlow) {
-              throw new Error("Codex login flow is unavailable.");
-            }
-            const nativeCommandRuntime = await loadTelegramNativeCommandRuntime();
-            const targetSessionKey = resolveCommandTargetSessionKey({
-              runtimeCfg,
-              route,
-              chatId,
-              isGroup,
-              senderId,
-              threadSpec,
-              botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
-              resolveThreadSessionKeys: nativeCommandRuntime.resolveThreadSessionKeys,
-            });
-            const targetSessionEntry = nativeCommandRuntime.getSessionEntry({
-              agentId: route.agentId,
-              sessionKey: targetSessionKey,
-            });
-            const loginResult = await codexChannelLoginRuntime.runDeviceLoginFlow({
-              runLoginFlow: loginFlow,
-              provider: loginProvider,
-              agentId: route.agentId,
-              config: runtimeCfg,
-              runtime,
-              sendMessage: sendLoginMessage,
-              sendDeviceCode: sendLoginDeviceCode,
-              unsupportedPromptMessage:
-                "Telegram /login supports only fixed Codex device-code auth.",
-            });
-            const nextProfileId = loginResult.profiles.find(
-              (profile) => profile.provider === loginProvider,
-            )?.profileId;
-            if (!nextProfileId) {
-              await sendLoginMessage(
-                "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
-              );
-              return;
-            }
-            const needsSessionUpdate =
-              targetSessionEntry &&
-              (targetSessionEntry.authProfileOverride !== nextProfileId ||
-                targetSessionEntry.authProfileOverrideSource !== "user" ||
-                targetSessionEntry.authProfileOverrideCompactionCount !== undefined);
-            if (targetSessionEntry) {
-              try {
+            try {
+              if (!loginFlow) {
+                throw new Error("Codex login flow is unavailable.");
+              }
+              const nativeCommandRuntime = await loadTelegramNativeCommandRuntime();
+              const targetSessionKey = resolveCommandTargetSessionKey({
+                runtimeCfg,
+                route,
+                chatId,
+                isGroup,
+                senderId,
+                threadSpec,
+                botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
+                resolveThreadSessionKeys: nativeCommandRuntime.resolveThreadSessionKeys,
+              });
+              const targetSessionEntryAtStart = nativeCommandRuntime.getSessionEntry({
+                agentId: route.agentId,
+                sessionKey: targetSessionKey,
+              });
+              const loginResult = await codexChannelLoginRuntime.runDeviceLoginFlow({
+                runLoginFlow: loginFlow,
+                provider: loginProvider,
+                agentId: route.agentId,
+                config: runtimeCfg,
+                runtime,
+                signal: flowSignal,
+                sendMessage: sendLoginMessage,
+                sendDeviceCode: async (deviceCode) => {
+                  flowSignal.throwIfAborted();
+                  await sendLoginDeviceCode(deviceCode);
+                  flowSignal.throwIfAborted();
+                  deviceCodeDelivered.resolve();
+                },
+                unsupportedPromptMessage:
+                  "Telegram /login supports only fixed Codex device-code auth.",
+              });
+              flowSignal.throwIfAborted();
+              const nextProfileId = loginResult.profiles.find(
+                (profile) => profile.provider === loginProvider,
+              )?.profileId;
+              terminalMessage = "Codex login complete. Try your request again now.";
+              if (!nextProfileId) {
+                terminalMessage = sessionSwitchFailedMessage;
+              } else {
                 const storePath = resolveStorePath(runtimeCfg.session?.store, {
                   agentId: route.agentId,
                 });
-                let snapshotMatched = false;
-                const persisted = await updateSessionStoreEntry({
-                  sessionKey: targetSessionKey,
-                  storePath,
-                  requireWriteSuccess: true,
-                  skipMaintenance: true,
-                  update: (entry) => {
-                    if (
-                      entry.sessionId !== targetSessionEntry.sessionId ||
-                      entry.authProfileOverride !== targetSessionEntry.authProfileOverride ||
-                      entry.authProfileOverrideSource !==
-                        targetSessionEntry.authProfileOverrideSource ||
-                      entry.authProfileOverrideCompactionCount !==
-                        targetSessionEntry.authProfileOverrideCompactionCount
-                    ) {
-                      return null;
-                    }
-                    snapshotMatched = true;
-                    return needsSessionUpdate
-                      ? {
-                          authProfileOverride: nextProfileId,
-                          authProfileOverrideSource: "user",
-                          authProfileOverrideCompactionCount: undefined,
-                        }
-                      : null;
-                  },
-                });
-                if (
-                  !snapshotMatched ||
-                  !persisted ||
-                  persisted.authProfileOverride !== nextProfileId ||
-                  persisted.authProfileOverrideSource !== "user" ||
-                  persisted.authProfileOverrideCompactionCount !== undefined
-                ) {
-                  await sendLoginMessage(
-                    "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
+                let entryObserved = false;
+                let adoptionAllowed = false;
+                try {
+                  const persisted = await updateSessionStoreEntry({
+                    sessionKey: targetSessionKey,
+                    storePath,
+                    requireWriteSuccess: true,
+                    skipMaintenance: true,
+                    update: (entry) => {
+                      entryObserved = true;
+                      const source =
+                        entry.authProfileOverrideSource ??
+                        (typeof entry.authProfileOverrideCompactionCount === "number"
+                          ? "auto"
+                          : entry.authProfileOverride
+                            ? "user"
+                            : undefined);
+                      if (
+                        flowSignal.aborted ||
+                        (targetSessionEntryAtStart
+                          ? entry.sessionId !== targetSessionEntryAtStart.sessionId ||
+                            entry.authProfileOverride !==
+                              targetSessionEntryAtStart.authProfileOverride ||
+                            entry.authProfileOverrideSource !==
+                              targetSessionEntryAtStart.authProfileOverrideSource ||
+                            entry.authProfileOverrideCompactionCount !==
+                              targetSessionEntryAtStart.authProfileOverrideCompactionCount
+                          : source === "user" && entry.authProfileOverride !== nextProfileId)
+                      ) {
+                        return null;
+                      }
+                      adoptionAllowed = true;
+                      return entry.authProfileOverride !== nextProfileId ||
+                        entry.authProfileOverrideSource !== "user" ||
+                        entry.authProfileOverrideCompactionCount !== undefined
+                        ? {
+                            authProfileOverride: nextProfileId,
+                            authProfileOverrideSource: "user",
+                            authProfileOverrideCompactionCount: undefined,
+                          }
+                        : null;
+                    },
+                  });
+                  flowSignal.throwIfAborted();
+                  if (
+                    entryObserved &&
+                    (!adoptionAllowed ||
+                      !persisted ||
+                      persisted.authProfileOverride !== nextProfileId ||
+                      persisted.authProfileOverrideSource !== "user" ||
+                      persisted.authProfileOverrideCompactionCount !== undefined)
+                  ) {
+                    terminalMessage = sessionSwitchFailedMessage;
+                  }
+                } catch (error) {
+                  flowSignal.throwIfAborted();
+                  runtime.error?.(
+                    danger(
+                      `telegram /login codex completed but failed to update session auth profile: ${String(
+                        error,
+                      )}`,
+                    ),
                   );
-                  return;
+                  terminalMessage = sessionSwitchFailedMessage;
                 }
-              } catch (error) {
-                runtime.error?.(
-                  danger(
-                    `telegram /login codex completed but failed to update session auth profile: ${String(
-                      error,
-                    )}`,
-                  ),
-                );
-                await sendLoginMessage(
-                  "Codex login completed, but this Telegram session could not switch to the newly authenticated profile. Retry `/login codex`, or select the profile manually.",
-                );
+              }
+            } catch (error) {
+              if (flowSignal.aborted) {
                 return;
               }
+              runtime.error?.(danger(`telegram /login codex failed: ${String(error)}`));
+              terminalMessage =
+                "Codex login did not complete. Send `/login codex` to request a new code.";
             }
-            await sendLoginMessage("Codex login complete. Try your request again now.");
-          } catch {
-            runtime.error?.(danger("telegram /login codex failed"));
-            await sendLoginMessage(
-              "Codex login did not complete. Send `/login codex` to request a new code.",
-            );
-          } finally {
+            if (flowSignal.aborted) {
+              return;
+            }
+            try {
+              await sendLoginResultMessage(terminalMessage);
+            } catch (error) {
+              runtime.error?.(
+                danger(`telegram /login codex result notification failed: ${String(error)}`),
+              );
+            }
+          })().finally(() => {
             codexChannelLoginRuntime.releaseFlow({
               flows: activeTelegramCodexLoginFlows,
               flowKey,
               record: reservation.record,
             });
-          }
+          });
+          await Promise.race([deviceCodeDelivered.promise, completion]);
           return;
         }
 

--- a/extensions/telegram/src/bot.types.ts
+++ b/extensions/telegram/src/bot.types.ts
@@ -20,6 +20,8 @@ export type TelegramBotOptions = {
   botInfo?: TelegramBotInfo;
   /** Signal to abort in-flight Telegram API fetch requests (e.g. getUpdates) on shutdown. */
   fetchAbortSignal?: AbortSignal;
+  /** Account-lifecycle signal; polling-cycle recovery must not abort account-owned work. */
+  accountAbortSignal?: AbortSignal;
   /** Signal to abort inbound media resolution without cancelling adopted-turn Bot API calls. */
   mediaAbortSignal?: AbortSignal;
   /** Minimum grammY client timeout when timeoutSeconds is configured on long-polling bots. */

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -883,7 +883,7 @@ describe("TelegramPollingSession", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
-  it("uses backoff helpers for recoverable polling retries", async () => {
+  it("keeps account work alive across recoverable classic polling retries", async () => {
     const abort = new AbortController();
     const recoverableError = new Error("recoverable polling error");
     const setStatus = vi.fn();
@@ -913,6 +913,20 @@ describe("TelegramPollingSession", () => {
       }
       return {
         task: async () => {
+          const firstBotOptions = mockObjectArg(
+            createTelegramBotMock,
+            "first createTelegramBot",
+            0,
+          );
+          const secondBotOptions = mockObjectArg(
+            createTelegramBotMock,
+            "second createTelegramBot",
+            1,
+          );
+          expect((firstBotOptions.fetchAbortSignal as AbortSignal).aborted).toBe(true);
+          expect(firstBotOptions.accountAbortSignal).toBe(abort.signal);
+          expect(secondBotOptions.accountAbortSignal).toBe(abort.signal);
+          expect(abort.signal.aborted).toBe(false);
           abort.abort();
         },
         stop: runnerStop,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -314,6 +314,7 @@ export class TelegramPollingSession {
         accountId: this.opts.accountId,
         botInfo: this.opts.botInfo,
         ...(botApiAbortSignal ? { fetchAbortSignal: botApiAbortSignal } : {}),
+        ...(this.opts.abortSignal ? { accountAbortSignal: this.opts.abortSignal } : {}),
         mediaAbortSignal: cycleAbortSignal,
         minimumClientTimeoutSeconds: TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS,
         ...(updateOffset ? { updateOffset } : {}),

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -623,7 +623,7 @@ describe("startTelegramWebhook", () => {
     );
   });
 
-  it("aborts bot media fetches when the webhook stops", async () => {
+  it("aborts bot fetches and account-owned work when the webhook stops", async () => {
     const callerAbort = new AbortController();
     const started = await startTelegramWebhook({
       token: TELEGRAM_TOKEN,
@@ -640,17 +640,28 @@ describe("startTelegramWebhook", () => {
         "createTelegramBot params",
       );
       const fetchAbortSignal = botParams.fetchAbortSignal;
+      const accountAbortSignal = botParams.accountAbortSignal;
       expect(fetchAbortSignal).toBeInstanceOf(AbortSignal);
-      if (!(fetchAbortSignal instanceof AbortSignal)) {
-        throw new Error("expected bot fetch abort signal");
+      expect(accountAbortSignal).toBeInstanceOf(AbortSignal);
+      if (
+        !(fetchAbortSignal instanceof AbortSignal) ||
+        !(accountAbortSignal instanceof AbortSignal)
+      ) {
+        throw new Error("expected bot fetch and account abort signals");
       }
-      const aborted = new Promise<void>((resolve) => {
+      const fetchAborted = new Promise<void>((resolve) => {
         fetchAbortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      const accountAborted = new Promise<void>((resolve) => {
+        accountAbortSignal.addEventListener("abort", () => resolve(), { once: true });
       });
 
       await started.stop();
 
-      await expect(aborted).resolves.toBeUndefined();
+      await expect(Promise.all([fetchAborted, accountAborted])).resolves.toEqual([
+        undefined,
+        undefined,
+      ]);
       expect(callerAbort.signal.aborted).toBe(false);
     } finally {
       await started.stop();

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -347,6 +347,9 @@ export async function startTelegramWebhook(opts: {
     return closeTransportPromise;
   };
   const botAbortController = new AbortController();
+  const accountAbortSignal = opts.abortSignal
+    ? AbortSignal.any([opts.abortSignal, shutdownAbortController.signal])
+    : shutdownAbortController.signal;
   const botFetchAbortSignal = opts.abortSignal
     ? AbortSignal.any([opts.abortSignal, botAbortController.signal])
     : botAbortController.signal;
@@ -355,6 +358,7 @@ export async function startTelegramWebhook(opts: {
     runtime,
     proxyFetch: opts.fetch,
     fetchAbortSignal: botFetchAbortSignal,
+    accountAbortSignal,
     config: opts.config,
     accountId: opts.accountId,
     telegramTransport,

--- a/src/auto-reply/reply/commands-login.test.ts
+++ b/src/auto-reply/reply/commands-login.test.ts
@@ -529,6 +529,57 @@ describe("handleLoginCommand", () => {
     await first;
   });
 
+  it("cancels an expired flow before replacing its reservation", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    let firstSignal: AbortSignal | undefined;
+    runModelsAuthLoginFlowMock
+      .mockImplementationOnce(async (opts: ModelsAuthLoginFlowOptions) => {
+        firstSignal = opts.signal;
+        if (!firstSignal) {
+          throw new Error("expected reservation signal");
+        }
+        const signal = firstSignal;
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                signal.reason instanceof Error ? signal.reason : new Error("Codex login cancelled"),
+              ),
+            { once: true },
+          );
+        });
+        throw new Error("unreachable");
+      })
+      .mockResolvedValueOnce({
+        providerId: "openai",
+        methodId: "device-code",
+        profiles: [],
+      });
+
+    const first = handleLoginCommand(
+      buildLoginParams("/login codex", { opts: blockReplyOpts() }),
+      true,
+    );
+    await vi.waitFor(() => expect(firstSignal).toBeDefined());
+    now.mockReturnValue(15 * 60_000 + 1_001);
+
+    const second = await handleLoginCommand(
+      buildLoginParams("/login codex", { opts: blockReplyOpts() }),
+      true,
+    );
+
+    expect(firstSignal?.aborted).toBe(true);
+    await expect(first).resolves.toEqual({
+      shouldContinue: false,
+      reply: {
+        text: "Codex login did not complete. Send `/login codex` to request a new code.",
+      },
+    });
+    expect(second?.reply?.text).toContain("could not switch");
+    now.mockRestore();
+  });
+
   it("rejects non-owner senders before starting login", async () => {
     const result = await handleLoginCommand(
       buildLoginParams("/login codex", {

--- a/src/auto-reply/reply/commands-login.ts
+++ b/src/auto-reply/reply/commands-login.ts
@@ -18,7 +18,7 @@ const PRIVATE_CHAT_TYPES = new Set(["direct", "dm", "im", "private"]);
 const PUBLIC_CHAT_TYPES = new Set(["channel", "forum", "group", "public", "supergroup", "topic"]);
 const WEB_LOGIN_SURFACES = new Set(["control", "control-ui", "dashboard", "internal", "web"]);
 
-const activeCodexLoginFlows = new Map<string, { expiresAt: number }>();
+const activeCodexLoginFlows = codexChannelLoginRuntime.createFlowRegistry();
 
 type RunLoginFlow = (opts: ModelsAuthLoginFlowOptions) => Promise<unknown>;
 
@@ -262,6 +262,7 @@ async function runChannelCodexLogin(params: {
       agentId: params.agentId,
       config: params.commandParams.cfg,
       runtime: params.runtime ?? defaultRuntime,
+      signal: reservation.record.signal,
       sendMessage: async (text) => await emitLoginMessage(params.commandParams, text),
       unsupportedPromptMessage: "Channel /login supports only fixed Codex device-code auth.",
       runLoginFlow: params.runLoginFlow,

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 
 type AuthRunCall = {
   agentDir?: string;
+  signal?: AbortSignal;
   workspaceDir?: string;
 };
 
@@ -272,6 +273,7 @@ const {
   modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  runModelsAuthLoginFlow,
 } = await import("./auth.js");
 
 function createRuntime(): RuntimeEnv {
@@ -856,6 +858,60 @@ describe("modelsAuthLoginCommand", () => {
     expect(
       (readMockCallArg(mocks.upsertAuthProfileWithLock) as UpsertAuthProfileCall).agentDir,
     ).toBe("/tmp/openclaw/agents/coder");
+  });
+
+  it("forwards an app-owned cancellation signal to provider auth", async () => {
+    const runtime = createRuntime();
+    const abortController = new AbortController();
+
+    await runModelsAuthLoginFlow({
+      provider: "openai",
+      method: "oauth",
+      config: currentConfig,
+      runtime,
+      prompter: mocks.createClackPrompter(),
+      signal: abortController.signal,
+    });
+
+    expect((readMockCallArg(runProviderAuth) as AuthRunCall).signal).toBe(abortController.signal);
+  });
+
+  it("does not persist credentials returned after app-owned cancellation", async () => {
+    const runtime = createRuntime();
+    const abortController = new AbortController();
+    const cancellation = new Error("Login was replaced");
+    runProviderAuth.mockImplementationOnce(() => {
+      abortController.abort(cancellation);
+      return {
+        profiles: [
+          {
+            profileId: "openai:late@example.com",
+            credential: {
+              type: "oauth",
+              provider: "openai",
+              access: "late-access-token",
+              refresh: "late-refresh-token",
+              expires: Date.now() + 60_000,
+            },
+          },
+        ],
+      };
+    });
+
+    await expect(
+      runModelsAuthLoginFlow({
+        provider: "openai",
+        method: "oauth",
+        config: currentConfig,
+        runtime,
+        prompter: mocks.createClackPrompter(),
+        signal: abortController.signal,
+      }),
+    ).rejects.toBe(cancellation);
+
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.promoteAuthProfileInOrder).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
   it("loads the owning plugin for an explicit provider even in a clean config", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -543,8 +543,10 @@ async function runProviderAuthMethod(params: {
   setDefault?: boolean;
   env?: NodeJS.ProcessEnv;
   isRemote?: boolean;
+  signal?: AbortSignal;
   openUrl?: (url: string) => Promise<void>;
 }): Promise<{ result: ProviderAuthResult; profiles: ProviderAuthResult["profiles"] }> {
+  params.signal?.throwIfAborted();
   const selectedProviderId = normalizeProviderId(params.provider.id);
   await clearStaleProfileLockouts(selectedProviderId, params.agentDir);
 
@@ -557,6 +559,7 @@ async function runProviderAuthMethod(params: {
     runtime: params.runtime,
     allowSecretRefPrompt: false,
     isRemote: params.isRemote ?? isRemoteEnvironment(),
+    signal: params.signal,
     openUrl:
       params.openUrl ??
       (async (url) => {
@@ -567,6 +570,7 @@ async function runProviderAuthMethod(params: {
       createVpsAwareHandlers: (runtimeParams) => createVpsAwareOAuthHandlers(runtimeParams),
     },
   });
+  params.signal?.throwIfAborted();
   const resultProviderIds = new Set(
     result.profiles.map((profile) => normalizeProviderId(profile.credential.provider)),
   );
@@ -922,6 +926,7 @@ export type ModelsAuthLoginFlowOptions = LoginOptions & {
   prompter: WizardPrompter;
   env?: NodeJS.ProcessEnv;
   isRemote?: boolean;
+  signal?: AbortSignal;
   openUrl?: (url: string) => Promise<void>;
 };
 
@@ -1084,6 +1089,7 @@ export async function runModelsAuthLoginFlow(
     setDefault: opts.setDefault,
     env: opts.env,
     isRemote: opts.isRemote,
+    signal: opts.signal,
     openUrl: opts.openUrl,
   });
   maybeLogOpenAICodexNativeSearchTip(opts.runtime, selectedProvider.id);

--- a/src/plugin-sdk/provider-auth-login-flow-runtime.ts
+++ b/src/plugin-sdk/provider-auth-login-flow-runtime.ts
@@ -26,11 +26,17 @@ const CODEX_LOGIN_PROVIDER_ALIASES = new Set(["codex", "openai"]);
 
 type CodexLoginFlowRecord = {
   expiresAt: number;
+  signal: AbortSignal;
+  cancel: () => void;
 };
 
 type CodexLoginFlowReservation =
   | { status: "active" }
   | { status: "reserved"; record: CodexLoginFlowRecord };
+
+function createCodexLoginFlowRegistry(): Map<string, CodexLoginFlowRecord> {
+  return new Map();
+}
 
 const loadProviderAuthLoginFlowRuntime = createLazyRuntimeModule(
   () => import("../commands/models/auth.js"),
@@ -80,9 +86,15 @@ function reserveCodexLoginFlow(params: {
     return { status: "active" };
   }
   if (activeFlow) {
+    activeFlow.cancel();
     params.flows.delete(params.flowKey);
   }
-  const record = { expiresAt: now + CODEX_LOGIN_FLOW_TTL_MS };
+  const abortController = new AbortController();
+  const record = {
+    expiresAt: now + CODEX_LOGIN_FLOW_TTL_MS,
+    signal: abortController.signal,
+    cancel: () => abortController.abort(new Error("Codex login was replaced by a newer flow.")),
+  };
   params.flows.set(params.flowKey, record);
   return { status: "reserved", record };
 }
@@ -100,14 +112,18 @@ function releaseCodexLoginFlow(params: {
 function buildCodexDeviceLoginPrompter(params: {
   sendMessage: (message: string) => Promise<void>;
   sendDeviceCode?: NonNullable<ModelsAuthLoginFlowOptions["prompter"]["deviceCode"]>;
+  signal?: AbortSignal;
   unsupportedPromptMessage: string;
 }): ModelsAuthLoginFlowOptions["prompter"] {
   const sendCleanMessage = async (message: string) => {
+    params.signal?.throwIfAborted();
     const text = message.trim();
     if (text) {
       await params.sendMessage(text);
+      params.signal?.throwIfAborted();
     }
   };
+  const sendDeviceCode = params.sendDeviceCode;
   const unsupportedPrompt = async () => {
     throw new Error(params.unsupportedPromptMessage);
   };
@@ -117,7 +133,15 @@ function buildCodexDeviceLoginPrompter(params: {
     note: async (message, title) => {
       await sendCleanMessage([title?.trim(), message.trim()].filter(Boolean).join("\n\n"));
     },
-    ...(params.sendDeviceCode ? { deviceCode: params.sendDeviceCode } : {}),
+    ...(sendDeviceCode
+      ? {
+          deviceCode: async (deviceCode) => {
+            params.signal?.throwIfAborted();
+            await sendDeviceCode(deviceCode);
+            params.signal?.throwIfAborted();
+          },
+        }
+      : {}),
     plain: sendCleanMessage,
     select: unsupportedPrompt as ModelsAuthLoginFlowOptions["prompter"]["select"],
     multiselect: unsupportedPrompt as ModelsAuthLoginFlowOptions["prompter"]["multiselect"],
@@ -183,6 +207,7 @@ async function runCodexDeviceLoginFlow(params: {
   runtime: RuntimeEnv;
   sendMessage: (message: string) => Promise<void>;
   sendDeviceCode?: NonNullable<ModelsAuthLoginFlowOptions["prompter"]["deviceCode"]>;
+  signal?: AbortSignal;
   unsupportedPromptMessage: string;
   runLoginFlow?: RunModelsAuthLoginFlow;
 }): Promise<ModelsAuthLoginFlowResult> {
@@ -193,9 +218,11 @@ async function runCodexDeviceLoginFlow(params: {
     ...(params.profileId ? { profileId: params.profileId } : {}),
     config: params.config,
     runtime: params.runtime,
+    signal: params.signal,
     prompter: buildCodexDeviceLoginPrompter({
       sendMessage: params.sendMessage,
       sendDeviceCode: params.sendDeviceCode,
+      signal: params.signal,
       unsupportedPromptMessage: params.unsupportedPromptMessage,
     }),
     isRemote: true,
@@ -205,6 +232,7 @@ async function runCodexDeviceLoginFlow(params: {
 }
 
 export const codexChannelLoginRuntime = {
+  createFlowRegistry: createCodexLoginFlowRegistry,
   resolveProvider: resolveCodexLoginProvider,
   hasConfiguredCommandOwnerAllowlist,
   resolveProviderScopedProfileId,


### PR DESCRIPTION
## What Problem This Solves

Telegram's native `/login codex` handler awaited the entire Codex device-auth poll after displaying the code. The same-chat lane could therefore stay blocked for up to 15 minutes even though the user already had everything needed to continue.

## Fix

- Release the Telegram lane only after the structured, tap-to-copy device-code message is delivered.
- Keep authentication completion in an account-lifecycle-owned background task, separate from recoverable polling-cycle cancellation.
- Deliver the terminal result through the stable Telegram sender so polling recovery cannot retire its bot instance.
- At completion, atomically adopt the returned profile when the session still matches the starting state or was created meanwhile without an explicit user selection. Preserve later user choices.
- Cancel in-flight auth when Telegram stops or an expired reservation is replaced. Suppress late sends and session writes after cancellation.
- Forward the provider `AbortSignal` through the shared login runtime. Guard every provider prompt send and credential-persistence boundary against cancellation.

This keeps one canonical provider flow. Telegram changes only transport scheduling and lifecycle ownership.

## Product Fit

The default Telegram path remains responsive and gives an immediate, structured next action. Completion reaches the current session without overwriting later user intent. No config/default, schema, migration, prompt, or plugin surface changes.

## Evidence

Exact head: `fdf4596eaae04cb932abf1ee6ae1bb43c9164e45`, rebased onto `832459d2ae76a08f17dfdb95dad78a5db4599762`.

### Tests and repository gates

- Focused suites: 300 tests passed across command, shared auth, auto-reply, polling, and webhook coverage.
- Exact interleavings: 6 tests passed for classic polling recovery, restart-safe terminal delivery, shutdown cancellation, missing-session adoption, and later-selection preservation.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` passed the full changed-scope guard, type, lint, SDK-surface, boundary, auth, schema, and extension lanes locally. Local fallback was required because the installed Crabbox binary failed its own `--version`/`--help` sanity check before remote execution.
- `git diff --check` passed.

### Real Telegram userbot proof

Driven with `$telegram-e2e-userbot` as a real Telegram user against a fresh gateway from this exact head, the real Telegram Bot API, the real OpenAI device-code endpoint, and a mock model provider:

1. `/login codex` produced exactly one structured device-code message after 951 ms. TDLib recorded a code entity. The model provider received zero requests.
2. In a separate run, a normal DM sent while authorization remained pending produced SUT typing and `OPENCLAW_E2E_OK` after 2,140 ms. The provider received exactly one `POST /v1/responses` request.

The normal turn crossed the serialized same-chat lane while auth remained pending. Raw artifacts are retained privately because they contain a live one-time code and Telegram identifiers.

```json
{
  "headSha": "fdf4596eaae04cb932abf1ee6ae1bb43c9164e45",
  "structuredDeviceCode": {
    "recordingComplete": true,
    "sutMessages": 1,
    "firstMessageMs": 951,
    "contentClass": "structured_device_code",
    "hasCodeEntity": true,
    "modelRequests": 0
  },
  "sameChatResponsiveness": {
    "authPending": true,
    "normalDmReplyMs": 2140,
    "replyClass": "OPENCLAW_E2E_OK",
    "modelRequests": 1,
    "modelEndpoint": "POST /v1/responses"
  },
  "focusedInterleavings": {
    "classicPollingRestartKeepsAccountSignal": true,
    "terminalDeliverySurvivesRetiredPollingBot": true,
    "accountShutdownBlocksLateProviderPromptsAndResults": true,
    "cancelledProviderResultCannotPersistCredentials": true,
    "missingSessionCreatedThenAdopted": true,
    "laterUserSelectionPreserved": true
  }
}
```

### Dependency contract

Direct source inspection at OpenAI Codex `4642370542739d5dd080b0c87a9de06a6435d3db`:

- [`device_code_auth.rs`](https://github.com/openai/codex/blob/4642370542739d5dd080b0c87a9de06a6435d3db/codex-rs/login/src/device_code_auth.rs#L99-L196): device code becomes available before polling completes; cancellation is signal-driven.
- [`account_processor.rs`](https://github.com/openai/codex/blob/4642370542739d5dd080b0c87a9de06a6435d3db/codex-rs/app-server/src/request_processors/account_processor.rs#L596-L669): app-server returns the code immediately and owns completion/cancellation in the background.

### Review passes

- ClawSweeper's P1 moves are applied: account-vs-polling-cycle lifetime, restart-safe terminal delivery, completion-time session adoption, cancellation-gated prompt egress, and cancellation-gated credential persistence.
- `$distill`: one structured readiness boundary, one flow registry, one completion-time session CAS; no duplicate auth implementation.
- `$greybeard`: rare-login allocations only; no hot-path polling, cache, discovery, or repeated metadata reads.
- `$autoreview`: secret scan and review bundle completed. The model pass could not run because no `codex`, `claude`, or `pi` executable is installed on this host; no clean autoreview verdict is claimed.

## Change Metrics

- Production: +208/-108, net +100 lines.
- Tests/support: +563/-94, net +469 lines.
- Production growth owns structured readiness/cancellation, account-vs-cycle lifecycle, restart-safe terminal delivery, completion-time session CAS, and the provider cancellation contract.
- Config/default surfaces: 0 added, changed, or removed.

AI-assisted implementation and review. Contributor authorship retained on the repaired commit.
