### PR TITLE
fix(cli): clarify oversized config mutation file errors

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2438,7 +2438,7 @@ describe("config cli", () => {
         fs.rmSync(pathname, { force: true });
       }
 
-      expectErrorIncludes("File exceeds 8388608 bytes");
+      expectErrorIncludes("--file exceeds the 8 MiB supported maximum (8388608 bytes)");
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1507,7 +1507,7 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
     raw = await readStdinText();
   } else {
     try {
-      raw = readConfigMutationFileSync(file as string);
+      raw = readConfigMutationFileSync(file as string, "--file");
     } catch (err) {
       if (hasErrnoCode(err, "ENOENT")) {
         throw new Error(`--file not found: ${file}`, { cause: err });

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -120,22 +120,17 @@ describe("config set input parsing", () => {
       " ".repeat(8 * 1024 * 1024 + 1),
       (batchPath) => {
         expect(() => parseBatchSource({ batchFile: batchPath })).toThrow(
-          "--batch-file exceeds the 8 MB supported maximum",
+          "--batch-file exceeds the 8 MiB supported maximum (8388608 bytes)",
         );
       },
     );
   });
 
   it("accepts --batch-file at exactly the size limit", () => {
-    // Valid JSON padded to exactly the 8 MB boundary (uses > not >=).
-    const prefix = '[{"path":"test","value":"';
-    const suffix = '"}]';
-    const paddingNeeded = 8 * 1024 * 1024 - Buffer.byteLength(prefix + suffix, "utf8");
-    const content = prefix + "x".repeat(paddingNeeded) + suffix;
+    const content = "[]".padEnd(8 * 1024 * 1024, " ");
     withBatchFile("openclaw-config-set-input-boundary-", content, (batchPath) => {
       const parsed = parseBatchSource({ batchFile: batchPath });
-      expect(parsed).toHaveLength(1);
-      expect(parsed![0]!.path).toBe("test");
+      expect(parsed).toEqual([]);
     });
   });
 });

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -120,9 +120,22 @@ describe("config set input parsing", () => {
       " ".repeat(8 * 1024 * 1024 + 1),
       (batchPath) => {
         expect(() => parseBatchSource({ batchFile: batchPath })).toThrow(
-          "File exceeds 8388608 bytes",
+          "--batch-file exceeds the 8 MB supported maximum",
         );
       },
     );
+  });
+
+  it("accepts --batch-file at exactly the size limit", () => {
+    // Valid JSON padded to exactly the 8 MB boundary (uses > not >=).
+    const prefix = '[{"path":"test","value":"';
+    const suffix = '"}]';
+    const paddingNeeded = 8 * 1024 * 1024 - Buffer.byteLength(prefix + suffix, "utf8");
+    const content = prefix + "x".repeat(paddingNeeded) + suffix;
+    withBatchFile("openclaw-config-set-input-boundary-", content, (batchPath) => {
+      const parsed = parseBatchSource({ batchFile: batchPath });
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]!.path).toBe("test");
+    });
   });
 });

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -48,12 +48,25 @@ export type ConfigSetBatchEntry = {
 
 const CONFIG_MUTATION_FILE_MAX_BYTES = 8 * 1024 * 1024;
 
-export function readConfigMutationFileSync(filePath: string): string {
+export function readConfigMutationFileSync(
+  filePath: string,
+  sourceLabel: "--batch-file" | "--file",
+): string {
   // These explicit CLI file flags have historically followed user-provided
   // symlinks. Pin the opened descriptor, then bound the read without changing that contract.
   const fd = fs.openSync(filePath, "r");
   try {
-    return readFileDescriptorBoundedSync(fd, CONFIG_MUTATION_FILE_MAX_BYTES).toString("utf8");
+    try {
+      return readFileDescriptorBoundedSync(fd, CONFIG_MUTATION_FILE_MAX_BYTES).toString("utf8");
+    } catch (error) {
+      if (error instanceof RangeError) {
+        throw new RangeError(
+          `${sourceLabel} exceeds the 8 MiB supported maximum (${CONFIG_MUTATION_FILE_MAX_BYTES} bytes): ${filePath}`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
   } finally {
     fs.closeSync(fd);
   }
@@ -153,18 +166,10 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   }
   let raw: string;
   try {
-    raw = readConfigMutationFileSync(pathname);
+    raw = readConfigMutationFileSync(pathname, "--batch-file");
   } catch (err) {
     if (hasErrnoCode(err, "ENOENT")) {
       throw new Error(`--batch-file not found: ${pathname}`, { cause: err });
-    }
-    // Document the supported size contract: if the file exceeds the 8 MB cap,
-    // produce a clear error that names the flag and the documented limit.
-    if (err instanceof RangeError) {
-      throw new Error(
-        `--batch-file exceeds the 8 MB supported maximum (${CONFIG_MUTATION_FILE_MAX_BYTES} bytes): ${pathname}`,
-        { cause: err },
-      );
     }
     throw err;
   }

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -158,6 +158,14 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
     if (hasErrnoCode(err, "ENOENT")) {
       throw new Error(`--batch-file not found: ${pathname}`, { cause: err });
     }
+    // Document the supported size contract: if the file exceeds the 8 MB cap,
+    // produce a clear error that names the flag and the documented limit.
+    if (err instanceof RangeError) {
+      throw new Error(
+        `--batch-file exceeds the 8 MB supported maximum (${CONFIG_MUTATION_FILE_MAX_BYTES} bytes): ${pathname}`,
+        { cause: err },
+      );
+    }
     throw err;
   }
   return parseBatchEntries(raw, "--batch-file");


### PR DESCRIPTION
Context: #110516

## What Problem This Solves

Current `main` already bounds config mutation files at 8 MiB through the pinned descriptor reader landed in #110516. Its overflow error is intentionally generic, however, so users of `config set --batch-file` or `config patch --file` only see `File exceeds 8388608 bytes` without the responsible flag or supported limit.

## Why This Change Was Made

The shared `readConfigMutationFileSync` owner now accepts the source flag and translates bounded-reader overflow consistently for both file-based config mutation commands. This keeps the existing security boundary, symlink behavior, descriptor pinning, and inclusive byte limit unchanged while avoiding duplicated caller policy.

The original contributor patch supplied the batch-file diagnostic and exact-boundary regression. The maintainer preparation consolidated that message at the shared reader, applied it to the sibling patch-file path, simplified the exact-limit fixture, and preserved contributor credit.

## User Impact

Files smaller than or exactly 8 MiB continue to work. Oversized inputs now report the responsible flag, the 8 MiB limit, the exact byte limit, and the path. Missing-file and malformed-JSON behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/cli/config-set-input.test.ts src/cli/config-cli.test.ts` — 2 files, 155 tests passed.
- Targeted `oxfmt --check` passed for all four touched files.
- `git diff --check` passed.
- Codex autoreview: clean, no accepted/actionable findings; patch correct at 0.96 confidence.
- Fresh exact-head CI is required for the prepared head before merge.

## Provenance

#110516 established the shared 8 MiB bounded reader on current `main`. This PR retains the original contributor's diagnostic and boundary-test work while finishing the sibling caller consistency at the same owner boundary.
