### PR TITLE
docs: fix stale 2gb session disk budget default on chrome extension page

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -164,7 +164,7 @@ different Gateway. After a browser crash, the next launch archives sessions
 left by the previous browser instance. Archived sessions reject new work, while
 their transcripts remain available in session history. Browser-copilot keys are
 thread sessions, so normal age and entry-count maintenance preserves them. The
-per-agent session disk budget still applies (default `2gb`) and may evict the
+per-agent session disk budget still applies (default `10gb`) and may evict the
 oldest sessions under pressure; see [session maintenance](/reference/session-management-compaction#store-maintenance-and-disk-controls).
 
 The side panel currently requires either a Gateway-hosted extension relay or a


### PR DESCRIPTION
Related: #110221

## What Problem This Solves

Fixes an issue where users reading the Chrome extension docs would see the per-agent session disk budget default listed as `2gb`, five times smaller than the actual default. PR #110221 raised the default to 10 GiB and updated the session maintenance reference page and the schema help text, but this mention on the Chrome extension page was not updated with it.

## Why This Change Was Made

One-word doc correction so the Chrome extension page matches the shipped default and the already-updated reference page. Written as `10gb` to match the notation used in `docs/reference/session-management-compaction.md`.

## User Impact

Chrome extension users sizing disk and retention expectations now see the correct 10 GiB default instead of a stale value that is 5x too small.

## Evidence

- Current default in source: `const DEFAULT_SESSION_MAX_DISK_BYTES = 10 * 1024 * 1024 * 1024;` (`src/config/sessions/store-maintenance.ts:29`, raised in afcca01f407 / #110221)
- That commit updated `docs/reference/session-management-compaction.md:53` (`maxDiskBytes` default `10gb`) and `src/config/schema.help.automation.ts:98` ("Defaults to `10gb`") but missed `docs/tools/chrome-extension.md:136`
- Swept the rest of `docs/` for stale `2gb` / `2 GiB` session-budget mentions; the remaining hits are unrelated (Fly/GCP instance memory sizing, a CI cache threshold)
- Docs-only change; `git diff --check` clean

**Re-verification after ClawSweeper review (2026-07-18):**
- Live `main` at `fa9ae68c342`: `src/config/sessions/store-maintenance.ts:29` reads `10 * 1024 * 1024 * 1024` (10 GiB)
- The review's own baseline commit `05fb8e6e6190` also already reads 10 GiB at the same line
- `git log` on `store-maintenance.ts` shows afcca01f407 (#110221) as the latest default change, with no revert after it

---

Disclosure: I'm a CS student getting started in open source and I put this PR together with the help of Claude Code, so please read it as AI-assisted work. I verified the default change and the missed doc line myself against current main before opening this. Happy to adjust anything.
