### PR TITLE
improve(ui): syntax-highlight the channel health snapshot in channel settings

### DIFF
--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -840,6 +840,11 @@ function highlightCode(text: string, lang: string): string {
   return escapeHtml(text);
 }
 
+/** Highlight a JSON/JSON5 snippet; output is escaped hljs markup safe for unsafeHTML in a code block. */
+export function highlightJsonHtml(text: string): string {
+  return highlightCode(text, "json");
+}
+
 function codeClassAttribute(lang: string, highlighted: string): string {
   const classes = [
     highlighted.includes("hljs-") ? "hljs" : "",

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -1,6 +1,7 @@
 // Channels hub: connected-channel rows, add-a-channel gallery, setup wizard,
 // and a per-channel detail overlay with the full config form.
 import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import "../../styles/channels.css";
 import type {
   ChannelAccountSnapshot,
@@ -16,6 +17,7 @@ import type {
   WhatsAppStatus,
 } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
+import { highlightJsonHtml } from "../../components/markdown.ts";
 import "../../components/openclaw-mascot.ts";
 import {
   renderSettingsEmpty,
@@ -108,8 +110,9 @@ export function renderChannels(props: ChannelsProps) {
         html`
           <div class="settings-row settings-row--stacked">
             <pre class="code-block">
-${props.snapshot ? JSON.stringify(props.snapshot, null, 2) : t("channels.health.noSnapshotYet")}
-            </pre>
+${props.snapshot
+                ? unsafeHTML(highlightJsonHtml(JSON.stringify(props.snapshot, null, 2)))
+                : t("channels.health.noSnapshotYet")}</pre>
           </div>
         `,
       )}


### PR DESCRIPTION
## What Problem This Solves

The Channel health section on Settings → Channels renders the gateway status snapshot as a plain monochrome JSON dump, which makes it hard to scan keys, values, and structure when debugging channel state.

## Why This Change Was Made

Reuses the Control UI's existing highlight.js setup (the `json` grammar is already registered for chat markdown code blocks) via a new narrow `highlightJsonHtml()` export, so the snapshot gets the same syntax colors as chat code blocks in both light and dark themes. No new dependency, no new CSS; the highlighter escapes its output before it reaches lit's `unsafeHTML`.

## User Impact

The Channel health snapshot is now syntax-highlighted (keys, strings, numbers, punctuation), matching code blocks elsewhere in the Control UI. The "No snapshot yet" empty state is unchanged.

## Evidence

Before:

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channel-health-json-highlight/before.png)

After:

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channel-health-json-highlight/after.png)

- Live-verified against the mock gateway harness (`scripts/control-ui-mock-dev.ts`) in dark and light themes; highlighted spans render inside the existing `pre.code-block`.
- Focused tests: `ui/src/pages/channels/view.test.ts` + `ui/src/components/markdown.test.ts` — 114 passed.
- `oxfmt` clean on touched files.
