### PR TITLE
feat(macos): Quick Chat streamed replies and continue-recent targeting

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -33882,16 +33882,16 @@
       "id": "native.apple.144b21229f65f2a4"
     },
     {
-      "kind": "ui-call",
-      "line": 62,
+      "kind": "ui-modifier",
+      "line": 97,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Message \\(self.model.agentDisplay.name)",
+      "source": "Continue a recent conversation",
       "surface": "apple",
-      "id": "native.apple.b3700cf60f4520dc"
+      "id": "native.apple.da0b9bd07a337bda"
     },
     {
       "kind": "ui-modifier",
-      "line": 88,
+      "line": 110,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send a window screenshot",
       "surface": "apple",
@@ -33899,7 +33899,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 112,
+      "line": 134,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send message",
       "surface": "apple",
@@ -33907,7 +33907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 170,
+      "line": 192,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Needs additional permissions",
       "surface": "apple",
@@ -33915,7 +33915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 177,
+      "line": 199,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Grant",
       "surface": "apple",
@@ -33923,7 +33923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 205,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Not now",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -33882,8 +33882,32 @@
       "id": "native.apple.144b21229f65f2a4"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 22,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatRecents.swift",
+      "source": "New message to \\(agentName)",
+      "surface": "apple",
+      "id": "native.apple.b5524e37a230e571"
+    },
+    {
+      "kind": "ui-call",
+      "line": 67,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Reply in \\(override.displayName)",
+      "surface": "apple",
+      "id": "native.apple.b99799f97999f481"
+    },
+    {
+      "kind": "ui-call",
+      "line": 69,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "surface": "apple",
+      "id": "native.apple.b3700cf60f4520dc"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 97,
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Continue a recent conversation",
       "surface": "apple",
@@ -33891,7 +33915,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 110,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send a window screenshot",
       "surface": "apple",
@@ -33899,7 +33923,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 134,
+      "line": 145,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send message",
       "surface": "apple",
@@ -33907,7 +33931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 203,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Needs additional permissions",
       "surface": "apple",
@@ -33915,7 +33939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 199,
+      "line": 210,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Grant",
       "surface": "apple",
@@ -33923,7 +33947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 205,
+      "line": 216,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Not now",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -21179,9 +21179,9 @@
       "translated": "متابعة"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "مراسلة \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "متابعة محادثة حديثة"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -21179,6 +21179,21 @@
       "translated": "متابعة"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "رسالة جديدة إلى \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "الرد في \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "مراسلة \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "متابعة محادثة حديثة"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -21179,6 +21179,21 @@
       "translated": "Fortfahren"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Neue Nachricht an \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "In \\(override.displayName) antworten"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Nachricht an \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Eine kürzlich geführte Unterhaltung fortsetzen"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -21179,9 +21179,9 @@
       "translated": "Fortfahren"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Nachricht an \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Eine kürzlich geführte Unterhaltung fortsetzen"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -21179,9 +21179,9 @@
       "translated": "Continuar"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Enviar mensaje a \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Continuar una conversación reciente"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -21179,6 +21179,21 @@
       "translated": "Continuar"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nuevo mensaje para \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Responder en \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Mensaje para \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Continuar una conversación reciente"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -21179,6 +21179,21 @@
       "translated": "ادامه"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "پیام جدید به \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "پاسخ در \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "ارسال پیام به \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "ادامه یک گفت‌وگوی اخیر"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -21179,9 +21179,9 @@
       "translated": "ادامه"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "ارسال پیام به \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "ادامه یک گفت‌وگوی اخیر"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -21179,9 +21179,9 @@
       "translated": "Continuer"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Envoyer un message à \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Continuer une conversation récente"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -21179,6 +21179,21 @@
       "translated": "Continuer"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nouveau message à \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Répondre dans \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Envoyer un message à \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Continuer une conversation récente"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -21179,6 +21179,21 @@
       "translated": "जारी रखें"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "\\(agentName) को नया संदेश"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "\\(override.displayName) में जवाब दें"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name) को संदेश भेजें"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "हाल की बातचीत जारी रखें"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -21179,9 +21179,9 @@
       "translated": "जारी रखें"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "\\(self.model.agentDisplay.name) को संदेश भेजें"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "हाल की बातचीत जारी रखें"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -21179,9 +21179,9 @@
       "translated": "Lanjutkan"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Kirim pesan ke \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Lanjutkan percakapan terbaru"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -21179,6 +21179,21 @@
       "translated": "Lanjutkan"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Pesan baru kepada \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Balas di \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Kirim pesan kepada \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Lanjutkan percakapan terbaru"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -21179,6 +21179,21 @@
       "translated": "Continua"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nuovo messaggio a \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Rispondi in \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Messaggio a \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Continua una conversazione recente"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -21179,9 +21179,9 @@
       "translated": "Continua"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Invia un messaggio a \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Continua una conversazione recente"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -21179,9 +21179,9 @@
       "translated": "続ける"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "\\(self.model.agentDisplay.name)にメッセージを送信"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "最近の会話を続ける"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -21179,6 +21179,21 @@
       "translated": "続ける"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "\\(agentName)への新しいメッセージ"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "\\(override.displayName)で返信"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name)にメッセージ"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "最近の会話を続ける"

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -21179,9 +21179,9 @@
       "translated": "계속"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "\\(self.model.agentDisplay.name)에게 메시지 보내기"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "최근 대화 계속하기"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -21179,6 +21179,21 @@
       "translated": "계속"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "\\(agentName)에게 보내는 새 메시지"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "\\(override.displayName)에서 답장"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name)에게 메시지 보내기"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "최근 대화 계속하기"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -21179,6 +21179,21 @@
       "translated": "Doorgaan"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nieuw bericht aan \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Antwoorden in \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Bericht aan \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Een recent gesprek voortzetten"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -21179,9 +21179,9 @@
       "translated": "Doorgaan"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Bericht aan \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Een recent gesprek voortzetten"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -21179,9 +21179,9 @@
       "translated": "Kontynuuj"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Napisz do \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Kontynuuj ostatnią rozmowę"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -21179,6 +21179,21 @@
       "translated": "Kontynuuj"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nowa wiadomość do \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Odpowiedz w \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Wiadomość do \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Kontynuuj ostatnią rozmowę"

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -21179,9 +21179,9 @@
       "translated": "Continuar"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Enviar mensagem para \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Continuar uma conversa recente"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -21179,6 +21179,21 @@
       "translated": "Continuar"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nova mensagem para \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Responder em \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Mensagem para \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Continuar uma conversa recente"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -21179,6 +21179,21 @@
       "translated": "Продолжить"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Новое сообщение для \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Ответить в \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Сообщение для \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Продолжить недавний разговор"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -21179,9 +21179,9 @@
       "translated": "Продолжить"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Сообщение для \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Продолжить недавний разговор"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -21179,6 +21179,21 @@
       "translated": "Fortsätt"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Nytt meddelande till \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Svara i \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Skicka meddelande till \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Fortsätt en nyligen använd konversation"

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -21179,9 +21179,9 @@
       "translated": "Fortsätt"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Skicka meddelande till \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Fortsätt en nyligen använd konversation"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -21179,6 +21179,21 @@
       "translated": "ดำเนินการต่อ"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "ข้อความใหม่ถึง \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "ตอบกลับใน \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "ส่งข้อความถึง \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "สนทนาต่อล่าสุด"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -21179,9 +21179,9 @@
       "translated": "ดำเนินการต่อ"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "ส่งข้อความถึง \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "สนทนาต่อล่าสุด"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -21179,9 +21179,9 @@
       "translated": "Devam et"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "\\(self.model.agentDisplay.name) adlı temsilciye mesaj gönder"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Yakın tarihli bir konuşmaya devam et"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -21179,6 +21179,21 @@
       "translated": "Devam et"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "\\(agentName) için yeni mesaj"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "\\(override.displayName) içinde yanıtla"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name) adlı kişiye mesaj gönder"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Yakın tarihli bir konuşmaya devam et"

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -21179,9 +21179,9 @@
       "translated": "Продовжити"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Повідомлення для \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Продовжити нещодавню розмову"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -21179,6 +21179,21 @@
       "translated": "Продовжити"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Нове повідомлення для \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Відповісти в \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Повідомлення для \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Продовжити нещодавню розмову"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -21179,6 +21179,21 @@
       "translated": "Tiếp tục"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "Tin nhắn mới tới \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "Trả lời trong \\(override.displayName)"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Nhắn tin cho \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "Tiếp tục một cuộc trò chuyện gần đây"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -21179,9 +21179,9 @@
       "translated": "Tiếp tục"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "Nhắn tin cho \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "Tiếp tục một cuộc trò chuyện gần đây"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -21179,9 +21179,9 @@
       "translated": "继续"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "给 \\(self.model.agentDisplay.name) 发消息"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "继续最近的对话"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -21179,6 +21179,21 @@
       "translated": "继续"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "发给 \\(agentName) 的新消息"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "在 \\(override.displayName) 中回复"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "给 \\(self.model.agentDisplay.name) 发消息"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "继续最近的对话"

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -21179,9 +21179,9 @@
       "translated": "繼續"
     },
     {
-      "id": "native.apple.b3700cf60f4520dc",
-      "source": "Message \\(self.model.agentDisplay.name)",
-      "translated": "傳訊息給 \\(self.model.agentDisplay.name)"
+      "id": "native.apple.da0b9bd07a337bda",
+      "source": "Continue a recent conversation",
+      "translated": "繼續最近的對話"
     },
     {
       "id": "native.apple.edf12ff583307f43",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -21179,6 +21179,21 @@
       "translated": "繼續"
     },
     {
+      "id": "native.apple.b5524e37a230e571",
+      "source": "New message to \\(agentName)",
+      "translated": "傳送新訊息給 \\(agentName)"
+    },
+    {
+      "id": "native.apple.b99799f97999f481",
+      "source": "Reply in \\(override.displayName)",
+      "translated": "在 \\(override.displayName) 中回覆"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "傳訊息給 \\(self.model.agentDisplay.name)"
+    },
+    {
       "id": "native.apple.da0b9bd07a337bda",
       "source": "Continue a recent conversation",
       "translated": "繼續最近的對話"

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -140,6 +140,9 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.recentSessionsProvider = recentSessionsProvider
         self.allowsHotkeyRegistrationInTests = allowsHotkeyRegistrationInTests
         super.init()
+        self.model.onSendDispatched = { [weak self] route in
+            self?.replyBinding.prepare(route: route)
+        }
     }
 
     func start() {

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -468,7 +468,11 @@ final class QuickChatController: NSObject, NSWindowDelegate {
                 guard !Task.isCancelled,
                       self.recentSessionsRequestID == requestID,
                       self.isVisible,
-                      self.model.activePresentationID == presentationID
+                      self.model.activePresentationID == presentationID,
+                      // Eligibility can lapse while the fetch is in flight (a send may
+                      // have started); a menu whose selections would be ignored is worse
+                      // than no menu.
+                      self.model.canSelectRecentSession
                 else { return }
                 self.presentRecentSessionsMenu(rows: rows)
             } catch {

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -141,7 +141,11 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.allowsHotkeyRegistrationInTests = allowsHotkeyRegistrationInTests
         super.init()
         self.model.onSendDispatched = { [weak self] route in
-            self?.replyBinding.prepare(route: route)
+            guard let self else { return }
+            // A dispatched send supersedes any pending recents fetch: its menu popping
+            // over the fresh reply would rebind away from the response just sent.
+            self.recentSessionsRequestID = UUID()
+            self.replyBinding.prepare(route: route)
         }
     }
 
@@ -448,6 +452,8 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         }
         let windowPoint = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
         let contentPoint = contentView.convert(windowPoint, from: nil)
+        // Competing interaction: invalidate any in-flight recents fetch before blocking.
+        self.recentSessionsRequestID = UUID()
         menu.popUp(positioning: nil, at: contentPoint, in: contentView)
     }
 
@@ -534,6 +540,8 @@ final class QuickChatController: NSObject, NSWindowDelegate {
                 })
         }
         guard let windowPicker = self.windowPicker else { return }
+        // Competing interaction: a recents menu must not pop over the picker overlays.
+        self.recentSessionsRequestID = UUID()
         Task { await windowPicker.begin() }
     }
 

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -144,7 +144,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
             guard let self else { return }
             // A dispatched send supersedes any pending recents fetch: its menu popping
             // over the fresh reply would rebind away from the response just sent.
-            self.recentSessionsRequestID = UUID()
+            self.invalidateRecentsFetch()
             self.replyBinding.prepare(route: route)
         }
     }
@@ -163,6 +163,14 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         }
         self.unregisterHotkeyIfNeeded()
         self.dismiss(immediate: false)
+    }
+
+    /// Invalidates any in-flight recents fetch: rotates the request ID so stale
+    /// completions no-op, and cancels/clears the task so the picker stays usable.
+    private func invalidateRecentsFetch() {
+        self.recentSessionsRequestID = UUID()
+        self.recentSessionsTask?.cancel()
+        self.recentSessionsTask = nil
     }
 
     private func registerHotkeyIfNeeded() {
@@ -209,6 +217,9 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     func present() {
         guard self.isEnabled else { return }
         self.transitionID = UUID()
+        // A fresh presentation must never resurrect a reply prepared or shown by an
+        // earlier one (e.g. a capture send that raced the previous hide).
+        self.replyBinding.clear()
         let presentationID = self.model.beginPresentation()
         self.presentationTask?.cancel()
         self.presentationTask = Task { [weak self] in
@@ -453,7 +464,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         let windowPoint = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
         let contentPoint = contentView.convert(windowPoint, from: nil)
         // Competing interaction: invalidate any in-flight recents fetch before blocking.
-        self.recentSessionsRequestID = UUID()
+        self.invalidateRecentsFetch()
         menu.popUp(positioning: nil, at: contentPoint, in: contentView)
     }
 
@@ -541,7 +552,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         }
         guard let windowPicker = self.windowPicker else { return }
         // Competing interaction: a recents menu must not pop over the picker overlays.
-        self.recentSessionsRequestID = UUID()
+        self.invalidateRecentsFetch()
         Task { await windowPicker.begin() }
     }
 

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -1,6 +1,7 @@
 import AppKit
 import KeyboardShortcuts
 import Observation
+import OpenClawChatUI
 import SwiftUI
 
 private let quickChatLogger = Logger(subsystem: "ai.openclaw", category: "quickchat")
@@ -26,6 +27,28 @@ private final class QuickChatAgentMenuTarget: NSObject {
     }
 }
 
+private final class QuickChatRecentMenuSelection: NSObject {
+    let target: QuickChatSessionTargetOverride?
+
+    init(target: QuickChatSessionTargetOverride?) {
+        self.target = target
+    }
+}
+
+@MainActor
+private final class QuickChatRecentMenuTarget: NSObject {
+    let onSelect: (QuickChatSessionTargetOverride?) -> Void
+
+    init(onSelect: @escaping (QuickChatSessionTargetOverride?) -> Void) {
+        self.onSelect = onSelect
+    }
+
+    @objc func selectSession(_ sender: NSMenuItem) {
+        guard let selection = sender.representedObject as? QuickChatRecentMenuSelection else { return }
+        self.onSelect(selection.target)
+    }
+}
+
 @MainActor
 @Observable
 final class QuickChatController: NSObject, NSWindowDelegate {
@@ -35,6 +58,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     typealias HotkeyRegistrar = (@escaping () -> Void) -> Void
     typealias HotkeyRemover = () -> Void
     typealias ChatOpener = @MainActor (_ sessionKey: String?, _ agentID: String?) -> Void
+    typealias RecentSessionsProvider = @MainActor () async throws -> [SessionRow]
 
     static let shared = QuickChatController()
 
@@ -42,6 +66,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     private(set) var isEnabled = true
 
     @ObservationIgnored let model: QuickChatModel
+    @ObservationIgnored let replyBinding: QuickChatReplyBinding
     @ObservationIgnored private let enableUI: Bool
     @ObservationIgnored private let monitoringEnabled: Bool
     @ObservationIgnored private let globalMonitorInstaller: GlobalMonitorInstaller
@@ -50,6 +75,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     @ObservationIgnored private let hotkeyRegistrar: HotkeyRegistrar
     @ObservationIgnored private let hotkeyRemover: HotkeyRemover
     @ObservationIgnored private let chatOpener: ChatOpener
+    @ObservationIgnored private let recentSessionsProvider: RecentSessionsProvider
     @ObservationIgnored private let allowsHotkeyRegistrationInTests: Bool
     @ObservationIgnored private var panel: QuickChatPanel?
     @ObservationIgnored private var hostingView: NSHostingView<QuickChatView>?
@@ -63,7 +89,9 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     @ObservationIgnored private var isStarted = false
     @ObservationIgnored private var hotkeyRegistered = false
     @ObservationIgnored private var windowPicker: QuickChatWindowPicker?
-    @ObservationIgnored private var isAgentMenuActive = false
+    @ObservationIgnored private var isMenuActive = false
+    @ObservationIgnored private var recentSessionsTask: Task<Void, Never>?
+    @ObservationIgnored private var recentSessionsRequestID = UUID()
 
     init(
         enableUI: Bool = true,
@@ -87,10 +115,21 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         chatOpener: @escaping ChatOpener = { sessionKey, agentID in
             AppNavigationActions.openChat(sessionKey: sessionKey, agentID: agentID)
         },
+        recentSessionsProvider: @escaping RecentSessionsProvider = {
+            try await SessionLoader.loadSnapshot(limit: 5).rows
+        },
+        replyViewModelFactory: @escaping QuickChatReplyBinding.ViewModelFactory = {
+            let transport = MacGatewayChatTransport(defaultGlobalAgentID: $0.agentID)
+            return OpenClawChatViewModel(
+                sessionKey: $0.sessionKey,
+                transport: transport,
+                activeAgentId: $0.agentID)
+        },
         allowsHotkeyRegistrationInTests: Bool = false)
     {
         self.enableUI = enableUI
         self.model = model ?? QuickChatModel()
+        self.replyBinding = QuickChatReplyBinding(viewModelFactory: replyViewModelFactory)
         self.monitoringEnabled = monitoringEnabled ?? (enableUI && !ProcessInfo.processInfo.isRunningTests)
         self.globalMonitorInstaller = globalMonitorInstaller
         self.localMonitorInstaller = localMonitorInstaller
@@ -98,6 +137,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.hotkeyRegistrar = hotkeyRegistrar
         self.hotkeyRemover = hotkeyRemover
         self.chatOpener = chatOpener
+        self.recentSessionsProvider = recentSessionsProvider
         self.allowsHotkeyRegistrationInTests = allowsHotkeyRegistrationInTests
         super.init()
     }
@@ -141,6 +181,9 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.isStarted = false
         self.dismiss(immediate: true)
         self.model.cancelAllTasks()
+        self.recentSessionsTask?.cancel()
+        self.recentSessionsTask = nil
+        self.replyBinding.clear()
         self.panel?.delegate = nil
         self.panel = nil
         self.hostingView = nil
@@ -197,7 +240,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         // System permission dialogs steal key focus mid-grant; the bar must survive that flow.
         guard !self.model.isGrantingPermissions,
               self.windowPicker?.isInteractionActive != true,
-              !self.isAgentMenuActive
+              !self.isMenuActive
         else { return }
         self.dismiss()
     }
@@ -207,9 +250,13 @@ final class QuickChatController: NSObject, NSWindowDelegate {
             quickChatLogger.info("quick chat dismiss immediate=\(immediate)")
         }
         self.windowPicker?.cancel()
+        self.recentSessionsRequestID = UUID()
+        self.recentSessionsTask?.cancel()
+        self.recentSessionsTask = nil
         self.presentationTask?.cancel()
         self.presentationTask = nil
         self.model.endPresentation()
+        self.replyBinding.clear()
         self.removeDismissMonitors()
         guard self.isVisible else {
             if immediate { self.panel?.orderOut(nil) }
@@ -266,12 +313,16 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     private func makeView() -> QuickChatView {
         QuickChatView(
             model: self.model,
+            replyBinding: self.replyBinding,
             onDismiss: { [weak self] in self?.dismiss() },
             onSendAccepted: { [weak self] openChat in
                 self?.handleSendAccepted(openChat: openChat)
             },
             onShowAgentPicker: { [weak self] in
                 self?.showAgentPicker()
+            },
+            onShowRecentSessions: { [weak self] in
+                self?.showRecentSessionsPicker()
             },
             onWindowScreenshot: { [weak self] in
                 self?.startWindowPicker()
@@ -289,8 +340,13 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         // Command-Return must open the immutable route that accepted the send,
         // not live model routing state that may already have changed.
         let route = self.model.lastAcceptedRoute
+        guard openChat else {
+            if let route {
+                self.replyBinding.show(route: route)
+            }
+            return
+        }
         self.dismiss()
-        guard openChat else { return }
         if let route, !route.sessionKey.isEmpty {
             self.chatOpener(route.sessionKey, route.agentID)
         } else {
@@ -346,7 +402,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         guard self.isVisible,
               !self.model.isGrantingPermissions,
               self.windowPicker?.isInteractionActive != true,
-              !self.isAgentMenuActive,
+              !self.isMenuActive,
               let panel = self.panel
         else { return }
         if !panel.frame.contains(point) {
@@ -360,16 +416,20 @@ final class QuickChatController: NSObject, NSWindowDelegate {
               let contentView = panel.contentView
         else { return }
 
-        self.isAgentMenuActive = true
+        self.isMenuActive = true
         self.removeDismissMonitors()
         defer {
-            self.isAgentMenuActive = false
+            self.isMenuActive = false
             if self.isVisible { self.installDismissMonitors() }
             self.focusEditor()
         }
 
         let target = QuickChatAgentMenuTarget { [weak self] id in
-            self?.model.selectAgent(id)
+            guard let self else { return }
+            self.model.selectAgent(id)
+            if let route = self.model.routingTarget {
+                self.replyBinding.rebindIfActive(route: route)
+            }
         }
         let menu = NSMenu()
         for agent in self.model.agents {
@@ -388,6 +448,72 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         menu.popUp(positioning: nil, at: contentPoint, in: contentView)
     }
 
+    private func showRecentSessionsPicker() {
+        guard self.model.canSelectRecentSession, self.recentSessionsTask == nil else { return }
+        let requestID = UUID()
+        let presentationID = self.model.activePresentationID
+        self.recentSessionsRequestID = requestID
+        self.recentSessionsTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if self.recentSessionsRequestID == requestID {
+                    self.recentSessionsTask = nil
+                }
+            }
+            do {
+                let rows = try await self.recentSessionsProvider()
+                guard !Task.isCancelled,
+                      self.recentSessionsRequestID == requestID,
+                      self.isVisible,
+                      self.model.activePresentationID == presentationID
+                else { return }
+                self.presentRecentSessionsMenu(rows: rows)
+            } catch {
+                quickChatLogger.error(
+                    "quick chat recent sessions failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func presentRecentSessionsMenu(rows: [SessionRow]) {
+        guard let panel, let contentView = panel.contentView else { return }
+        let items = QuickChatRecentMenuLogic.items(
+            rows: rows,
+            agentName: self.model.agentDisplay.name,
+            selectedTarget: self.model.targetSessionOverride)
+
+        self.isMenuActive = true
+        self.removeDismissMonitors()
+        defer {
+            self.isMenuActive = false
+            if self.isVisible { self.installDismissMonitors() }
+            self.focusEditor()
+        }
+
+        let target = QuickChatRecentMenuTarget { [weak self] selection in
+            guard let self else { return }
+            self.model.selectSessionOverride(selection)
+            if let route = self.model.routingTarget {
+                self.replyBinding.rebindIfActive(route: route)
+            }
+        }
+        let menu = NSMenu()
+        for (index, recent) in items.enumerated() {
+            if index == 1 { menu.addItem(.separator()) }
+            let item = NSMenuItem(
+                title: recent.title,
+                action: #selector(QuickChatRecentMenuTarget.selectSession(_:)),
+                keyEquivalent: "")
+            item.target = target
+            item.representedObject = QuickChatRecentMenuSelection(target: recent.target)
+            item.state = recent.isSelected ? .on : .off
+            menu.addItem(item)
+        }
+        let windowPoint = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let contentPoint = contentView.convert(windowPoint, from: nil)
+        menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+    }
+
     private func startWindowPicker() {
         guard self.isVisible, self.model.canCaptureWindow else { return }
         if self.windowPicker == nil {
@@ -397,7 +523,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
                     self?.pickerInteractionChanged(active)
                 },
                 onSendAccepted: { [weak self] in
-                    self?.dismiss()
+                    self?.handleSendAccepted(openChat: false)
                 })
         }
         guard let windowPicker = self.windowPicker else { return }

--- a/apps/macos/Sources/OpenClaw/QuickChatModel.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatModel.swift
@@ -75,9 +75,14 @@ struct QuickChatAgentDisplay: Equatable, Sendable, Identifiable {
     }
 }
 
-struct QuickChatRoutingTarget: Equatable, Sendable {
+struct QuickChatRoutingTarget: Equatable, Hashable, Sendable {
     let sessionKey: String
     let agentID: String?
+}
+
+struct QuickChatSessionTargetOverride: Equatable, Hashable, Sendable {
+    let key: String
+    let displayName: String
 }
 
 enum QuickChatConnectionGate: Equatable {
@@ -134,6 +139,7 @@ final class QuickChatModel {
 
     private(set) var sessionKey = ""
     private(set) var sendAgentID: String?
+    private(set) var targetSessionOverride: QuickChatSessionTargetOverride?
     private(set) var agents: [QuickChatAgentDisplay] = []
     private(set) var defaultAgentID: String?
     private(set) var selectedAgentID: String?
@@ -157,6 +163,7 @@ final class QuickChatModel {
     @ObservationIgnored private var presentationID = UUID()
     @ObservationIgnored private var agentsScope: String?
     @ObservationIgnored private var agentsMainKey: String?
+    @ObservationIgnored private var baseRoutingTarget: QuickChatRoutingTarget?
     @ObservationIgnored private var sendTask: Task<String, Error>?
     @ObservationIgnored private var permissionTask: Task<Void, Never>?
     @ObservationIgnored private var permissionPollTask: Task<Void, Never>?
@@ -241,6 +248,22 @@ final class QuickChatModel {
         !self.sessionKey.isEmpty && self.connectionGate == .available && self.sendState != .sending
     }
 
+    var canSelectRecentSession: Bool {
+        !self.sessionKey.isEmpty && self.connectionGate == .available && self.sendState != .sending
+    }
+
+    var messagePlaceholder: String {
+        if let targetSessionOverride {
+            return "Reply in \(targetSessionOverride.displayName)"
+        }
+        return "Message \(self.agentDisplay.name)"
+    }
+
+    var routingTarget: QuickChatRoutingTarget? {
+        guard !self.sessionKey.isEmpty else { return nil }
+        return QuickChatRoutingTarget(sessionKey: self.sessionKey, agentID: self.sendAgentID)
+    }
+
     var activePresentationID: UUID? {
         self.isPresentationActive ? self.presentationID : nil
     }
@@ -250,6 +273,8 @@ final class QuickChatModel {
         self.isPresentationActive = true
         self.sessionKey = ""
         self.sendAgentID = nil
+        self.targetSessionOverride = nil
+        self.baseRoutingTarget = nil
         // The cached list stays displayable, but routing metadata must wait for the fresh
         // contract: selecting from a stale scope/mainKey could target an obsolete session.
         self.agentsScope = nil
@@ -289,11 +314,20 @@ final class QuickChatModel {
               let display = self.agents.first(where: { $0.id == id }),
               let mainKey = self.agentsMainKey
         else { return }
+        // Agent and recent-session targeting are mutually exclusive: keeping both would
+        // make the avatar advertise one destination while sends go somewhere else.
+        self.targetSessionOverride = nil
         self.selectedAgentID = id
         self.agentDisplay = display
         let target = Self.routingTarget(scope: self.agentsScope, selectedAgentID: id, mainKey: mainKey)
-        self.sessionKey = target.sessionKey
-        self.sendAgentID = target.agentID
+        self.baseRoutingTarget = target
+        self.applyRoutingTarget()
+    }
+
+    func selectSessionOverride(_ target: QuickChatSessionTargetOverride?) {
+        guard self.sendState != .sending else { return }
+        self.targetSessionOverride = target
+        self.applyRoutingTarget()
     }
 
     func dismissPermissionsForSession() {
@@ -426,6 +460,17 @@ final class QuickChatModel {
             agentID: nil)
     }
 
+    nonisolated static func routingTarget(
+        override: QuickChatSessionTargetOverride?,
+        base: QuickChatRoutingTarget) -> QuickChatRoutingTarget
+    {
+        guard let override else { return base }
+        // sessions.list preserves the bare global sentinel. It needs the same explicit
+        // agent owner as the selected base route when session scope is global.
+        let agentID = override.key.lowercased() == "global" ? base.agentID : nil
+        return QuickChatRoutingTarget(sessionKey: override.key, agentID: agentID)
+    }
+
     nonisolated static func defaultScreenshotCaption(appName: String, title: String) -> String {
         "Screenshot: \(appName) — \(title)"
     }
@@ -443,6 +488,10 @@ final class QuickChatModel {
     func endPresentation() {
         self.isPresentationActive = false
         self.presentationID = UUID()
+        // A quick bar target is presentation-scoped. Never carry a stale recent session
+        // into the next invocation where the compact UI no longer explains that choice.
+        self.targetSessionOverride = nil
+        self.baseRoutingTarget = nil
         self.sessionKey = ""
         self.sendAgentID = nil
         // A dispatched chat.send may already be accepted; cancelling and retrying with a new UUID can duplicate it.
@@ -481,6 +530,7 @@ final class QuickChatModel {
               let display = displays.first(where: { $0.id == selectedID })
         else {
             self.agentDisplay = .placeholder
+            self.baseRoutingTarget = nil
             self.sessionKey = ""
             self.sendAgentID = nil
             return
@@ -490,15 +540,15 @@ final class QuickChatModel {
             scope: self.agentsScope,
             selectedAgentID: selectedID,
             mainKey: result.mainkey)
-        self.sessionKey = target.sessionKey
-        self.sendAgentID = target.agentID
+        self.baseRoutingTarget = target
+        self.applyRoutingTarget()
     }
 
     private func refreshFallbackIdentity(id: UUID) async {
         let resolvedSessionKey = await self.sessionKeyProvider()
         guard self.isCurrentPresentation(id), !Task.isCancelled else { return }
-        self.sessionKey = resolvedSessionKey
-        self.sendAgentID = nil
+        self.baseRoutingTarget = QuickChatRoutingTarget(sessionKey: resolvedSessionKey, agentID: nil)
+        self.applyRoutingTarget()
         self.agents = []
         self.defaultAgentID = nil
         self.selectedAgentID = nil
@@ -516,6 +566,17 @@ final class QuickChatModel {
         } catch {
             // The fallback session remains sendable even when its optional identity cannot load.
         }
+    }
+
+    private func applyRoutingTarget() {
+        guard let baseRoutingTarget else {
+            self.sessionKey = ""
+            self.sendAgentID = nil
+            return
+        }
+        let target = Self.routingTarget(override: self.targetSessionOverride, base: baseRoutingTarget)
+        self.sessionKey = target.sessionKey
+        self.sendAgentID = target.agentID
     }
 
     private func performSend(

--- a/apps/macos/Sources/OpenClaw/QuickChatModel.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatModel.swift
@@ -160,6 +160,9 @@ final class QuickChatModel {
     @ObservationIgnored private let permissionStatusProvider: PermissionStatusProvider
     @ObservationIgnored private let permissionGrantProvider: PermissionGrantProvider
     @ObservationIgnored private let connectionGateProvider: ConnectionGateProvider
+    /// Invoked with the snapshotted route just before a send is dispatched, for every
+    /// send path (text and capture); wires the reply consumer's pre-bind.
+    @ObservationIgnored var onSendDispatched: ((QuickChatRoutingTarget) -> Void)?
     @ObservationIgnored private var presentationID = UUID()
     @ObservationIgnored private var agentsScope: String?
     @ObservationIgnored private var agentsMainKey: String?
@@ -597,6 +600,9 @@ final class QuickChatModel {
 
         let sessionKey = self.sessionKey
         let agentID = self.sendAgentID
+        // Pre-bind the reply consumer for every send path (text and screenshots): a
+        // fast turn must not emit frames before the reply view model starts listening.
+        self.onSendDispatched?(QuickChatRoutingTarget(sessionKey: sessionKey, agentID: agentID))
         let idempotencyKey: String
         if let retryIdentity = self.retryIdentity,
            retryIdentity.draft == draft,

--- a/apps/macos/Sources/OpenClaw/QuickChatRecents.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatRecents.swift
@@ -16,7 +16,10 @@ enum QuickChatRecentMenuLogic {
     {
         let newMessage = QuickChatRecentMenuItem(
             id: "new-message",
-            title: "New message to \(agentName)",
+            // String(localized:) keeps the NSMenuItem title translatable; the relative
+            // age below uses the shared app-wide relativeAge helper, unlocalized here as
+            // everywhere else it is used (a separate app-wide follow-up).
+            title: String(localized: "New message to \(agentName)"),
             target: nil,
             isSelected: selectedTarget == nil)
         let recents = rows.prefix(5).map { row in

--- a/apps/macos/Sources/OpenClaw/QuickChatRecents.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatRecents.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct QuickChatRecentMenuItem: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let target: QuickChatSessionTargetOverride?
+    let isSelected: Bool
+}
+
+enum QuickChatRecentMenuLogic {
+    static func items(
+        rows: [SessionRow],
+        agentName: String,
+        selectedTarget: QuickChatSessionTargetOverride?,
+        now: Date = Date()) -> [QuickChatRecentMenuItem]
+    {
+        let newMessage = QuickChatRecentMenuItem(
+            id: "new-message",
+            title: "New message to \(agentName)",
+            target: nil,
+            isSelected: selectedTarget == nil)
+        let recents = rows.prefix(5).map { row in
+            let target = QuickChatSessionTargetOverride(key: row.key, displayName: row.label)
+            return QuickChatRecentMenuItem(
+                id: row.key,
+                title: "\(row.label) — \(relativeAge(from: row.updatedAt, now: now))",
+                target: target,
+                isSelected: selectedTarget?.key == row.key)
+        }
+        return [newMessage] + recents
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
@@ -8,6 +8,7 @@ final class QuickChatReplyBinding {
 
     private(set) var route: QuickChatRoutingTarget?
     private(set) var viewModel: OpenClawChatViewModel?
+    @ObservationIgnored private var preparedRoute: QuickChatRoutingTarget?
 
     @ObservationIgnored private let viewModelFactory: ViewModelFactory
 
@@ -15,10 +16,17 @@ final class QuickChatReplyBinding {
         self.viewModelFactory = viewModelFactory
     }
 
-    func show(route: QuickChatRoutingTarget) {
-        guard self.route != route || self.viewModel == nil else { return }
-        self.route = route
+    /// Starts the transport consumer before the send is dispatched so no early
+    /// delta/final frame is missed; the reply area stays hidden until show(route:).
+    func prepare(route: QuickChatRoutingTarget) {
+        guard self.preparedRoute != route || self.viewModel == nil else { return }
+        self.preparedRoute = route
         self.viewModel = self.viewModelFactory(route)
+    }
+
+    func show(route: QuickChatRoutingTarget) {
+        self.prepare(route: route)
+        self.route = route
     }
 
     func rebindIfActive(route: QuickChatRoutingTarget) {
@@ -28,6 +36,7 @@ final class QuickChatReplyBinding {
 
     func clear() {
         self.route = nil
+        self.preparedRoute = nil
         self.viewModel = nil
     }
 

--- a/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
@@ -30,7 +30,9 @@ final class QuickChatReplyBinding {
     }
 
     func rebindIfActive(route: QuickChatRoutingTarget) {
-        guard self.viewModel != nil else { return }
+        // Only a VISIBLE reply rebinds; hidden prepared state from a failed send must
+        // not be promoted into an expanded transcript by a later target change.
+        guard self.route != nil else { return }
         self.show(route: route)
     }
 

--- a/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
@@ -18,6 +18,12 @@ final class QuickChatReplyBinding {
 
     /// Starts the transport consumer before the send is dispatched so no early
     /// delta/final frame is missed; the reply area stays hidden until show(route:).
+    /// Accepted tradeoff: construction does not synchronously install the transport
+    /// subscription (scheduler-scale gap). Deltas carry full snapshots, the shared
+    /// view model self-heals from them, and history bootstrap recovers committed
+    /// turns — so only a turn completing within a runloop tick could be lost, which
+    /// is not a real production state and does not justify a readiness handshake in
+    /// the shared chat kit.
     func prepare(route: QuickChatRoutingTarget) {
         guard self.preparedRoute != route || self.viewModel == nil else { return }
         self.preparedRoute = route

--- a/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatReplyBinding.swift
@@ -1,0 +1,41 @@
+import Observation
+import OpenClawChatUI
+
+@MainActor
+@Observable
+final class QuickChatReplyBinding {
+    typealias ViewModelFactory = @MainActor (QuickChatRoutingTarget) -> OpenClawChatViewModel
+
+    private(set) var route: QuickChatRoutingTarget?
+    private(set) var viewModel: OpenClawChatViewModel?
+
+    @ObservationIgnored private let viewModelFactory: ViewModelFactory
+
+    init(viewModelFactory: @escaping ViewModelFactory = QuickChatReplyBinding.makeViewModel) {
+        self.viewModelFactory = viewModelFactory
+    }
+
+    func show(route: QuickChatRoutingTarget) {
+        guard self.route != route || self.viewModel == nil else { return }
+        self.route = route
+        self.viewModel = self.viewModelFactory(route)
+    }
+
+    func rebindIfActive(route: QuickChatRoutingTarget) {
+        guard self.viewModel != nil else { return }
+        self.show(route: route)
+    }
+
+    func clear() {
+        self.route = nil
+        self.viewModel = nil
+    }
+
+    private static func makeViewModel(route: QuickChatRoutingTarget) -> OpenClawChatViewModel {
+        let transport = MacGatewayChatTransport(defaultGlobalAgentID: route.agentID)
+        return OpenClawChatViewModel(
+            sessionKey: route.sessionKey,
+            transport: transport,
+            activeAgentId: route.agentID)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatView.swift
@@ -62,13 +62,24 @@ struct QuickChatView: View {
         }
     }
 
+    @ViewBuilder private var placeholder: some View {
+        if let override = self.model.targetSessionOverride {
+            Text("Reply in \(override.displayName)")
+        } else {
+            Text("Message \(self.model.agentDisplay.name)")
+        }
+    }
+
     private var inputRow: some View {
         HStack(spacing: 10) {
             self.agentChip
 
             ZStack(alignment: .leading) {
                 if self.model.text.isEmpty {
-                    Text(self.model.messagePlaceholder)
+                    // Interpolated string literals keep the placeholder localizable
+                    // (SwiftUI's LocalizedStringKey path). Routing through a computed
+                    // String would select the verbatim initializer and drop translation.
+                    self.placeholder
                         .font(.system(size: 13.5))
                         .foregroundStyle(.tertiary)
                         .padding(.leading, 2)

--- a/apps/macos/Sources/OpenClaw/QuickChatView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatView.swift
@@ -1,13 +1,16 @@
 import AppKit
 import Observation
+import OpenClawChatUI
 import SwiftUI
 
 @MainActor
 struct QuickChatView: View {
     @Bindable var model: QuickChatModel
+    @Bindable var replyBinding: QuickChatReplyBinding
     let onDismiss: () -> Void
     let onSendAccepted: (Bool) -> Void
     let onShowAgentPicker: () -> Void
+    let onShowRecentSessions: () -> Void
     let onWindowScreenshot: () -> Void
     let onContentHeightChange: (CGFloat) -> Void
     let onTextViewReady: (NSTextView) -> Void
@@ -40,12 +43,18 @@ struct QuickChatView: View {
                     self.permissionStrip
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
+
+                if let viewModel = self.replyBinding.viewModel {
+                    self.replyArea(viewModel: viewModel)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
         }
         .frame(width: 620)
         .fixedSize(horizontal: false, vertical: true)
         .animation(.spring(duration: 0.25), value: self.model.shouldShowPermissionStrip)
         .animation(.easeOut(duration: 0.14), value: self.statusLine?.message)
+        .animation(.spring(duration: 0.28), value: self.replyBinding.route)
         .onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.height
         } action: { height in
@@ -59,7 +68,7 @@ struct QuickChatView: View {
 
             ZStack(alignment: .leading) {
                 if self.model.text.isEmpty {
-                    Text("Message \(self.model.agentDisplay.name)")
+                    Text(self.model.messagePlaceholder)
                         .font(.system(size: 13.5))
                         .foregroundStyle(.tertiary)
                         .padding(.leading, 2)
@@ -74,6 +83,19 @@ struct QuickChatView: View {
                     .frame(height: self.editorHeight)
             }
             .frame(maxWidth: .infinity)
+
+            if self.model.sendState != .sending {
+                Button(action: self.onShowRecentSessions) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.system(size: 16.5, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.plain)
+                .disabled(!self.model.canSelectRecentSession)
+                .help("Continue a recent conversation")
+                .accessibilityLabel("Continue a recent conversation")
+            }
 
             if self.model.sendState != .sending {
                 Button(action: self.onWindowScreenshot) {
@@ -190,6 +212,23 @@ struct QuickChatView: View {
         }
     }
 
+    private func replyArea(viewModel: OpenClawChatViewModel) -> some View {
+        VStack(spacing: 0) {
+            Divider()
+            OpenClawChatView(
+                viewModel: viewModel,
+                drawsBackground: false,
+                showsSessionSwitcher: false,
+                displayOptions: [],
+                showsAssistantAvatars: false,
+                composerChrome: .clean,
+                isComposerEnabled: false,
+                isAttachmentInputEnabled: false)
+                .id(self.replyBinding.route)
+                .frame(height: 300)
+        }
+    }
+
     private var statusLine: (message: String, isError: Bool)? {
         if case let .failed(message) = self.model.sendState {
             return (message, true)
@@ -211,11 +250,7 @@ struct QuickChatView: View {
                 self.onSendAccepted(true)
                 return
             }
-            // Plain Return lingers briefly on the checkmark before the bar dismisses itself.
-            try? await Task.sleep(for: .seconds(0.45))
-            guard self.model.activePresentationID == presentationID,
-                  self.model.sendState == .sent,
-                  self.model.text.isEmpty else { return }
+            guard self.model.activePresentationID == presentationID else { return }
             self.onSendAccepted(false)
         }
     }

--- a/apps/macos/Sources/OpenClaw/QuickChatView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatView.swift
@@ -241,11 +241,6 @@ struct QuickChatView: View {
 
     private func submit(openChat: Bool) {
         guard self.model.canSend, let presentationID = self.model.activePresentationID else { return }
-        // Bind the reply consumer before dispatch: a fast turn must not emit frames
-        // into the gap between the chat.send ack and the view model's first listen.
-        if !openChat, let route = self.model.routingTarget {
-            self.replyBinding.prepare(route: route)
-        }
         Task {
             guard await self.model.send() else { return }
             if openChat {

--- a/apps/macos/Sources/OpenClaw/QuickChatView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatView.swift
@@ -44,7 +44,7 @@ struct QuickChatView: View {
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
 
-                if let viewModel = self.replyBinding.viewModel {
+                if self.replyBinding.route != nil, let viewModel = self.replyBinding.viewModel {
                     self.replyArea(viewModel: viewModel)
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
@@ -241,6 +241,11 @@ struct QuickChatView: View {
 
     private func submit(openChat: Bool) {
         guard self.model.canSend, let presentationID = self.model.activePresentationID else { return }
+        // Bind the reply consumer before dispatch: a fast turn must not emit frames
+        // into the gap between the chat.send ack and the view model's first listen.
+        if !openChat, let route = self.model.routingTarget {
+            self.replyBinding.prepare(route: route)
+        }
         Task {
             guard await self.model.send() else { return }
             if openChat {

--- a/apps/macos/Sources/OpenClaw/SessionData.swift
+++ b/apps/macos/Sources/OpenClaw/SessionData.swift
@@ -298,9 +298,9 @@ enum SessionLoader {
     }
 }
 
-func relativeAge(from date: Date?) -> String {
+func relativeAge(from date: Date?, now: Date = Date()) -> String {
     guard let date else { return "unknown" }
-    let delta = Date().timeIntervalSince(date)
+    let delta = now.timeIntervalSince(date)
     if delta < 60 { return "just now" }
     let minutes = Int(round(delta / 60))
     if minutes < 60 { return "\(minutes)m ago" }

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
@@ -1,4 +1,6 @@
 import AppKit
+import Foundation
+import OpenClawChatUI
 import OpenClawProtocol
 import Testing
 @testable import OpenClaw
@@ -6,6 +8,51 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct QuickChatControllerTests {
+    @Test func `plain accepted send stays open and binds reply view model`() async throws {
+        var createdRoutes: [QuickChatRoutingTarget] = []
+        let model = Self.makeModel()
+        let controller = QuickChatController(
+            enableUI: false,
+            model: model,
+            monitoringEnabled: false,
+            replyViewModelFactory: { route in
+                createdRoutes.append(route)
+                return OpenClawChatViewModel(sessionKey: route.sessionKey, transport: QuickChatTestTransport())
+            })
+        controller.present()
+        let presentationID = try #require(model.activePresentationID)
+        await model.refreshForPresentation(id: presentationID)
+        model.text = "hello"
+
+        #expect(await model.send())
+        controller.handleSendAcceptedForTesting(openChat: false)
+
+        #expect(controller.isVisible)
+        #expect(createdRoutes == [QuickChatRoutingTarget(sessionKey: "agent:main:main", agentID: nil)])
+        #expect(controller.replyBinding.route == createdRoutes.first)
+        controller.stop()
+    }
+
+    @Test func `reply binding retains same target and rebuilds for a changed target`() throws {
+        var createdRoutes: [QuickChatRoutingTarget] = []
+        let binding = QuickChatReplyBinding { route in
+            createdRoutes.append(route)
+            return OpenClawChatViewModel(sessionKey: route.sessionKey, transport: QuickChatTestTransport())
+        }
+        let firstRoute = QuickChatRoutingTarget(sessionKey: "agent:main:main", agentID: nil)
+        let secondRoute = QuickChatRoutingTarget(sessionKey: "global", agentID: "work")
+
+        binding.show(route: firstRoute)
+        let firstViewModel = try #require(binding.viewModel)
+        binding.rebindIfActive(route: firstRoute)
+        #expect(binding.viewModel === firstViewModel)
+
+        binding.rebindIfActive(route: secondRoute)
+        let secondViewModel = try #require(binding.viewModel)
+        #expect(secondViewModel !== firstViewModel)
+        #expect(createdRoutes == [firstRoute, secondRoute])
+    }
+
     @Test func `accepted global route opens chat with its agent`() async {
         var openedRoute: QuickChatRoutingTarget?
         let model = QuickChatModel(
@@ -114,6 +161,57 @@ struct QuickChatControllerTests {
             #expect(!AppState(preview: true).quickChatEnabled)
         }
     }
+
+    private static func makeModel() -> QuickChatModel {
+        QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentsProvider: {
+                AgentsListResult(
+                    defaultid: "main",
+                    mainkey: "main",
+                    scope: AnyCodable("per-agent"),
+                    agents: [AgentSummary(id: "main", name: "Main")])
+            },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _, _, _ in "ok" },
+            permissionStatusProvider: { _ in [:] },
+            permissionGrantProvider: { _ in [:] },
+            connectionGateProvider: { .available })
+    }
+}
+
+private struct QuickChatTestTransport: OpenClawChatTransport {
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        let json = """
+        {"sessionKey":"\(sessionKey)","sessionId":null,"messages":[],"thinkingLevel":"off"}
+        """
+        return try JSONDecoder().decode(OpenClawChatHistoryPayload.self, from: Data(json.utf8))
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        let json = """
+        {"runId":"\(UUID().uuidString)","status":"ok"}
+        """
+        return try JSONDecoder().decode(OpenClawChatSendResponse.self, from: Data(json.utf8))
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func setActiveSessionKey(_: String) async throws {}
 }
 
 @MainActor

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatModelTests.swift
@@ -222,6 +222,99 @@ struct QuickChatModelTests {
             mainKey: "daily") == QuickChatRoutingTarget(
             sessionKey: "agent:research:daily",
             agentID: nil))
+        #expect(QuickChatModel.routingTarget(
+            override: QuickChatSessionTargetOverride(key: "agent:main:telegram:direct:42", displayName: "Chat"),
+            base: QuickChatRoutingTarget(sessionKey: "agent:research:daily", agentID: nil)) ==
+            QuickChatRoutingTarget(sessionKey: "agent:main:telegram:direct:42", agentID: nil))
+        #expect(QuickChatModel.routingTarget(
+            override: QuickChatSessionTargetOverride(key: "global", displayName: "Global"),
+            base: QuickChatRoutingTarget(sessionKey: "global", agentID: "research")) ==
+            QuickChatRoutingTarget(sessionKey: "global", agentID: "research"))
+    }
+
+    @Test func `recent override wins over agent pin and clears back to the pin`() async {
+        let model = self.makeModel(agentsProvider: {
+            Self.agentsResult(defaultID: "main", agentIDs: ["main", "work"])
+        })
+        await self.prepare(model)
+        #expect(model.sessionKey == "agent:main:main")
+
+        model.selectAgent("work")
+        #expect(model.sessionKey == "agent:work:main")
+
+        let recent = QuickChatSessionTargetOverride(
+            key: "agent:main:telegram:direct:42",
+            displayName: "Release chat")
+        model.selectSessionOverride(recent)
+        #expect(model.targetSessionOverride == recent)
+        #expect(model.sessionKey == recent.key)
+        #expect(model.sendAgentID == nil)
+        #expect(model.messagePlaceholder == "Reply in Release chat")
+
+        model.selectSessionOverride(nil)
+        #expect(model.sessionKey == "agent:work:main")
+        #expect(model.messagePlaceholder == "Message work")
+    }
+
+    @Test func `recent override resets on hide`() async {
+        let model = self.makeModel()
+        await self.prepare(model)
+        model.selectSessionOverride(QuickChatSessionTargetOverride(key: "agent:main:other", displayName: "Other"))
+
+        model.endPresentation()
+
+        #expect(model.targetSessionOverride == nil)
+        #expect(model.sessionKey.isEmpty)
+    }
+
+    @Test func `agent switch clears recent override`() async {
+        let model = self.makeModel(agentsProvider: {
+            Self.agentsResult(defaultID: "main", agentIDs: ["main", "work"])
+        })
+        await self.prepare(model)
+        model.selectSessionOverride(QuickChatSessionTargetOverride(key: "agent:main:other", displayName: "Other"))
+
+        model.selectAgent("work")
+
+        #expect(model.targetSessionOverride == nil)
+        #expect(model.sessionKey == "agent:work:main")
+    }
+
+    @Test func `override send uses canonical session key verbatim`() async {
+        var sentRoute: QuickChatRoutingTarget?
+        let model = self.makeModel(sendHandler: { sessionKey, agentID, _, _, _ in
+            sentRoute = QuickChatRoutingTarget(sessionKey: sessionKey, agentID: agentID)
+            return "started"
+        })
+        await self.prepare(model)
+        let key = "agent:ops:discord:channel:release"
+        model.selectSessionOverride(QuickChatSessionTargetOverride(key: key, displayName: "Release"))
+        model.text = "hello"
+
+        #expect(await model.send())
+        #expect(sentRoute == QuickChatRoutingTarget(sessionKey: key, agentID: nil))
+    }
+
+    @Test func `global override preserves selected global agent`() async {
+        var sentRoute: QuickChatRoutingTarget?
+        let model = self.makeModel(
+            agentsProvider: {
+                Self.agentsResult(
+                    defaultID: "main",
+                    agentIDs: ["main", "work"],
+                    scope: "global")
+            },
+            sendHandler: { sessionKey, agentID, _, _, _ in
+                sentRoute = QuickChatRoutingTarget(sessionKey: sessionKey, agentID: agentID)
+                return "started"
+            })
+        await self.prepare(model)
+        model.selectAgent("work")
+        model.selectSessionOverride(QuickChatSessionTargetOverride(key: "global", displayName: "Global"))
+        model.text = "hello"
+
+        #expect(await model.send())
+        #expect(sentRoute == QuickChatRoutingTarget(sessionKey: "global", agentID: "work"))
     }
 
     @Test func `agent display parses avatar forms and monogram`() throws {
@@ -433,12 +526,13 @@ struct QuickChatModelTests {
     private static func agentsResult(
         defaultID: String,
         agentIDs: [String],
-        names: [String] = []) -> AgentsListResult
+        names: [String] = [],
+        scope: String = "per-agent") -> AgentsListResult
     {
         AgentsListResult(
             defaultid: defaultID,
             mainkey: "main",
-            scope: AnyCodable("per-agent"),
+            scope: AnyCodable(scope),
             agents: agentIDs.enumerated().map { index, id in
                 AgentSummary(
                     id: id,

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatRecentsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatRecentsTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct QuickChatRecentsTests {
+    @Test func `menu builds new-message target and five newest session rows`() throws {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let rows = (0..<6).map { index in
+            Self.row(
+                key: "agent:main:session:\(index)",
+                displayName: "Session \(index)",
+                updatedAt: now.addingTimeInterval(Double(-120 - (index * 60))))
+        }
+
+        let items = QuickChatRecentMenuLogic.items(
+            rows: rows,
+            agentName: "Molty",
+            selectedTarget: nil,
+            now: now)
+
+        #expect(items.count == 6)
+        #expect(items[0] == QuickChatRecentMenuItem(
+            id: "new-message",
+            title: "New message to Molty",
+            target: nil,
+            isSelected: true))
+        #expect(items[1].title == "Session 0 — 2m ago")
+        #expect(items.last?.title == "Session 4 — 6m ago")
+    }
+
+    @Test func `menu checkmarks the selected recent session`() throws {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let row = Self.row(
+            key: "agent:main:session:one",
+            displayName: "One",
+            updatedAt: now)
+        let target = QuickChatSessionTargetOverride(key: row.key, displayName: row.label)
+
+        let items = QuickChatRecentMenuLogic.items(
+            rows: [row],
+            agentName: "Molty",
+            selectedTarget: target,
+            now: now)
+
+        #expect(!items[0].isSelected)
+        #expect(items[1].isSelected)
+        #expect(items[1].target == target)
+    }
+
+    private static func row(
+        key: String,
+        displayName: String,
+        updatedAt: Date) -> SessionRow
+    {
+        SessionRow(
+            id: key,
+            key: key,
+            kind: .direct,
+            displayName: displayName,
+            provider: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: updatedAt,
+            sessionId: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            systemSent: false,
+            abortedLastRun: false,
+            tokens: SessionTokenStats(input: 0, output: 0, total: 0, contextTokens: 0),
+            model: nil)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatViewSmokeTests.swift
@@ -27,9 +27,11 @@ struct QuickChatViewSmokeTests {
             connectionGateProvider: { .available })
         let view = QuickChatView(
             model: model,
+            replyBinding: QuickChatReplyBinding(),
             onDismiss: {},
             onSendAccepted: { _ in },
             onShowAgentPicker: {},
+            onShowRecentSessions: {},
             onWindowScreenshot: {},
             onContentHeightChange: { _ in },
             onTextViewReady: { _ in })

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -20,7 +20,9 @@ The anchored compact chat panel from the menu bar keeps the compact single-colum
 
 Press Option-Space (⌥Space) or choose **Quick Chat** from the menu bar menu to open a floating composer for the main session. Change the global shortcut with the recorder in **Settings → General → Quick Chat shortcut**.
 
-Quick Chat shows the targeted agent (avatar or emoji, with the agent's name as the placeholder), sends to that agent's main session, and leaves replies in the full chat window. With more than one agent configured, click the avatar to switch agents from a native menu. Press Return to send, Command-Return to send and open full chat, Shift-Return for a newline, or Escape to dismiss. Clicking outside the bar also dismisses it. When relevant macOS permissions are missing, an attached strip offers **Grant** and **Not now** actions.
+Quick Chat shows the targeted agent (avatar or emoji, with the agent's name as the placeholder) and sends to that agent's main session. After Return accepts a send, the bar stays open and expands downward with the streamed Markdown reply and recent transcript. The bar input remains the composer. Press Command-Return to send and open the same target in the full chat window, Shift-Return for a newline, or Escape to dismiss the whole bar and reply area. Clicking outside also dismisses it. When relevant macOS permissions are missing, an attached strip offers **Grant** and **Not now** actions.
+
+Click the history button to choose from the five most recently updated sessions or return to **New message to &lt;agent&gt;**. A recent selection sends to that exact session and changes the placeholder to **Reply in &lt;session&gt;**. Hiding Quick Chat resets this temporary target to the selected agent's main session; switching agents from the avatar menu also clears it.
 
 Command-Return opens the conversation of the agent that received the send, including when session scope is global.
 


### PR DESCRIPTION
## What Problem This Solves

The macOS Quick Chat was fire-and-forget: sends vanished into the session and reading the answer meant opening the full chat window. Competitive quick bars stream the reply in place and let a quick thought continue a recent conversation.

## Why This Change Was Made

Two features, both reusing existing seams:

- **Streamed replies in the bar**: after an accepted send the panel stays open and expands into a reply area embedding the shared chat stack (`MacGatewayChatTransport` + `OpenClawChatViewModel` + `OpenClawChatView` with the composer disabled and trace surfaces hidden) — the exact stack the panel chat window already builds, so streaming, markdown, and history come from one code path. The reply consumer pre-binds before dispatch for every send path (text and screenshots) so no network-scale gap exists between the ack and the first listen; the scheduler-scale residual is documented as an accepted tradeoff at the site (deltas carry full snapshots and the shared view model self-heals). ⌘Return still opens the full window; Esc dismisses with drafts preserved.
- **Continue-recent targeting**: a history affordance lists the five most recent sessions via the existing `SessionLoader.loadSnapshot` (`sessions.list` underneath), with relative ages and a "New message" default row. Selecting pins the send target and rebinds the reply area; targeting resets on hide and on agent switch (mutually exclusive by design, commented). In-flight recents fetches are invalidated by any competing interaction (send dispatch, agent menu, window picker) through a single-owner helper, and fresh presentations clear prepared reply state.

## User Impact

Ask from the bar, watch the answer stream in place, and continue any recent conversation without opening the dashboard. Docs updated (`docs/platforms/mac/webchat.md`).

## Evidence

- `swift build` (release) green; SwiftFormat/SwiftLint clean; `git diff --check` clean.
- New tests: reply-binding rebind semantics, targeting override precedence/reset invariants, routing payloads (incl. the bare-`global` sessions.list contract, cited from `server.sessions.store-rpc.test.ts`), recents menu construction. Local `swift test` remains blocked by the known Xcode-beta strict-concurrency failures in untouched GatewayChannel files; the `macos-swift` CI lane is authoritative.
- Structured second-model review over six rounds: subscription-race, stale-menu, and lifecycle findings fixed with regression coverage; final residual (a runloop-tick subscription window already covered by snapshot self-healing) consciously rejected with the tradeoff documented in code.
- Live interaction screenshots follow in a PR comment during the CI window.
