### PR TITLE
fix(ui): settings language picker was oversized and unthemed

### DIFF
--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -414,12 +414,18 @@ wa-radio-group.settings-segmented::part(radios) {
 .settings-select {
   width: 100%;
   min-width: 0;
+  font: inherit;
+  font-size: var(--control-ui-input-text-size);
+}
+
+/* Native controls own their box. wa-select draws the same box on its shadow
+   combobox part below; host chrome would double-border the web component. */
+.settings-input,
+select.settings-select {
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
   color: var(--text);
-  font: inherit;
-  font-size: var(--control-ui-input-text-size);
   padding: 7px 10px;
   transition: border-color var(--duration-fast) var(--ease-out);
 }
@@ -435,10 +441,71 @@ wa-radio-group.settings-segmented::part(radios) {
 }
 
 .settings-input:focus-visible,
-.settings-select:focus-visible {
+select.settings-select:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border) 45%);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+/* ── Web Awesome select ── */
+
+wa-select.settings-select {
+  --wa-form-control-activated-color: var(--accent);
+}
+
+wa-select.settings-select::part(combobox) {
+  min-height: var(--settings-control-height);
+  padding-inline: 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
+  color: var(--text);
+  cursor: default;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+/* [open] is required alongside :focus-within: Chromium does not propagate
+   :focus-within to the host while a slotted option holds focus, so the open
+   state must key off the reflected attribute or the stock ring leaks through. */
+wa-select.settings-select[open]::part(combobox),
+wa-select.settings-select:focus-within::part(combobox) {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border) 45%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+wa-select.settings-select::part(expand-icon) {
+  margin-inline-start: var(--space-2);
+  font-size: var(--control-ui-text-sm);
+  color: var(--muted);
+}
+
+wa-select.settings-select::part(listbox) {
+  max-height: min(320px, calc(100vh - 48px));
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 86%, transparent);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-lg);
+  color: var(--text);
+}
+
+wa-select.settings-select wa-option {
+  padding: 6px 8px;
+  border-radius: calc(var(--radius-md) - 4px);
+  font-size: var(--control-ui-text-md);
+  color: var(--text);
+  cursor: default;
+}
+
+/* The roving "current" option already carries the accent fill; the global
+   :focus-visible accent outline on top of it is pure noise. */
+wa-select.settings-select wa-option:focus-visible {
+  outline: none;
+}
+
+wa-select.settings-select wa-option:state(current) {
+  color: var(--accent-foreground);
 }
 
 textarea.settings-input {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -510,6 +510,21 @@ wa-select.settings-select wa-option:state(current) {
   color: var(--accent-foreground);
 }
 
+/* Forced colors suppresses the box-shadow ring and accent fill that stand in
+   for the outlines removed above, so restore system-color outlines there. */
+@media (forced-colors: active) {
+  wa-select.settings-select[open]::part(combobox),
+  wa-select.settings-select:focus-within::part(combobox) {
+    outline: 2px solid SelectedItem;
+    outline-offset: 2px;
+  }
+
+  wa-select.settings-select wa-option:focus-visible {
+    outline: 2px solid SelectedItem;
+    outline-offset: 2px;
+  }
+}
+
 textarea.settings-input {
   min-height: 88px;
   resize: vertical;

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -481,7 +481,9 @@ wa-select.settings-select::part(expand-icon) {
 }
 
 wa-select.settings-select::part(listbox) {
-  max-height: min(320px, calc(100vh - 48px));
+  /* Keep Web Awesome's collision-aware bound in the cap; replacing it outright
+     would let the listbox overflow when the popup has little room to open. */
+  max-height: min(320px, var(--auto-size-available-height, calc(100vh - 48px)));
   padding: 6px;
   border: 1px solid color-mix(in srgb, var(--border-strong) 86%, transparent);
   border-radius: var(--radius-md);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Language picker on the General settings page looked broken: a double-boxed, oversized control (~64px tall against the 32px settings control height), and opening it showed a completely unthemed dropdown — stock blue selected row, stock blue focus ring, and a doubled accent outline on the highlighted option.

The picker is the only `wa-select` carrying the `.settings-select` class. Those box styles were written for native `<select>` elements, so the Web Awesome host got its own border/padding/background wrapped around the component's internally styled combobox, and the listbox never received any app theming.

## Why This Change Was Made

The Web Awesome control migration (#106865) is the intended direction, so the fix themes the component instead of reverting to a native select: the native box styles are scoped to `select.settings-select`, and `wa-select.settings-select` now draws the identical settings-control box on its shadow `combobox` part (32px height, same border/background/radius/focus treatment as `.settings-input`), with the `listbox` styled like the app's other menus and options themed via `--wa-form-control-activated-color: var(--accent)`.

Two quirks worth knowing: the open-state ring override needs `[open]` alongside `:focus-within` because Chromium does not propagate `:focus-within` to the host while a slotted option holds focus, and the roving current option suppresses the global `:focus-visible` outline since its accent fill already is the focus indicator.

## User Impact

The Language picker now looks like every other control on the settings pages, in both dark and light themes: compact closed state, accent-colored focus ring, and a properly elevated dropdown with accent-highlighted selection.

## Evidence

Focused test: `node scripts/run-vitest.mjs ui/src/pages/config/quick.test.ts` — 14/14 pass. `oxfmt --check ui/src/styles/settings.css` clean. Verified interactively against the mock-gateway dev harness in dark and light themes, closed/open/keyboard-focus states. The listbox cap keeps Web Awesome's collision-aware `--auto-size-available-height` bound: in a 420px-tall viewport the open listbox resolved to 216px max-height, stayed fully on-screen, and scrolled internally.

| | Before | After |
| --- | --- | --- |
| Closed | ![before closed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/language-picker-styling/lang-before-row.png) | ![after closed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/language-picker-styling/lang-after-row.png) |

Open (before):
![before open](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/language-picker-styling/lang-before-open.png)

Open (after, dark):
![after open dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/language-picker-styling/lang-after-open.png)

Open (after, light):
![after open light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/language-picker-styling/lang-light-open.png)
