### PR TITLE
fix: prevent TUI PTY tests from aborting after completion

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -513,7 +513,7 @@ async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv } = {}) {
     waitForLogEntry: async (predicate: (entry: FixtureLogEntry) => boolean, timeoutMs?: number) =>
       await waitForFixtureLogEntry(logPath, predicate, timeoutMs),
     cleanup: async () => {
-      run.dispose();
+      await run.dispose();
       await rm(tempDir, { recursive: true, force: true });
     },
   };
@@ -561,12 +561,12 @@ describe.sequential("TUI PTY harness", () => {
 
   afterAll(async () => {
     for (const run of activeRuns.splice(0)) {
-      run.dispose();
+      await run.dispose();
     }
     for (const started of [fixture, compactFooterFixture, slowStartupFixture]) {
       await (started as Awaited<ReturnType<typeof startTuiFixture>> | undefined)?.cleanup();
     }
-  });
+  }, STARTUP_TEST_TIMEOUT_MS);
 
   it("renders local ready on startup", () => {
     expect(fixture.run.output()).toContain("local ready");

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -571,7 +571,7 @@ async function startLocalModeTui(
   });
 
   const cleanup = createIdempotentCleanup(async () => {
-    run.dispose();
+    await run.dispose();
     await mockModel.stop();
     await rm(tempDir, { recursive: true, force: true });
   });
@@ -776,7 +776,7 @@ async function startGatewayModeTui(
   });
   const cleanup = createIdempotentCleanup(async () => {
     shared.mockModel.releaseFirstResponse(scenario.modelId);
-    run.dispose();
+    await run.dispose();
     for (const key of sessionKeys) {
       await shared.controlClient.abortChat({ sessionKey: key });
     }

--- a/src/tui/tui-pty-test-support.test.ts
+++ b/src/tui/tui-pty-test-support.test.ts
@@ -19,8 +19,9 @@ describe("TUI PTY test support", () => {
   it("waits for PTY exit before completing idempotent disposal", async () => {
     const order: string[] = [];
     let exitListener: ((event: { exitCode: number; signal?: number }) => void) | undefined;
+    const kill = vi.fn(() => order.push("kill"));
     const pty = {
-      kill: vi.fn(() => order.push("kill")),
+      kill,
       onData: vi.fn(() => ({ dispose: () => order.push("data-dispose") })),
       onExit: vi.fn((listener: typeof exitListener) => {
         exitListener = listener;
@@ -46,6 +47,6 @@ describe("TUI PTY test support", () => {
     await disposal;
 
     expect(order).toEqual(["data-dispose", "kill", "exit", "exit-dispose"]);
-    expect(pty.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
   });
 });

--- a/src/tui/tui-pty-test-support.test.ts
+++ b/src/tui/tui-pty-test-support.test.ts
@@ -1,0 +1,51 @@
+import type { IPty } from "@lydell/node-pty";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const nodePtyMocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("@lydell/node-pty", () => ({
+  spawn: nodePtyMocks.spawn,
+}));
+
+import { startPty } from "./tui-pty-test-support.js";
+
+describe("TUI PTY test support", () => {
+  beforeEach(() => {
+    nodePtyMocks.spawn.mockReset();
+  });
+
+  it("waits for PTY exit before completing idempotent disposal", async () => {
+    const order: string[] = [];
+    let exitListener: ((event: { exitCode: number; signal?: number }) => void) | undefined;
+    const pty = {
+      kill: vi.fn(() => order.push("kill")),
+      onData: vi.fn(() => ({ dispose: () => order.push("data-dispose") })),
+      onExit: vi.fn((listener: typeof exitListener) => {
+        exitListener = listener;
+        return { dispose: () => order.push("exit-dispose") };
+      }),
+      write: vi.fn(),
+    } as unknown as IPty;
+    nodePtyMocks.spawn.mockReturnValue(pty);
+
+    const run = startPty("node", [], {
+      cwd: process.cwd(),
+      env: {},
+      exitTimeoutMs: 1_000,
+      outputTimeoutMs: 1_000,
+    });
+
+    const disposal = run.dispose();
+    expect(run.dispose()).toBe(disposal);
+    expect(order).toEqual(["data-dispose", "kill"]);
+
+    order.push("exit");
+    exitListener?.({ exitCode: 0 });
+    await disposal;
+
+    expect(order).toEqual(["data-dispose", "kill", "exit", "exit-dispose"]);
+    expect(pty.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/src/tui/tui-pty-test-support.ts
+++ b/src/tui/tui-pty-test-support.ts
@@ -13,8 +13,10 @@ export type PtyRun = {
   write: (data: string, opts?: { delay?: boolean }) => Promise<void>;
   waitForOutput: (needle: string, timeoutMs?: number) => Promise<string>;
   waitForExit: (timeoutMs?: number) => Promise<PtyExitEvent>;
-  dispose: () => void;
+  dispose: () => Promise<void>;
 };
+
+const PTY_EXIT_SETTLE_MS = 25;
 
 /** Polls until a reader returns a value or the timeout expires. */
 export function waitFor<T>(params: {
@@ -116,13 +118,22 @@ export function startPty(
     },
   });
 
-  pty.onData((data) => {
+  const dataSubscription = pty.onData((data) => {
     output += data;
     mirrorPtyOutput(data);
   });
-  pty.onExit((event) => {
+  const exitSubscription = pty.onExit((event) => {
     exitEvent = event;
   });
+
+  const waitForExit = async (timeoutMs = opts.exitTimeoutMs) =>
+    await waitFor({
+      timeoutMs,
+      read: () => exitEvent,
+      onTimeout: () => new Error(`timed out waiting for PTY exit\n${output}`),
+    });
+
+  let disposePromise: Promise<void> | undefined;
 
   const run: PtyRun = {
     output: () => output,
@@ -143,16 +154,23 @@ export function startPty(
         },
         onTimeout: () => new Error(`timed out waiting for ${JSON.stringify(needle)}\n${output}`),
       }),
-    waitForExit: async (timeoutMs = opts.exitTimeoutMs) =>
-      await waitFor({
-        timeoutMs,
-        read: () => exitEvent,
-        onTimeout: () => new Error(`timed out waiting for PTY exit\n${output}`),
-      }),
+    waitForExit,
     dispose: () => {
-      if (!exitEvent) {
-        pty.kill("SIGTERM");
-      }
+      disposePromise ??= (async () => {
+        dataSubscription.dispose();
+        try {
+          if (!exitEvent) {
+            pty.kill("SIGTERM");
+          }
+          await waitForExit();
+          // node-pty releases its native exit callback after onExit returns.
+          // Give that release a turn before Vitest tears down the worker.
+          await sleep(PTY_EXIT_SETTLE_MS);
+        } finally {
+          exitSubscription.dispose();
+        }
+      })();
+      return disposePromise;
     },
   };
   opts.activeRuns?.push(run);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `core-runtime-tui-pty` CI shard could abort with `SIGABRT` after every TUI PTY assertion had passed. The observed failure was CI run 29634950206, job 88055607467.

## Why This Change Was Made

PTY cleanup is now asynchronous and idempotent. It detaches the data listener, signals the child, waits for the bounded `onExit` event, gives the native exit callback one event-loop turn to release, and only then removes the exit listener. Suite-level PTYs are disposed sequentially before Vitest worker teardown.

This follows the pinned `@lydell/node-pty@1.2.0-beta.12` contract: event listeners return disposables, Unix `onExit` is intentionally delayed until the socket closes, `kill()` only sends a signal, and the native exit thread releases its N-API thread-safe callback after the JavaScript callback returns.

No Vitest pool or isolation setting changed; the existing config already uses one worker and disables file parallelism.

AI-assisted: yes. I understand and reviewed the lifecycle change.

## User Impact

No product-runtime behavior changes. Maintainers get deterministic TUI PTY test teardown instead of an intermittent post-test native abort on Linux CI.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29634950206/job/88055607467 — 10 local PTY tests and 21 harness tests passed, then node-pty threw `Napi::Error` and Vitest exited by `SIGABRT`.
- Dependency contract inspected at the exact upstream source used by `@lydell/node-pty@1.2.0-beta.12`:
  - Listener disposables and `onExit`: https://github.com/microsoft/node-pty/blob/fc30d875fed963259e10e40e1c70b20251a0e786/typings/node-pty.d.ts#L145-L156
  - Exit waits for socket close; `kill()` only signals: https://github.com/microsoft/node-pty/blob/fc30d875fed963259e10e40e1c70b20251a0e786/src/unixTerminal.ts#L78-L103 and https://github.com/microsoft/node-pty/blob/fc30d875fed963259e10e40e1c70b20251a0e786/src/unixTerminal.ts#L236-L253
  - Native exit-thread callback and release: https://github.com/microsoft/node-pty/blob/fc30d875fed963259e10e40e1c70b20251a0e786/src/unix/pty.cc#L149-L249
- Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/29639217268
  - Focused disposal contract test: 1/1 passed.
  - Five bounded CI-mode loops of `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`: 155/155 tests passed with five clean process exits.
- `git diff --check`: passed.
- Changed gate: conflict-marker, max-lines, attribution, boundary, dependency-pin, formatting, and Plugin SDK export checks passed. The remote gate then stopped on unrelated current-main generated Plugin SDK baseline drift.
- Autoreview: clean, no accepted/actionable findings; overall correctness 0.90.
