### PR TITLE
refactor(chat-ui): render iOS tool calls as flat expandable rows

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36738,16 +36738,8 @@
       "id": "native.apple.fccc8a9ba3da1426"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 357,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "\\(display.emoji) \\(display.title)",
-      "surface": "apple",
-      "id": "native.apple.8509385953c19619"
-    },
-    {
       "kind": "ui-localized-call",
-      "line": 371,
+      "line": 368,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
@@ -36755,31 +36747,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 544,
+      "line": 553,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
       "id": "native.apple.3c8c3679fd99c074"
     },
     {
-      "kind": "conditional-branch",
-      "line": 630,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "Show full output",
-      "surface": "apple",
-      "id": "native.apple.aff6385b0a8dd0ac"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 630,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "Show less",
-      "surface": "apple",
-      "id": "native.apple.b9c78020ae8be34a"
-    },
-    {
       "kind": "ui-call",
-      "line": 689,
+      "line": 598,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -36787,7 +36763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 715,
+      "line": 624,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -36795,7 +36771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 627,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -36803,7 +36779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 726,
+      "line": 635,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -36811,19 +36787,11 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 727,
+      "line": 636,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
       "id": "native.apple.142c01bf6b97e380"
-    },
-    {
-      "kind": "ui-call",
-      "line": 896,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "Running tools…",
-      "surface": "apple",
-      "id": "native.apple.6b18ea1d85b5d3a2"
     },
     {
       "kind": "ui-localized-call",
@@ -37858,6 +37826,46 @@
       "id": "native.apple.e7beeef6043ffd2a"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 76,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Running",
+      "surface": "apple",
+      "id": "native.apple.f390b84397c0d240"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 109,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Collapse tool result",
+      "surface": "apple",
+      "id": "native.apple.e2e7faa7c9c5c61f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 109,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Expand tool result",
+      "surface": "apple",
+      "id": "native.apple.4e7850fe95fcd898"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 130,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Show less",
+      "surface": "apple",
+      "id": "native.apple.d65ae0776d6b86ce"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 132,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Show all %lld lines",
+      "surface": "apple",
+      "id": "native.apple.065f4da5ddaf14a1"
+    },
+    {
       "kind": "conditional-branch",
       "line": 1347,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",
@@ -37899,7 +37907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 489,
+      "line": 487,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -37907,7 +37915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 503,
+      "line": 501,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -37915,7 +37923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 537,
+      "line": 535,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -37923,7 +37931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 540,
+      "line": 538,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -37931,7 +37939,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 631,
+      "line": 629,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -37939,7 +37947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 651,
+      "line": 649,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -37947,7 +37955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1038,
+      "line": 1036,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -37955,7 +37963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1061,
+      "line": 1059,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -37963,7 +37971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1082,
+      "line": 1080,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -37971,7 +37979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1092,
+      "line": 1090,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -37979,7 +37987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1094,
+      "line": 1092,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -37987,7 +37995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1160,
+      "line": 1158,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -37995,7 +38003,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1240,
+      "line": 1238,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -22964,11 +22964,6 @@
       "translated": "الصورة الرمزية للوكيل"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "استخدام الرسائل"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "عرض المخرجات كاملة"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "عرض أقل"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "جارٍ التحدث، اضغط للإيقاف"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "جارٍ تشغيل الأدوات…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "الإعداد الافتراضي للنظام"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "قيد التشغيل"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "طي نتيجة الأداة"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "توسيع نتيجة الأداة"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "عرض أقل"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "عرض جميع الأسطر البالغ عددها %lld"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -22964,11 +22964,6 @@
       "translated": "Agenten-Avatar"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Nachrichtennutzung"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Vollständige Ausgabe anzeigen"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Weniger anzeigen"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Spricht, zum Stoppen tippen"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Tools werden ausgeführt…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Systemstandard"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Wird ausgeführt"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Tool-Ergebnis einklappen"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Tool-Ergebnis ausklappen"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Weniger anzeigen"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Alle %lld Zeilen anzeigen"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -22964,11 +22964,6 @@
       "translated": "Avatar del agente"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Uso de mensajes"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Mostrar salida completa"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Mostrar menos"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Hablando, toca para detener"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Ejecutando herramientas…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Predeterminado del sistema"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "En ejecución"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Contraer el resultado de la herramienta"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Expandir el resultado de la herramienta"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Mostrar menos"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Mostrar las %lld líneas"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -22964,11 +22964,6 @@
       "translated": "آواتار عامل"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "مصرف پیام"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "نمایش خروجی کامل"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "نمایش کمتر"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "در حال صحبت، برای توقف ضربه بزنید"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "در حال اجرای ابزارها…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "پیش‌فرض سیستم"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "در حال اجرا"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "جمع کردن نتیجه ابزار"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "باز کردن نتیجه ابزار"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "نمایش کمتر"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "نمایش همه %lld خط"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -22964,11 +22964,6 @@
       "translated": "Avatar de l’agent"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Utilisation des messages"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Afficher la sortie complète"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Afficher moins"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Lecture, toucher pour arrêter"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Exécution des outils…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Réglage système par défaut"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "En cours"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Réduire le résultat de l’outil"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Développer le résultat de l’outil"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Afficher moins"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Afficher les %lld lignes"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -22964,11 +22964,6 @@
       "translated": "एजेंट का अवतार"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "संदेश उपयोग"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "पूरा आउटपुट दिखाएँ"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "कम दिखाएँ"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "बोला जा रहा है, रोकने के लिए टैप करें"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "टूल चल रहे हैं…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "सिस्टम डिफ़ॉल्ट"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "चल रहा है"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "टूल परिणाम संक्षिप्त करें"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "टूल परिणाम विस्तृत करें"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "कम दिखाएँ"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "सभी %lld पंक्तियाँ दिखाएँ"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -22964,11 +22964,6 @@
       "translated": "Avatar agen"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Penggunaan pesan"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Tampilkan output lengkap"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Tampilkan lebih sedikit"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Berbicara, ketuk untuk berhenti"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Menjalankan tools…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Default Sistem"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Berjalan"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Ciutkan hasil alat"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Perluas hasil alat"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Tampilkan lebih sedikit"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Tampilkan semua %lld baris"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -22964,11 +22964,6 @@
       "translated": "Avatar dell'agente"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Utilizzo messaggi"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Mostra output completo"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Mostra meno"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Riproduzione vocale, tocca per interrompere"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Esecuzione strumenti…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Predefinito di sistema"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "In esecuzione"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Comprimi il risultato dello strumento"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Espandi il risultato dello strumento"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Mostra meno"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Mostra tutte le %lld righe"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -22964,11 +22964,6 @@
       "translated": "エージェントのアバター"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "メッセージ使用量"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "完全な出力を表示"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "表示を減らす"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "読み上げ中、タップして停止"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "ツールを実行中…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "システムデフォルト"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "実行中"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "ツールの結果を折りたたむ"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "ツールの結果を展開"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "表示を減らす"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "%lld 行すべてを表示"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -22964,11 +22964,6 @@
       "translated": "에이전트 아바타"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "메시지 사용량"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "전체 출력 표시"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "간략히 보기"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "말하는 중, 탭하여 중지"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "도구 실행 중…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "시스템 기본값"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "실행 중"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "도구 결과 접기"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "도구 결과 펼치기"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "간략히 보기"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "%lld줄 모두 보기"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -22964,11 +22964,6 @@
       "translated": "Agentavatar"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Berichtgebruik"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Volledige uitvoer tonen"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Minder tonen"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Spreekt, tik om te stoppen"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Tools uitvoeren…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Systeemstandaard"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Actief"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Toolresultaat samenvouwen"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Toolresultaat uitvouwen"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Minder weergeven"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Alle %lld regels weergeven"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -22964,11 +22964,6 @@
       "translated": "Awatar agenta"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Wykorzystanie wiadomości"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Pokaż pełne dane wyjściowe"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Pokaż mniej"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Mówienie, stuknij, aby zatrzymać"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Uruchamianie narzędzi…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Domyślne ustawienie systemowe"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Uruchomiono"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Zwiń wynik narzędzia"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Rozwiń wynik narzędzia"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Pokaż mniej"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Pokaż wszystkie wiersze (%lld)"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -22964,11 +22964,6 @@
       "translated": "Avatar do agente"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Uso de mensagens"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Mostrar saída completa"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Mostrar menos"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Falando, toque para parar"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Executando ferramentas…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Padrão do sistema"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Em execução"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Recolher resultado da ferramenta"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Expandir resultado da ferramenta"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Mostrar menos"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Mostrar todas as %lld linhas"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -22964,11 +22964,6 @@
       "translated": "Аватар агента"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Использование сообщений"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Показать полный вывод"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Показать меньше"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Воспроизведение речи, нажмите, чтобы остановить"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Запуск инструментов…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Системные настройки"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Выполняется"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Свернуть результат инструмента"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Развернуть результат инструмента"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Показать меньше"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Показать все %lld строк"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -22964,11 +22964,6 @@
       "translated": "Agentavatar"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Meddelandeanvändning"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Visa fullständig utdata"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Visa mindre"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Talar, tryck för att stoppa"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Kör verktyg…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Systemstandard"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Körs"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Dölj verktygsresultat"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Visa verktygsresultat"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Visa mindre"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Visa alla %lld rader"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -22964,11 +22964,6 @@
       "translated": "อวตารของเอเจนต์"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "การใช้ข้อความ"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "แสดงผลลัพธ์ทั้งหมด"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "แสดงน้อยลง"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "กำลังพูด แตะเพื่อหยุด"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "กำลังเรียกใช้เครื่องมือ…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "ค่าเริ่มต้นของระบบ"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "กำลังทำงาน"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "ยุบผลลัพธ์ของเครื่องมือ"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "ขยายผลลัพธ์ของเครื่องมือ"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "แสดงน้อยลง"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "แสดงทั้งหมด %lld บรรทัด"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -22964,11 +22964,6 @@
       "translated": "Ajan avatarı"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Mesaj kullanımı"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Tam çıktıyı göster"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Daha az göster"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Konuşuyor, durdurmak için dokunun"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Araçlar çalıştırılıyor…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Sistem Varsayılanı"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Çalışıyor"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Araç sonucunu daralt"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Araç sonucunu genişlet"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Daha az göster"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "%lld satırın tümünü göster"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -22964,11 +22964,6 @@
       "translated": "Аватар агента"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Використання повідомлень"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Показати повний вивід"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Показати менше"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Озвучення, торкніться, щоб зупинити"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Виконання інструментів…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Системне значення за замовчуванням"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Виконується"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Згорнути результат інструмента"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Розгорнути результат інструмента"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Показати менше"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Показати всі %lld рядків"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -22964,11 +22964,6 @@
       "translated": "Ảnh đại diện của tác tử"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Mức dùng tin nhắn"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "Hiển thị toàn bộ đầu ra"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "Hiển thị ít hơn"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "Đang nói, chạm để dừng"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "Đang chạy công cụ…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "Mặc định hệ thống"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "Đang chạy"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "Thu gọn kết quả công cụ"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "Mở rộng kết quả công cụ"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "Hiển thị ít hơn"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "Hiển thị tất cả %lld dòng"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -22964,11 +22964,6 @@
       "translated": "智能体头像"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "消息使用量"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "显示完整输出"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "显示较少内容"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "正在朗读，轻点以停止"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "正在运行工具…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "系统默认"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "运行中"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "折叠工具结果"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "展开工具结果"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "收起"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "显示全部 %lld 行"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -22964,11 +22964,6 @@
       "translated": "代理程式頭像"
     },
     {
-      "id": "native.apple.8509385953c19619",
-      "source": "\\(display.emoji) \\(display.title)",
-      "translated": "\\(display.emoji) \\(display.title)"
-    },
-    {
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "訊息用量"
@@ -22977,16 +22972,6 @@
       "id": "native.apple.3c8c3679fd99c074",
       "source": "Voice note",
       "translated": "Voice note"
-    },
-    {
-      "id": "native.apple.aff6385b0a8dd0ac",
-      "source": "Show full output",
-      "translated": "顯示完整輸出"
-    },
-    {
-      "id": "native.apple.b9c78020ae8be34a",
-      "source": "Show less",
-      "translated": "顯示較少"
     },
     {
       "id": "native.apple.e9914cfc93a514cb",
@@ -23012,11 +22997,6 @@
       "id": "native.apple.142c01bf6b97e380",
       "source": "Speaking, tap to stop",
       "translated": "正在朗讀，點一下即可停止"
-    },
-    {
-      "id": "native.apple.6b18ea1d85b5d3a2",
-      "source": "Running tools…",
-      "translated": "正在執行工具…"
     },
     {
       "id": "native.apple.51ef5e41f9124819",
@@ -23662,6 +23642,31 @@
       "id": "native.apple.e7beeef6043ffd2a",
       "source": "System Default",
       "translated": "系統預設"
+    },
+    {
+      "id": "native.apple.f390b84397c0d240",
+      "source": "Running",
+      "translated": "執行中"
+    },
+    {
+      "id": "native.apple.e2e7faa7c9c5c61f",
+      "source": "Collapse tool result",
+      "translated": "收合工具結果"
+    },
+    {
+      "id": "native.apple.4e7850fe95fcd898",
+      "source": "Expand tool result",
+      "translated": "展開工具結果"
+    },
+    {
+      "id": "native.apple.d65ae0776d6b86ce",
+      "source": "Show less",
+      "translated": "顯示較少"
+    },
+    {
+      "id": "native.apple.065f4da5ddaf14a1",
+      "source": "Show all %lld lines",
+      "translated": "顯示全部 %lld 行"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -280,38 +280,46 @@ private struct ChatMessageBody: View {
     var body: some View {
         let text = self.primaryText
         let textColor = self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText
+        let shouldRenderBubble = self.shouldRenderBubble
+        let toolActivityItems = self.toolActivityItems
 
-        if self.usesBubble {
-            self.messageContent(text: text, textColor: textColor)
-                .padding(.vertical, 10)
-                .padding(.horizontal, 12)
-                .background(self.bubbleBackground)
-                .clipShape(self.bubbleShape)
-                .overlay(self.bubbleBorder)
-                .shadow(
-                    color: self.bubbleShadowColor,
-                    radius: self.bubbleShadowRadius,
-                    y: self.bubbleShadowYOffset)
-                .padding(.leading, self.tailPaddingLeading)
-                .padding(.trailing, self.tailPaddingTrailing)
-        } else {
-            self.messageContent(text: text, textColor: textColor)
-                .padding(.vertical, 5)
-                .padding(.horizontal, 4)
+        VStack(alignment: .leading, spacing: 6) {
+            if shouldRenderBubble {
+                if self.usesBubble {
+                    self.messageContent(text: text, textColor: textColor)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 12)
+                        .background(self.bubbleBackground)
+                        .clipShape(self.bubbleShape)
+                        .overlay(self.bubbleBorder)
+                        .shadow(
+                            color: self.bubbleShadowColor,
+                            radius: self.bubbleShadowRadius,
+                            y: self.bubbleShadowYOffset)
+                        .padding(.leading, self.tailPaddingLeading)
+                        .padding(.trailing, self.tailPaddingTrailing)
+                } else {
+                    self.messageContent(text: text, textColor: textColor)
+                        .padding(.vertical, 5)
+                        .padding(.horizontal, 4)
+                }
+            }
+
+            if !toolActivityItems.isEmpty {
+                ChatToolActivityList(items: toolActivityItems)
+                    .padding(.horizontal, 4)
+            }
+
+            if !shouldRenderBubble, let usagePresentation = self.usagePresentation {
+                self.usageLine(usagePresentation)
+                    .padding(.horizontal, 4)
+            }
         }
     }
 
     private func messageContent(text: String, textColor: Color) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            if self.isToolResultMessage {
-                if self.displayOptions.contains(.toolActivity), !text.isEmpty {
-                    ToolResultCard(
-                        title: self.toolResultTitle,
-                        text: text,
-                        isUser: self.isUser,
-                        toolName: self.message.toolName)
-                }
-            } else if self.isUser {
+            if self.isUser {
                 ChatMarkdownRenderer(
                     text: text,
                     context: .user,
@@ -342,44 +350,54 @@ private struct ChatMessageBody: View {
                     resolveResource: self.inlineWidgetResourceResolver)
             }
 
-            if self.displayOptions.contains(.toolActivity), !self.toolCalls.isEmpty {
-                ForEach(self.toolCalls.indices, id: \.self) { idx in
-                    ToolCallCard(
-                        content: self.toolCalls[idx])
-                }
-            }
-
-            if self.displayOptions.contains(.toolActivity), !self.inlineToolResults.isEmpty {
-                ForEach(self.inlineToolResults.indices, id: \.self) { idx in
-                    let toolResult = self.inlineToolResults[idx]
-                    let display = ToolDisplayRegistry.resolve(name: toolResult.name ?? "tool", args: nil)
-                    ToolResultCard(
-                        title: "\(display.emoji) \(display.title)",
-                        text: toolResult.text ?? "",
-                        isUser: self.isUser,
-                        toolName: toolResult.name)
-                }
-            }
-
             if let usagePresentation = self.usagePresentation {
-                Text(usagePresentation.text)
-                    .font(OpenClawChatTypography.caption2)
-                    .monospacedDigit()
-                    .foregroundStyle(self.usageTint(usagePresentation.pressure))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(String(localized: "Message usage"))
-                    .accessibilityValue(usagePresentation.accessibilityValue)
+                self.usageLine(usagePresentation)
             }
         }
         .textSelection(.enabled)
         .foregroundStyle(textColor)
     }
 
+    private func usageLine(_ presentation: ChatMessageUsagePresentation) -> some View {
+        Text(presentation.text)
+            .font(OpenClawChatTypography.caption2)
+            .monospacedDigit()
+            .foregroundStyle(self.usageTint(presentation.pressure))
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "Message usage"))
+            .accessibilityValue(presentation.accessibilityValue)
+    }
+
     private var usesBubble: Bool {
         // Keep the guarded base condition; iOS additionally opts assistant
         // messages into bubbles via the clean-chrome environment flag.
         self.isUser || self.style == .onboarding || !self.isClean || self.assistantBubblesInClean
+    }
+
+    private var shouldRenderBubble: Bool {
+        guard !self.isToolResultMessage else { return false }
+        return !self.primaryText.isEmpty ||
+            !self.inlineAttachments.isEmpty ||
+            !self.inlineWidgets.isEmpty ||
+            (self.showsLinkPreview && chatFirstPreviewURL(in: self.primaryText) != nil)
+    }
+
+    private var toolActivityItems: [ChatToolActivityItem] {
+        guard self.displayOptions.contains(.toolActivity) else { return [] }
+        // Results normally reach us merged into the calling assistant message
+        // (OpenClawChatView.mergeToolResults); this branch is the orphan
+        // fallback for results whose call is not in the preceding message.
+        if self.isToolResultMessage {
+            return [ChatToolActivityItem(
+                id: self.message.content.first?.id ?? "result-0",
+                name: self.message.toolName,
+                arguments: nil,
+                resultText: self.primaryText,
+                isPending: false)]
+        }
+        guard self.message.role.lowercased() == "assistant" else { return [] }
+        return ChatToolActivity.items(calls: self.toolCalls, results: self.inlineToolResults)
     }
 
     private var showsLinkPreview: Bool {
@@ -459,15 +477,6 @@ private struct ChatMessageBody: View {
         case .danger:
             OpenClawChatTheme.danger
         }
-    }
-
-    private var toolResultTitle: String {
-        if let name = self.message.toolName, !name.isEmpty {
-            let display = ToolDisplayRegistry.resolve(name: name, args: nil)
-            return "\(display.emoji) \(display.title)"
-        }
-        let display = ToolDisplayRegistry.resolve(name: "tool", args: nil)
-        return "\(display.emoji) \(display.title)"
     }
 
     private var bubbleFillColor: Color {
@@ -562,106 +571,6 @@ private struct AttachmentRow: View {
 
     private var isAudio: Bool {
         self.att.mimeType?.hasPrefix("audio/") == true
-    }
-}
-
-private struct ToolCallCard: View {
-    let content: OpenClawChatMessageContent
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Text(self.toolName)
-                    .font(OpenClawChatTypography.footnoteSemiBold)
-                Spacer(minLength: 0)
-            }
-
-            if let summary = self.summary, !summary.isEmpty {
-                Text(summary)
-                    .font(OpenClawChatTypography.mono(size: 13, relativeTo: .footnote))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-            }
-        }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(OpenClawChatTheme.subtleCard)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)))
-    }
-
-    private var toolName: String {
-        "\(self.display.emoji) \(self.display.title)"
-    }
-
-    private var summary: String? {
-        self.display.detailLine
-    }
-
-    private var display: ToolDisplaySummary {
-        ToolDisplayRegistry.resolve(name: self.content.name ?? "tool", args: self.content.arguments)
-    }
-}
-
-private struct ToolResultCard: View {
-    let title: String
-    let text: String
-    let isUser: Bool
-    let toolName: String?
-    @State private var expanded = false
-
-    var body: some View {
-        if !self.displayContent.isEmpty {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 6) {
-                    Text(self.title)
-                        .font(OpenClawChatTypography.footnoteSemiBold)
-                    Spacer(minLength: 0)
-                }
-
-                Text(self.displayText)
-                    .font(OpenClawChatTypography.mono(size: 13, relativeTo: .footnote))
-                    .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
-                    .lineLimit(self.expanded ? nil : Self.previewLineLimit)
-
-                if self.shouldShowToggle {
-                    Button(self.expanded ? "Show less" : "Show full output") {
-                        self.expanded.toggle()
-                    }
-                    .buttonStyle(.plain)
-                    .font(OpenClawChatTypography.caption)
-                    .foregroundStyle(.secondary)
-                }
-            }
-            .padding(10)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(OpenClawChatTheme.subtleCard)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)))
-        }
-    }
-
-    private static let previewLineLimit = 8
-
-    private var displayContent: String {
-        ToolResultTextFormatter.format(text: self.text, toolName: self.toolName)
-    }
-
-    private var lines: [Substring] {
-        self.displayContent.components(separatedBy: .newlines).map { Substring($0) }
-    }
-
-    private var displayText: String {
-        guard !self.expanded, self.lines.count > Self.previewLineLimit else { return self.displayContent }
-        return self.lines.prefix(Self.previewLineLimit).joined(separator: "\n") + "\n…"
-    }
-
-    private var shouldShowToggle: Bool {
-        self.lines.count > Self.previewLineLimit
     }
 }
 
@@ -889,44 +798,27 @@ struct ChatStreamingAssistantBubble: View {
 @MainActor
 struct ChatPendingToolsBubble: View {
     let toolCalls: [OpenClawChatPendingToolCall]
-    let isClean: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label("Running tools…", systemImage: "hammer")
-                .font(OpenClawChatTypography.caption)
-                .foregroundStyle(.secondary)
+        ChatToolActivityList(items: self.items)
+            .padding(4)
+    }
 
-            ForEach(self.toolCalls) { call in
-                let display = ToolDisplayRegistry.resolve(name: call.name, args: call.args)
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(verbatim: "\(display.emoji) \(display.label)")
-                            .font(OpenClawChatTypography.mono(size: 13, relativeTo: .footnote))
-                            .lineLimit(1)
-                        Spacer(minLength: 0)
-                        ProgressView().controlSize(.mini)
-                    }
-                    if let detail = display.detailLine, !detail.isEmpty {
-                        Text(detail)
-                            .font(OpenClawChatTypography.mono(size: 12, relativeTo: .caption))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-                }
-                .padding(10)
-                .background(Color.white.opacity(0.06))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            }
+    private var items: [ChatToolActivityItem] {
+        self.toolCalls.map { call in
+            ChatToolActivityItem(
+                id: call.id,
+                name: call.name,
+                arguments: call.args,
+                resultText: nil,
+                isPending: true)
         }
-        .padding(self.isClean ? 4 : 12)
-        .assistantBubbleContainerStyle(isClean: self.isClean)
     }
 }
 
 extension ChatPendingToolsBubble: @MainActor Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.toolCalls == rhs.toolCalls && lhs.isClean == rhs.isClean
+        lhs.toolCalls == rhs.toolCalls
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -1,0 +1,261 @@
+// Flat rows match the web Control UI's tool rendering and avoid card-in-card chrome.
+// Card chrome appears only when a result's detail is expanded.
+
+import Foundation
+import OpenClawKit
+import SwiftUI
+
+struct ChatToolActivityItem: Identifiable, Equatable {
+    let id: String
+    let name: String?
+    let arguments: AnyCodable?
+    let resultText: String?
+    let isPending: Bool
+}
+
+enum ChatToolActivity {
+    static func items(
+        calls: [OpenClawChatMessageContent],
+        results: [OpenClawChatMessageContent]) -> [ChatToolActivityItem]
+    {
+        var remainingResults = Array(results.enumerated())
+        var items = calls.enumerated().map { index, call in
+            let resultIndex = call.id.flatMap { callID in
+                remainingResults.firstIndex { _, result in result.id == callID }
+            }
+            let result = resultIndex.map { remainingResults.remove(at: $0).element }
+
+            return ChatToolActivityItem(
+                id: call.id ?? "call-\(index)",
+                name: call.name,
+                arguments: call.arguments,
+                resultText: result?.text,
+                isPending: false)
+        }
+
+        items.append(contentsOf: remainingResults.map { index, result in
+            ChatToolActivityItem(
+                id: result.id ?? "result-\(index)",
+                name: result.name,
+                arguments: nil,
+                resultText: result.text,
+                isPending: false)
+        })
+        return items
+    }
+}
+
+struct ChatToolActivityRow: View {
+    let item: ChatToolActivityItem
+    @State private var expanded = false
+    @State private var showsFullResult = false
+
+    private static let disclosureWidth: CGFloat = 12
+    private static let expandedLineLimit = 40
+
+    private var display: ToolDisplaySummary {
+        ToolDisplayRegistry.resolve(name: self.item.name ?? "tool", args: self.item.arguments)
+    }
+
+    private var detailLine: String? {
+        guard let detail = self.display.detailLine, !detail.isEmpty else { return nil }
+        return detail
+    }
+
+    private var formattedResult: String {
+        guard let resultText = self.item.resultText else { return "" }
+        return ToolResultTextFormatter.format(text: resultText, toolName: self.item.name)
+    }
+
+    private var expandable: Bool {
+        !self.formattedResult.isEmpty
+    }
+
+    private var accessibilityValue: String {
+        guard self.item.isPending else { return self.detailLine ?? "" }
+        let running = String(localized: "Running")
+        return self.detailLine.map { "\(running), \($0)" } ?? running
+    }
+
+    private var resultLineCount: Int {
+        self.formattedResult.components(separatedBy: .newlines).count
+    }
+
+    private var isResultTruncated: Bool {
+        self.resultLineCount > Self.expandedLineLimit
+    }
+
+    private var expandedResult: String {
+        guard self.isResultTruncated, !self.showsFullResult else { return self.formattedResult }
+        let lines = self.formattedResult.components(separatedBy: .newlines)
+        return lines.prefix(Self.expandedLineLimit - 1).joined(separator: "\n") + "\n…"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if self.expandable {
+                Button {
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        self.expanded.toggle()
+                    }
+                } label: {
+                    self.collapsedRow
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(self.display.title)
+                .accessibilityValue(self.accessibilityValue)
+                .accessibilityHint(self.expanded ? "Collapse tool result" : "Expand tool result")
+            } else {
+                self.collapsedRow
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(self.display.title)
+                    .accessibilityValue(self.accessibilityValue)
+            }
+
+            if self.expanded, self.expandable {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(self.expandedResult)
+                        .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+
+                    if self.isResultTruncated {
+                        Button {
+                            self.showsFullResult.toggle()
+                        } label: {
+                            Text(
+                                self.showsFullResult
+                                    ? String(localized: "Show less")
+                                    : String(
+                                        format: String(localized: "Show all %lld lines"),
+                                        Int64(self.resultLineCount)))
+                                .font(OpenClawChatTypography.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(OpenClawChatTheme.subtleCard))
+                .padding(.leading, 19)
+            }
+        }
+    }
+
+    private var collapsedRow: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Group {
+                if self.item.isPending {
+                    ProgressView()
+                        .controlSize(.mini)
+                } else if self.expandable {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .opacity(0.7)
+                        .rotationEffect(.degrees(self.expanded ? 90 : 0))
+                } else {
+                    Color.clear
+                }
+            }
+            .frame(width: Self.disclosureWidth)
+
+            Image(systemName: Self.symbol(forToolName: self.item.name))
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            Text(self.display.title)
+                .font(OpenClawChatTypography.footnoteSemiBold)
+                .foregroundStyle(OpenClawChatTheme.assistantText)
+                .lineLimit(1)
+
+            if let detailLine = self.detailLine {
+                Text(detailLine)
+                    .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 3)
+    }
+
+    private static func symbol(forToolName name: String?) -> String {
+        let normalized = name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        let exact: [String: String] = [
+            "agent": "rectangle.stack",
+            "bash": "terminal",
+            "browser": "safari",
+            "canvas": "photo",
+            "clock": "clock",
+            "command": "terminal",
+            "cron": "clock",
+            "edit": "pencil.line",
+            "exec": "terminal",
+            "fetch": "globe",
+            "find": "magnifyingglass",
+            "gateway": "server.rack",
+            "glob": "magnifyingglass",
+            "grep": "magnifyingglass",
+            "image": "photo",
+            "list": "magnifyingglass",
+            "ls": "magnifyingglass",
+            "memory": "brain",
+            "message": "bubble.left",
+            "node": "server.rack",
+            "patch": "pencil.line",
+            "photo": "photo",
+            "read": "doc.text",
+            "reply": "bubble.left",
+            "schedule": "clock",
+            "screenshot": "photo",
+            "search": "magnifyingglass",
+            "send": "bubble.left",
+            "session": "rectangle.stack",
+            "shell": "terminal",
+            "terminal": "terminal",
+            "web": "globe",
+            "write": "square.and.pencil",
+        ]
+        if let symbol = exact[normalized] { return symbol }
+
+        let fallbacks: [([String], String)] = [
+            (["canvas", "image", "screenshot", "photo"], "photo"),
+            (["browser"], "safari"),
+            (["message", "send", "reply"], "bubble.left"),
+            (["node", "gateway"], "server.rack"),
+            (["cron", "schedule", "clock"], "clock"),
+            (["memory"], "brain"),
+            (["session", "agent"], "rectangle.stack"),
+            (["exec", "bash", "shell", "command", "terminal"], "terminal"),
+            (["edit", "patch"], "pencil.line"),
+            (["write"], "square.and.pencil"),
+            (["grep", "glob", "find", "search", "list"], "magnifyingglass"),
+            (["read"], "doc.text"),
+            (["fetch", "web"], "globe"),
+        ]
+        return fallbacks.first { keys, _ in keys.contains(where: normalized.contains) }?.1
+            ?? "wrench.and.screwdriver"
+    }
+}
+
+struct ChatToolActivityList: View {
+    let items: [ChatToolActivityItem]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            // Protocol IDs can collide with specified fallback IDs; encounter order is unique here.
+            ForEach(self.items.indices, id: \.self) { index in
+                ChatToolActivityRow(item: self.items[index])
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -423,9 +423,7 @@ public struct OpenClawChatView: View {
         }
 
         if self.displayOptions.contains(.toolActivity), !self.viewModel.pendingToolCalls.isEmpty {
-            ChatPendingToolsBubble(
-                toolCalls: self.viewModel.pendingToolCalls,
-                isClean: self.composerChrome == .clean)
+            ChatPendingToolsBubble(toolCalls: self.viewModel.pendingToolCalls)
                 .equatable()
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolActivityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolActivityTests.swift
@@ -1,0 +1,75 @@
+import Testing
+@testable import OpenClawChatUI
+
+@Suite("ChatToolActivity")
+struct ChatToolActivityTests {
+    @Test func `pairs call and result by ID`() {
+        let items = ChatToolActivity.items(
+            calls: [self.content(type: "toolCall", id: "call-1", name: "exec")],
+            results: [self.content(type: "toolResult", text: "done", id: "call-1", name: "exec")])
+
+        #expect(items == [ChatToolActivityItem(
+            id: "call-1",
+            name: "exec",
+            arguments: nil,
+            resultText: "done",
+            isPending: false)])
+    }
+
+    @Test func `appends orphan result`() {
+        let items = ChatToolActivity.items(
+            calls: [],
+            results: [self.content(type: "toolResult", text: "orphaned", name: "read")])
+
+        #expect(items == [ChatToolActivityItem(
+            id: "result-0",
+            name: "read",
+            arguments: nil,
+            resultText: "orphaned",
+            isPending: false)])
+    }
+
+    @Test func `preserves call order`() {
+        let items = ChatToolActivity.items(
+            calls: [
+                self.content(type: "toolCall", id: "call-1", name: "read"),
+                self.content(type: "toolCall", id: "call-2", name: "write"),
+            ],
+            results: [
+                self.content(type: "toolResult", text: "second", id: "call-2", name: "write"),
+                self.content(type: "toolResult", text: "first", id: "call-1", name: "read"),
+            ])
+
+        #expect(items.map(\.id) == ["call-1", "call-2"])
+        #expect(items.map(\.resultText) == ["first", "second"])
+    }
+
+    @Test func `leaves call without result unexpandable`() {
+        let items = ChatToolActivity.items(
+            calls: [self.content(type: "toolCall", name: "search")],
+            results: [])
+
+        #expect(items == [ChatToolActivityItem(
+            id: "call-0",
+            name: "search",
+            arguments: nil,
+            resultText: nil,
+            isPending: false)])
+    }
+
+    private func content(
+        type: String,
+        text: String? = nil,
+        id: String? = nil,
+        name: String? = nil) -> OpenClawChatMessageContent
+    {
+        OpenClawChatMessageContent(
+            type: type,
+            text: text,
+            mimeType: nil,
+            fileName: nil,
+            content: nil,
+            id: id,
+            name: name)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Tool calls in the iOS app rendered as rounded cards *inside* the assistant message bubble — an outer card with inner cards — and each tool invocation showed up twice (one card for the call, another for the result), with up to 8 lines of raw output inline. Dense agent activity was hard to scan and visually noisy compared to the web Control UI.

## Why This Change Was Made

Align the shared SwiftUI chat (iOS + macOS apps via `OpenClawChatUI`) with the web Control UI's tool rendering language (`ui/src/styles/chat/tool-cards.css`): flat rows with no card chrome, one row per tool call with the result folded in, and detail surfaces that appear only on expand.

- New `ChatToolActivityViews.swift`: `ChatToolActivity.items(calls:results:)` pairs calls with results by tool-call id (orphan results keep a fallback row); `ChatToolActivityRow` renders chevron + SF-symbol kind icon + title + one-line mono detail, expanding on tap into a subtle surface with the formatted result (40-line cap with "Show all N lines" toggle).
- `ChatMessageBody` renders tool activity outside the bubble; tool-only messages get no bubble chrome at all. Standalone tool-result messages render as rows (results normally arrive pre-merged by `OpenClawChatView.mergeToolResults`).
- `ChatPendingToolsBubble` (running tools) reuses the same rows with a mini spinner instead of the "Running tools…" header card.
- Net −114 LOC in `ChatMessageViews.swift` (three card implementations deleted).

## User Impact

Chat with agent tool activity is far more scannable: one compact row per tool, no nested cards, output on demand. Same rendering improvement applies to the macOS app which consumes the shared package.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --parallel` → 917 tests in 82 suites passed (one unrelated `ChatViewModelAttachmentTests` timeout flake seen once under heavy parallel load, passes clean).
- New `ChatToolActivityTests` cover call/result pairing, ordering, and orphan results.
- Autoreview (Codex, gpt-5.6-sol, xhigh): clean after addressing one finding (long results now reveal fully via "Show all N lines").
- Screenshots below from the iPhone 17 simulator (`--openclaw-screenshot-mode` with a locally seeded tool-activity fixture; identical data on both builds).

| Before (light) | After (light) |
| --- | --- |
| ![before light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-rows/before-light.png) | ![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-rows/after-light.png) |

| Before (dark) | After (dark) |
| --- | --- |
| ![before dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-rows/before-dark.png) | ![after dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-rows/after-dark.png) |

Expanded rows (tap to reveal output):

![after expanded](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-rows/after-expanded.png)
