### PR TITLE
feat(ui): link Get the apps from the mobile pairing dialog

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1509,6 +1509,10 @@ class OpenClawShell extends OpenClawLightDomElement {
             context.overlays.closeDevicePairSetup();
             this.navigate("nodes");
           },
+          onGetApps: () => {
+            context.overlays.closeDevicePairSetup();
+            this.navigate("apps");
+          },
         })}
         ${onboarding && activeRoute !== "custodian"
           ? html`<openclaw-onboarding-memory-import

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -283,6 +283,8 @@ export const en: TranslationMap = {
       adminRequired: "Administrator access is required to create setup codes.",
       title: "OpenClaw mobile",
       subtitle: "Scan this QR code in the mobile app to connect a new phone.",
+      noApp: "Don't have the app yet?",
+      getApps: "Get the apps",
       generating: "Creating a secure setup code…",
       accessTitle: "Mobile access",
       fullAccess: "Full access (recommended)",

--- a/ui/src/pages/nodes/view-pairing.ts
+++ b/ui/src/pages/nodes/view-pairing.ts
@@ -20,6 +20,7 @@ type DevicePairSetupProps = {
   onClose: () => void;
   onCopy: (setupCode: string) => void;
   onManageDevices: () => void;
+  onGetApps: () => void;
 };
 
 export function renderDevicePairSetup(props: DevicePairSetupProps) {
@@ -40,6 +41,10 @@ export function renderDevicePairSetup(props: DevicePairSetupProps) {
           <div>
             <h2>${title}</h2>
             <p>${description}</p>
+            <p class="device-pair-setup__get-apps">
+              ${t("nodes.pairing.noApp")}
+              <button type="button" @click=${props.onGetApps}>${t("nodes.pairing.getApps")}</button>
+            </p>
           </div>
           <button
             class="btn btn--icon btn--ghost device-pair-setup__close"

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4672,6 +4672,32 @@ td.data-table-key-col {
   line-height: 1.5;
 }
 
+.device-pair-setup__header p.device-pair-setup__get-apps {
+  margin-top: 2px;
+  font-size: 13px;
+}
+
+.device-pair-setup__get-apps button {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.device-pair-setup__get-apps button:hover {
+  color: var(--text-strong);
+}
+
+.device-pair-setup__get-apps button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: 4px;
+}
+
 .device-pair-setup__phone {
   display: grid;
   width: 44px;


### PR DESCRIPTION
Related: #110563

## What Problem This Solves

The mobile pairing dialog ("Pair mobile device") assumes the OpenClaw app is already installed — its copy says "Scan this QR code in the mobile app" with no path for users who don't have the app yet. This was the original motivation for the Apps & extensions page (#110563), but the pairing dialog itself still didn't link there.

## Why This Change Was Made

Close the loop from the surface where users actually hit the "I don't have the app" wall. A one-line affordance in the dialog header routes them to the new `/apps` page with the store links.

## User Impact

The pairing dialog now shows "Don't have the app yet? Get the apps" under its subtitle. Clicking it closes the dialog and navigates to the Apps & extensions page. No other pairing behavior changes.

## Evidence

- Live-verified in the mock dev harness: dialog renders the new line; clicking closes the overlay and lands on `/apps` (`location.pathname === "/apps"`, hero visible).
- `pnpm tsgo:ui` green; `pnpm ui:i18n:baseline` + `pnpm ui:i18n:verify` green (two new English keys under `nodes.pairing`).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, "no accepted/actionable findings".
- Styling scoped to `.device-pair-setup__get-apps`, tokens only, focus-visible ring included.
