### PR TITLE
fix(zalo): prevent webhook message loss after acknowledgment

### DIFF
--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -60,13 +60,13 @@ This page covers **Zalo Bot Creator / Marketplace bots**. **Zalo Official Accoun
 
 ## Limits
 
-| Limit                          | Value                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| Outbound text chunk size       | 2000 characters (Zalo API limit)                                              |
-| Media size (inbound/outbound)  | `channels.zalo.mediaMaxMb`, default `5` MB                                    |
-| Webhook request body           | 1 MB, 30s read timeout                                                        |
-| Webhook rate limit             | 120 requests / 60s per path+client IP, then HTTP 429                          |
-| Webhook duplicate-event window | 5 minutes (keyed on path + account + event name + chat + sender + message id) |
+| Limit                         | Value                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| Outbound text chunk size      | 2000 characters (Zalo API limit)                                         |
+| Media size (inbound/outbound) | `channels.zalo.mediaMaxMb`, default `5` MB                               |
+| Webhook request body          | 1 MB, 30s read timeout                                                   |
+| Webhook rate limit            | 120 requests / 60s per path+client IP, then HTTP 429                     |
+| Webhook replay tombstones     | 30 days, up to 20,000 completed events per account (keyed by message id) |
 
 ## Access control
 
@@ -97,6 +97,7 @@ Group chats are supported by the plugin (`chatTypes: ["direct", "group"]`) and g
   - Zalo sends events with an `X-Bot-Api-Secret-Token` header, checked with a constant-time comparison.
   - Gateway HTTP handles webhook requests at `channels.zalo.webhookPath` (defaults to the webhook URL's path).
   - Requests must use `Content-Type: application/json` (or a `+json` media type).
+  - HTTP 200 is returned only after the raw event is durably stored; storage failures return HTTP 500.
   - getUpdates polling and webhook are mutually exclusive per Zalo API docs.
 
 ## Supported message types

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -1,17 +1,26 @@
 // Zalo tests cover monitor.lifecycle plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   createEmptyPluginRegistry,
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../runtime-api.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "./accounts.js";
 
 const getWebhookInfoMock = vi.fn(async () => ({ ok: true, result: { url: "" } }));
 const deleteWebhookMock = vi.fn(async () => ({ ok: true, result: { url: "" } }));
 const getUpdatesMock = vi.fn(() => new Promise(() => {}));
 const setWebhookMock = vi.fn(async () => ({ ok: true, result: { url: "" } }));
+const getZaloRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./api.js", async () => {
   const actual = await vi.importActual<typeof import("./api.js")>("./api.js");
@@ -25,11 +34,7 @@ vi.mock("./api.js", async () => {
 });
 
 vi.mock("./runtime.js", () => ({
-  getZaloRuntime: () => ({
-    logging: {
-      shouldLogVerbose: () => false,
-    },
-  }),
+  getZaloRuntime: getZaloRuntimeMock,
 }));
 
 const TEST_ACCOUNT = {
@@ -38,6 +43,8 @@ const TEST_ACCOUNT = {
 } as unknown as ResolvedZaloAccount;
 
 const TEST_CONFIG = {} as OpenClawConfig;
+let testStateDir: string | undefined;
+let previousStateDir: string | undefined;
 
 async function settleLifecycleWork(): Promise<void> {
   for (let i = 0; i < 6; i += 1) {
@@ -70,11 +77,37 @@ async function startLifecycleMonitor(
 }
 
 describe("monitorZaloProvider lifecycle", () => {
-  afterEach(() => {
+  beforeEach(async () => {
+    const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-monitor-"));
+    testStateDir = await fs.realpath(createdDir);
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = testStateDir;
+    const core = createPluginRuntimeMock();
+    core.state.openChannelIngressQueue = (<T>(options: { accountId?: string }) =>
+      createChannelIngressQueueForTests<T>({
+        channelId: "zalo",
+        accountId: options.accountId ?? "default",
+        stateDir: testStateDir,
+      })) as PluginRuntime["state"]["openChannelIngressQueue"];
+    getZaloRuntimeMock.mockReturnValue(core);
+  });
+
+  afterEach(async () => {
     vi.clearAllMocks();
     getUpdatesMock.mockReset();
     getUpdatesMock.mockImplementation(() => new Promise(() => {}));
     setActivePluginRegistry(createEmptyPluginRegistry());
+    closeOpenClawStateDatabaseForTest();
+    if (testStateDir) {
+      await fs.rm(testStateDir, { recursive: true, force: true });
+      testStateDir = undefined;
+    }
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      previousStateDir = undefined;
+    }
   });
 
   it("stays alive in polling mode until abort", async () => {
@@ -184,6 +217,7 @@ describe("monitorZaloProvider lifecycle", () => {
       resolveSetWebhookCalled = resolve;
     });
     setWebhookMock.mockImplementationOnce(async () => {
+      expect(registry.httpRoutes).toHaveLength(2);
       resolveSetWebhookCalled?.();
       return { ok: true, result: { url: "" } };
     });

--- a/extensions/zalo/src/monitor.reply-once.lifecycle.test-support.ts
+++ b/extensions/zalo/src/monitor.reply-once.lifecycle.test-support.ts
@@ -72,7 +72,8 @@ describe("Zalo reply-once lifecycle", () => {
 
   it("routes one accepted webhook event to one visible reply across duplicate replay", async () => {
     dispatchReplyWithBufferedBlockDispatcherMock.mockImplementation(
-      async ({ dispatcherOptions }) => {
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions.turnAdoptionLifecycle?.onAdopted();
         await dispatcherOptions.deliver({ text: "zalo reply once" });
       },
     );
@@ -132,8 +133,10 @@ describe("Zalo reply-once lifecycle", () => {
   it("does not emit a second visible reply when replay arrives after a post-send failure", async () => {
     let dispatchAttempts = 0;
     dispatchReplyWithBufferedBlockDispatcherMock.mockImplementation(
-      async ({ dispatcherOptions }) => {
+      async ({ dispatcherOptions, replyOptions }) => {
         dispatchAttempts += 1;
+        expect(replyOptions.turnAdoptionLifecycle).toBeDefined();
+        await replyOptions.turnAdoptionLifecycle?.onAdopted();
         await dispatcherOptions.deliver({ text: "zalo reply after failure" });
         if (dispatchAttempts === 1) {
           throw new Error("post-send failure");
@@ -173,9 +176,7 @@ describe("Zalo reply-once lifecycle", () => {
 
       expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
       expect(sendMessageMock).toHaveBeenCalledTimes(1);
-      expect(monitor.runtime.error).toHaveBeenCalledWith(
-        "[acct-zalo-lifecycle] Zalo webhook failed: Error: post-send failure",
-      );
+      expect(monitor.runtime.error).not.toHaveBeenCalled();
     } finally {
       await monitor.stop();
     }

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -48,6 +48,7 @@ import {
 } from "./outbound-media.js";
 import { resolveZaloProxyFetch } from "./proxy.js";
 import { getZaloRuntime } from "./runtime.js";
+import type { ZaloWebhookIngressLifecycle } from "./webhook-spool.js";
 
 /** Default idle timeout for Zalo inbound photo downloads (30 seconds). */
 const ZALO_MEDIA_READ_IDLE_TIMEOUT_MS = 30_000;
@@ -88,6 +89,7 @@ type ZaloProcessingContext = {
   webhookPath?: string;
   statusSink?: ZaloStatusSink;
   fetcher?: ZaloFetch;
+  turnAdoptionLifecycle?: ZaloWebhookIngressLifecycle;
 };
 
 type ZaloPollingLoopParams = ZaloProcessingContext & {
@@ -106,7 +108,13 @@ function resolveZaloTimestampMs(date: number | undefined): number | undefined {
   return date >= UNIX_MILLISECONDS_THRESHOLD ? date : date * 1000;
 }
 
-const loadZaloWebhookModule = createLazyRuntimeModule(() => import("./monitor.webhook.js"));
+const loadZaloWebhookModule = createLazyRuntimeModule(async () => {
+  const [webhook, spool] = await Promise.all([
+    import("./monitor.webhook.js"),
+    import("./webhook-spool.js"),
+  ]);
+  return { ...webhook, ...spool };
+});
 
 function releaseSharedHostedMediaRouteRef(routePath: string): void {
   const current = hostedMediaRouteRefs.get(routePath);
@@ -210,22 +218,7 @@ async function handleZaloWebhookRequest(
 ): Promise<boolean> {
   const { handleZaloWebhookRequest: handleZaloWebhookRequestInternal } =
     await loadZaloWebhookModule();
-  return await handleZaloWebhookRequestInternal(req, res, async ({ update, target }) => {
-    await processUpdate({
-      update,
-      token: target.token,
-      account: target.account,
-      config: target.config,
-      runtime: target.runtime,
-      core: target.core as ZaloCoreRuntime,
-      mediaMaxMb: target.mediaMaxMb,
-      canHostMedia: target.canHostMedia,
-      webhookUrl: target.webhookUrl,
-      webhookPath: target.webhookPath,
-      statusSink: target.statusSink,
-      fetcher: target.fetcher,
-    });
-  });
+  return await handleZaloWebhookRequestInternal(req, res);
 }
 
 function startPollingLoop(params: ZaloPollingLoopParams) {
@@ -313,6 +306,7 @@ async function processUpdate(params: ZaloUpdateProcessingParams): Promise<void> 
     webhookPath: params.webhookPath,
     statusSink,
     fetcher,
+    turnAdoptionLifecycle: params.turnAdoptionLifecycle,
   };
   if (!message) {
     return undefined;
@@ -725,6 +719,9 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
         runtime.error?.(`zalo: failed updating session meta: ${String(err)}`);
       },
     },
+    ...(params.turnAdoptionLifecycle
+      ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+      : {}),
   });
 }
 
@@ -840,6 +837,7 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
 
   let stopped = false;
   const stopHandlers: Array<() => void> = [];
+  const asyncStopHandlers: Array<() => Promise<void>> = [];
   let cleanupWebhook: (() => Promise<void>) | undefined;
 
   const stop = () => {
@@ -874,7 +872,7 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
     }
 
     if (useWebhook) {
-      const { registerZaloWebhookTarget } = await loadZaloWebhookModule();
+      const { createZaloWebhookIngress, registerZaloWebhookTarget } = await loadZaloWebhookModule();
       if (!effectiveWebhookUrl || !webhookSecret) {
         throw new Error("Zalo webhookUrl and webhookSecret are required for webhook mode");
       }
@@ -893,43 +891,38 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       runtime.log?.(
         `[${account.accountId}] Zalo configuring webhook path=${path} target=${describeWebhookTarget(effectiveWebhookUrl)}`,
       );
-      await setWebhook(token, { url: effectiveWebhookUrl, secret_token: webhookSecret }, fetcher);
-      let webhookCleanupPromise: Promise<void> | undefined;
-      cleanupWebhook = async () => {
-        if (!webhookCleanupPromise) {
-          webhookCleanupPromise = (async () => {
-            runtime.log?.(`[${account.accountId}] Zalo stopping; deleting webhook`);
-            try {
-              await deleteWebhook(token, fetcher, WEBHOOK_CLEANUP_TIMEOUT_MS);
-              runtime.log?.(`[${account.accountId}] Zalo webhook deleted`);
-            } catch (err) {
-              const detail =
-                err instanceof Error && err.name === "AbortError"
-                  ? `timed out after ${String(WEBHOOK_CLEANUP_TIMEOUT_MS)}ms`
-                  : formatZaloError(err);
-              runtime.error?.(`[${account.accountId}] Zalo webhook delete failed: ${detail}`);
-            }
-          })();
-        }
-        await webhookCleanupPromise;
-      };
-      runtime.log?.(`[${account.accountId}] Zalo webhook registered path=${path}`);
-
+      const ingress = createZaloWebhookIngress({
+        accountId: account.accountId,
+        runtime,
+        deliver: async (update, turnAdoptionLifecycle) => {
+          statusSink?.({ lastInboundAt: Date.now() });
+          await processUpdate({
+            update,
+            token,
+            account,
+            config,
+            runtime,
+            core,
+            mediaMaxMb: effectiveMediaMaxMb,
+            canHostMedia,
+            webhookUrl: effectiveWebhookUrl,
+            webhookPath: path,
+            statusSink,
+            fetcher,
+            turnAdoptionLifecycle,
+          });
+        },
+      });
+      ingress.start();
+      asyncStopHandlers.push(ingress.stop);
       const unregister = registerZaloWebhookTarget(
         {
-          token,
           account,
           config,
           runtime,
-          core,
           path,
-          webhookUrl: effectiveWebhookUrl,
-          webhookPath: path,
           secret: webhookSecret,
-          statusSink: (patch) => statusSink?.(patch),
-          mediaMaxMb: effectiveMediaMaxMb,
-          canHostMedia,
-          fetcher,
+          acceptWebhook: ingress.accept,
         },
         {
           route: {
@@ -951,6 +944,31 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
         },
       );
       stopHandlers.push(unregister);
+      await setWebhook(
+        token,
+        { url: effectiveWebhookUrl, secret_token: webhookSecret }, // pragma: allowlist secret
+        fetcher,
+      );
+      let webhookCleanupPromise: Promise<void> | undefined;
+      cleanupWebhook = async () => {
+        if (!webhookCleanupPromise) {
+          webhookCleanupPromise = (async () => {
+            runtime.log?.(`[${account.accountId}] Zalo stopping; deleting webhook`);
+            try {
+              await deleteWebhook(token, fetcher, WEBHOOK_CLEANUP_TIMEOUT_MS);
+              runtime.log?.(`[${account.accountId}] Zalo webhook deleted`);
+            } catch (err) {
+              const detail =
+                err instanceof Error && err.name === "AbortError"
+                  ? `timed out after ${String(WEBHOOK_CLEANUP_TIMEOUT_MS)}ms`
+                  : formatZaloError(err);
+              runtime.error?.(`[${account.accountId}] Zalo webhook delete failed: ${detail}`);
+            }
+          })();
+        }
+        await webhookCleanupPromise;
+      };
+      runtime.log?.(`[${account.accountId}] Zalo webhook registered path=${path}`);
       await waitForAbortSignal(abortSignal);
       return;
     }
@@ -1012,6 +1030,9 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
     abortSignal.removeEventListener("abort", stopOnAbort);
     await cleanupWebhook?.();
     stop();
+    for (const stopAsync of asyncStopHandlers) {
+      await stopAsync();
+    }
     runtime.log?.(`[${account.accountId}] Zalo provider stopped mode=${mode}`);
   }
 }

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -8,7 +8,10 @@ import {
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import {
+  createLazyRuntimeModule,
+  createLazyRuntimeNamedExport,
+} from "openclaw/plugin-sdk/lazy-runtime";
 import {
   deliverTextOrMediaReply,
   resolveSendableOutboundReplyParts,
@@ -108,13 +111,18 @@ function resolveZaloTimestampMs(date: number | undefined): number | undefined {
   return date >= UNIX_MILLISECONDS_THRESHOLD ? date : date * 1000;
 }
 
-const loadZaloWebhookModule = createLazyRuntimeModule(async () => {
-  const [webhook, spool] = await Promise.all([
-    import("./monitor.webhook.js"),
-    import("./webhook-spool.js"),
-  ]);
-  return { ...webhook, ...spool };
-});
+const loadZaloWebhookRuntime = createLazyRuntimeNamedExport(
+  () => import("./monitor.webhook.js"),
+  "zaloWebhookRuntime",
+);
+const loadZaloWebhookIngressRuntime = createLazyRuntimeNamedExport(
+  () => import("./webhook-spool.js"),
+  "zaloWebhookIngressRuntime",
+);
+const loadZaloWebhookModule = createLazyRuntimeModule(async () => ({
+  ...(await loadZaloWebhookRuntime()),
+  ...(await loadZaloWebhookIngressRuntime()),
+}));
 
 function releaseSharedHostedMediaRouteRef(routePath: string): void {
   const current = hostedMediaRouteRefs.get(routePath);

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -8,15 +8,17 @@ import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
-import {
+import { zaloWebhookRuntime } from "./monitor.webhook.js";
+import type { ResolvedZaloAccount } from "./types.js";
+import { ZaloWebhookPayloadError } from "./webhook-spool.js";
+
+const {
   clearZaloWebhookSecurityStateForTest,
   getZaloWebhookRateLimitStateSizeForTest,
   getZaloWebhookStatusCounterSizeForTest,
-  handleZaloWebhookRequest as handleZaloWebhookRequestInternal,
+  handleZaloWebhookRequest: handleZaloWebhookRequestInternal,
   registerZaloWebhookTarget,
-} from "./monitor.webhook.js";
-import type { ResolvedZaloAccount } from "./types.js";
-import { ZaloWebhookPayloadError } from "./webhook-spool.js";
+} = zaloWebhookRuntime;
 
 const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   accountId: "default",

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -6,7 +6,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+import type { OpenClawConfig } from "../runtime-api.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
 import {
   clearZaloWebhookSecurityStateForTest,
@@ -14,19 +14,9 @@ import {
   getZaloWebhookStatusCounterSizeForTest,
   handleZaloWebhookRequest as handleZaloWebhookRequestInternal,
   registerZaloWebhookTarget,
-  type ZaloWebhookProcessUpdate,
-  ZaloRetryableWebhookError,
 } from "./monitor.webhook.js";
-import { createTextUpdate, postWebhookReplay } from "./test-support/lifecycle-test-support.js";
 import type { ResolvedZaloAccount } from "./types.js";
-
-const runDetachedWebhookWork = vi.hoisted(() => vi.fn((run: () => Promise<void>) => run()));
-
-vi.mock("openclaw/plugin-sdk/webhook-request-guards", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("openclaw/plugin-sdk/webhook-request-guards")>();
-  return { ...actual, runDetachedWebhookWork };
-});
+import { ZaloWebhookPayloadError } from "./webhook-spool.js";
 
 const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   accountId: "default",
@@ -36,12 +26,10 @@ const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   config: {},
 };
 
-function createWebhookRequestHandler(
-  processUpdate: ZaloWebhookProcessUpdate = async () => {},
-): RequestListener {
+function createWebhookRequestHandler(): RequestListener {
   return (req, res) => {
     void (async () => {
-      const handled = await handleZaloWebhookRequestInternal(req, res, processUpdate);
+      const handled = await handleZaloWebhookRequestInternal(req, res);
       if (!handled) {
         res.statusCode = 404;
         res.end("not found");
@@ -58,22 +46,45 @@ function registerTarget(params: {
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   account?: ResolvedZaloAccount;
   config?: OpenClawConfig;
-  core?: PluginRuntime;
   runtime?: Partial<ZaloRuntimeEnv>;
+  acceptWebhook?: (rawEvent: string) => Promise<void>;
 }): () => void {
   return registerZaloWebhookTarget({
-    token: "tok",
     account: params.account ?? DEFAULT_ACCOUNT,
     config: params.config ?? ({} as OpenClawConfig),
     runtime: (params.runtime ?? {}) as ZaloRuntimeEnv,
-    core: params.core ?? ({} as PluginRuntime),
     secret: params.secret ?? "secret",
     path: params.path,
-    webhookUrl: `https://example.com${params.path}`,
-    webhookPath: params.path,
-    mediaMaxMb: 5,
-    canHostMedia: true,
-    statusSink: params.statusSink,
+    acceptWebhook:
+      params.acceptWebhook ??
+      (async (rawEvent) => {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(rawEvent);
+        } catch (error) {
+          throw new ZaloWebhookPayloadError("invalid JSON", { cause: error });
+        }
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new ZaloWebhookPayloadError("payload must be an object");
+        }
+        params.statusSink?.({ lastInboundAt: Date.now() });
+      }),
+  });
+}
+
+async function postWebhook(params: {
+  baseUrl: string;
+  path: string;
+  body: string;
+  secret?: string;
+}) {
+  return await fetch(`${params.baseUrl}${params.path}`, {
+    method: "POST",
+    headers: {
+      "x-bot-api-secret-token": params.secret ?? "secret",
+      "content-type": "application/json",
+    },
+    body: params.body,
   });
 }
 
@@ -102,44 +113,6 @@ async function postUntilRateLimited(params: {
     }
   }
   return false;
-}
-
-async function postWebhookJson(params: {
-  baseUrl: string;
-  path: string;
-  secret: string;
-  payload: unknown;
-}) {
-  return fetch(`${params.baseUrl}${params.path}`, {
-    method: "POST",
-    headers: {
-      "x-bot-api-secret-token": params.secret,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(params.payload),
-  });
-}
-
-async function expectTwoWebhookPostsOk(params: {
-  baseUrl: string;
-  first: { path: string; secret: string; payload: unknown };
-  second: { path: string; secret: string; payload: unknown };
-}) {
-  const first = await postWebhookJson({
-    baseUrl: params.baseUrl,
-    path: params.first.path,
-    secret: params.first.secret,
-    payload: params.first.payload,
-  });
-  const second = await postWebhookJson({
-    baseUrl: params.baseUrl,
-    path: params.second.path,
-    secret: params.second.secret,
-    payload: params.second.payload,
-  });
-
-  expect(first.status).toBe(200);
-  expect(second.status).toBe(200);
 }
 
 describe("handleZaloWebhookRequest", () => {
@@ -218,308 +191,72 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
-  it("deduplicates webhook replay for the same event origin", async () => {
-    runDetachedWebhookWork.mockClear();
-    const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay", statusSink: sink });
-    const payload = createTextUpdate({
-      messageId: "msg-replay-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
+  it("waits for durable admission before acknowledging", async () => {
+    let releaseAdmission = () => {};
+    const admission = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
     });
+    const acceptWebhook = vi.fn(async () => {
+      await admission;
+    });
+    const unregister = registerTarget({ path: "/hook-durable-ack", acceptWebhook });
 
     try {
       await withServer(webhookRequestHandler, async (baseUrl) => {
-        const { first, replay } = await postWebhookReplay({
+        let settled = false;
+        const responsePromise = postWebhook({
           baseUrl,
-          path: "/hook-replay",
-          secret: "secret",
-          payload,
+          path: "/hook-durable-ack",
+          body: '{"event_name":"message.text.received"}',
+        }).then((response) => {
+          settled = true;
+          return response;
         });
 
-        expect(first.status).toBe(200);
-        expect(replay.status).toBe(200);
-        expect(sink).toHaveBeenCalledTimes(1);
-        expect(runDetachedWebhookWork).toHaveBeenCalledTimes(2);
+        await vi.waitFor(() => expect(acceptWebhook).toHaveBeenCalledTimes(1));
+        expect(settled).toBe(false);
+        releaseAdmission();
+        expect((await responsePromise).status).toBe(200);
       });
     } finally {
+      releaseAdmission();
       unregister();
     }
   });
 
-  it("allows a retry after processUpdate throws a retryable replay error", async () => {
-    const error = vi.fn();
-    const unregister = registerTarget({
-      path: "/hook-retry-after-failure",
-      runtime: { error },
-    });
-    const payload = createTextUpdate({
-      messageId: "msg-retry-after-failure-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
-    });
-    let attempts = 0;
-    const processUpdate = vi.fn<ZaloWebhookProcessUpdate>(async () => {
-      attempts += 1;
-      if (attempts === 1) {
-        throw new ZaloRetryableWebhookError("boom");
-      }
-    });
-
-    try {
-      await withServer(createWebhookRequestHandler(processUpdate), async (baseUrl) => {
-        const first = await postWebhookJson({
-          baseUrl,
-          path: "/hook-retry-after-failure",
-          secret: "secret",
-          payload,
-        });
-
-        expect(first.status).toBe(200);
-        await vi.waitFor(() => expect(error).toHaveBeenCalledTimes(1));
-
-        const second = await postWebhookJson({
-          baseUrl,
-          path: "/hook-retry-after-failure",
-          secret: "secret",
-          payload,
-        });
-
-        expect(second.status).toBe(200);
-        await vi.waitFor(() => expect(processUpdate).toHaveBeenCalledTimes(2));
-      });
-    } finally {
-      unregister();
-    }
-  });
-
-  it("keeps replay dedupe isolated per authenticated target", async () => {
-    const sinkA = vi.fn();
-    const sinkB = vi.fn();
-    const unregisterA = registerTarget({
-      path: "/hook-replay-scope",
-      secret: "secret-a",
-      statusSink: sinkA,
-    });
-    const unregisterB = registerTarget({
-      path: "/hook-replay-scope",
-      secret: "secret-b",
-      statusSink: sinkB,
-      account: {
-        ...DEFAULT_ACCOUNT,
-        accountId: "work",
-      },
-    });
-    const payload = createTextUpdate({
-      messageId: "msg-replay-scope-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
-    });
+  it("passes the exact raw webhook JSON to durable admission", async () => {
+    const acceptWebhook = vi.fn(async () => {});
+    const unregister = registerTarget({ path: "/hook-raw", acceptWebhook });
+    const body = '{ "event_name": "message.text.received", "extra": true }';
 
     try {
       await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-scope", secret: "secret-a", payload },
-          second: { path: "/hook-replay-scope", secret: "secret-b", payload },
-        });
-      });
-
-      expect(sinkA).toHaveBeenCalledTimes(1);
-      expect(sinkB).toHaveBeenCalledTimes(1);
-    } finally {
-      unregisterA();
-      unregisterB();
-    }
-  });
-
-  it("does not collide replay dedupe across different chats", async () => {
-    const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay-chat-scope", statusSink: sink });
-    const firstPayload = createTextUpdate({
-      messageId: "msg-replay-chat-1",
-      userId: "123",
-      userName: "",
-      chatId: "chat-a",
-      text: "hello from a",
-    });
-    const secondPayload = createTextUpdate({
-      messageId: "msg-replay-chat-1",
-      userId: "123",
-      userName: "",
-      chatId: "chat-b",
-      text: "hello from b",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-chat-scope", secret: "secret", payload: firstPayload },
-          second: { path: "/hook-replay-chat-scope", secret: "secret", payload: secondPayload },
-        });
-      });
-
-      expect(sink).toHaveBeenCalledTimes(2);
-    } finally {
-      unregister();
-    }
-  });
-
-  it("does not collide replay dedupe across different senders in the same chat", async () => {
-    const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay-sender-scope", statusSink: sink });
-    const firstPayload = createTextUpdate({
-      messageId: "msg-replay-sender-1",
-      userId: "user-a",
-      userName: "",
-      chatId: "chat-shared",
-      text: "hello from user a",
-    });
-    const secondPayload = createTextUpdate({
-      messageId: "msg-replay-sender-1",
-      userId: "user-b",
-      userName: "",
-      chatId: "chat-shared",
-      text: "hello from user b",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-sender-scope", secret: "secret", payload: firstPayload },
-          second: { path: "/hook-replay-sender-scope", secret: "secret", payload: secondPayload },
-        });
-      });
-
-      expect(sink).toHaveBeenCalledTimes(2);
-    } finally {
-      unregister();
-    }
-  });
-
-  it("accepts replay metadata when optional fields are missing", async () => {
-    const sink = vi.fn();
-    const unregister = registerTarget({ path: "/hook-replay-partial", statusSink: sink });
-    const payload = {
-      event_name: "message.text.received",
-      message: {
-        message_id: "msg-replay-partial-1",
-        date: Math.floor(Date.now() / 1000),
-        text: "hello",
-      },
-    };
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        const response = await fetch(`${baseUrl}/hook-replay-partial`, {
-          method: "POST",
-          headers: {
-            "x-bot-api-secret-token": "secret",
-            "content-type": "application/json",
-          },
-          body: JSON.stringify(payload),
-        });
-
+        const response = await postWebhook({ baseUrl, path: "/hook-raw", body });
         expect(response.status).toBe(200);
       });
-
-      expect(sink).toHaveBeenCalledTimes(1);
+      expect(acceptWebhook).toHaveBeenCalledWith(body);
     } finally {
       unregister();
     }
   });
 
-  it("keeps replay dedupe isolated when path/account values collide under colon-joined keys", async () => {
-    const sinkA = vi.fn();
-    const sinkB = vi.fn();
-    // Old key format `${path}:${accountId}:${event_name}:${messageId}` would collide for these two targets.
-    const unregisterA = registerTarget({
-      path: "/hook-replay-collision:a",
-      secret: "secret-a",
-      statusSink: sinkA,
-      account: {
-        ...DEFAULT_ACCOUNT,
-        accountId: "team",
-      },
+  it("does not acknowledge a durable admission failure", async () => {
+    const acceptWebhook = vi.fn(async () => {
+      throw new Error("sqlite unavailable");
     });
-    const unregisterB = registerTarget({
-      path: "/hook-replay-collision",
-      secret: "secret-b",
-      statusSink: sinkB,
-      account: {
-        ...DEFAULT_ACCOUNT,
-        accountId: "a:team",
-      },
-    });
-    const payload = createTextUpdate({
-      messageId: "msg-replay-collision-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
-    });
+    const unregister = registerTarget({ path: "/hook-append-failure", acceptWebhook });
 
     try {
       await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
+        const response = await postWebhook({
           baseUrl,
-          first: { path: "/hook-replay-collision:a", secret: "secret-a", payload },
-          second: { path: "/hook-replay-collision", secret: "secret-b", payload },
+          path: "/hook-append-failure",
+          body: '{"event_name":"message.text.received"}',
         });
+        expect(response.status).toBe(500);
       });
-
-      expect(sinkA).toHaveBeenCalledTimes(1);
-      expect(sinkB).toHaveBeenCalledTimes(1);
     } finally {
-      unregisterA();
-      unregisterB();
-    }
-  });
-
-  it("keeps replay dedupe isolated across different webhook paths", async () => {
-    const sinkA = vi.fn();
-    const sinkB = vi.fn();
-    const sharedSecret = "secret";
-    const unregisterA = registerTarget({
-      path: "/hook-replay-scope-a",
-      secret: sharedSecret,
-      statusSink: sinkA,
-    });
-    const unregisterB = registerTarget({
-      path: "/hook-replay-scope-b",
-      secret: sharedSecret,
-      statusSink: sinkB,
-    });
-    const payload = createTextUpdate({
-      messageId: "msg-replay-cross-path-1",
-      userId: "123",
-      userName: "",
-      chatId: "123",
-      text: "hello",
-    });
-
-    try {
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        await expectTwoWebhookPostsOk({
-          baseUrl,
-          first: { path: "/hook-replay-scope-a", secret: sharedSecret, payload },
-          second: { path: "/hook-replay-scope-b", secret: sharedSecret, payload },
-        });
-      });
-
-      expect(sinkA).toHaveBeenCalledTimes(1);
-      expect(sinkB).toHaveBeenCalledTimes(1);
-    } finally {
-      unregisterA();
-      unregisterB();
+      unregister();
     }
   });
 

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -1,15 +1,12 @@
 // Zalo plugin module implements monitor.webhook behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
-import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
+import { readWebhookBodyOrReject } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { ResolvedZaloAccount } from "./accounts.js";
-import type { ZaloFetch, ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
 import {
   createFixedWindowRateLimiter,
   createWebhookAnomalyTracker,
-  readJsonWebhookBodyOrReject,
   applyBasicWebhookRequestGuards,
   registerWebhookTargetWithPluginRoute,
   type RegisterWebhookTargetOptions,
@@ -22,29 +19,16 @@ import {
   resolveClientIp,
   type OpenClawConfig,
 } from "./runtime-api.js";
-
-const ZALO_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
+import { ZaloWebhookPayloadError } from "./webhook-spool.js";
 
 type ZaloWebhookTarget = {
-  token: string;
   account: ResolvedZaloAccount;
   config: OpenClawConfig;
   runtime: ZaloRuntimeEnv;
-  core: unknown;
   secret: string;
   path: string;
-  webhookUrl: string;
-  webhookPath: string;
-  mediaMaxMb: number;
-  canHostMedia: boolean;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
-  fetcher?: ZaloFetch;
+  acceptWebhook: (rawEvent: string) => Promise<void>;
 };
-
-export type ZaloWebhookProcessUpdate = (params: {
-  update: ZaloUpdate;
-  target: ZaloWebhookTarget;
-}) => Promise<void>;
 
 const webhookTargets = new Map<string, ZaloWebhookTarget[]>();
 const webhookRateLimiter = createFixedWindowRateLimiter({
@@ -60,7 +44,6 @@ const webhookAnomalyTracker = createWebhookAnomalyTracker({
 
 export function clearZaloWebhookSecurityStateForTest(): void {
   webhookRateLimiter.clear();
-  recentWebhookEvents.clearMemory();
   webhookAnomalyTracker.clear();
 }
 
@@ -70,62 +53,6 @@ export function getZaloWebhookRateLimitStateSizeForTest(): number {
 
 export function getZaloWebhookStatusCounterSizeForTest(): number {
   return webhookAnomalyTracker.size();
-}
-
-function buildReplayEventCacheKey(target: ZaloWebhookTarget, update: ZaloUpdate): string | null {
-  const messageId = update.message?.message_id;
-  if (!messageId) {
-    return null;
-  }
-  const chatId = update.message?.chat?.id ?? "";
-  const senderId = update.message?.from?.id ?? "";
-  return JSON.stringify([
-    target.path,
-    target.account.accountId,
-    update.event_name,
-    chatId,
-    senderId,
-    messageId,
-  ]);
-}
-
-const recentWebhookEvents = createChannelReplayGuard<{
-  target: ZaloWebhookTarget;
-  update: ZaloUpdate;
-}>({
-  dedupe: {
-    ttlMs: ZALO_WEBHOOK_REPLAY_WINDOW_MS,
-    memoryMaxSize: 5000,
-  },
-  buildReplayKey: ({ target, update }) => buildReplayEventCacheKey(target, update),
-});
-
-export class ZaloRetryableWebhookError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "ZaloRetryableWebhookError";
-  }
-}
-
-async function processZaloReplayGuardedUpdate(params: {
-  target: ZaloWebhookTarget;
-  update: ZaloUpdate;
-  processUpdate: ZaloWebhookProcessUpdate;
-  nowMs?: number;
-}): Promise<"processed" | "duplicate"> {
-  const event = { target: params.target, update: params.update };
-  const result = await recentWebhookEvents.processGuarded(
-    event,
-    async () => {
-      params.target.statusSink?.({ lastInboundAt: Date.now() });
-      await params.processUpdate(event);
-    },
-    {
-      dedupe: { now: params.nowMs },
-      onError: (error) => (error instanceof ZaloRetryableWebhookError ? "release" : "commit"),
-    },
-  );
-  return result.kind === "processed" ? "processed" : "duplicate";
 }
 
 function recordWebhookStatus(
@@ -169,7 +96,6 @@ export function registerZaloWebhookTarget(
 export async function handleZaloWebhookRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  processUpdate: ZaloWebhookProcessUpdate,
 ): Promise<boolean> {
   return await withResolvedWebhookRequestPipeline({
     req,
@@ -226,46 +152,30 @@ export async function handleZaloWebhookRequest(
         recordWebhookStatus(target.runtime, path, res.statusCode);
         return true;
       }
-      const body = await readJsonWebhookBodyOrReject({
+      const body = await readWebhookBodyOrReject({
         req,
         res,
         maxBytes: 1024 * 1024,
         timeoutMs: 30_000,
-        emptyObjectOnEmpty: false,
-        invalidJsonMessage: "Bad Request",
+        invalidBodyMessage: "Bad Request",
       });
       if (!body.ok) {
         recordWebhookStatus(target.runtime, path, res.statusCode);
         return true;
       }
-      const raw = body.value;
-
-      // Zalo sends updates directly as { event_name, message, ... }, not wrapped in { ok, result }.
-      const record = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
-      const update: ZaloUpdate | undefined =
-        record && record.ok === true && record.result
-          ? (record.result as ZaloUpdate)
-          : ((record as ZaloUpdate | null) ?? undefined);
-
-      if (!update?.event_name) {
-        res.statusCode = 400;
-        res.end("Bad Request");
+      try {
+        // Ack only after the raw envelope is durably appended. The spool reserves
+        // detached drain work before this request's admission root is released.
+        await target.acceptWebhook(body.value);
+      } catch (error) {
+        res.statusCode = error instanceof ZaloWebhookPayloadError ? 400 : 500;
+        res.end(res.statusCode === 400 ? "Bad Request" : "Internal Server Error");
         recordWebhookStatus(target.runtime, path, res.statusCode);
+        target.runtime.error?.(
+          `[${target.account.accountId}] Zalo webhook admission failed: ${String(error)}`,
+        );
         return true;
       }
-
-      // Reserve the detached task before the HTTP admission is released;
-      // otherwise later queue work inherits a released admission root.
-      void runDetachedWebhookWork(() =>
-        processZaloReplayGuardedUpdate({
-          target,
-          update,
-          processUpdate,
-          nowMs,
-        }),
-      ).catch((err: unknown) => {
-        target.runtime.error?.(`[${target.account.accountId}] Zalo webhook failed: ${String(err)}`);
-      });
 
       res.statusCode = 200;
       res.end("ok");

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -42,16 +42,16 @@ const webhookAnomalyTracker = createWebhookAnomalyTracker({
   logEvery: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.logEvery,
 });
 
-export function clearZaloWebhookSecurityStateForTest(): void {
+function clearZaloWebhookSecurityStateForTest(): void {
   webhookRateLimiter.clear();
   webhookAnomalyTracker.clear();
 }
 
-export function getZaloWebhookRateLimitStateSizeForTest(): number {
+function getZaloWebhookRateLimitStateSizeForTest(): number {
   return webhookRateLimiter.size();
 }
 
-export function getZaloWebhookStatusCounterSizeForTest(): number {
+function getZaloWebhookStatusCounterSizeForTest(): number {
   return webhookAnomalyTracker.size();
 }
 
@@ -73,7 +73,7 @@ function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
-export function registerZaloWebhookTarget(
+function registerZaloWebhookTarget(
   target: ZaloWebhookTarget,
   opts?: {
     route?: RegisterWebhookPluginRouteOptions;
@@ -93,7 +93,7 @@ export function registerZaloWebhookTarget(
   return registerWebhookTarget(webhookTargets, target, opts).unregister;
 }
 
-export async function handleZaloWebhookRequest(
+async function handleZaloWebhookRequest(
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<boolean> {
@@ -183,3 +183,11 @@ export async function handleZaloWebhookRequest(
     },
   });
 }
+
+export const zaloWebhookRuntime = {
+  clearZaloWebhookSecurityStateForTest,
+  getZaloWebhookRateLimitStateSizeForTest,
+  getZaloWebhookStatusCounterSizeForTest,
+  handleZaloWebhookRequest,
+  registerZaloWebhookTarget,
+};

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -126,7 +126,7 @@ export async function resetLifecycleTestState() {
     previousLifecycleStateDir = undefined;
   }
   vi.clearAllMocks();
-  (await importCachedWebhookModule()).clearZaloWebhookSecurityStateForTest();
+  (await importCachedWebhookModule()).zaloWebhookRuntime.clearZaloWebhookSecurityStateForTest();
   setActivePluginRegistry(createEmptyPluginRegistry());
 }
 

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -1,13 +1,20 @@
 // Zalo plugin module implements monitor mocks test support behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   createEmptyPluginRegistry,
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi, type Mock } from "vitest";
-import type { OpenClawConfig } from "../runtime-api.js";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "../types.js";
 
 type MonitorModule = typeof import("../monitor.js");
@@ -23,6 +30,8 @@ const runtimeModuleId = new URL("../runtime.js", import.meta.url).pathname;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 type AsyncUnknownMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 const cachedMonitorModules = new Map<string, Promise<MonitorModule>>();
+let lifecycleStateDir: string | undefined;
+let previousLifecycleStateDir: string | undefined;
 
 type ZaloLifecycleMocks = {
   setWebhookMock: AsyncUnknownMock;
@@ -105,9 +114,35 @@ const importCachedWebhookModule = createLazyRuntimeModule(
 );
 
 export async function resetLifecycleTestState() {
+  closeOpenClawStateDatabaseForTest();
+  if (lifecycleStateDir) {
+    await fs.rm(lifecycleStateDir, { recursive: true, force: true });
+    lifecycleStateDir = undefined;
+  }
+  if (previousLifecycleStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = previousLifecycleStateDir;
+    previousLifecycleStateDir = undefined;
+  }
   vi.clearAllMocks();
   (await importCachedWebhookModule()).clearZaloWebhookSecurityStateForTest();
   setActivePluginRegistry(createEmptyPluginRegistry());
+}
+
+async function installLifecycleWebhookIngressState(): Promise<void> {
+  const runtime = getZaloRuntimeMock() as PluginRuntime;
+  const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-lifecycle-"));
+  const stateDir = await fs.realpath(createdDir);
+  previousLifecycleStateDir = process.env.OPENCLAW_STATE_DIR;
+  lifecycleStateDir = stateDir;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  runtime.state.openChannelIngressQueue = (<T>(options: { accountId?: string }) =>
+    createChannelIngressQueueForTests<T>({
+      channelId: "zalo",
+      accountId: options.accountId ?? "default",
+      stateDir,
+    })) as PluginRuntime["state"]["openChannelIngressQueue"];
 }
 
 export function setLifecycleRuntimeCore(
@@ -150,6 +185,7 @@ export async function startWebhookLifecycleMonitor(params: {
   webhookSecret?: string;
   cacheKey?: string;
 }) {
+  await installLifecycleWebhookIngressState();
   const registry = createEmptyPluginRegistry();
   setActivePluginRegistry(registry);
   const abort = new AbortController();

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -1,6 +1,5 @@
 // Zalo plugin module implements monitor mocks test support behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -13,6 +12,7 @@ import {
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { vi, type Mock } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "../types.js";
@@ -132,7 +132,9 @@ export async function resetLifecycleTestState() {
 
 async function installLifecycleWebhookIngressState(): Promise<void> {
   const runtime = getZaloRuntimeMock() as PluginRuntime;
-  const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-lifecycle-"));
+  const createdDir = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-zalo-lifecycle-"),
+  );
   const stateDir = await fs.realpath(createdDir);
   previousLifecycleStateDir = process.env.OPENCLAW_STATE_DIR;
   lifecycleStateDir = stateDir;

--- a/extensions/zalo/src/webhook-spool.test-support.ts
+++ b/extensions/zalo/src/webhook-spool.test-support.ts
@@ -1,0 +1,73 @@
+// Zalo tests share isolated durable-ingress state and Bot API envelopes.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { expect, vi } from "vitest";
+import type { createZaloWebhookIngress } from "./webhook-spool.js";
+
+export type ZaloWebhookTestQueue = NonNullable<
+  Parameters<typeof createZaloWebhookIngress>[0]["queue"]
+>;
+export type ZaloWebhookTestPayload = Parameters<ZaloWebhookTestQueue["enqueue"]>[1];
+
+export function createZaloWebhookTestEvent(params?: {
+  messageId?: string;
+  userId?: string;
+  chatId?: string;
+  text?: string;
+  date?: number;
+}) {
+  return {
+    event_name: "message.text.received" as const,
+    message: {
+      message_id: params?.messageId ?? "message-1",
+      from: { id: params?.userId ?? "user-1", name: "Test User" },
+      chat: { id: params?.chatId ?? "chat-1", chat_type: "PRIVATE" as const },
+      date: params?.date ?? Date.now(),
+      text: params?.text ?? "hello",
+    },
+  };
+}
+
+export async function withZaloWebhookTestQueue<T>(
+  fn: (queue: ZaloWebhookTestQueue) => Promise<T>,
+): Promise<T> {
+  const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-ingress-"));
+  const stateDir = await fs.realpath(createdDir);
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  const queue = createChannelIngressQueueForTests<ZaloWebhookTestPayload>({
+    channelId: "zalo",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await fn(queue);
+  } finally {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+export async function waitForZaloWebhookVerdict(
+  queue: ZaloWebhookTestQueue,
+  eventId: string,
+  expected: "completed" | "failed",
+): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const verdict = await queue.enqueue(eventId, { version: 1, rawEvent: "{}" });
+      expect(verdict.kind).toBe(expected);
+    },
+    { timeout: 5_000 },
+  );
+}

--- a/extensions/zalo/src/webhook-spool.test-support.ts
+++ b/extensions/zalo/src/webhook-spool.test-support.ts
@@ -7,11 +7,11 @@ import {
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { expect, vi } from "vitest";
-import type { createZaloWebhookIngress } from "./webhook-spool.js";
+import type { zaloWebhookIngressRuntime } from "./webhook-spool.js";
 
-export type ZaloWebhookTestQueue = NonNullable<
-  Parameters<typeof createZaloWebhookIngress>[0]["queue"]
->;
+type CreateZaloWebhookIngress = (typeof zaloWebhookIngressRuntime)["createZaloWebhookIngress"];
+
+type ZaloWebhookTestQueue = NonNullable<Parameters<CreateZaloWebhookIngress>[0]["queue"]>;
 export type ZaloWebhookTestPayload = Parameters<ZaloWebhookTestQueue["enqueue"]>[1];
 
 export function createZaloWebhookTestEvent(params?: {

--- a/extensions/zalo/src/webhook-spool.test-support.ts
+++ b/extensions/zalo/src/webhook-spool.test-support.ts
@@ -1,11 +1,11 @@
 // Zalo tests share isolated durable-ingress state and Bot API envelopes.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { expect, vi } from "vitest";
 import type { zaloWebhookIngressRuntime } from "./webhook-spool.js";
 
@@ -36,7 +36,9 @@ export function createZaloWebhookTestEvent(params?: {
 export async function withZaloWebhookTestQueue<T>(
   fn: (queue: ZaloWebhookTestQueue) => Promise<T>,
 ): Promise<T> {
-  const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-ingress-"));
+  const createdDir = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-zalo-ingress-"),
+  );
   const stateDir = await fs.realpath(createdDir);
   const previousStateDir = process.env.OPENCLAW_STATE_DIR;
   process.env.OPENCLAW_STATE_DIR = stateDir;

--- a/extensions/zalo/src/webhook-spool.test.ts
+++ b/extensions/zalo/src/webhook-spool.test.ts
@@ -1,0 +1,365 @@
+// Zalo tests cover durable webhook admission, replay, recovery, and failure taxonomy.
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createZaloWebhookIngress } from "./webhook-spool.js";
+import {
+  createZaloWebhookTestEvent,
+  waitForZaloWebhookVerdict,
+  withZaloWebhookTestQueue,
+  type ZaloWebhookTestPayload,
+} from "./webhook-spool.test-support.js";
+
+function runtime() {
+  return { error: vi.fn(), log: vi.fn() };
+}
+
+function rawEvent(params?: Parameters<typeof createZaloWebhookTestEvent>[0]): string {
+  return JSON.stringify(createZaloWebhookTestEvent(params));
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("Zalo durable webhook ingress", () => {
+  it("serializes concurrent admissions across append backoff", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const realEnqueue = queue.enqueue.bind(queue);
+      const admissionOrder: string[] = [];
+      let failedFirstAttempt = false;
+      const enqueue: typeof queue.enqueue = async (...args) => {
+        admissionOrder.push(args[0]);
+        if (!failedFirstAttempt) {
+          failedFirstAttempt = true;
+          throw new Error("sqlite busy");
+        }
+        return await realEnqueue(...args);
+      };
+      const serializedQueue: ChannelIngressQueue<ZaloWebhookTestPayload> = {
+        ...queue,
+        enqueue,
+      };
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue: serializedQueue,
+        deliver: vi.fn(),
+      });
+
+      await Promise.all([
+        ingress.accept(rawEvent({ messageId: "admission-a", chatId: "same-chat" })),
+        ingress.accept(rawEvent({ messageId: "admission-b", chatId: "same-chat" })),
+      ]);
+
+      expect(admissionOrder).toEqual(["admission-a", "admission-a", "admission-b"]);
+      expect((await queue.listPending({ limit: "all" })).map((entry) => entry.id)).toEqual([
+        "admission-a",
+        "admission-b",
+      ]);
+      await ingress.stop();
+    });
+  });
+
+  it("retries a failed append before acknowledging and fails closed after the bound", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const enqueue = vi.fn(async () => {
+        throw new Error("sqlite unavailable");
+      });
+      const failingQueue: ChannelIngressQueue<ZaloWebhookTestPayload> = { ...queue, enqueue };
+      const deliver = vi.fn(async () => {});
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue: failingQueue,
+        deliver,
+      });
+
+      await expect(ingress.accept(rawEvent({ messageId: "append-failure" }))).rejects.toThrow(
+        "sqlite unavailable",
+      );
+      expect(enqueue).toHaveBeenCalledTimes(3);
+      expect(deliver).not.toHaveBeenCalled();
+      await ingress.stop();
+    });
+  });
+
+  it("recovers an uncompleted event with a fresh drain and dispatches exactly once", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const interrupted = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver: vi.fn(),
+      });
+      await interrupted.accept(rawEvent({ messageId: "restart" }));
+      await interrupted.stop();
+
+      const deliver = vi.fn(async (_update, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const recovered = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      recovered.start();
+      try {
+        await waitForZaloWebhookVerdict(queue, "restart", "completed");
+        expect(deliver).toHaveBeenCalledTimes(1);
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("keeps a completion tombstone and rejects a post-completion duplicate", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const deliver = vi.fn(async (_update, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      const raw = rawEvent({ messageId: "duplicate" });
+      ingress.start();
+      try {
+        await ingress.accept(raw);
+        await waitForZaloWebhookVerdict(queue, "duplicate", "completed");
+        await ingress.accept(raw);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
+        expect(deliver).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("preserves old replay-guard parity for the same message id with changed payload bytes", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const deliver = vi.fn(async (_update, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      ingress.start();
+      try {
+        await ingress.accept(rawEvent({ messageId: "redelivery", text: "original", date: 1 }));
+        await waitForZaloWebhookVerdict(queue, "redelivery", "completed");
+        await ingress.accept(
+          rawEvent({ messageId: "redelivery", text: "transport redelivery", date: 2 }),
+        );
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
+        expect(deliver).toHaveBeenCalledTimes(1);
+        expect(deliver.mock.calls[0]?.[0].message?.text).toBe("original");
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("stores raw JSON and derives the conversation lane before dispatch normalization", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const event = createZaloWebhookTestEvent({
+        messageId: "raw",
+        chatId: "conversation-42",
+        text: "before",
+      });
+      const deliveredText: string[] = [];
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver: async (update, lifecycle) => {
+          deliveredText.push(update.message?.text ?? "");
+          await lifecycle.onAdopted();
+        },
+      });
+      const raw = JSON.stringify(event);
+      await ingress.accept(raw);
+      expect(await queue.listPending()).toEqual([
+        expect.objectContaining({
+          id: "raw",
+          laneKey: "chat:conversation-42",
+          payload: { version: 1, rawEvent: raw },
+        }),
+      ]);
+      event.message.text = "after";
+
+      ingress.start();
+      try {
+        await waitForZaloWebhookVerdict(queue, "raw", "completed");
+        expect(deliveredText).toEqual(["before"]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters malformed persisted JSON without dispatch", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      await queue.enqueue(
+        "malformed",
+        { version: 1, rawEvent: "{" },
+        { laneKey: "chat:conversation-1" },
+      );
+      const deliver = vi.fn(async () => {});
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      ingress.start();
+      try {
+        await waitForZaloWebhookVerdict(queue, "malformed", "failed");
+        expect(deliver).not.toHaveBeenCalled();
+        const verdict = await queue.enqueue("malformed", { version: 1, rawEvent: "{}" });
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("invalid-event");
+        }
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("retries transient dispatch failures", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const deliver = vi.fn(async (_update, lifecycle) => {
+        if (deliver.mock.calls.length === 1) {
+          throw new Error("temporary dispatch outage");
+        }
+        await lifecycle.onAdopted();
+      });
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      ingress.start();
+      try {
+        await ingress.accept(rawEvent({ messageId: "retry" }));
+        await waitForZaloWebhookVerdict(queue, "retry", "completed");
+        expect(deliver).toHaveBeenCalledTimes(2);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters authentication failures without retry", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      const deliver = vi.fn(async () => {
+        throw Object.assign(new Error("invalid Zalo token"), { statusCode: 401 });
+      });
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      ingress.start();
+      try {
+        await ingress.accept(rawEvent({ messageId: "auth-failure" }));
+        await waitForZaloWebhookVerdict(queue, "auth-failure", "failed");
+        expect(deliver).toHaveBeenCalledTimes(1);
+        const verdict = await queue.enqueue("auth-failure", { version: 1, rawEvent: "{}" });
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("authentication-failed");
+        }
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("waits for an active delivery before shutdown returns", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      let releaseDelivery = () => {};
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      const deliver = vi.fn(async (_update, lifecycle) => {
+        await lifecycle.onAdopted();
+        await deliveryGate;
+      });
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      ingress.start();
+      await ingress.accept(rawEvent({ messageId: "active-stop" }));
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+
+      let stopped = false;
+      const stopping = ingress.stop().then(() => {
+        stopped = true;
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(stopped).toBe(false);
+      releaseDelivery();
+      await stopping;
+      expect(stopped).toBe(true);
+    });
+  });
+
+  it("holds a deferred claim through shutdown until adoption settles", async () => {
+    await withZaloWebhookTestQueue(async (queue) => {
+      let deferredLifecycle:
+        | Parameters<Parameters<typeof createZaloWebhookIngress>[0]["deliver"]>[1]
+        | undefined;
+      const deliver = vi.fn(async (_update, lifecycle) => {
+        deferredLifecycle = lifecycle;
+        lifecycle.onDeferred();
+      });
+      const ingress = createZaloWebhookIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      ingress.start();
+      await ingress.accept(rawEvent({ messageId: "deferred-stop" }));
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      let stopped = false;
+      const stopping = ingress.stop().then(() => {
+        stopped = true;
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(stopped).toBe(false);
+      if (!deferredLifecycle) {
+        throw new Error("Zalo delivery did not expose its deferred lifecycle");
+      }
+      await deferredLifecycle.onAdopted();
+      await stopping;
+      expect(stopped).toBe(true);
+      const verdict = await queue.enqueue("deferred-stop", { version: 1, rawEvent: "{}" });
+      expect(verdict.kind).toBe("completed");
+    });
+  });
+});

--- a/extensions/zalo/src/webhook-spool.test.ts
+++ b/extensions/zalo/src/webhook-spool.test.ts
@@ -2,13 +2,15 @@
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createZaloWebhookIngress } from "./webhook-spool.js";
+import { zaloWebhookIngressRuntime } from "./webhook-spool.js";
 import {
   createZaloWebhookTestEvent,
   waitForZaloWebhookVerdict,
   withZaloWebhookTestQueue,
   type ZaloWebhookTestPayload,
 } from "./webhook-spool.test-support.js";
+
+const { createZaloWebhookIngress } = zaloWebhookIngressRuntime;
 
 function runtime() {
   return { error: vi.fn(), log: vi.fn() };

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -1,0 +1,362 @@
+// Zalo plugin owns raw webhook durable admission and replay draining.
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_ADOPTION_STALL_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
+import { ZaloApiError, type ZaloUpdate } from "./api.js";
+import type { ZaloRuntimeEnv } from "./monitor.types.js";
+import { getZaloRuntime } from "./runtime.js";
+
+const ZALO_WEBHOOK_SPOOL_VERSION = 1;
+const ZALO_WEBHOOK_DRAIN_INTERVAL_MS = 500;
+const ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES = 8;
+const ZALO_WEBHOOK_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
+// Durable tombstones dominate the retired 5-minute / 5,000-key replay cache.
+const ZALO_WEBHOOK_COMPLETED_TTL_MS = 30 * 24 * 60 * 60_000;
+const ZALO_WEBHOOK_COMPLETED_MAX_ENTRIES = 20_000;
+const ZALO_WEBHOOK_FAILED_TTL_MS = 30 * 24 * 60 * 60_000;
+const ZALO_WEBHOOK_FAILED_MAX_ENTRIES = 5_000;
+const ZALO_WEBHOOK_APPEND_RETRY_DELAYS_MS = [0, 100, 300] as const;
+
+type ZaloWebhookSpoolPayload = {
+  version: 1;
+  rawEvent: string;
+};
+
+export type ZaloWebhookIngressLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
+
+export class ZaloWebhookPayloadError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ZaloWebhookPayloadError";
+  }
+}
+
+type ZaloWebhookIngress = {
+  accept: (rawEvent: string) => Promise<void>;
+  start: () => void;
+  stop: () => Promise<void>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseRawRecord(rawEvent: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawEvent);
+  } catch (error) {
+    throw new ZaloWebhookPayloadError("Zalo webhook body contains invalid JSON.", { cause: error });
+  }
+  if (!isRecord(parsed)) {
+    throw new ZaloWebhookPayloadError("Zalo webhook body must be a JSON object.");
+  }
+  return parsed;
+}
+
+function resolveUpdateRecord(envelope: Record<string, unknown>): Record<string, unknown> {
+  // Preserve the accepted direct and legacy { ok, result } envelope shapes.
+  if (envelope.ok === true && isRecord(envelope.result)) {
+    return envelope.result;
+  }
+  return envelope;
+}
+
+function inspectZaloWebhookEvent(rawEvent: string): {
+  eventId: string;
+  laneKey: string;
+  update: Record<string, unknown>;
+} {
+  const update = resolveUpdateRecord(parseRawRecord(rawEvent));
+  const message = isRecord(update.message) ? update.message : null;
+  const eventId = nonEmptyString(message?.message_id);
+  if (!eventId) {
+    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.message_id.");
+  }
+  const chat = isRecord(message?.chat) ? message.chat : null;
+  const chatId = nonEmptyString(chat?.id);
+  if (!chatId) {
+    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.chat.id.");
+  }
+  return { eventId, laneKey: `chat:${chatId}`, update };
+}
+
+function parseClaimedUpdate(payload: ZaloWebhookSpoolPayload, claimedId: string): ZaloUpdate {
+  if (payload.version !== ZALO_WEBHOOK_SPOOL_VERSION || typeof payload.rawEvent !== "string") {
+    throw new ZaloWebhookPayloadError("Zalo webhook spool payload is invalid.");
+  }
+  const facts = inspectZaloWebhookEvent(payload.rawEvent);
+  if (facts.eventId !== claimedId) {
+    throw new ZaloWebhookPayloadError("Zalo webhook message id changed after durable admission.");
+  }
+  const eventName = nonEmptyString(facts.update.event_name);
+  if (
+    eventName !== "message.text.received" &&
+    eventName !== "message.image.received" &&
+    eventName !== "message.sticker.received" &&
+    eventName !== "message.unsupported.received"
+  ) {
+    throw new ZaloWebhookPayloadError("Zalo webhook event_name is unsupported.");
+  }
+  const message = facts.update.message as Record<string, unknown>;
+  const from = isRecord(message.from) ? message.from : null;
+  const chat = isRecord(message.chat) ? message.chat : null;
+  if (!nonEmptyString(from?.id)) {
+    throw new ZaloWebhookPayloadError("Zalo webhook message is missing message.from.id.");
+  }
+  if (chat?.chat_type !== "PRIVATE" && chat?.chat_type !== "GROUP") {
+    throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid chat type.");
+  }
+  if (typeof message.date !== "number" || !Number.isFinite(message.date)) {
+    throw new ZaloWebhookPayloadError("Zalo webhook message has an invalid date.");
+  }
+  if (eventName === "message.text.received" && typeof message.text !== "string") {
+    throw new ZaloWebhookPayloadError("Zalo text event is missing message.text.");
+  }
+  return facts.update as unknown as ZaloUpdate;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isZaloAuthenticationFailure(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as {
+      cause?: unknown;
+      errorCode?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+    };
+    if (
+      (current instanceof ZaloApiError &&
+        (current.errorCode === 401 || current.errorCode === 403)) ||
+      candidate.status === 401 ||
+      candidate.status === 403 ||
+      candidate.statusCode === 401 ||
+      candidate.statusCode === 403
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+export function createZaloWebhookIngress(options: {
+  accountId: string;
+  runtime: Pick<ZaloRuntimeEnv, "error" | "log">;
+  deliver: (update: ZaloUpdate, lifecycle: ZaloWebhookIngressLifecycle) => Promise<void>;
+  queue?: ChannelIngressQueue<ZaloWebhookSpoolPayload>;
+}): ZaloWebhookIngress {
+  const queue =
+    options.queue ??
+    getZaloRuntime().state.openChannelIngressQueue<ZaloWebhookSpoolPayload>({
+      accountId: options.accountId,
+    });
+  let running = false;
+  let stopped = false;
+  let drainRequested = false;
+  let drainTask: Promise<void> | undefined;
+  let drainTimer: ReturnType<typeof setInterval> | undefined;
+  let lastPrunedAt = 0;
+  let admissionTail: Promise<void> = Promise.resolve();
+  const activeDeliveries = new Set<Promise<void>>();
+  const deferredClaims = new Map<string, Promise<void>>();
+
+  const drain = createChannelIngressDrain<ZaloWebhookSpoolPayload>({
+    queue,
+    adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
+    startLimit: ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
+    retryPolicy: {
+      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      deadLetterMinAgeMs: 0,
+    },
+    resolveNonRetryableFailure: (error) => {
+      if (error instanceof ZaloWebhookPayloadError) {
+        return { reason: "invalid-event", message: error.message };
+      }
+      if (isZaloAuthenticationFailure(error)) {
+        return { reason: "authentication-failed", message: errorText(error) };
+      }
+      return null;
+    },
+    onLog: (message) => options.runtime.error?.(`zalo ingress: ${message}`),
+    dispatchClaimedEvent: async (claimed, lifecycle) => {
+      if (!running || lifecycle.abortSignal.aborted) {
+        return { kind: "failed-retryable", error: new Error("Zalo ingress stopped.") };
+      }
+      const update = parseClaimedUpdate(claimed.payload, claimed.id);
+      const boundLifecycle = bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle;
+      let resolveDeferredClaim!: () => void;
+      const deferredClaim = new Promise<void>((resolve) => {
+        resolveDeferredClaim = resolve;
+      });
+      let deferredClaimSettled = false;
+      const settleDeferredClaim = () => {
+        if (deferredClaimSettled) {
+          return;
+        }
+        deferredClaimSettled = true;
+        if (deferredClaims.get(claimed.id) === deferredClaim) {
+          deferredClaims.delete(claimed.id);
+        }
+        resolveDeferredClaim();
+      };
+      const delivery = options.deliver(update, {
+        ...boundLifecycle,
+        onAdopted: async () => {
+          try {
+            await boundLifecycle.onAdopted();
+          } finally {
+            settleDeferredClaim();
+          }
+        },
+        onDeferred: () => {
+          if (!deferredClaimSettled) {
+            deferredClaims.set(claimed.id, deferredClaim);
+          }
+          boundLifecycle.onDeferred();
+        },
+        onAbandoned: () => {
+          void Promise.resolve(boundLifecycle.onAbandoned()).finally(settleDeferredClaim);
+        },
+      });
+      activeDeliveries.add(delivery);
+      try {
+        await delivery;
+      } finally {
+        activeDeliveries.delete(delivery);
+      }
+      return deferredClaims.has(claimed.id) ? { kind: "deferred" } : { kind: "completed" };
+    },
+  });
+
+  const pruneIfDue = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastPrunedAt < ZALO_WEBHOOK_PRUNE_INTERVAL_MS) {
+      return;
+    }
+    await queue.prune({
+      completedTtlMs: ZALO_WEBHOOK_COMPLETED_TTL_MS,
+      completedMaxEntries: ZALO_WEBHOOK_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: ZALO_WEBHOOK_FAILED_TTL_MS,
+      failedMaxEntries: ZALO_WEBHOOK_FAILED_MAX_ENTRIES,
+      now,
+    });
+    lastPrunedAt = now;
+  };
+
+  const requestDrain = (): void => {
+    if (!running || stopped) {
+      return;
+    }
+    drainRequested = true;
+    if (drainTask) {
+      return;
+    }
+    drainTask = runDetachedWebhookWork(async () => {
+      while (drainRequested) {
+        if (!running) {
+          break;
+        }
+        drainRequested = false;
+        await pruneIfDue();
+        // stop() can run during the async prune; never start a new claim afterwards.
+        if (!running) {
+          break;
+        }
+        await drain.drainOnce({
+          shouldStop: () =>
+            !running || activeDeliveries.size >= ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
+        });
+      }
+    })
+      .catch((error: unknown) => {
+        options.runtime.error?.(`zalo ingress drain failed: ${errorText(error)}`);
+      })
+      .finally(() => {
+        drainTask = undefined;
+        if (running && drainRequested) {
+          requestDrain();
+        }
+      });
+  };
+
+  const admitOnce = async (rawEvent: string): Promise<void> => {
+    const facts = inspectZaloWebhookEvent(rawEvent);
+    const receivedAt = Date.now();
+    let lastError: unknown;
+    for (const delayMs of ZALO_WEBHOOK_APPEND_RETRY_DELAYS_MS) {
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+      }
+      try {
+        await queue.enqueue(
+          facts.eventId,
+          { version: ZALO_WEBHOOK_SPOOL_VERSION, rawEvent },
+          { receivedAt, laneKey: facts.laneKey },
+        );
+        requestDrain();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
+  };
+
+  return {
+    accept: (rawEvent) => {
+      // Serialize concurrent webhook admissions so append backoff cannot invert lane order.
+      const admission = admissionTail.then(() => admitOnce(rawEvent));
+      admissionTail = admission.catch(() => undefined);
+      return admission;
+    },
+    start: () => {
+      if (running || stopped) {
+        return;
+      }
+      running = true;
+      requestDrain();
+      drainTimer = setInterval(requestDrain, ZALO_WEBHOOK_DRAIN_INTERVAL_MS);
+      drainTimer.unref?.();
+    },
+    stop: async () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      running = false;
+      if (drainTimer) {
+        clearInterval(drainTimer);
+        drainTimer = undefined;
+      }
+      // Every accepted request must finish its durable append before shutdown returns.
+      await admissionTail;
+      drain.dispose();
+      await drainTask;
+      // A pump may have been between prune and drain when the first dispose ran.
+      drain.dispose();
+      await Promise.allSettled(activeDeliveries);
+      await Promise.allSettled(deferredClaims.values());
+      await drain.waitForIdle();
+    },
+  };
+}

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -157,7 +157,7 @@ function isZaloAuthenticationFailure(error: unknown): boolean {
   return false;
 }
 
-export function createZaloWebhookIngress(options: {
+function createZaloWebhookIngress(options: {
   accountId: string;
   runtime: Pick<ZaloRuntimeEnv, "error" | "log">;
   deliver: (update: ZaloUpdate, lifecycle: ZaloWebhookIngressLifecycle) => Promise<void>;
@@ -360,3 +360,5 @@ export function createZaloWebhookIngress(options: {
     },
   };
 }
+
+export const zaloWebhookIngressRuntime = { createZaloWebhookIngress };


### PR DESCRIPTION
Related: #109657

## What Problem This Solves

Fixes an issue where Zalo webhook users could lose incoming messages when detached processing failed after the webhook had already returned success. The previous replay guard was also process-local, so it could not recover accepted work after restart.

## Why This Change Was Made

Zalo now appends the raw webhook envelope durably before returning HTTP 200, using the Bot API message ID for deduplication and the chat ID for lane serialization. Delivery then adopts the shared durable ingress drain contract for bounded retries, dead-letter handling, shutdown safety, restart recovery, and durable tombstones; polling and webhook transports remain mutually exclusive.

## User Impact

Accepted Zalo webhook messages now survive process interruption and retry through the shared ingress lifecycle without duplicate visible replies. Failed persistence does not acknowledge the webhook.

## Evidence

- Full Zalo plugin suite: 22 files, 128 tests passed.
- Dead-code gates: unused files 0; unused exports 0. Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/29641402697
- Packaged build passed. Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/29641506845
- Oxfmt check passed for all 10 changed files; git diff check clean.
- Focused lifecycle and spool coverage includes append-before-ack, append failure responses, lane ordering, deduplication, shutdown adoption, bounded retry/dead-letter, and restart redelivery.
- Mechanical follow-up kept the webhook runtime helpers private so both dead-code gates remain clean.
- CI-required mechanical follow-up moved Zalo test state under the managed OpenClaw temporary root; the exact boundary gate and full Zalo suite pass afterward.
- Maintainer-round live-proof gap: this lane had no authorized Zalo bot/account for a real webhook round-trip. Please validate delivery and restart redelivery with a maintainer bot during rollout.

The whole-branch autoreview bundle scanner rejected deleted-line token-field references as secret-like content before model invocation. The mechanical follow-up diff received a clean autoreview, and the full branch received a manual evidence-map review across Zalo entry points, core drain ownership, sibling channel drains, and focused tests; no message-loss, duplicate-reply, or data-corruption defect was found.
