### PR TITLE
fix(tui): exit reliably after quit

### DIFF
--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -653,6 +653,34 @@ describe("GatewayChatClient", () => {
     vi.useRealTimers();
   });
 
+  it("waits for gateway transport teardown on stop", async () => {
+    const client = new GatewayChatClient({
+      url: "ws://127.0.0.1:18789",
+      token: "test-token",
+      allowInsecureLocalOperatorUi: true,
+    });
+    let finishStop: (() => void) | undefined;
+    const stopAndWait = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishStop = resolve;
+        }),
+    );
+    (client as unknown as { client: { stopAndWait: typeof stopAndWait } }).client.stopAndWait =
+      stopAndWait;
+
+    let stopped = false;
+    const stopPromise = client.stop().then(() => {
+      stopped = true;
+    });
+
+    expect(stopAndWait).toHaveBeenCalledOnce();
+    expect(stopped).toBe(false);
+    finishStop?.();
+    await stopPromise;
+    expect(stopped).toBe(true);
+  });
+
   it("identifies the TUI as a tui client and skips device identity on insecure local ui paths", async () => {
     const constructedOptions: Array<Record<string, unknown>> = [];
 

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -220,7 +220,9 @@ export class GatewayChatClient implements TuiBackend {
   }
 
   stop() {
-    this.client.stop();
+    // Keep TUI teardown ordered after the transport closes. Otherwise the
+    // late close callback can re-arm UI timers after shutdown cleared them.
+    return this.client.stopAndWait();
   }
 
   async subscribeSessionEvents() {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -701,7 +701,7 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
     const fixtureMockModel = mockModel;
     const fixtureControlClient = controlClient;
     const cleanup = createIdempotentCleanup(async () => {
-      fixtureControlClient.stop();
+      await fixtureControlClient.stop();
       try {
         await fixtureGateway.cleanup();
       } finally {
@@ -719,7 +719,7 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
       cleanup,
     };
   } catch (error) {
-    controlClient?.stop();
+    await controlClient?.stop();
     try {
       await gateway?.cleanup();
     } finally {
@@ -1033,7 +1033,7 @@ describe("TUI PTY real backends", () => {
           await fixture.run.write("/exit\r", { delay: false });
           expect((await fixture.run.waitForExit()).exitCode).toBe(0);
         } finally {
-          eventProbe?.stop();
+          await eventProbe?.stop();
           await fixture.cleanup();
         }
       },
@@ -1357,7 +1357,7 @@ describe("TUI PTY real backends", () => {
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);
       } finally {
-        queueClient.stop();
+        await queueClient.stop();
         await fixture.cleanup();
       }
     },

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,6 +1,6 @@
 // Covers core TUI state transitions and backend event rendering.
 import { EventEmitter } from "node:events";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../infra/parse-finite-number.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
@@ -426,6 +426,10 @@ describe("resolveTuiCtrlCAction", () => {
 });
 
 describe("TUI shutdown safety", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("drains terminal input before stopping the TUI", async () => {
     const calls: string[] = [];
     const drainInput = vi.fn(async () => {
@@ -543,12 +547,10 @@ describe("TUI shutdown safety", () => {
     expect(finish).toHaveBeenCalledTimes(1);
   });
 
-  it("schedules a process-exit guard after standalone TUI return", () => {
-    let callback: (() => void) | undefined;
+  it("does not keep a clean standalone TUI alive for the watchdog deadline", () => {
     const unref = vi.fn();
-    const setTimeoutFn = vi.fn((fn: () => void, ms: number) => {
-      callback = fn;
-      expect(ms).toBe(2000);
+    const setTimeoutFn = vi.fn((_callback: () => void, delayMs: number) => {
+      expect(delayMs).toBe(2000);
       return { unref };
     });
     const exit = vi.fn();
@@ -558,9 +560,25 @@ describe("TUI shutdown safety", () => {
 
     expect(setTimeoutFn).toHaveBeenCalledOnce();
     expect(unref).toHaveBeenCalledOnce();
-    callback?.();
+    expect(writeStderr).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("forces standalone TUI exit on deadline while another handle lingers", async () => {
+    vi.useFakeTimers();
+    const lingeringHandle = setInterval(() => {}, 60_000);
+    const exit = vi.fn();
+    const writeStderr = vi.fn();
+
+    const timer = scheduleProcessExitAfterTuiReturn({ exit, writeStderr });
+
+    expect((timer as NodeJS.Timeout).hasRef()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(exit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
     expect(writeStderr).toHaveBeenCalledWith("openclaw tui forcing process exit after return\n");
     expect(exit).toHaveBeenCalledWith(0);
+    clearInterval(lingeringHandle);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw tui` did not exit on quit. On any quit path (double Ctrl-C, `/quit`, `/exit`, Ctrl-D) it printed `gateway disconnected` then the Node process hung indefinitely (>65s, needed SIGKILL). A SIGUSR2 handle dump showed a lingering `TCPSocketWrap` + a pending `Timeout` keeping the event loop alive after shutdown. This is separate from the one-shot CLI-hang fix (the TUI is interactive and excluded from that CA respawn path).

## Why This Change Was Made

Found by the R6 QA campaign (TUI regression lane, 100% reproducible). `GatewayChatClient.stop()` did not return the transport teardown promise, so the shutdown chain resolved before the gateway socket was actually closed, leaving it registered.

## User Impact

`stop()` now returns the transport-teardown promise so the quit path awaits real socket close; with the socket properly torn down the event loop drains and the process exits **naturally** (measured `/quit` → exit code 0 in ~256ms, vs >65s hang). The process-exit watchdog remains `.unref()`'d — it never delays a clean exit and only force-exits if some other handle unexpectedly keeps the loop alive past the deadline.

## Evidence

- Live PTY proof (built gateway): `/quit` exits code 0 in 256ms, no watchdog warning.
- Tests: 100/100 TUI (`src/tui/tui.test.ts`, `src/tui/gateway-chat.test.ts`) — cover the async stop contract and watchdog behavior (clean exit does not wait the watchdog deadline; a simulated lingering handle still force-exits within it).
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.93)". +40/−14.
