### PR TITLE
fix(ci): bound mantis discord smoke ref-validation git fetch with timeout

### DIFF
--- a/.github/workflows/mantis-discord-smoke.yml
+++ b/.github/workflows/mantis-discord-smoke.yml
@@ -85,14 +85,14 @@ jobs:
           selected_revision="$(git rev-parse HEAD)"
           trusted_reason=""
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
           if git merge-base --is-ancestor "$selected_revision" refs/remotes/origin/main; then
             trusted_reason="main-ancestor"
           elif git tag --points-at "$selected_revision" | grep -Eq '^v'; then
             trusted_reason="release-tag"
           elif [[ "$INPUT_REF" =~ ^release/[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
-            git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
+            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
             release_branch_sha="$(git rev-parse "refs/remotes/origin/${INPUT_REF}")"
             if [[ "$selected_revision" == "$release_branch_sha" ]]; then
               trusted_reason="release-branch-head"


### PR DESCRIPTION
## What Problem This Solves

The `Validate selected ref` step in `.github/workflows/mantis-discord-smoke.yml` runs two bare `git fetch` statements under `set -euo pipefail` — one for `refs/heads/main`, one for the release-branch ref. Neither has a timeout bound, so a stalled GitHub network operation could hang the QA smoke job indefinitely instead of failing the step and surfacing a retryable CI error.

## Why This Change Was Made

Both fetches now run under `timeout --signal=TERM --kill-after=10s 120s`, the exact wrapper shape merged for `docs-agent.yml` (#110026), the `docs-sync-publish.yml` clone (#109173), `linux-app-release.yml` (#110027), and `macos-release.yml` (#109174). On a stall the fetch is killed after 120s and the step's existing `set -euo pipefail` semantics fail the job explicitly — the same fast-failure behavior a plain fetch error produces today, just bounded in time.

## Changes

- Wrap both `git fetch --no-tags origin ...` invocations in the validate step with `timeout --signal=TERM --kill-after=10s 120s` (2 lines).

## User Impact

A stalled network during ref validation can no longer hang a Mantis discord-smoke QA run indefinitely; the job fails fast with a clear, retryable error.

## Evidence

Exact head: 21bd02bc286765ff73a5547f72885307871f2aeb.

**Controlled-runtime proof** — a real local git repo whose `origin` is a blackhole TCP server (accepts the connection, never responds), reproducing a stalled Git transport; executed as a file under bash so `set -euo pipefail` semantics are real.

Part 1 — the exact wrapper terminates a stalled `git fetch` at the 120s bound (exit 124):

```text
=== PART 1: exact wrapper (timeout --signal=TERM --kill-after=10s 120s) terminates a stalled git fetch ===
[proof] part1: exit=124 elapsed=120s (124 = killed by timeout(1))
[proof] part1 ok: stalled fetch was terminated by the wrapper
```

Part 2 — the validate-step failure path (`set -euo pipefail` + bare timeout-wrapped fetch, verbatim step semantics; only the timeout duration compressed 120s→5s, wrapper flags unchanged): the step dies at the bound instead of continuing or hanging:

```text
=== PART 2: validate-step failure path (set -euo pipefail + bare timeout-wrapped fetch; timeout compressed 120s->5s to keep the demo short, wrapper flags unchanged) ===
[proof] part2: step exit=124 elapsed=5s; the 'continued past the fetch' line must be absent above
[proof] part2 ok: step died at the bounded timeout (fast, explicit failure instead of an indefinite hang)

[proof] ALL PARTS PASS
```

- Same fix shape as the merged siblings: #110026 (`docs-agent.yml` fetches), #109173 (`docs-sync-publish.yml` clone), #110027 (`linux-app-release.yml`), #109174 (`macos-release.yml`) — identical `timeout --signal=TERM --kill-after=10s 120s` wrapper.
- YAML parse verified (`yaml` package): document loads, both fetch sites now carry the wrapper (count = 2); `git diff --check` clean.
- What was not tested: a live CI run (same proof scope as the merged siblings).

## Intentionally out of scope

- The other `mantis-*.yml` QA workflows and `ci.yml` carry the same unbounded fetch shape; keeping this PR to a single file per the sibling merge pattern.
- No change to the refspecs, validation logic, or step structure.
