### PR TITLE
fix(signal): preserve durable ingress retry ownership

### DIFF
--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -6,6 +6,7 @@ import {
   getSignalToolResultTestMocks,
   installSignalToolResultTestHooks,
   setSignalToolResultTestConfig,
+  toSignalToolResultTestError,
 } from "./monitor.tool-result.test-harness.js";
 
 installSignalToolResultTestHooks();
@@ -155,11 +156,11 @@ describe("monitorSignalProvider tool results", () => {
       baseUrl: "http://127.0.0.1:8080",
       abortSignal: abortController.signal,
     });
-    let waitError: unknown;
+    let waitError: Error | undefined;
     try {
       await vi.waitFor(() => expect(replyMock).toHaveBeenCalledTimes(1), { timeout: 5_000 });
     } catch (error) {
-      waitError = error;
+      waitError = toSignalToolResultTestError(error, "Signal reply was not dispatched");
     } finally {
       abortController.abort(new Error("monitor stopped"));
     }

--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -127,7 +127,6 @@ describe("monitorSignalProvider tool results", () => {
   });
 
   it("cancels a pending reply-session conflict retry when the monitor stops", async () => {
-    vi.useFakeTimers();
     const abortController = new AbortController();
     replyMock.mockRejectedValue(
       new Error(
@@ -151,22 +150,25 @@ describe("monitorSignalProvider tool results", () => {
       });
     });
 
+    const monitorPromise = monitorSignalProvider({
+      autoStart: false,
+      baseUrl: "http://127.0.0.1:8080",
+      abortSignal: abortController.signal,
+    });
+    let waitError: unknown;
     try {
-      const monitorPromise = monitorSignalProvider({
-        autoStart: false,
-        baseUrl: "http://127.0.0.1:8080",
-        abortSignal: abortController.signal,
-      });
-
-      await vi.waitFor(() => expect(replyMock).toHaveBeenCalledTimes(1));
-      abortController.abort(new Error("monitor stopped"));
-      await monitorPromise;
-      await vi.advanceTimersByTimeAsync(10_000);
-
-      expect(replyMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(replyMock).toHaveBeenCalledTimes(1), { timeout: 5_000 });
+    } catch (error) {
+      waitError = error;
     } finally {
-      vi.useRealTimers();
+      abortController.abort(new Error("monitor stopped"));
     }
+    await monitorPromise;
+    if (waitError) {
+      throw waitError;
+    }
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 
   it("drains an inline inbound message accepted before the monitor stops", async () => {

--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -10,6 +10,7 @@ import {
   getSignalToolResultTestMocks,
   installSignalToolResultTestHooks,
   setSignalToolResultTestConfig,
+  toSignalToolResultTestError,
   waitForSignalToolResultIngressIdle,
 } from "./monitor.tool-result.test-harness.js";
 
@@ -49,7 +50,7 @@ async function receiveSignalPayloads(params: {
   opts?: Partial<MonitorSignalProviderOptions>;
 }) {
   const abortController = new AbortController();
-  let ingressIdleError: unknown;
+  let ingressIdleError: Error | undefined;
   streamMock.mockImplementation(async ({ onEvent }) => {
     for (const payload of params.payloads) {
       await onEvent({
@@ -60,7 +61,7 @@ async function receiveSignalPayloads(params: {
     try {
       await waitForSignalToolResultIngressIdle();
     } catch (error) {
-      ingressIdleError = error;
+      ingressIdleError = toSignalToolResultTestError(error, "Signal ingress did not become idle");
     } finally {
       abortController.abort();
     }
@@ -533,7 +534,7 @@ describe("monitorSignalProvider tool results", () => {
     });
     replyMock.mockResolvedValue({ text: "reply" });
     const abortController = new AbortController();
-    let ingressIdleError: unknown;
+    let ingressIdleError: Error | undefined;
     streamMock.mockImplementation(async ({ onEvent }) => {
       for (const [timestamp, message] of [
         [1700000000001, "first message"],
@@ -557,7 +558,10 @@ describe("monitorSignalProvider tool results", () => {
         });
         await waitForSignalToolResultIngressIdle();
       } catch (error) {
-        ingressIdleError = error;
+        ingressIdleError = toSignalToolResultTestError(
+          error,
+          "Batched Signal ingress did not become idle",
+        );
       } finally {
         abortController.abort();
       }

--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -10,6 +10,7 @@ import {
   getSignalToolResultTestMocks,
   installSignalToolResultTestHooks,
   setSignalToolResultTestConfig,
+  waitForSignalToolResultIngressIdle,
 } from "./monitor.tool-result.test-harness.js";
 
 installSignalToolResultTestHooks();
@@ -31,7 +32,7 @@ const SIGNAL_BASE_URL = "http://127.0.0.1:8080";
 type MonitorSignalProviderOptions = NonNullable<Parameters<typeof monitorSignalProvider>[0]>;
 
 function waitForSignalDelivery(assertion: () => void) {
-  return vi.waitFor(assertion, { interval: 1 });
+  return vi.waitFor(assertion, { interval: 1, timeout: 5_000 });
 }
 
 async function runMonitorWithMocks(opts: MonitorSignalProviderOptions) {
@@ -48,6 +49,7 @@ async function receiveSignalPayloads(params: {
   opts?: Partial<MonitorSignalProviderOptions>;
 }) {
   const abortController = new AbortController();
+  let ingressIdleError: unknown;
   streamMock.mockImplementation(async ({ onEvent }) => {
     for (const payload of params.payloads) {
       await onEvent({
@@ -55,11 +57,13 @@ async function receiveSignalPayloads(params: {
         data: JSON.stringify(payload),
       });
     }
-    // Durable receive returns after append; let the drain start before simulating shutdown.
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    abortController.abort();
+    try {
+      await waitForSignalToolResultIngressIdle();
+    } catch (error) {
+      ingressIdleError = error;
+    } finally {
+      abortController.abort();
+    }
   });
 
   await runMonitorWithMocks({
@@ -68,6 +72,9 @@ async function receiveSignalPayloads(params: {
     abortSignal: abortController.signal,
     ...params.opts,
   });
+  if (ingressIdleError) {
+    throw ingressIdleError;
+  }
 }
 
 function hasQueuedReactionEventFor(sender: string) {
@@ -517,61 +524,64 @@ describe("monitorSignalProvider tool results", () => {
   });
 
   it("keeps durable conversation events separate in batched reply mode", async () => {
-    vi.useFakeTimers();
-    try {
-      setSignalToolResultTestConfig({
-        ...createSignalToolResultConfig({
-          autoStart: false,
-          replyToMode: "batched",
-        }),
-        messages: { inbound: { debounceMs: 10 } },
-      });
-      replyMock.mockResolvedValue({ text: "reply" });
-      const abortController = new AbortController();
-      streamMock.mockImplementation(async ({ onEvent }) => {
-        for (const [timestamp, message] of [
-          [1700000000001, "first message"],
-          [1700000000002, "second message"],
-        ] as const) {
-          await onEvent({
-            event: "receive",
-            data: JSON.stringify({
-              envelope: {
-                sourceNumber: "+15550001111",
-                sourceName: "Ada",
-                timestamp,
-                dataMessage: { message },
-              },
-            }),
-          });
-        }
-        try {
-          await vi.advanceTimersByTimeAsync(2_000);
-          expect(replyMock).toHaveBeenCalledTimes(2);
-        } finally {
-          abortController.abort();
-        }
-      });
-
-      await runMonitorWithMocks({
+    setSignalToolResultTestConfig({
+      ...createSignalToolResultConfig({
         autoStart: false,
-        baseUrl: SIGNAL_BASE_URL,
-        abortSignal: abortController.signal,
-      });
-
-      expect(sendMock).toHaveBeenCalledTimes(2);
-      for (const call of sendMock.mock.calls) {
-        expect(call[2]).not.toHaveProperty("replyToId");
-        expect(call[2]).not.toHaveProperty("replyToAuthor");
-        expect(call[2]).not.toHaveProperty("replyToBody");
+        replyToMode: "batched",
+      }),
+      messages: { inbound: { debounceMs: 10 } },
+    });
+    replyMock.mockResolvedValue({ text: "reply" });
+    const abortController = new AbortController();
+    let ingressIdleError: unknown;
+    streamMock.mockImplementation(async ({ onEvent }) => {
+      for (const [timestamp, message] of [
+        [1700000000001, "first message"],
+        [1700000000002, "second message"],
+      ] as const) {
+        await onEvent({
+          event: "receive",
+          data: JSON.stringify({
+            envelope: {
+              sourceNumber: "+15550001111",
+              sourceName: "Ada",
+              timestamp,
+              dataMessage: { message },
+            },
+          }),
+        });
       }
-    } finally {
-      vi.useRealTimers();
+      try {
+        await waitForSignalDelivery(() => {
+          expect(replyMock).toHaveBeenCalledTimes(2);
+        });
+        await waitForSignalToolResultIngressIdle();
+      } catch (error) {
+        ingressIdleError = error;
+      } finally {
+        abortController.abort();
+      }
+    });
+
+    await runMonitorWithMocks({
+      autoStart: false,
+      baseUrl: SIGNAL_BASE_URL,
+      abortSignal: abortController.signal,
+    });
+    if (ingressIdleError) {
+      throw ingressIdleError;
+    }
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    for (const call of sendMock.mock.calls) {
+      expect(call[2]).not.toHaveProperty("replyToId");
+      expect(call[2]).not.toHaveProperty("replyToAuthor");
+      expect(call[2]).not.toHaveProperty("replyToBody");
     }
   });
 
   it("passes inbound Signal quote metadata to media replies", async () => {
-    replyMock.mockResolvedValue({ text: "caption", mediaUrl: "file:///tmp/reply.png" });
+    replyMock.mockResolvedValue({ text: "caption", mediaUrl: "https://example.com/reply.png" });
 
     await receiveSignalPayloads({
       payloads: [
@@ -592,7 +602,7 @@ describe("monitorSignalProvider tool results", () => {
       expect(sendMock).toHaveBeenCalledTimes(1);
     });
     expect(sendMock.mock.calls[0]?.[2]).toMatchObject({
-      mediaUrl: "file:///tmp/reply.png",
+      mediaUrl: "https://example.com/reply.png",
       replyToId: "1700000000001",
       replyToAuthor: "+15550001111",
       replyToBody: "quote me",

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -44,6 +44,28 @@ const signalToolResultSessionStorePath = vi.hoisted(
   () => `/tmp/openclaw-signal-tool-result-sessions-${process.pid}.json`,
 );
 let signalToolResultStateDir: string | undefined;
+let signalToolResultIngressQueue: ReturnType<typeof createChannelIngressQueueForTests> | undefined;
+
+export async function waitForSignalToolResultIngressIdle() {
+  const queue = signalToolResultIngressQueue;
+  if (!queue) {
+    throw new Error("Signal tool-result ingress queue is not initialized");
+  }
+  await vi.waitFor(
+    async () => {
+      // Pending must be read before claims so a pending→claimed transition cannot
+      // disappear between two concurrent snapshots and produce a false idle.
+      const pending = await queue.listPending({ limit: "all" });
+      const claims = await queue.listClaims();
+      if (pending.length > 0 || claims.length > 0) {
+        throw new Error(
+          `Signal tool-result ingress still active: ${pending.length} pending, ${claims.length} claimed, ${replyMock.mock.calls.length} replies, ${sendMock.mock.calls.length} sends`,
+        );
+      }
+    },
+    { interval: 10, timeout: 5_000 },
+  );
+}
 
 export function getSignalToolResultTestMocks(): SignalToolResultTestMocks {
   return {
@@ -130,69 +152,30 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
-    "openclaw/plugin-sdk/reply-runtime",
+vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
+    "openclaw/plugin-sdk/channel-inbound",
   );
   return {
     ...actual,
-    getReplyFromConfig: (...args: unknown[]) => replyMock(...args),
-    dispatchInboundMessage: async (params: {
-      ctx: unknown;
-      cfg: unknown;
-      replyOptions?: {
-        turnAdoptionLifecycle?: { onAdopted?: () => void | Promise<void> };
-      };
-      dispatcher: {
-        sendFinalReply: (payload: {
-          text?: string;
-          mediaUrl?: string;
-          mediaUrls?: string[];
-        }) => boolean;
-        markComplete?: () => void;
-        waitForIdle?: () => Promise<void>;
-      };
-    }) => {
-      type TestReplyPayload = {
-        text?: string;
-        mediaUrl?: string;
-        mediaUrls?: string[];
-        isCompactionNotice?: boolean;
-        isFallbackNotice?: boolean;
-        isStatusNotice?: boolean;
-        replyToId?: string;
-        replyToTag?: boolean;
-        replyToCurrent?: boolean;
-      };
-      const resolved = (await replyMock(params.ctx, {}, params.cfg)) as
-        | {
-            replies?: TestReplyPayload[];
-          }
-        | TestReplyPayload
-        | TestReplyPayload[]
-        | undefined;
-      const resolvedPayloads = Array.isArray(resolved)
-        ? resolved
-        : Array.isArray((resolved as { replies?: unknown })?.replies)
-          ? (resolved as { replies: TestReplyPayload[] }).replies
-          : resolved
-            ? [resolved as TestReplyPayload]
-            : [];
-      let queuedFinal = false;
-      for (const resolvedPayload of resolvedPayloads) {
-        const text = typeof resolvedPayload.text === "string" ? resolvedPayload.text.trim() : "";
-        const hasMedia =
-          typeof resolvedPayload.mediaUrl === "string" ||
-          (Array.isArray(resolvedPayload.mediaUrls) && resolvedPayload.mediaUrls.length > 0);
-        if (text || hasMedia) {
-          queuedFinal = true;
-          params.dispatcher.sendFinalReply(resolvedPayload);
-        }
-      }
-      params.dispatcher.markComplete?.();
-      await params.dispatcher.waitForIdle?.();
-      await params.replyOptions?.turnAdoptionLifecycle?.onAdopted?.();
-      return { queuedFinal };
+    runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) => {
+      const resolveTurn = params.adapter.resolveTurn;
+      return await actual.runChannelInboundEvent({
+        ...params,
+        adapter: {
+          ...params.adapter,
+          resolveTurn: async (...args: Parameters<typeof resolveTurn>) => {
+            const resolved = await resolveTurn(...args);
+            if ("runDispatch" in resolved) {
+              return resolved;
+            }
+            return {
+              ...resolved,
+              replyResolver: (...replyArgs: unknown[]) => replyMock(...replyArgs),
+            } as typeof resolved;
+          },
+        },
+      });
     },
   };
 });
@@ -277,6 +260,7 @@ export function installSignalToolResultTestHooks() {
     );
     const stateDir = await fs.realpath(createdStateDir);
     signalToolResultStateDir = stateDir;
+    signalToolResultIngressQueue = undefined;
     setSignalRuntime({
       logging: {
         getChildLogger: () => ({
@@ -294,11 +278,13 @@ export function installSignalToolResultTestHooks() {
         openChannelIngressQueue: (
           options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
         ) => {
-          return createChannelIngressQueueForTests({
+          const queue = createChannelIngressQueueForTests({
             ...options,
             channelId: "signal",
             stateDir: options?.stateDir ?? stateDir,
           });
+          signalToolResultIngressQueue = queue;
+          return queue;
         },
       },
     } as unknown as PluginRuntime);
@@ -327,6 +313,7 @@ export function installSignalToolResultTestHooks() {
 
   afterEach(async () => {
     clearSignalRuntimeForTest();
+    signalToolResultIngressQueue = undefined;
     closeOpenClawStateDatabaseForTest();
     if (signalToolResultStateDir) {
       await fs.rm(signalToolResultStateDir, { recursive: true, force: true });

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -46,6 +46,10 @@ const signalToolResultSessionStorePath = vi.hoisted(
 let signalToolResultStateDir: string | undefined;
 let signalToolResultIngressQueue: ReturnType<typeof createChannelIngressQueueForTests> | undefined;
 
+export function toSignalToolResultTestError(value: unknown, fallbackMessage: string): Error {
+  return value instanceof Error ? value : new Error(fallbackMessage, { cause: value });
+}
+
 export async function waitForSignalToolResultIngressIdle() {
   const queue = signalToolResultIngressQueue;
   if (!queue) {

--- a/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
+++ b/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
@@ -43,18 +43,6 @@ vi.mock("../send-reactions.js", () => ({
   removeReactionSignal: vi.fn(async () => ({ ok: true })),
 }));
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
-    "openclaw/plugin-sdk/reply-runtime",
-  );
-  return {
-    ...actual,
-    dispatchInboundMessage: dispatchInboundMessageMock,
-    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
-    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
-  };
-});
-
 vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
     "openclaw/plugin-sdk/channel-inbound",
@@ -62,27 +50,44 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
   return {
     ...actual,
-    runChannelInboundEvent: (params: RunParams) => {
-      const resolveTurn = params.adapter.resolveTurn;
-      return actual.runChannelInboundEvent({
-        ...params,
-        adapter: {
-          ...params.adapter,
-          resolveTurn: async (input, eventClass, preflight) => {
-            const resolved = await resolveTurn(input, eventClass, preflight);
-            if (!("route" in resolved) || !("runDispatch" in resolved)) {
-              return resolved;
-            }
-            const { route, ...turn } = resolved;
-            return {
-              ...turn,
-              routeSessionKey: route.sessionKey,
-              storePath: "/tmp/openclaw/signal-sessions.json",
-              recordInboundSession: recordInboundSessionMock,
-            };
-          },
-        },
+    runChannelInboundEvent: async (params: RunParams) => {
+      const input = await params.adapter.ingest(params.raw);
+      if (!input) {
+        return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
+      }
+      const eventClass = (await params.adapter.classify?.(input)) ?? {
+        kind: "message" as const,
+        canStartAgentTurn: true,
+      };
+      const preflight = (await params.adapter.preflight?.(input, eventClass)) ?? {};
+      const resolved = await params.adapter.resolveTurn(
+        input,
+        eventClass,
+        "kind" in preflight ? { admission: preflight } : preflight,
+      );
+      if (!("route" in resolved) || !("delivery" in resolved)) {
+        throw new Error("expected assembled Signal channel turn plan");
+      }
+      const result = await actual.runPreparedInboundReply({
+        channel: resolved.channel,
+        accountId: resolved.accountId,
+        routeSessionKey: resolved.route.sessionKey,
+        storePath: "/tmp/openclaw/signal-sessions.json",
+        ctxPayload: resolved.ctxPayload,
+        recordInboundSession: recordInboundSessionMock,
+        afterRecord: resolved.afterRecord,
+        record: resolved.record,
+        history: resolved.history,
+        admission: resolved.admission,
+        botLoopProtection: resolved.botLoopProtection,
+        runDispatch: async () =>
+          await dispatchInboundMessageMock({
+            ctx: resolved.ctxPayload,
+            replyOptions: resolved.replyOptions,
+          }),
       });
+      await params.adapter.onFinalize?.(result);
+      return result;
     },
   };
 });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -596,6 +596,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           },
           dispatcherOptions,
           delivery,
+          // Signal retries the whole debounced flush below so the keyed lane and durable claims
+          // remain owned during backoff; a nested dispatch retry breaks shutdown cancellation.
+          sessionInitRetry: { delaysMs: [] },
           replyOptions: {
             ...(entry.turnAdoptionLifecycle
               ? bindIngressLifecycleToReplyOptions(entry.turnAdoptionLifecycle)


### PR DESCRIPTION
Related: #110495

## What Problem This Solves

Fixes an issue where a Signal monitor encountering a reply-session initialization conflict could remain alive through nested generic retries after shutdown, while the affected tool-result tests could time out because their old mock no longer intercepted the refactored core channel dispatcher.

## Why This Change Was Made

Signal keeps its established full-flush retry owner, which preserves keyed debounce ordering, tracked shutdown work, and durable claim abandonment; its assembled turn explicitly disables the newly activated nested dispatch retry. The shared test harness now wraps the public channel-inbound seam, injects only the synthetic reply resolver, and waits for both pending and claimed durable ingress work before stopping the monitor.

The broader three-layer session retry architecture is intentionally unchanged here. Removing Signal's owner loop would alter retry scope and lose claim/task ownership without additional core contracts.

## User Impact

Signal shutdown remains prompt during reply-session conflicts, and accepted inbound messages retain their durable queue ownership through retry. Maintainers also get deterministic Signal tool-result coverage through the real core dispatch path.

## Evidence

- Exact final head: four Signal suites, 58/58 tests passed locally after the Testbox sync backend timed out before code execution.
- Prior exact functional head: the same four suites passed 58/58 on Blacksmith; changed gate passed checksum, boundaries, formatting, and both extension typechecks, then identified only the three captured-error lint sites fixed in the final test-helper commit.
- Exact final head targeted `oxlint` and `oxfmt` checks passed on all changed files.
- Canonical Plugin SDK generated-baseline check passed.
- Fresh full-stack autoreview: clean, no accepted/actionable findings (0.90 confidence).

AI-assisted: yes. Two independent reviewers verified the Signal owner boundary and rejected the broader retry refactor as unsafe for this low-risk repair.
