### PR TITLE
fix(security): restore fs import dropped by bounded manifest-read change

### DIFF
--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -3,6 +3,7 @@
  *
  * These functions perform I/O (filesystem, config reads) to detect security issues.
  */
+import fs from "node:fs/promises";
 import path from "node:path";
 import { clearTimeout as clearNodeTimeout, setTimeout as setNodeTimeout } from "node:timers";
 import {


### PR DESCRIPTION
## What Problem This Solves

Main is red on every push since `aa0c92186b67c` (#101773): `check-prod-types`, `check-lint`, `check-test-types`, `check-additional-extension-package-boundary`, and `checks-node-compact-large-5` all fail with `src/security/audit-extra.async.ts(196,5): error TS2304: Cannot find name 'fs'` (and the security shard fails at runtime on the same reference).

## Why This Change Was Made

#101773 removed the file-wide `node:fs/promises` import while converting the plugin-manifest read to the bounded `fs-safe` helpers — but `getSkillCodeSafetySummary` still calls `fs.readFile` for skill content (the file's only remaining real `fs.` use; the other matches are checkId string literals). Restoring the import is the minimal fix that keeps #101773's manifest hardening intact without extending its bounded-read policy to a new call site unreviewed.

## User Impact

Main CI green again. No behavior change: the skill-content read behaves exactly as before #101773.

## Evidence

- Run 29638284216 failure logs: TS2304 at `audit-extra.async.ts(196,5)` across the type/lint lanes; `src/security/audit-extra.async.test.ts` failures in the security shard.
- With this fix: `node scripts/run-vitest.mjs src/security/audit-extra.async.test.ts` passes (the exact CI-failing file). Local Testbox delegation was unavailable (broker timeout), so proof is local per the trusted-source fallback policy; PR CI is the authoritative gate.
- Follow-up for #101773's author noted in the commit: migrate the skill read to `readRegularFile` with an explicit size cap if bounded reads should cover it too.
