### PR TITLE
fix(security): bound skill-file audit read (restore removed fs dependency)

### DIFF
--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -3,7 +3,6 @@
  *
  * These functions perform I/O (filesystem, config reads) to detect security issues.
  */
-import fs from "node:fs/promises";
 import path from "node:path";
 import { clearTimeout as clearNodeTimeout, setTimeout as setNodeTimeout } from "node:timers";
 import {
@@ -99,6 +98,10 @@ function expandTilde(p: string, env: NodeJS.ProcessEnv): string | null {
 }
 
 const MAX_PLUGIN_MANIFEST_BYTES = 1024 * 1024;
+// Skill file audit reads are bounded like other audit reads; matches the
+// workspace loader's DEFAULT_MAX_SKILL_FILE_BYTES so oversized SKILL.md files
+// cannot force an unbounded read during the code-safety scan.
+const MAX_SKILL_AUDIT_FILE_BYTES = 256_000;
 
 async function readPluginManifestExtensions(pluginPath: string): Promise<string[]> {
   const manifestPath = path.join(pluginPath, "package.json");
@@ -194,7 +197,10 @@ async function getSkillCodeSafetySummary(params: {
       dirPath: params.dirPath,
       summaryCache: params.summaryCache,
     }),
-    fs.readFile(params.skillFilePath, "utf-8"),
+    readRegularFile({
+      filePath: params.skillFilePath,
+      maxBytes: MAX_SKILL_AUDIT_FILE_BYTES,
+    }).then(({ buffer }) => buffer.toString("utf-8")),
     loadSkillScannerModule(),
   ]);
   const skillFindings = [


### PR DESCRIPTION
## What Problem This Solves

`main` is broken: `src/security/audit-extra.async.ts` calls `fs.readFile(params.skillFilePath, ...)` at line ~196 but has no `fs` import, so typecheck fails (`Cannot find name 'fs'`) and blocks CI.

## Why This Change Was Made

The "bound file reads in audit" series (#101773, #101775) converted the plugin-manifest read to the safe `readRegularFile` helper and removed the now-unused `import fs from "node:fs/promises"` — but missed the SKILL.md read added by #109363, which still used `fs.readFile`. That left an orphaned reference and a broken build.

## User Impact

Restores a green build. Consistent with the series intent, the skill-file audit read is now bounded via `readRegularFile` (cap `256_000` bytes, matching the workspace loader's `DEFAULT_MAX_SKILL_FILE_BYTES`) instead of an unbounded `fs.readFile`, so an oversized attacker-controlled `SKILL.md` cannot force an unbounded read during the code-safety scan.

## Evidence

- Single-file change: adds `MAX_SKILL_AUDIT_FILE_BYTES = 256_000` and converts the one orphaned `fs.readFile` to `readRegularFile({...}).then(({buffer}) => buffer.toString("utf-8"))`, mirroring the existing manifest-read pattern at line ~114. No remaining `fs.method()` calls; no `fs` import needed.
- The file was green at ab99029 (had `import fs`); this restores correctness after the import was removed.
