### PR TITLE
fix: custom Anthropic models work without maxTokens

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1262,19 +1262,19 @@ describe("anthropic transport stream", () => {
     expect(latestAnthropicRequest().payload.stream).toBe(true);
   });
 
-  it("fails locally when Anthropic maxTokens is non-positive after resolution", async () => {
+  it("uses a default maxTokens for custom Anthropic models that omit it", async () => {
     const model = attachModelProviderRequestTransport(
       {
-        id: "claude-haiku-4-5",
-        name: "Claude Haiku 4.5",
+        id: "custom-model",
+        name: "Custom Model",
         api: "anthropic-messages",
-        provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        provider: "custom-anthropic",
+        baseUrl: "https://custom.example/anthropic",
         reasoning: false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 32000,
-        maxTokens: 0,
+        contextWindow: 200_000,
+        maxTokens: undefined as never,
       } satisfies Model<"anthropic-messages">,
       {
         proxy: {
@@ -1293,6 +1293,76 @@ describe("anthropic transport stream", () => {
         {
           apiKey: "sk-ant-api",
         } as Parameters<typeof streamFn>[2],
+      ),
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      model: "custom-model",
+      max_tokens: 8_192,
+      stream: true,
+    });
+  });
+
+  it("clamps the custom Anthropic maxTokens fallback to the context window", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "custom-model",
+        name: "Custom Model",
+        api: "anthropic-messages",
+        provider: "custom-anthropic",
+        baseUrl: "https://custom.example/anthropic",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4_096,
+        maxTokens: undefined as never,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+
+    await runTransportStream(
+      model,
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      { apiKey: "fake" } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.max_tokens).toBe(1_024);
+  });
+
+  it("fails locally when a custom Anthropic model has an invalid maxTokens", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "custom-model",
+        name: "Custom Model",
+        api: "anthropic-messages",
+        provider: "custom-anthropic",
+        baseUrl: "https://custom.example/anthropic",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_000,
+        maxTokens: 0,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        { messages: [{ role: "user", content: "hello" }] } as Parameters<typeof streamFn>[1],
+        { apiKey: "fake" } as Parameters<typeof streamFn>[2],
       ),
     );
 

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1301,7 +1301,7 @@ describe("anthropic transport stream", () => {
     expect(result.stopReason).toBe("stop");
     expect(latestAnthropicRequest().payload).toMatchObject({
       model: "custom-model",
-      max_tokens: 8_192,
+      max_tokens: 4_096,
       stream: true,
     });
   });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -94,7 +94,7 @@ const CLAUDE_CODE_BILLING_SYSTEM_BLOCK = `x-anthropic-billing-header: cc_version
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
-const ANTHROPIC_MESSAGES_DEFAULT_MAX_TOKENS = 8_192;
+const ANTHROPIC_MESSAGES_DEFAULT_MAX_TOKENS = 4_096;
 const ANTHROPIC_MESSAGES_FALLBACK_CONTEXT_DIVISOR = 4;
 // Mirror the fetch sanitizer cap here because compatible routes such as Kimi
 // bypass that layer; without a parser-local guard, partial frames grow forever.
@@ -270,7 +270,7 @@ function resolveAnthropicMessagesMaxTokens(params: {
     return undefined;
   }
   // Anthropic requires max_tokens even when an optional custom-model row has no output cap.
-  // Reserve most of a known context window for input instead of claiming it all for output.
+  // Use a conservative compatibility baseline; higher model limits require explicit metadata.
   const contextWindow = resolvePositiveAnthropicTokenLimit(params.modelContextWindow);
   return contextWindow === undefined
     ? ANTHROPIC_MESSAGES_DEFAULT_MAX_TOKENS

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -94,6 +94,8 @@ const CLAUDE_CODE_BILLING_SYSTEM_BLOCK = `x-anthropic-billing-header: cc_version
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+const ANTHROPIC_MESSAGES_DEFAULT_MAX_TOKENS = 8_192;
+const ANTHROPIC_MESSAGES_FALLBACK_CONTEXT_DIVISOR = 4;
 // Mirror the fetch sanitizer cap here because compatible routes such as Kimi
 // bypass that layer; without a parser-local guard, partial frames grow forever.
 const ANTHROPIC_MESSAGES_SSE_PENDING_BUFFER_MAX_CHARS = 16 * 1024 * 1024;
@@ -242,7 +244,7 @@ function clampReasoningLevel(level: ThinkingLevel): "minimal" | "low" | "medium"
   return level === "xhigh" || level === "max" ? "high" : level;
 }
 
-function resolvePositiveAnthropicMaxTokens(value: unknown): number | undefined {
+function resolvePositiveAnthropicTokenLimit(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
   }
@@ -251,20 +253,34 @@ function resolvePositiveAnthropicMaxTokens(value: unknown): number | undefined {
 }
 
 function resolveAnthropicMessagesMaxTokens(params: {
+  modelContextWindow: number | undefined;
   modelMaxTokens: number | undefined;
   requestedMaxTokens: number | undefined;
   useModelDefault?: boolean;
 }): number | undefined {
-  const requested = resolvePositiveAnthropicMaxTokens(params.requestedMaxTokens);
+  const requested = resolvePositiveAnthropicTokenLimit(params.requestedMaxTokens);
   if (requested !== undefined) {
     return requested;
   }
-  const modelMax = resolvePositiveAnthropicMaxTokens(params.modelMaxTokens);
-  return modelMax !== undefined
-    ? params.useModelDefault
-      ? modelMax
-      : Math.min(modelMax, 32_000)
-    : undefined;
+  const modelMax = resolvePositiveAnthropicTokenLimit(params.modelMaxTokens);
+  if (modelMax !== undefined) {
+    return params.useModelDefault ? modelMax : Math.min(modelMax, 32_000);
+  }
+  if (params.modelMaxTokens !== undefined) {
+    return undefined;
+  }
+  // Anthropic requires max_tokens even when an optional custom-model row has no output cap.
+  // Reserve most of a known context window for input instead of claiming it all for output.
+  const contextWindow = resolvePositiveAnthropicTokenLimit(params.modelContextWindow);
+  return contextWindow === undefined
+    ? ANTHROPIC_MESSAGES_DEFAULT_MAX_TOKENS
+    : Math.max(
+        1,
+        Math.min(
+          ANTHROPIC_MESSAGES_DEFAULT_MAX_TOKENS,
+          Math.floor(contextWindow / ANTHROPIC_MESSAGES_FALLBACK_CONTEXT_DIVISOR),
+        ),
+      );
 }
 
 function adjustMaxTokensForThinking(params: {
@@ -1000,6 +1016,7 @@ function buildAnthropicParams(
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const replayThinkingEnabled = mandatoryAdaptiveThinking || options?.thinkingEnabled === true;
   const maxTokens = resolveAnthropicMessagesMaxTokens({
+    modelContextWindow: model.contextWindow,
     modelMaxTokens: model.maxTokens,
     requestedMaxTokens: options?.maxTokens,
   });
@@ -1130,6 +1147,7 @@ function resolveAnthropicTransportOptions(
   apiKey: string,
 ): AnthropicTransportOptions {
   const baseMaxTokens = resolveAnthropicMessagesMaxTokens({
+    modelContextWindow: model.contextWindow,
     modelMaxTokens: model.maxTokens,
     requestedMaxTokens: options?.maxTokens,
     useModelDefault: resolveClaudeSonnet5ModelIdentity(model) !== undefined,
@@ -1140,7 +1158,7 @@ function resolveAnthropicTransportOptions(
     );
   }
   const reasoningModelMaxTokens =
-    resolvePositiveAnthropicMaxTokens(model.maxTokens) ?? baseMaxTokens;
+    resolvePositiveAnthropicTokenLimit(model.maxTokens) ?? baseMaxTokens;
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const reasoning =
     options?.reasoning === "off" && mandatoryAdaptiveThinking ? "low" : options?.reasoning;


### PR DESCRIPTION
Closes #110616

## What Problem This Solves

Fixes an issue where users of custom Anthropic-protocol providers would see every agent turn fail before the provider request when the schema-valid model row omitted `maxTokens`.

## Why This Change Was Made

The Anthropic Messages transport now supplies a conservative 4,096-token fallback only when model metadata omits the output limit. For smaller known context windows, the fallback uses at most one quarter of the context so input capacity remains available. Explicit positive limits remain authoritative, while explicitly invalid limits still fail locally. Higher model output limits require explicit metadata.

## User Impact

Custom `anthropic-messages` provider models can omit optional `maxTokens` and still complete requests. Existing configured caps and invalid-config diagnostics keep their prior behavior.

## Evidence

- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts` — 110 tests passed on Blacksmith Testbox.
- Targeted `oxfmt --check` passed for both touched files.
- Focused transport coverage proves omitted metadata emits `max_tokens: 4096`, small known contexts reserve input capacity, and explicitly invalid limits still fail before fetch.
- Source-blind local-agent CLI proof completed both omitted and explicit-limit turns through a mock Anthropic Messages endpoint; captured request bodies remained positive and preserved explicit `maxTokens: 2048`.
- Mandatory autoreview passed with no accepted/actionable findings after fixes.
- `pnpm check:changed` passed all reached touched-surface gates, then stopped at the unrelated Plugin SDK baseline manifest drift; the same manifest failure reproduced on exact `origin/main`.

## Release note

Custom Anthropic-protocol providers no longer fail at request time when optional model `maxTokens` metadata is omitted.

## AI assistance

AI-assisted. I reviewed the implementation, tests, black-box behavior proof, and autoreview findings.
