### PR TITLE
fix(agents): bypass messaging tool suppression for synthetic media-only payloads

### DIFF
--- a/src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
@@ -36,6 +36,22 @@ describe("mergeAttemptToolMediaPayloads", () => {
         mediaUrls: ["/tmp/reply.opus"],
         mediaUrl: "/tmp/reply.opus",
         audioAsVoice: true,
+        bypassMessagingToolSuppression: true,
+      },
+    ]);
+  });
+
+  it("marks synthetic media-only payload to bypass messaging tool suppression", () => {
+    const result = mergeAttemptToolMediaPayloads({
+      payloads: [],
+      toolMediaUrls: ["/tmp/image.png"],
+    });
+    expect(result).toEqual([
+      {
+        mediaUrls: ["/tmp/image.png"],
+        mediaUrl: "/tmp/image.png",
+        audioAsVoice: undefined,
+        bypassMessagingToolSuppression: true,
       },
     ]);
   });

--- a/src/agents/pi-embedded-runner/run/tool-media-payloads.ts
+++ b/src/agents/pi-embedded-runner/run/tool-media-payloads.ts
@@ -34,6 +34,7 @@ export function mergeAttemptToolMediaPayloads(params: {
       mediaUrls: mediaUrls.length ? mediaUrls : undefined,
       mediaUrl: mediaUrls[0],
       audioAsVoice: params.toolAudioAsVoice || undefined,
+      bypassMessagingToolSuppression: true,
     },
   ];
 }

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -35,6 +35,9 @@ export type ReplyPayload = {
    *  Should be excluded from TTS transcript accumulation so compaction
    *  status lines are not synthesised into the spoken assistant reply. */
   isCompactionNotice?: boolean;
+  /** When true, this payload bypasses messaging-tool reply suppression.
+   *  Set on synthetic media-only payloads that were never sent via a messaging tool. */
+  bypassMessagingToolSuppression?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
 };

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -236,7 +236,9 @@ export async function buildReplyPayloads(params: {
             (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
           )
         : dedupedPayloads;
-  const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
+  const replyPayloads = suppressMessagingToolReplies
+    ? filteredPayloads.filter((payload) => payload.bypassMessagingToolSuppression)
+    : filteredPayloads;
 
   return {
     replyPayloads,


### PR DESCRIPTION
## Summary

Fixes #110394 — Codex-native generated images are dropped on `message_tool_only` routes.

## Related Issue

Closes #110394

## Changes

When `mergeAttemptToolMediaPayloads` creates a synthetic media-only payload (the fallback when no visible non-reasoning assistant text exists), it now sets `bypassMessagingToolSuppression: true` on that payload.

In `buildReplyPayloads`, the messaging-tool reply suppression logic (`suppressMessagingToolReplies`) now filters for payloads with this flag instead of blanket-dropping all payloads. This preserves existing suppression for text-bearing source replies and message-tool transcript mirrors while allowing synthetic media-only payloads (like Codex-native image generation results) to reach the user.

### Files changed

| File | Change |
|------|--------|
| `src/auto-reply/reply-payload.ts` | Add optional `bypassMessagingToolSuppression` boolean to `ReplyPayload` type |
| `src/agents/pi-embedded-runner/run/tool-media-payloads.ts` | Set `bypassMessagingToolSuppression: true` on synthetic media-only payload |
| `src/auto-reply/reply/agent-runner-payloads.ts` | Filter for bypass flag instead of `[]` when suppressing |
| `src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts` | Add test for bypass flag on synthetic payloads |

## Testing

- `tool-media-payloads.test.ts`: 3/3 pass (including new test for bypass flag)
- `agent-runner-payloads.test.ts`: 21/21 pass (existing dedupe/suppression behavior preserved)

## Real behavior proof

**Behavior or issue addressed**: Codex-native `imagegen` tool produces a saved image with no assistant text. Under `message_tool_only` delivery mode, `shouldSuppressMessagingToolReplies` evaluates to true and the synthetic media-only payload is dropped, resulting in no reply to the user.

**Real environment tested**: Linux x64, Node v24.18.0, vitest 4.1.9

**Exact steps or command run after this patch**: `npx vitest run src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts`

**Evidence after fix**: 24/24 tests pass. The new test verifies that synthetic media-only payloads (created when `payloads` is empty or reasoning-only and `toolMediaUrls` has entries) carry `bypassMessagingToolSuppression: true`. The existing suppression tests in `agent-runner-payloads.test.ts` continue to pass, confirming text-bearing reply suppression is unaffected.

**Observed result after fix**: Test Files 2 passed (2), Tests 24 passed (24)

**What was not tested**: End-to-end iMessage delivery with a real Codex app-server harness and `message_tool_only` route config (requires macOS + iMessage + Codex OAuth setup not available in CI).
