### PR TITLE
fix(agents): use fatal TextDecoder to reject malformed UTF-8 in provider transport streams

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -759,7 +759,7 @@ async function* parseAnthropicSseBody(
   signal?: AbortSignal,
 ): AsyncIterable<Record<string, unknown>> {
   const reader = body.getReader();
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   let buffer = "";
   let completed = false;
   try {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -156,7 +156,7 @@ function sanitizeOpenAISdkSseResponse(
     (/\bapplication\/json\b/i.test(contentType) || /\+json\b/i.test(contentType))
   ) {
     const source = response.body;
-    const decoder = new TextDecoder();
+    const decoder = new TextDecoder("utf-8", { fatal: true });
     const encoder = new TextEncoder();
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
     let buffer = "";
@@ -210,7 +210,7 @@ function sanitizeOpenAISdkSseResponse(
   }
 
   const source = response.body;
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   const encoder = new TextEncoder();
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let buffer = "";
@@ -337,7 +337,7 @@ async function classifyOpenAISdkStreamBody(response: Response): Promise<OpenAISd
     return "unknown";
   }
 
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   let total = 0;
   let text = "";
   try {


### PR DESCRIPTION
## What Problem This Solves

Four `new TextDecoder()` instances in the fetch transport and Anthropic stream handlers use the default non-fatal mode, silently replacing malformed UTF-8 bytes with U+FFFD. Provider APIs can return malformed bytes in streaming responses, and the corruption is absorbed without detection.

Second sibling of #110502 (memory batch output), following #110598 (ChatGPT Responses stream) — all three fix silent malformed-UTF-8 absorption in network data decoders.

## Fix

Switch all four `new TextDecoder()` to `new TextDecoder("utf-8", { fatal: true })`. Malformed bytes now throw `TypeError`, caught by existing try/catch in the stream processing pipelines.

- `provider-transport-fetch.ts`: 3 TextDecoder instances (stream init, body decode, event decode)
- `anthropic-transport-stream.ts`: 1 TextDecoder instance (SSE event decode)

## Evidence

### Function probe

```
$ node --import tsx -e "..."

=== Before (fatal: false, default) ===
new TextDecoder().decode(new Uint8Array([0xc3, 0x28]));
→ "�("  (silent U+FFFD replacement)

=== After (fatal: true) ===
new TextDecoder("utf-8", { fatal: true }).decode(new Uint8Array([0xc3, 0x28]));
→ throws TypeError
```

### Vitest output (404/404 tests pass)

```
$ npx vitest run src/agents/provider-transport-fetch.test.ts src/agents/anthropic-transport-stream.test.ts --reporter=verbose

 ✓ keeps aggregate cache billing buckets out of the context total
 ✓ does not fall back to aggregate usage when the final iteration is malformed
 ✓ uses complete final usage when message-start prompt buckets are zero placeholders
 ✓ does not treat zero start placeholders as complete final prompt usage
 ✓ uses accumulated prompt buckets when the final usage update is partial
 ✓ preserves valid message-start billing buckets when a sibling is malformed
 ✓ tags pre-tool narration as commentary when a proxy mislabels stop_reason
 ✓ uses the guarded fetch transport for api-key Anthropic requests
 ✓ sends server-side fallback params for direct Fable API-key requests
 ... (404 total)

 Test Files  4 passed (4)
      Tests  404 passed (404)
```

## Test plan

- [x] All 404 existing tests pass (no regression)
- [x] Same pattern verified in #110502 (merged) and #110598
- [x] Network transport streams decode external data — malformed UTF-8 possible