### PR TITLE
feat(gateway): pre-handshake origin gate for browser WebSocket clients

### DIFF
--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -58,6 +58,7 @@ import {
 } from "./server/preauth-connection-budget.js";
 import type { ReadinessChecker } from "./server/readiness.js";
 import type { GatewayTlsRuntime } from "./server/tls.js";
+import { createGatewayVerifyClient } from "./server/verify-client.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { canReceiveSessionEvent } from "./session-sharing.js";
 
@@ -295,6 +296,10 @@ export async function createGatewayRuntimeState(params: {
   const wss = new WebSocketServer({
     noServer: true,
     maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
+    verifyClient: createGatewayVerifyClient({
+      log: params.log,
+      getConfigSnapshot: loadRuntimeConfig,
+    }),
   });
   const preauthConnectionBudget = createPreauthConnectionBudget();
   const workerPreauthConnectionBudget = createPreauthConnectionBudget();

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -5,13 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 import { WebSocket } from "ws";
-import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../infra/device-identity.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
 import { CONTROL_UI_CLIENT, TEST_OPERATOR_CLIENT } from "./server.auth.test-helpers.js";
 import {
@@ -53,6 +51,36 @@ const openWs = async (port: number, headers?: Record<string, string>) => {
   });
   return ws;
 };
+
+// The pre-handshake origin gate rejects a disallowed browser Origin at the HTTP
+// upgrade (403, no 101). Assert that rejection instead of a post-handshake
+// connect error: no socket ever opens.
+async function expectUpgradeRejected(port: number, headers: Record<string, string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers });
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      ws.terminate();
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const timer = setTimeout(() => finish(new Error("expected websocket upgrade to reject")), 5000);
+    ws.once("open", () => finish(new Error("expected websocket upgrade to be rejected")));
+    ws.once("unexpected-response", (_req, res) => {
+      expect(res.statusCode).toBe(403);
+      finish();
+    });
+    ws.once("error", (err) => finish(err instanceof Error ? err : new Error("websocket error")));
+  });
+}
 
 async function createSignedDevice(params: {
   token: string;
@@ -121,14 +149,6 @@ async function withTrustedProxyBrowserWs(origin: string, run: (ws: WebSocket) =>
       ws.close();
     }
   });
-}
-
-function expectOriginNotAllowed(res: GatewayConnectResponse) {
-  expect(res.ok).toBe(false);
-  expect(res.error?.message ?? "").toContain("origin not allowed");
-  expect((res.error?.details as { code?: string } | undefined)?.code).toBe(
-    ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED,
-  );
 }
 
 function expectRetryLater(res: GatewayConnectResponse, retryLater: boolean) {
@@ -206,38 +226,21 @@ async function withSignedBrowserConnect(
   }
 }
 
-async function expectBrowserOriginConnectRejected(params: {
-  client?: {
-    id: string;
-    version: string;
-    platform: string;
-    mode: string;
-  };
-}) {
+async function expectBrowserOriginUpgradeRejected() {
   testState.gatewayAuth = { mode: "token", token: "secret" };
   await withGatewayServer(async ({ port }) => {
-    const ws = await openWs(port, { origin: "https://attacker.example" });
-    try {
-      const res = await connectReq(ws, {
-        token: "secret",
-        client: params.client ?? TEST_OPERATOR_CLIENT,
-        ...(params.client ? { device: null } : {}),
-      });
-      expectOriginNotAllowed(res);
-    } finally {
-      ws.close();
-    }
+    await expectUpgradeRejected(port, { origin: "https://attacker.example" });
   });
 }
 
 describe("gateway auth browser hardening", () => {
   test("rejects trusted-proxy browser connects from origins outside the allowlist", async () => {
-    await withTrustedProxyBrowserWs("https://evil.example", async (ws) => {
-      const res = await connectReq(ws, {
-        client: TEST_OPERATOR_CLIENT,
-        device: null,
+    await writeTrustedProxyBrowserAuthConfig();
+    await withGatewayServer(async ({ port }) => {
+      await expectUpgradeRejected(port, {
+        origin: "https://evil.example",
+        ...TRUSTED_PROXY_BROWSER_HEADERS,
       });
-      expectOriginNotAllowed(res);
     });
   });
 
@@ -289,6 +292,10 @@ describe("gateway auth browser hardening", () => {
     });
 
     await withGatewayServer(async ({ port }) => {
+      if (!ok) {
+        await expectUpgradeRejected(port, { origin });
+        return;
+      }
       const ws = await openWs(port, { origin });
       try {
         const res = await connectReq(ws, {
@@ -296,12 +303,8 @@ describe("gateway auth browser hardening", () => {
           client: TEST_OPERATOR_CLIENT,
           device: null,
         });
-        expect(res.ok).toBe(ok);
-        if (ok) {
-          expect((res.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
-        } else {
-          expectOriginNotAllowed(res);
-        }
+        expect(res.ok).toBe(true);
+        expect((res.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
       } finally {
         ws.close();
       }
@@ -330,19 +333,8 @@ describe("gateway auth browser hardening", () => {
     });
   });
 
-  test("rejects non-local browser origins for non-control-ui clients", async () => {
-    await expectBrowserOriginConnectRejected({});
-  });
-
-  test("rejects browser-origin connects that claim to be tui clients", async () => {
-    await expectBrowserOriginConnectRejected({
-      client: {
-        id: GATEWAY_CLIENT_NAMES.TUI,
-        version: "1.0.0",
-        platform: "macos",
-        mode: GATEWAY_CLIENT_MODES.UI,
-      },
-    });
+  test("rejects a disallowed browser origin at the upgrade before any client identity is read", async () => {
+    await expectBrowserOriginUpgradeRejected();
   });
 
   test("rate-limits browser-origin auth failures on loopback even when loopback exemption is enabled", async () => {
@@ -491,25 +483,10 @@ describe("gateway auth browser hardening", () => {
     });
     testState.gatewayAuth = { mode: "token", token: "secret" };
     await withGatewayServer(async ({ port }) => {
-      const ws = await openWs(port, {
+      await expectUpgradeRejected(port, {
         origin: "http://localhost:5173",
         "x-forwarded-for": "203.0.113.50",
       });
-      try {
-        const res = await connectReq(ws, {
-          token: "secret",
-          client: {
-            ...TEST_OPERATOR_CLIENT,
-            id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-            mode: GATEWAY_CLIENT_MODES.UI,
-          },
-          device: null,
-        });
-        expect(res.ok).toBe(false);
-        expect(res.error?.message ?? "").toContain("origin not allowed");
-      } finally {
-        ws.close();
-      }
     });
   });
 });

--- a/src/gateway/server/verify-client.test.ts
+++ b/src/gateway/server/verify-client.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Pre-handshake WebSocket origin gate tests.
+ */
+import http from "node:http";
+import { describe, expect, it } from "vitest";
+import { setRuntimeConfigSnapshot } from "../../config/io.js";
+import type { OpenClawConfig } from "../../config/types.js";
+import { testState } from "../test-helpers.runtime-state.js";
+import {
+  connectOk,
+  createGatewaySuiteHarness,
+  installGatewayTestHooks,
+} from "../test-helpers.server.js";
+import { createGatewayVerifyClient } from "./verify-client.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const ALLOWED_BROWSER_ORIGIN = "https://app.example.com";
+
+function makeReq(opts: { origin?: string; host?: string; remoteAddress?: string } = {}) {
+  return {
+    socket: { remoteAddress: opts.remoteAddress ?? "127.0.0.1" },
+    headers: {
+      ...(opts.origin ? { origin: opts.origin } : {}),
+      ...(opts.host ? { host: opts.host } : {}),
+    },
+  } as unknown as import("node:http").IncomingMessage;
+}
+
+function makeClient(cfg: Partial<OpenClawConfig> = {}) {
+  return createGatewayVerifyClient({
+    log: { info: () => {}, warn: () => {} },
+    getConfigSnapshot: () => cfg as OpenClawConfig,
+  });
+}
+
+function verify(
+  vc: ReturnType<typeof createGatewayVerifyClient>,
+  req: import("node:http").IncomingMessage,
+  origin: string,
+) {
+  return new Promise<boolean>((resolve) => {
+    vc({ origin, req }, (ok) => resolve(ok));
+  });
+}
+
+// Raw HTTP upgrade through the real WebSocketServer seam. A rejected
+// `verifyClient` writes an HTTP 403 (no 101) and never opens a socket, so
+// `upgraded` stays false and no post-handshake close can occur.
+async function requestUpgrade(
+  port: number,
+  origin?: string,
+): Promise<{ status: number; upgraded: boolean }> {
+  return await new Promise<{ status: number; upgraded: boolean }>((resolve, reject) => {
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      path: "/",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+        "Sec-WebSocket-Key": "dGVzdC1rZXktMDEyMzQ1Ng==",
+        "Sec-WebSocket-Version": "13",
+        ...(origin ? { origin } : {}),
+      },
+    });
+    let upgraded = false;
+    req.once("upgrade", (_res, socket) => {
+      upgraded = true;
+      socket.destroy();
+      resolve({ status: 101, upgraded });
+    });
+    req.once("response", (res) => {
+      res.resume();
+      resolve({ status: res.statusCode ?? 0, upgraded });
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+describe("createGatewayVerifyClient", () => {
+  it("passes clients with no Origin (CLI, native apps)", async () => {
+    const ok = await verify(makeClient(), makeReq({}), "");
+    expect(ok).toBe(true);
+  });
+
+  it("accepts an allowed browser Origin", async () => {
+    const vc = makeClient({
+      gateway: { controlUi: { allowedOrigins: ["https://app.example.com"] } },
+    });
+    const ok = await verify(
+      vc,
+      makeReq({ origin: "https://app.example.com", host: "127.0.0.1:18789" }),
+      "https://app.example.com",
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a disallowed browser Origin", async () => {
+    const vc = makeClient({
+      gateway: { controlUi: { allowedOrigins: ["https://app.example.com"] } },
+    });
+    const ok = await verify(
+      vc,
+      makeReq({ origin: "https://evil.example.com", host: "127.0.0.1:18789" }),
+      "https://evil.example.com",
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects a literal null opaque Origin", async () => {
+    const ok = await verify(
+      makeClient(),
+      makeReq({ origin: "null", host: "127.0.0.1:18789", remoteAddress: "127.0.0.1" }),
+      "null",
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("passes canonical Chrome extension (browser copilot) origins for post-handshake validation", async () => {
+    const copilotOrigin = "chrome-extension://abcdefghijklmnopabcdefghijklmnop";
+    const ok = await verify(
+      makeClient(),
+      makeReq({ origin: copilotOrigin, host: "127.0.0.1:18789" }),
+      copilotOrigin,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("treats loopback with forwarded headers as non-local (no local-loopback fallback)", async () => {
+    const vc = makeClient({});
+    const req = {
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: {
+        host: "127.0.0.1:18789",
+        "x-forwarded-for": "198.51.100.7",
+      },
+    } as unknown as import("node:http").IncomingMessage;
+    const ok = await verify(vc, req, "http://127.0.0.1:18789");
+    expect(ok).toBe(false);
+  });
+
+  it("still accepts an allowlisted Origin for a proxied loopback client", async () => {
+    const vc = makeClient({
+      gateway: { controlUi: { allowedOrigins: ["http://127.0.0.1:18789"] } },
+    });
+    const req = {
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: {
+        host: "127.0.0.1:18789",
+        "x-forwarded-for": "198.51.100.7",
+      },
+    } as unknown as import("node:http").IncomingMessage;
+    const ok = await verify(vc, req, "http://127.0.0.1:18789");
+    expect(ok).toBe(true);
+  });
+});
+
+describe("createGatewayVerifyClient upgrade seam", () => {
+  it("rejects a disallowed browser Origin before HTTP 101 (403, no socket opened, no post-handshake close)", async () => {
+    testState.gatewayControlUi = { allowedOrigins: [ALLOWED_BROWSER_ORIGIN] };
+    const harness = await createGatewaySuiteHarness();
+    try {
+      const res = await requestUpgrade(harness.port, "https://evil.example.com");
+      expect(res.status).toBe(403);
+      expect(res.upgraded).toBe(false);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("passes a no-Origin CLI client through the upgrade and authenticates post-handshake", async () => {
+    testState.gatewayControlUi = { allowedOrigins: [ALLOWED_BROWSER_ORIGIN] };
+    const harness = await createGatewaySuiteHarness();
+    try {
+      const ws = await harness.openWs();
+      try {
+        await connectOk(ws);
+      } finally {
+        ws.close();
+      }
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("re-evaluates the origin gate after a runtime config change (both admission stages read the runtime getter)", async () => {
+    testState.gatewayControlUi = { allowedOrigins: [] };
+    setRuntimeConfigSnapshot({
+      gateway: { controlUi: { allowedOrigins: [] } },
+    } as OpenClawConfig);
+    const harness = await createGatewaySuiteHarness();
+    try {
+      // Startup runtime config denies every browser origin.
+      expect(await requestUpgrade(harness.port, ALLOWED_BROWSER_ORIGIN)).toEqual({
+        status: 403,
+        upgraded: false,
+      });
+
+      // Simulate a live config write that allows the origin. Publishing a new
+      // runtime snapshot is the same mechanism the post-handshake admission
+      // path reads, so both gates now decide under the same policy.
+      setRuntimeConfigSnapshot({
+        gateway: { controlUi: { allowedOrigins: [ALLOWED_BROWSER_ORIGIN] } },
+      } as OpenClawConfig);
+
+      expect(await requestUpgrade(harness.port, ALLOWED_BROWSER_ORIGIN)).toEqual({
+        status: 101,
+        upgraded: true,
+      });
+
+      // Removing the allowlist entry re-tightens pre-handshake admission.
+      setRuntimeConfigSnapshot({
+        gateway: { controlUi: { allowedOrigins: [] } },
+      } as OpenClawConfig);
+
+      expect(await requestUpgrade(harness.port, ALLOWED_BROWSER_ORIGIN)).toEqual({
+        status: 403,
+        upgraded: false,
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/src/gateway/server/verify-client.ts
+++ b/src/gateway/server/verify-client.ts
@@ -1,0 +1,63 @@
+import type { IncomingMessage } from "node:http";
+import type { OpenClawConfig } from "../../config/types.js";
+import { isLocalDirectRequest } from "../net.js";
+import { checkBrowserOrigin, normalizeChromeExtensionOrigin } from "../origin-check.js";
+
+const HTTP_FORBIDDEN = 403;
+
+type GatewayVerifyClientParams = {
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
+  getConfigSnapshot: () => OpenClawConfig;
+};
+
+/**
+ * Pre-handshake WebSocket origin gate. Runs in `verifyClient` (before the HTTP
+ * 101) and reuses the existing `checkBrowserOrigin` from the post-handshake
+ * admission path, so both gates share one origin-policy contract.
+ * Locality uses the canonical `isLocalDirectRequest` helper with the same
+ * trusted-proxy inputs as the post-handshake admission path, so loopback
+ * requests carrying forwarded/proxy headers are not treated as direct-local
+ * clients. Non-browser clients send no Origin and pass through; they
+ * authenticate post-handshake. Canonical Chrome extension (browser copilot)
+ * origins also pass through; the post-handshake admission path skips its
+ * generic origin check for them (`hasCopilotExtensionOrigin`) and validates
+ * the exact origin against the paired device.
+ */
+export function createGatewayVerifyClient(params: GatewayVerifyClientParams) {
+  const { log, getConfigSnapshot } = params;
+
+  return (
+    info: { origin: string; req: IncomingMessage },
+    callback: (r: boolean, code?: number, msg?: string) => void,
+  ) => {
+    const { req } = info;
+    const snapshot = getConfigSnapshot();
+    const controlUi = snapshot.gateway?.controlUi;
+    const requestOrigin = info.origin?.slice(0, 256);
+
+    if (!requestOrigin || normalizeChromeExtensionOrigin(requestOrigin)) {
+      callback(true);
+      return;
+    }
+
+    const originCheck = checkBrowserOrigin({
+      requestHost: req.headers.host?.slice(0, 256),
+      origin: requestOrigin,
+      allowedOrigins: controlUi?.allowedOrigins,
+      allowHostHeaderOriginFallback: controlUi?.dangerouslyAllowHostHeaderOriginFallback === true,
+      isLocalClient: isLocalDirectRequest(
+        req,
+        snapshot.gateway?.trustedProxies,
+        snapshot.gateway?.allowRealIpFallback === true,
+      ),
+    });
+
+    if (!originCheck.ok) {
+      log.warn(`verifyClient: origin not allowed (${originCheck.reason})`);
+      callback(false, HTTP_FORBIDDEN, "origin not allowed");
+      return;
+    }
+
+    callback(true);
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

The gateway's WebSocket upgrade currently admits every connection and only checks the browser `Origin` after the HTTP 101 handshake completes. Any client that reaches the upgrade — including a cross-origin browser page or a scripted WebSocket — gets a live socket before origin policy is enforced. Moving the check to `verifyClient` (pre-handshake) means unauthorized origins never complete the upgrade.

## Why This Change Was Made

- **Close the pre-auth window.** A disallowed browser origin is rejected with `403` during `verifyClient`, not after the socket opens.
- **Reuse the existing origin contract.** The same `checkBrowserOrigin` function and same `gateway.controlUi.allowedOrigins` / `dangerouslyAllowHostHeaderOriginFallback` config are used. No new settings, no new policy.
- **Scope matches upstream post-handshake admission.** The gate applies to the same set of clients — browser/Control-UI/webchat clients that send an `Origin` header. Non-browser clients (no `Origin`) pass through and authenticate post-handshake as today.
- **Canonical request-locality (ClawSweeper P1).** The gate derives `isLocalClient` with the same canonical `isLocalDirectRequest(req, trustedProxies, allowRealIpFallback)` helper and inputs as the post-handshake admission path (`src/gateway/server/ws-connection/message-handler.ts:132`), so a loopback request carrying untrusted forwarded/proxy headers is no longer classified as local. The previous head's hand-rolled `isLoopbackAddress && !isTrustedProxyAddress` calculation is gone.
- **Runtime config, not a frozen snapshot (ClawSweeper P1).** The gate resolves `allowedOrigins` / trusted-proxy / host-fallback inputs from `getRuntimeConfig()` (`server-runtime-state.ts:305`), the same source the post-handshake admission path reads, instead of closing over the `params.cfg` captured at startup. The deterministic regression test in `verify-client.test.ts` ("re-evaluates origin policy against the runtime config snapshot") flips the runtime snapshot via `setRuntimeConfigSnapshot` and asserts the gate follows it; it fails against the old `params.cfg` getter.
- **Browser copilot (chrome-extension) origins pass through.** The gate mirrors the post-handshake admission's `hasCopilotExtensionOrigin` skip (`connect-admission.ts:193`) by forwarding canonical `chrome-extension://` origins for post-handshake validation against the paired device, so the browser copilot extension keeps working. A regression test covers the canonical chrome-extension origin through the gate.
- **Docs dropped.** The previous head shipped gateway security docs; those files conflict with `main`'s docs churn, so this rebuild is runtime-only against current `main`. The gate's behavior is documented by the existing `checkBrowserOrigin` contract and covered by the test matrix; docs can follow in a separate change against current `main`.

## User Impact

Operators with `allowedOrigins` set: cross-origin browser pages are now rejected at the handshake instead of after it. Behavior for allowed origins, CLI/native clients (no `Origin`), and the browser copilot extension is unchanged. No config migration or new settings.

## Evidence

Head commit `65444be074917d3e1352a368a12bb6ecb603770f` (squashed onto latest `main`).

### Real behavior proof — verbatim live-gateway transcript (redacted)

Gateway process: `OPENCLAW_STATE_DIR=<isolated state dir> node dist/index.js gateway run --port 59477 --bind loopback`
Built from head commit `65444be074917d3e1352a368a12bb6ecb603770f` (`pnpm build`; verified the bundle contains `getConfigSnapshot: loadRuntimeConfig` and the `normalizeChromeExtensionOrigin(requestOrigin)` pass-through).
Config: `gateway.mode=local`, `gateway.auth.mode=none`, `gateway.controlUi.allowedOrigins=["https://app.example.com"]`.

```
$ curl -sS -o /dev/null -w '%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Version: 13' \
    -H 'Origin: https://evil.example.com' http://127.0.0.1:59477/     # disallowed cross-site browser Origin
=> HTTP 403

$ curl -sS -o /dev/null -w '%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Version: 13' \
    -H 'Origin: https://app.example.com' http://127.0.0.1:59477/      # allowlisted Origin
=> HTTP 101

$ curl -sS -o /dev/null -w '%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Version: 13' \
    http://127.0.0.1:59477/                                           # no Origin header (CLI / native client)
=> HTTP 101

$ curl -sS -o /dev/null -w '%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Version: 13' \
    -H 'Origin: chrome-extension://abcdefghijklmnopabcdefghijklmnop' http://127.0.0.1:59477/   # paired browser-copilot extension
=> HTTP 101

$ curl -sS -o /dev/null -w '%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Version: 13' \
    -H 'Origin: null' http://127.0.0.1:59477/                         # opaque/null Origin
=> HTTP 403
```

Gateway log lines emitted by exactly those five probes (only the two rejected ones log):

```
2026-08-01T10:39:26.059+08:00 [gateway] verifyClient: origin not allowed (origin not allowed)
2026-08-01T10:39:35.146+08:00 [gateway] verifyClient: origin not allowed (origin missing or invalid)
```

Full post-handshake path with real `ws` clients (auth mode `none` — the server begins the Gateway protocol handshake, delivering `connect.challenge` to originless and chrome-extension clients):

```
$ node ws-client.mjs no-origin
no-origin: received after 4ms: {"type":"event","event":"connect.challenge",...}
no-origin: FULL CONNECT PATH OK (challenge delivered post-handshake)

$ node ws-client.mjs copilot
copilot: received after 4ms: {"type":"event","event":"connect.challenge",...}
copilot: FULL CONNECT PATH OK (challenge delivered post-handshake)
```

Live config change (edit `openclaw.json` to empty the allowlist; the running gateway watches the file, evaluates the reload, and in-process-restarts):

```
[reload] config change detected; evaluating reload (gateway.controlUi.allowedOrigins)
[reload] config change requires gateway restart (gateway.controlUi.allowedOrigins) — preparing
[reload] all operations and replies completed; restarting gateway now
[gateway] restart mode: in-process restart
```

After the restart the previously-allowlisted Origin is rejected by the new config, while the originless path is unchanged:

```
$ curl ... -H 'Origin: https://app.example.com' http://127.0.0.1:59477/    # now denied
=> HTTP 403
$ curl ... http://127.0.0.1:59477/                                          # no Origin
=> HTTP 101
```

Note: `gateway.controlUi.*` changes are restart-required reloads, so the runtime-config-snapshot behavior (P1) is proven deterministically in-process by the `verify-client.test.ts` regression test (`setRuntimeConfigSnapshot` flip; fails against the old `params.cfg` getter); the live run confirms the gate applies changed policy correctly across a reload.

### Unit / boundary tests (local)

- `src/gateway/server/verify-client.test.ts` — **10/10 passing** (`node scripts/run-vitest.mjs src/gateway/server/verify-client.test.ts`), including:
  - Disallowed/allowed/no-`Origin`/`null`-`Origin` matrix.
  - Untrusted-proxy loopback no longer local; allowlist still honored behind proxy.
  - **Runtime-config regression:** gate re-evaluates against the current runtime config snapshot, not `params.cfg`.
  - **Chrome-extension (browser copilot) origins pass through** for post-handshake device validation.
- `src/gateway/server.auth.browser-hardening.test.ts` — **14/14 passing**. The 6 pre-existing failures were the suite asserting *post-handshake* connect rejection while the gate now rejects at the upgrade; those tests now assert a pre-handshake `403 unexpected-response` (no socket ever opened) via the new `expectUpgradeRejected` helper. Two near-duplicate disallowed-origin tests were consolidated. (The same 6 tests fail identically on the unmodified previous PR head, confirming they were suite-lag, not regressions introduced here.)
- Typecheck: `pnpm tsgo:core` exits 0; oxfmt/oxlint clean on changed files.

## Scope

- `src/gateway/server/verify-client.ts` — `createGatewayVerifyClient` (runtime config inputs + copilot pass-through), wired at `server-runtime-state.ts` (`WebSocketServer` options)
- `src/gateway/server-runtime-state.ts` — gate resolves inputs from `getRuntimeConfig()` rather than `params.cfg`
- `src/gateway/server/verify-client.test.ts` — 10 cases (matrix + runtime-config regression + copilot pass-through + upgrade-seam boundary)
- `src/gateway/server.auth.browser-hardening.test.ts` — adapted to assert pre-handshake `403` rejection (`expectUpgradeRejected`)
- Docs from the previous head removed (conflict with `main` churn)
