### PR TITLE
feat(macos): Quick Chat area capture and focused-app text context

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -33899,6 +33899,158 @@
     },
     {
       "kind": "ui-localized-call",
+      "line": 616,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Capture Window…",
+      "surface": "apple",
+      "id": "native.apple.0a4fcdf09c5e7b3f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 617,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Capture Area…",
+      "surface": "apple",
+      "id": "native.apple.d7ac1580e29304af"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 203,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "focused app",
+      "surface": "apple",
+      "id": "native.apple.33adb82aa3c53c00"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 208,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "No focused application is available.",
+      "surface": "apple",
+      "id": "native.apple.5d20c8bd1235a43c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 212,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Focused app",
+      "surface": "apple",
+      "id": "native.apple.3c1a2f1ac3b50de0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 216,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Focus another app before attaching its text.",
+      "surface": "apple",
+      "id": "native.apple.511248f39affffc4"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 227,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "surface": "apple",
+      "id": "native.apple.1c94e8c0010021d9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 252,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "No focused window is available in \\(appName).",
+      "surface": "apple",
+      "id": "native.apple.a3e3d4b0ab6e94d9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 264,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Focused Window",
+      "surface": "apple",
+      "id": "native.apple.a2a454a96a011397"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 299,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "surface": "apple",
+      "id": "native.apple.67d183bf2f9e4c2c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 302,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "No readable text was found in \\(appName).",
+      "surface": "apple",
+      "id": "native.apple.2f56bc484453a456"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 313,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "surface": "apple",
+      "id": "native.apple.507c2d9c7e94716f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 314,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "surface": "apple",
+      "id": "native.apple.c5313d544a833af0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 315,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Grant Access",
+      "surface": "apple",
+      "id": "native.apple.e68aeef0995a7d00"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 316,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.43dd985a6d9ec004"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 154,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "focused app",
+      "surface": "apple",
+      "id": "native.apple.a8880557335b5a25"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 466,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Couldn't capture that image.",
+      "surface": "apple",
+      "id": "native.apple.6af15237e49bd0bd"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 488,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Screenshot: \\(label)",
+      "surface": "apple",
+      "id": "native.apple.b31041aa0da3768c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 549,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "surface": "apple",
+      "id": "native.apple.72e5bffb7ee89f19"
+    },
+    {
+      "kind": "ui-localized-call",
       "line": 22,
       "path": "apps/macos/Sources/OpenClaw/QuickChatRecents.swift",
       "source": "New message to \\(agentName)",
@@ -33907,7 +34059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 67,
+      "line": 75,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Reply in \\(override.displayName)",
       "surface": "apple",
@@ -33915,7 +34067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 69,
+      "line": 77,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Message \\(self.model.agentDisplay.name)",
       "surface": "apple",
@@ -33923,23 +34075,31 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 108,
+      "line": 116,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Continue a recent conversation",
       "surface": "apple",
       "id": "native.apple.da0b9bd07a337bda"
     },
     {
-      "kind": "ui-modifier",
-      "line": 121,
+      "kind": "ui-localized-call",
+      "line": 135,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Send a window screenshot",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
       "surface": "apple",
-      "id": "native.apple.edf12ff583307f43"
+      "id": "native.apple.c76e52d21bef75ba"
     },
     {
       "kind": "ui-modifier",
-      "line": 145,
+      "line": 146,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Capture a screenshot",
+      "surface": "apple",
+      "id": "native.apple.aedd7e9870c3579a"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 170,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send message",
       "surface": "apple",
@@ -33947,7 +34107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
+      "line": 228,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Needs additional permissions",
       "surface": "apple",
@@ -33955,7 +34115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 210,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Grant",
       "surface": "apple",
@@ -33963,11 +34123,75 @@
     },
     {
       "kind": "ui-call",
-      "line": 216,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Not now",
       "surface": "apple",
       "id": "native.apple.a3332fa4db187973"
+    },
+    {
+      "kind": "ui-call",
+      "line": 255,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "surface": "apple",
+      "id": "native.apple.1962232c9bc52e12"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 264,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Remove attached text context",
+      "surface": "apple",
+      "id": "native.apple.66ec93e9eefd9bd7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 215,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Allow OpenClaw to capture windows",
+      "surface": "apple",
+      "id": "native.apple.88d0123c86b06144"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 216,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Allow OpenClaw to capture a screen area",
+      "surface": "apple",
+      "id": "native.apple.677c5733cd132aed"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 217,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "surface": "apple",
+      "id": "native.apple.529a6fc5aeba03b0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 218,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Grant Access",
+      "surface": "apple",
+      "id": "native.apple.615245bf05ed3234"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 219,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.2a64131ba32d175d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 493,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Selected area",
+      "surface": "apple",
+      "id": "native.apple.6521871fc0ddc987"
     },
     {
       "kind": "conditional-branch",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -21189,6 +21189,101 @@
       "translated": "متابعة"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "التقاط نافذة…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "التقاط منطقة…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "التطبيق النشط"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "لا يتوفر تطبيق نشط."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "التطبيق النشط"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "انتقل إلى تطبيق آخر قبل إرفاق نصه."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "يلزم منح إذن تسهيلات الاستخدام لإرفاق نص من \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "لا تتوفر نافذة نشطة في \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "النافذة النشطة"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "لا يستجيب \\(appName) لطلبات تسهيلات الاستخدام."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "لم يتم العثور على نص قابل للقراءة في \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "السماح لـ OpenClaw بقراءة النص من \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "يتطلب إرفاق نص النافذة النشطة إذن تسهيلات الاستخدام في macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "منح الإذن"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "التطبيق النشط"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "تعذر التقاط تلك الصورة."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "لقطة شاشة: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "سياق من \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "رسالة جديدة إلى \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "متابعة محادثة حديثة"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "إرسال لقطة شاشة لنافذة"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "إرفاق نص من \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "التقاط لقطة شاشة"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "ليس الآن"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) حرفًا)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "إزالة سياق النص المرفق"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "السماح لـ OpenClaw بالتقاط النوافذ"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "السماح لـ OpenClaw بالتقاط منطقة من الشاشة"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "يتطلب إرسال لقطة شاشة إذن تسجيل الشاشة في macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "منح الإذن"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "المنطقة المحددة"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -21189,6 +21189,101 @@
       "translated": "Fortfahren"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Fenster aufnehmen…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Bereich aufnehmen…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "fokussierte App"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Es ist keine fokussierte App verfügbar."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Fokussierte App"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Fokussieren Sie eine andere App, bevor Sie deren Text anhängen."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Bedienungshilfenzugriff ist erforderlich, um Text aus \\(appName) anzuhängen."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "In \\(appName) ist kein fokussiertes Fenster verfügbar."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Fokussiertes Fenster"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) reagiert nicht auf Anfragen der Bedienungshilfen."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "In \\(appName) wurde kein lesbarer Text gefunden."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "OpenClaw erlauben, Text aus \\(appName) zu lesen"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Zum Anhängen von Text aus dem fokussierten Fenster ist macOS-Bedienungshilfenzugriff erforderlich."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Zugriff gewähren"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "fokussierte App"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Dieses Bild konnte nicht aufgenommen werden."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Bildschirmfoto: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Kontext aus \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Neue Nachricht an \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Eine kürzlich geführte Unterhaltung fortsetzen"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Screenshot eines Fensters senden"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Text aus \\(self.model.frontmostAppName) anhängen"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Bildschirmfoto aufnehmen"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Nicht jetzt"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) Zeichen)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Angehängten Textkontext entfernen"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "OpenClaw das Aufnehmen von Fenstern erlauben"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "OpenClaw das Aufnehmen eines Bildschirmbereichs erlauben"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Zum Senden eines Bildschirmfotos ist der macOS-Zugriff für Bildschirmaufnahmen erforderlich."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Zugriff gewähren"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Ausgewählter Bereich"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -21189,6 +21189,101 @@
       "translated": "Continuar"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Capturar ventana…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Capturar área…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "aplicación enfocada"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "No hay ninguna aplicación enfocada disponible."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Aplicación enfocada"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Enfoque otra aplicación antes de adjuntar su texto."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Se requiere acceso de Accesibilidad para adjuntar texto de \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "No hay ninguna ventana enfocada disponible en \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Ventana enfocada"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) no responde a las solicitudes de Accesibilidad."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "No se encontró texto legible en \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Permitir que OpenClaw lea texto de \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Para adjuntar el texto de la ventana enfocada se requiere acceso de Accesibilidad de macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Conceder acceso"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "aplicación enfocada"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "No se pudo capturar esa imagen."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Captura de pantalla: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Contexto de \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nuevo mensaje para \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Continuar una conversación reciente"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Enviar una captura de pantalla de la ventana"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Adjuntar texto de \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Capturar una captura de pantalla"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Ahora no"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) caracteres)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Eliminar el contexto de texto adjunto"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Permitir que OpenClaw capture ventanas"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Permitir que OpenClaw capture un área de la pantalla"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Para enviar una captura de pantalla, se requiere acceso a Grabación de pantalla de macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Conceder acceso"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Área seleccionada"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -21189,6 +21189,101 @@
       "translated": "ادامه"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "ثبت پنجره…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "ثبت ناحیه…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "برنامهٔ فعال"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "هیچ برنامهٔ فعالی در دسترس نیست."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "برنامهٔ فعال"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "پیش از پیوست‌کردن متن، برنامهٔ دیگری را فعال کنید."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "برای پیوست‌کردن متن از \\(appName)، دسترسی Accessibility لازم است."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "هیچ پنجرهٔ فعالی در \\(appName) در دسترس نیست."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "پنجرهٔ فعال"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) به درخواست‌های Accessibility پاسخ نمی‌دهد."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "هیچ متن خوانایی در \\(appName) یافت نشد."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "به OpenClaw اجازه دهید متن را از \\(appName) بخواند"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "پیوست‌کردن متن پنجرهٔ فعال از دسترسی Accessibility در macOS استفاده می‌کند."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "اعطای دسترسی"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "برنامهٔ فعال"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "ثبت آن تصویر ممکن نشد."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "نماگرفت: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "زمینه از \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "پیام جدید به \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "ادامه یک گفت‌وگوی اخیر"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "ارسال تصویر صفحه از پنجره"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "پیوست‌کردن متن از \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "گرفتن اسکرین‌شات"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "فعلاً نه"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) نویسه)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "حذف متن زمینهٔ پیوست‌شده"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "اجازه به OpenClaw برای ثبت پنجره‌ها"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "اجازه به OpenClaw برای ثبت بخشی از صفحه‌نمایش"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "ارسال اسکرین‌شات از دسترسی ضبط صفحه‌نمایش macOS استفاده می‌کند."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "اعطای دسترسی"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "ناحیهٔ انتخاب‌شده"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -21189,6 +21189,101 @@
       "translated": "Continuer"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Capturer une fenêtre…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Capturer une zone…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "application active"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Aucune application active n’est disponible."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Application active"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Activez une autre application avant de joindre son texte."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "L’accès aux fonctionnalités d’accessibilité est requis pour joindre le texte de \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Aucune fenêtre active n’est disponible dans \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Fenêtre active"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) ne répond pas aux requêtes d’accessibilité."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Aucun texte lisible n’a été trouvé dans \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Autoriser OpenClaw à lire le texte de \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Joindre le texte de la fenêtre active nécessite l’accès aux fonctionnalités d’accessibilité de macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Accorder l’accès"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "application active"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Impossible de capturer cette image."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Capture d’écran : \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Contexte de \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nouveau message à \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Continuer une conversation récente"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Envoyer une capture d’écran de la fenêtre"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Joindre le texte de \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Capturer une capture d’écran"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Pas maintenant"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) caractères)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Supprimer le contexte textuel joint"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Autoriser OpenClaw à capturer des fenêtres"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Autoriser OpenClaw à capturer une zone de l’écran"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "L’envoi d’une capture d’écran nécessite l’accès à l’enregistrement de l’écran de macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Accorder l’accès"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Zone sélectionnée"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -21189,6 +21189,101 @@
       "translated": "जारी रखें"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "विंडो कैप्चर करें…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "क्षेत्र कैप्चर करें…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "फ़ोकस किया गया ऐप"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "कोई फ़ोकस किया गया एप्लिकेशन उपलब्ध नहीं है।"
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "फ़ोकस किया गया ऐप"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "उसका टेक्स्ट अटैच करने से पहले किसी अन्य ऐप पर फ़ोकस करें।"
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "\\(appName) से टेक्स्ट अटैच करने के लिए Accessibility एक्सेस आवश्यक है।"
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "\\(appName) में कोई फ़ोकस की गई विंडो उपलब्ध नहीं है।"
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "फ़ोकस की गई विंडो"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) Accessibility अनुरोधों का जवाब नहीं दे रहा है।"
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "\\(appName) में कोई पठनीय टेक्स्ट नहीं मिला।"
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "OpenClaw को \\(appName) से टेक्स्ट पढ़ने की अनुमति दें"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "फ़ोकस की गई विंडो का टेक्स्ट अटैच करने के लिए macOS Accessibility एक्सेस का उपयोग होता है।"
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "एक्सेस दें"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "फ़ोकस किया गया ऐप"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "उस इमेज को कैप्चर नहीं किया जा सका।"
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "स्क्रीनशॉट: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "\\(context.appName) से संदर्भ — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "\\(agentName) को नया संदेश"
@@ -21209,9 +21304,14 @@
       "translated": "हाल की बातचीत जारी रखें"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "विंडो का स्क्रीनशॉट भेजें"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "\\(self.model.frontmostAppName) से टेक्स्ट अटैच करें"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "स्क्रीनशॉट कैप्चर करें"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "अभी नहीं"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) वर्ण)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "संलग्न टेक्स्ट संदर्भ हटाएँ"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "OpenClaw को विंडो कैप्चर करने की अनुमति दें"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "OpenClaw को स्क्रीन का क्षेत्र कैप्चर करने की अनुमति दें"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "स्क्रीनशॉट भेजने के लिए macOS Screen Recording एक्सेस का उपयोग किया जाता है।"
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "एक्सेस दें"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "चयनित क्षेत्र"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -21189,6 +21189,101 @@
       "translated": "Lanjutkan"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Ambil Gambar Jendela…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Ambil Gambar Area…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "aplikasi yang difokuskan"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Tidak ada aplikasi yang sedang difokuskan."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Aplikasi yang difokuskan"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Fokuskan aplikasi lain sebelum melampirkan teksnya."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Akses Aksesibilitas diperlukan untuk melampirkan teks dari \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Tidak ada jendela yang sedang difokuskan di \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Jendela yang Difokuskan"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) tidak merespons permintaan Aksesibilitas."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Tidak ditemukan teks yang dapat dibaca di \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Izinkan OpenClaw membaca teks dari \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Melampirkan teks dari jendela yang difokuskan menggunakan akses Aksesibilitas macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Berikan Akses"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "aplikasi yang difokuskan"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Tidak dapat mengambil gambar tersebut."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Tangkapan layar: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Konteks dari \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Pesan baru kepada \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Lanjutkan percakapan terbaru"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Kirim tangkapan layar jendela"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Lampirkan teks dari \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Ambil tangkapan layar"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Jangan sekarang"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) karakter)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Hapus konteks teks terlampir"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Izinkan OpenClaw menangkap jendela"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Izinkan OpenClaw menangkap area layar"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Mengirim tangkapan layar menggunakan akses Perekaman Layar macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Berikan Akses"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Area yang dipilih"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -21189,6 +21189,101 @@
       "translated": "Continua"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Acquisisci finestra…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Acquisisci area…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "app in primo piano"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Nessuna applicazione in primo piano disponibile."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "App in primo piano"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Porta un'altra app in primo piano prima di allegarne il testo."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "È necessario l'accesso ad Accessibilità per allegare il testo da \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Nessuna finestra in primo piano disponibile in \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Finestra in primo piano"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) non risponde alle richieste di Accessibilità."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Non è stato trovato testo leggibile in \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Consenti a OpenClaw di leggere il testo da \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Per allegare il testo della finestra in primo piano è necessario l'accesso ad Accessibilità di macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Concedi accesso"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "app in primo piano"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Impossibile acquisire l'immagine."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Schermata: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Contesto da \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nuovo messaggio a \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Continua una conversazione recente"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Invia uno screenshot della finestra"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Allega testo da \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Acquisisci uno screenshot"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Non ora"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) caratteri)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Rimuovi il contesto testuale allegato"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Consenti a OpenClaw di acquisire le finestre"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Consenti a OpenClaw di acquisire un'area dello schermo"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "L'invio di uno screenshot richiede l'accesso alla registrazione dello schermo di macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Concedi accesso"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Area selezionata"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -21189,6 +21189,101 @@
       "translated": "続ける"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "ウインドウをキャプチャ…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "範囲をキャプチャ…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "フォーカス中のアプリ"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "フォーカス中のアプリケーションはありません。"
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "フォーカス中のアプリ"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "テキストを添付する前に、別のアプリにフォーカスしてください。"
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "\\(appName)からテキストを添付するには、アクセシビリティへのアクセスが必要です。"
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "\\(appName)にはフォーカス中のウインドウがありません。"
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "フォーカス中のウインドウ"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName)はアクセシビリティのリクエストに応答していません。"
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "\\(appName)に読み取り可能なテキストが見つかりませんでした。"
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "OpenClawに\\(appName)からのテキストの読み取りを許可"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "フォーカス中のウインドウのテキストを添付するには、macOSのアクセシビリティへのアクセスが必要です。"
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "アクセスを許可"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "フォーカス中のアプリ"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "画像をキャプチャできませんでした。"
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "スクリーンショット：\\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "\\(context.appName)からのコンテキスト — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "\\(agentName)への新しいメッセージ"
@@ -21209,9 +21304,14 @@
       "translated": "最近の会話を続ける"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "ウインドウのスクリーンショットを送信"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "\\(self.model.frontmostAppName)からテキストを添付"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "スクリーンショットを撮影"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "後で"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle)（\\(context.characterCount)文字）"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "添付されたテキストコンテキストを削除"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "OpenClawによるウインドウのキャプチャを許可"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "OpenClawによる画面領域のキャプチャを許可"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "スクリーンショットを送信するには、macOSの画面収録へのアクセス権が必要です。"
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "アクセスを許可"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "選択した領域"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -21189,6 +21189,101 @@
       "translated": "계속"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "윈도우 캡처…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "영역 캡처…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "포커스된 앱"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "포커스된 애플리케이션이 없습니다."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "포커스된 앱"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "텍스트를 첨부하기 전에 다른 앱에 포커스를 맞추세요."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "\\(appName)의 텍스트를 첨부하려면 손쉬운 사용 권한이 필요합니다."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "\\(appName)에 포커스된 윈도우가 없습니다."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "포커스된 윈도우"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName)이(가) 손쉬운 사용 요청에 응답하지 않습니다."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "\\(appName)에서 읽을 수 있는 텍스트를 찾지 못했습니다."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "OpenClaw가 \\(appName)의 텍스트를 읽도록 허용"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "포커스된 윈도우의 텍스트를 첨부하려면 macOS 손쉬운 사용 권한이 필요합니다."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "접근 권한 부여"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "포커스된 앱"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "해당 이미지를 캡처할 수 없습니다."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "스크린샷: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "\\(context.appName)의 컨텍스트 — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "\\(agentName)에게 보내는 새 메시지"
@@ -21209,9 +21304,14 @@
       "translated": "최근 대화 계속하기"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "창 스크린샷 보내기"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "\\(self.model.frontmostAppName)의 텍스트 첨부"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "스크린샷 캡처"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "나중에"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount)자)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "첨부된 텍스트 컨텍스트 제거"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "OpenClaw가 윈도우를 캡처하도록 허용"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "OpenClaw가 화면 영역을 캡처하도록 허용"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "스크린샷을 보내려면 macOS 화면 기록 접근 권한이 필요합니다."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "접근 권한 부여"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "선택한 영역"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -21189,6 +21189,101 @@
       "translated": "Doorgaan"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Venster vastleggen…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Gebied vastleggen…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "actieve app"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Er is geen actieve app beschikbaar."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Actieve app"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Activeer een andere app voordat je de tekst ervan bijvoegt."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Toegang tot Toegankelijkheid is vereist om tekst uit \\(appName) bij te voegen."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Er is geen actief venster beschikbaar in \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Actief venster"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) reageert niet op toegankelijkheidsverzoeken."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Er is geen leesbare tekst gevonden in \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Sta OpenClaw toe tekst uit \\(appName) te lezen"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Voor het bijvoegen van tekst uit het actieve venster is toegang tot macOS-toegankelijkheid vereist."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Toegang verlenen"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Annuleren"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "actieve app"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Kan die afbeelding niet vastleggen."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Schermafbeelding: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Context van \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nieuw bericht aan \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Een recent gesprek voortzetten"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Stuur een schermafbeelding van het venster"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Tekst uit \\(self.model.frontmostAppName) bijvoegen"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Maak een schermafbeelding"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Niet nu"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) tekens)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Bijgevoegde tekstcontext verwijderen"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "OpenClaw toestaan vensters vast te leggen"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "OpenClaw toestaan een schermgebied vast te leggen"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Voor het verzenden van een schermafbeelding is toegang tot Schermopname in macOS vereist."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Toegang verlenen"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Annuleren"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Geselecteerd gebied"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -21189,6 +21189,101 @@
       "translated": "Kontynuuj"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Przechwyć okno…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Przechwyć obszar…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "aktywna aplikacja"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Brak aktywnej aplikacji."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Aktywna aplikacja"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Przełącz się na inną aplikację, zanim załączysz jej tekst."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Dostęp do funkcji Dostępność jest wymagany, aby załączyć tekst z aplikacji \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Brak aktywnego okna w aplikacji \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Aktywne okno"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "Aplikacja \\(appName) nie odpowiada na żądania funkcji Dostępność."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Nie znaleziono tekstu możliwego do odczytania w aplikacji \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Zezwól OpenClaw na odczytywanie tekstu z aplikacji \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Załączanie tekstu z aktywnego okna wymaga dostępu do funkcji Dostępność w systemie macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Udziel dostępu"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "aktywna aplikacja"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Nie udało się przechwycić tego obrazu."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Zrzut ekranu: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Kontekst z aplikacji \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nowa wiadomość do \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Kontynuuj ostatnią rozmowę"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Wyślij zrzut ekranu okna"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Załącz tekst z aplikacji \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Zrób zrzut ekranu"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Nie teraz"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (liczba znaków: \\(context.characterCount))"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Usuń dołączony kontekst tekstowy"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Zezwól OpenClaw na przechwytywanie okien"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Zezwól OpenClaw na przechwytywanie obszaru ekranu"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Wysyłanie zrzutu ekranu wymaga dostępu do nagrywania ekranu w macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Przyznaj dostęp"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Wybrany obszar"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -21189,6 +21189,101 @@
       "translated": "Continuar"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Capturar janela…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Capturar área…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "app em foco"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Nenhum aplicativo em foco está disponível."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "App em foco"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Coloque outro app em foco antes de anexar o texto dele."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "É necessário acesso de Acessibilidade para anexar texto de \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Nenhuma janela em foco está disponível em \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Janela em foco"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) não está respondendo às solicitações de Acessibilidade."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Nenhum texto legível foi encontrado em \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Permitir que o OpenClaw leia texto de \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Anexar o texto da janela em foco usa o acesso de Acessibilidade do macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Conceder acesso"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "app em foco"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Não foi possível capturar essa imagem."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Captura de tela: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Contexto de \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nova mensagem para \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Continuar uma conversa recente"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Enviar uma captura de tela da janela"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Anexar texto de \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Capturar uma imagem da tela"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Agora não"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) caracteres)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Remover contexto de texto anexado"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Permitir que o OpenClaw capture janelas"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Permitir que o OpenClaw capture uma área da tela"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "O envio de uma imagem da tela usa o acesso à Gravação de Tela do macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Conceder acesso"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Área selecionada"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -21189,6 +21189,101 @@
       "translated": "Продолжить"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Снимок окна…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Снимок области…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "активное приложение"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Нет доступного активного приложения."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Активное приложение"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Переключитесь на другое приложение, прежде чем прикреплять его текст."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Для прикрепления текста из \\(appName) требуется доступ к Универсальному доступу."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "В \\(appName) нет доступного активного окна."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Активное окно"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) не отвечает на запросы Универсального доступа."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "В \\(appName) не найдено доступного для чтения текста."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Разрешить OpenClaw читать текст из \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Для прикрепления текста активного окна требуется доступ macOS к Универсальному доступу."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Предоставить доступ"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "активное приложение"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Не удалось сделать снимок."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Снимок экрана: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Контекст из \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Новое сообщение для \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Продолжить недавний разговор"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Отправить снимок окна"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Прикрепить текст из \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Сделать снимок экрана"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Не сейчас"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (символов: \\(context.characterCount))"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Удалить прикреплённый текстовый контекст"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Разрешить OpenClaw захватывать окна"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Разрешить OpenClaw захватывать область экрана"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Для отправки снимка экрана требуется доступ macOS к записи экрана."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Предоставить доступ"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Выбранная область"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -21189,6 +21189,101 @@
       "translated": "Fortsätt"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Ta skärmbild av fönster…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Ta skärmbild av område…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "fokuserad app"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Ingen fokuserad app är tillgänglig."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Fokuserad app"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Fokusera på en annan app innan du bifogar dess text."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Åtkomst till Hjälpmedel krävs för att bifoga text från \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Inget fokuserat fönster är tillgängligt i \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Fokuserat fönster"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) svarar inte på förfrågningar från Hjälpmedel."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Ingen läsbar text hittades i \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Tillåt OpenClaw att läsa text från \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "För att bifoga text från det fokuserade fönstret krävs åtkomst till Hjälpmedel i macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Bevilja åtkomst"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "fokuserad app"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Det gick inte att ta den skärmbilden."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Skärmbild: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Kontext från \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Nytt meddelande till \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Fortsätt en nyligen använd konversation"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Skicka en skärmbild av fönstret"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Bifoga text från \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Ta en skärmbild"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Inte nu"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) tecken)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Ta bort bifogad textkontext"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Tillåt OpenClaw att ta skärmbilder av fönster"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Tillåt OpenClaw att ta en skärmbild av ett skärmområde"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "För att skicka en skärmbild krävs åtkomst till skärminspelning i macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Bevilja åtkomst"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Markerat område"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -21189,6 +21189,101 @@
       "translated": "ดำเนินการต่อ"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "จับภาพหน้าต่าง…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "จับภาพพื้นที่…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "แอปที่โฟกัสอยู่"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "ไม่มีแอปพลิเคชันที่โฟกัสอยู่"
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "แอปที่โฟกัสอยู่"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "โฟกัสแอปอื่นก่อนแนบข้อความจากแอปนั้น"
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "ต้องมีสิทธิ์การช่วยการเข้าถึงเพื่อแนบข้อความจาก \\(appName)"
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "ไม่มีหน้าต่างที่โฟกัสอยู่ใน \\(appName)"
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "หน้าต่างที่โฟกัสอยู่"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) ไม่ตอบสนองต่อคำขอการช่วยการเข้าถึง"
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "ไม่พบข้อความที่อ่านได้ใน \\(appName)"
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "อนุญาตให้ OpenClaw อ่านข้อความจาก \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "การแนบข้อความจากหน้าต่างที่โฟกัสอยู่ต้องใช้สิทธิ์การช่วยการเข้าถึงของ macOS"
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "ให้สิทธิ์การเข้าถึง"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "แอปที่โฟกัสอยู่"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "ไม่สามารถจับภาพนั้นได้"
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "ภาพหน้าจอ: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "บริบทจาก \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "ข้อความใหม่ถึง \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "สนทนาต่อล่าสุด"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "ส่งภาพหน้าจอของหน้าต่าง"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "แนบข้อความจาก \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "จับภาพหน้าจอ"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "ไว้ภายหลัง"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) อักขระ)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "ลบบริบทข้อความที่แนบมา"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "อนุญาตให้ OpenClaw จับภาพหน้าต่าง"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "อนุญาตให้ OpenClaw จับภาพพื้นที่หน้าจอ"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "การส่งภาพหน้าจอต้องใช้สิทธิ์เข้าถึงการบันทึกหน้าจอของ macOS"
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "อนุญาตการเข้าถึง"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "พื้นที่ที่เลือก"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -21189,6 +21189,101 @@
       "translated": "Devam et"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Pencereyi Yakala…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Alanı Yakala…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "odaktaki uygulama"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Odakta bir uygulama yok."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Odaktaki uygulama"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Metnini eklemeden önce başka bir uygulamaya odaklanın."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "\\(appName) uygulamasından metin eklemek için Erişilebilirlik erişimi gereklidir."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "\\(appName) uygulamasında odakta bir pencere yok."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Odaktaki Pencere"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName), Erişilebilirlik isteklerine yanıt vermiyor."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "\\(appName) uygulamasında okunabilir metin bulunamadı."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "OpenClaw'ın \\(appName) uygulamasındaki metni okumasına izin ver"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Odaktaki pencerenin metnini eklemek için macOS Erişilebilirlik erişimi kullanılır."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Erişim İzni Ver"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "odaktaki uygulama"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Bu görüntü yakalanamadı."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Ekran görüntüsü: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "\\(context.appName) bağlamı — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "\\(agentName) için yeni mesaj"
@@ -21209,9 +21304,14 @@
       "translated": "Yakın tarihli bir konuşmaya devam et"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Pencere ekran görüntüsü gönder"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "\\(self.model.frontmostAppName) uygulamasından metin ekle"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Ekran görüntüsü al"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Şimdi değil"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) karakter)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Ekli metin bağlamını kaldır"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "OpenClaw'un pencereleri yakalamasına izin ver"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "OpenClaw'un bir ekran alanını yakalamasına izin ver"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Ekran görüntüsü göndermek için macOS Ekran Kaydı erişimi gerekir."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Erişim Ver"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Seçili alan"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -21189,6 +21189,101 @@
       "translated": "Продовжити"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Знімок вікна…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Знімок області…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "активна програма"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Немає доступної активної програми."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Активна програма"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Перейдіть до іншої програми, перш ніж прикріплювати її текст."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Щоб прикріпити текст із \\(appName), потрібен доступ до універсального доступу."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "У \\(appName) немає доступного активного вікна."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Активне вікно"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) не відповідає на запити універсального доступу."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "У \\(appName) не знайдено тексту, доступного для читання."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Дозволити OpenClaw читати текст із \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Для прикріплення тексту з активного вікна потрібен доступ до універсального доступу macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Надати доступ"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "активна програма"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Не вдалося зробити цей знімок."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Знімок екрана: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Контекст із \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Нове повідомлення для \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Продовжити нещодавню розмову"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Надіслати знімок вікна"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Прикріпити текст із \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Зробити знімок екрана"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Не зараз"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) симв.)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Видалити прикріплений текстовий контекст"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Дозволити OpenClaw захоплювати вікна"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Дозволити OpenClaw захоплювати область екрана"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Для надсилання знімка екрана потрібен доступ до запису екрана в macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Надати доступ"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Вибрана область"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -21189,6 +21189,101 @@
       "translated": "Tiếp tục"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "Chụp cửa sổ…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "Chụp vùng…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "ứng dụng đang được chọn"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "Không có ứng dụng nào đang được chọn."
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "Ứng dụng đang được chọn"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "Chọn một ứng dụng khác trước khi đính kèm văn bản của ứng dụng đó."
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "Cần có quyền Trợ năng để đính kèm văn bản từ \\(appName)."
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "Không có cửa sổ nào đang được chọn trong \\(appName)."
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "Cửa sổ đang được chọn"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) không phản hồi các yêu cầu Trợ năng."
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "Không tìm thấy văn bản có thể đọc được trong \\(appName)."
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "Cho phép OpenClaw đọc văn bản từ \\(appName)"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "Việc đính kèm văn bản từ cửa sổ đang được chọn sử dụng quyền Trợ năng của macOS."
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "Cấp quyền truy cập"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "ứng dụng đang được chọn"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "Không thể chụp hình ảnh đó."
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "Ảnh chụp màn hình: \\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "Ngữ cảnh từ \\(context.appName) — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "Tin nhắn mới tới \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "Tiếp tục một cuộc trò chuyện gần đây"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "Gửi ảnh chụp màn hình cửa sổ"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "Đính kèm văn bản từ \\(self.model.frontmostAppName)"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "Chụp ảnh màn hình"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "Để sau"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) ký tự)"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "Xóa ngữ cảnh văn bản đính kèm"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "Cho phép OpenClaw chụp các cửa sổ"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "Cho phép OpenClaw chụp một vùng màn hình"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "Việc gửi ảnh chụp màn hình sử dụng quyền truy cập Ghi màn hình của macOS."
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "Cấp quyền truy cập"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "Vùng đã chọn"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -21189,6 +21189,101 @@
       "translated": "继续"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "截取窗口…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "截取区域…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "当前聚焦的应用"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "当前没有聚焦的应用。"
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "当前聚焦的应用"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "请先聚焦另一个应用，再附加其中的文本。"
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "需要辅助功能访问权限才能附加来自 \\(appName) 的文本。"
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "\\(appName) 中没有当前聚焦的窗口。"
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "当前聚焦的窗口"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) 未响应辅助功能请求。"
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "在 \\(appName) 中未找到可读取的文本。"
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "允许 OpenClaw 读取 \\(appName) 中的文本"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "附加当前聚焦窗口中的文本需要 macOS 辅助功能访问权限。"
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "授予访问权限"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "当前聚焦的应用"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "无法截取该图像。"
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "截图：\\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "来自 \\(context.appName) 的上下文 — \\(context.windowTitle)"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "发给 \\(agentName) 的新消息"
@@ -21209,9 +21304,14 @@
       "translated": "继续最近的对话"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "发送窗口截图"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "附加来自 \\(self.model.frontmostAppName) 的文本"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "截取屏幕截图"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "暂不"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle)（\\(context.characterCount) 个字符）"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "移除附加的文本上下文"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "允许 OpenClaw 捕获窗口"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "允许 OpenClaw 捕获屏幕区域"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "发送屏幕截图需要 macOS 屏幕录制权限。"
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "授予访问权限"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "所选区域"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -21189,6 +21189,101 @@
       "translated": "繼續"
     },
     {
+      "id": "native.apple.0a4fcdf09c5e7b3f",
+      "source": "Capture Window…",
+      "translated": "擷取視窗…"
+    },
+    {
+      "id": "native.apple.d7ac1580e29304af",
+      "source": "Capture Area…",
+      "translated": "擷取區域…"
+    },
+    {
+      "id": "native.apple.33adb82aa3c53c00",
+      "source": "focused app",
+      "translated": "目前聚焦的 App"
+    },
+    {
+      "id": "native.apple.5d20c8bd1235a43c",
+      "source": "No focused application is available.",
+      "translated": "目前沒有可用的聚焦應用程式。"
+    },
+    {
+      "id": "native.apple.3c1a2f1ac3b50de0",
+      "source": "Focused app",
+      "translated": "聚焦的 App"
+    },
+    {
+      "id": "native.apple.511248f39affffc4",
+      "source": "Focus another app before attaching its text.",
+      "translated": "請先聚焦其他 App，再附加其中的文字。"
+    },
+    {
+      "id": "native.apple.1c94e8c0010021d9",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "translated": "需要輔助使用權限，才能附加來自 \\(appName) 的文字。"
+    },
+    {
+      "id": "native.apple.a3e3d4b0ab6e94d9",
+      "source": "No focused window is available in \\(appName).",
+      "translated": "\\(appName) 中目前沒有可用的聚焦視窗。"
+    },
+    {
+      "id": "native.apple.a2a454a96a011397",
+      "source": "Focused Window",
+      "translated": "聚焦的視窗"
+    },
+    {
+      "id": "native.apple.67d183bf2f9e4c2c",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "translated": "\\(appName) 未回應輔助使用要求。"
+    },
+    {
+      "id": "native.apple.2f56bc484453a456",
+      "source": "No readable text was found in \\(appName).",
+      "translated": "在 \\(appName) 中找不到可讀取的文字。"
+    },
+    {
+      "id": "native.apple.507c2d9c7e94716f",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "translated": "允許 OpenClaw 讀取 \\(appName) 中的文字"
+    },
+    {
+      "id": "native.apple.c5313d544a833af0",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "translated": "附加聚焦視窗中的文字需要 macOS 輔助使用權限。"
+    },
+    {
+      "id": "native.apple.e68aeef0995a7d00",
+      "source": "Grant Access",
+      "translated": "授予權限"
+    },
+    {
+      "id": "native.apple.43dd985a6d9ec004",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.a8880557335b5a25",
+      "source": "focused app",
+      "translated": "目前聚焦的 App"
+    },
+    {
+      "id": "native.apple.6af15237e49bd0bd",
+      "source": "Couldn't capture that image.",
+      "translated": "無法擷取該影像。"
+    },
+    {
+      "id": "native.apple.b31041aa0da3768c",
+      "source": "Screenshot: \\(label)",
+      "translated": "截圖：\\(label)"
+    },
+    {
+      "id": "native.apple.72e5bffb7ee89f19",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "translated": "來自 \\(context.appName) — \\(context.windowTitle) 的內容"
+    },
+    {
       "id": "native.apple.b5524e37a230e571",
       "source": "New message to \\(agentName)",
       "translated": "傳送新訊息給 \\(agentName)"
@@ -21209,9 +21304,14 @@
       "translated": "繼續最近的對話"
     },
     {
-      "id": "native.apple.edf12ff583307f43",
-      "source": "Send a window screenshot",
-      "translated": "傳送視窗截圖"
+      "id": "native.apple.c76e52d21bef75ba",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "translated": "附加來自 \\(self.model.frontmostAppName) 的文字"
+    },
+    {
+      "id": "native.apple.aedd7e9870c3579a",
+      "source": "Capture a screenshot",
+      "translated": "擷取螢幕截圖"
     },
     {
       "id": "native.apple.136cef9f750d3803",
@@ -21232,6 +21332,46 @@
       "id": "native.apple.a3332fa4db187973",
       "source": "Not now",
       "translated": "現在不要"
+    },
+    {
+      "id": "native.apple.1962232c9bc52e12",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "translated": "\\(context.appName) — \\(context.windowTitle)（\\(context.characterCount) 個字元）"
+    },
+    {
+      "id": "native.apple.66ec93e9eefd9bd7",
+      "source": "Remove attached text context",
+      "translated": "移除附加的文字內容"
+    },
+    {
+      "id": "native.apple.88d0123c86b06144",
+      "source": "Allow OpenClaw to capture windows",
+      "translated": "允許 OpenClaw 擷取視窗"
+    },
+    {
+      "id": "native.apple.677c5733cd132aed",
+      "source": "Allow OpenClaw to capture a screen area",
+      "translated": "允許 OpenClaw 擷取螢幕區域"
+    },
+    {
+      "id": "native.apple.529a6fc5aeba03b0",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "translated": "傳送螢幕截圖需要 macOS 的螢幕錄製權限。"
+    },
+    {
+      "id": "native.apple.615245bf05ed3234",
+      "source": "Grant Access",
+      "translated": "授予權限"
+    },
+    {
+      "id": "native.apple.2a64131ba32d175d",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.6521871fc0ddc987",
+      "source": "Selected area",
+      "translated": "所選區域"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/macos/Sources/OpenClaw/QuickChatAreaPickerView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatAreaPickerView.swift
@@ -1,0 +1,144 @@
+import AppKit
+
+enum QuickChatAreaPickerLogic {
+    static let minimumSelectionDimension: CGFloat = 8
+
+    static func normalizedSelection(from start: CGPoint, to end: CGPoint) -> CGRect? {
+        let rect = CGRect(
+            x: min(start.x, end.x),
+            y: min(start.y, end.y),
+            width: abs(end.x - start.x),
+            height: abs(end.y - start.y))
+        // Tiny drags are almost always clicks or hand jitter; treating them as cancel
+        // avoids surprising one-pixel captures and invalid capture-area requests.
+        guard rect.width >= Self.minimumSelectionDimension,
+              rect.height >= Self.minimumSelectionDimension
+        else { return nil }
+        return rect
+    }
+
+    /// Converts AppKit's bottom-left global screen space into the top-left global
+    /// display coordinates consumed by Peekaboo captureArea/SCDisplay.frame.
+    static func globalDisplayRect(
+        appKitRect: CGRect,
+        screenFrame: CGRect,
+        displayBounds: CGRect) -> CGRect
+    {
+        CGRect(
+            x: displayBounds.minX + appKitRect.minX - screenFrame.minX,
+            y: displayBounds.minY + screenFrame.maxY - appKitRect.maxY,
+            width: appKitRect.width,
+            height: appKitRect.height)
+    }
+}
+
+@MainActor
+final class QuickChatAreaPickerView: NSView {
+    private let onSelect: (CGRect) -> Void
+    private let onCancel: () -> Void
+    private var dragStart: CGPoint?
+    private var selection: CGRect?
+
+    init(frame: CGRect, onSelect: @escaping (CGRect) -> Void, onCancel: @escaping () -> Void) {
+        self.onSelect = onSelect
+        self.onCancel = onCancel
+        super.init(frame: frame)
+        self.wantsLayer = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+        true
+    }
+
+    override func resetCursorRects() {
+        self.addCursorRect(self.bounds, cursor: .crosshair)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = self.clamped(self.convert(event.locationInWindow, from: nil))
+        self.dragStart = point
+        self.selection = nil
+        self.needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let dragStart else { return }
+        let point = self.clamped(self.convert(event.locationInWindow, from: nil))
+        self.selection = self.normalizedRect(from: dragStart, to: point)
+        self.needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard let dragStart else {
+            self.onCancel()
+            return
+        }
+        let point = self.clamped(self.convert(event.locationInWindow, from: nil))
+        self.dragStart = nil
+        guard let selection = QuickChatAreaPickerLogic.normalizedSelection(from: dragStart, to: point) else {
+            self.onCancel()
+            return
+        }
+        self.onSelect(selection)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let dimmingPath = NSBezierPath(rect: self.bounds)
+        if let selection {
+            dimmingPath.appendRect(selection)
+        }
+        dimmingPath.windingRule = .evenOdd
+        NSColor.black.withAlphaComponent(0.35).setFill()
+        dimmingPath.fill()
+
+        guard let selection, selection.width > 0, selection.height > 0 else { return }
+        let scale = self.window?.backingScaleFactor ?? 1
+        let border = NSBezierPath(rect: selection.insetBy(dx: 0.5 / scale, dy: 0.5 / scale))
+        border.lineWidth = 1 / scale
+        NSColor.controlAccentColor.setStroke()
+        border.stroke()
+        self.drawSizeBadge(for: selection)
+    }
+
+    private func drawSizeBadge(for selection: CGRect) {
+        let text = "\(Int(selection.width.rounded())) × \(Int(selection.height.rounded()))" as NSString
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .medium),
+            .foregroundColor: NSColor.white,
+        ]
+        let textSize = text.size(withAttributes: attributes)
+        let badgeSize = CGSize(width: textSize.width + 14, height: textSize.height + 8)
+        let preferredY = selection.maxY + 7
+        let fallbackY = selection.minY - badgeSize.height - 7
+        let y = preferredY + badgeSize.height <= self.bounds.maxY ? preferredY : max(self.bounds.minY + 4, fallbackY)
+        let x = min(
+            max(self.bounds.minX + 4, selection.minX),
+            self.bounds.maxX - badgeSize.width - 4)
+        let badgeRect = CGRect(origin: CGPoint(x: x, y: y), size: badgeSize)
+        NSColor.black.withAlphaComponent(0.78).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 6, yRadius: 6).fill()
+        text.draw(
+            at: CGPoint(x: badgeRect.minX + 7, y: badgeRect.minY + 4),
+            withAttributes: attributes)
+    }
+
+    private func normalizedRect(from start: CGPoint, to end: CGPoint) -> CGRect {
+        CGRect(
+            x: min(start.x, end.x),
+            y: min(start.y, end.y),
+            width: abs(end.x - start.x),
+            height: abs(end.y - start.y))
+    }
+
+    private func clamped(_ point: CGPoint) -> CGPoint {
+        CGPoint(
+            x: min(max(point.x, self.bounds.minX), self.bounds.maxX),
+            y: min(max(point.y, self.bounds.minY), self.bounds.maxY))
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -27,6 +27,27 @@ private final class QuickChatAgentMenuTarget: NSObject {
     }
 }
 
+private enum QuickChatCaptureMenuAction: String {
+    case window
+    case area
+}
+
+@MainActor
+private final class QuickChatCaptureMenuTarget: NSObject {
+    let onSelect: (QuickChatCaptureMenuAction) -> Void
+
+    init(onSelect: @escaping (QuickChatCaptureMenuAction) -> Void) {
+        self.onSelect = onSelect
+    }
+
+    @objc func selectCapture(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let action = QuickChatCaptureMenuAction(rawValue: rawValue)
+        else { return }
+        self.onSelect(action)
+    }
+}
+
 private final class QuickChatRecentMenuSelection: NSObject {
     let target: QuickChatSessionTargetOverride?
 
@@ -257,6 +278,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         guard self.isVisible else { return }
         // System permission dialogs steal key focus mid-grant; the bar must survive that flow.
         guard !self.model.isGrantingPermissions,
+              !self.model.isCapturingTextContext,
               self.windowPicker?.isInteractionActive != true,
               !self.isMenuActive
         else { return }
@@ -342,8 +364,14 @@ final class QuickChatController: NSObject, NSWindowDelegate {
             onShowRecentSessions: { [weak self] in
                 self?.showRecentSessionsPicker()
             },
-            onWindowScreenshot: { [weak self] in
-                self?.startWindowPicker()
+            onCaptureTextContext: { [weak self] in
+                self?.captureFocusedAppText()
+            },
+            onShowCaptureMenu: { [weak self] in
+                self?.showCaptureMenu()
+            },
+            onGrantPermissions: { [weak self] in
+                self?.grantMissingPermissions()
             },
             onContentHeightChange: { [weak self] height in
                 self?.updateContentHeight(height)
@@ -419,6 +447,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     private func dismissIfClickOutside(at point: NSPoint) {
         guard self.isVisible,
               !self.model.isGrantingPermissions,
+              !self.model.isCapturingTextContext,
               self.windowPicker?.isInteractionActive != true,
               !self.isMenuActive,
               let panel = self.panel
@@ -465,11 +494,13 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         let contentPoint = contentView.convert(windowPoint, from: nil)
         // Competing interaction: invalidate any in-flight recents fetch before blocking.
         self.invalidateRecentsFetch()
-        menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+        withExtendedLifetime(target) {
+            menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+        }
     }
 
     private func showRecentSessionsPicker() {
-        guard self.model.canSelectRecentSession, self.recentSessionsTask == nil else { return }
+        guard self.canShowRecentSessions, self.recentSessionsTask == nil else { return }
         let requestID = UUID()
         let presentationID = self.model.activePresentationID
         self.recentSessionsRequestID = requestID
@@ -484,12 +515,11 @@ final class QuickChatController: NSObject, NSWindowDelegate {
                 let rows = try await self.recentSessionsProvider()
                 guard !Task.isCancelled,
                       self.recentSessionsRequestID == requestID,
-                      self.isVisible,
                       self.model.activePresentationID == presentationID,
                       // Eligibility can lapse while the fetch is in flight (a send may
                       // have started); a menu whose selections would be ignored is worse
                       // than no menu.
-                      self.model.canSelectRecentSession
+                      self.canShowRecentSessions
                 else { return }
                 self.presentRecentSessionsMenu(rows: rows)
             } catch {
@@ -497,6 +527,25 @@ final class QuickChatController: NSObject, NSWindowDelegate {
                     "quick chat recent sessions failed: \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+
+    private var canShowRecentSessions: Bool {
+        self.isVisible &&
+            self.model.canSelectRecentSession &&
+            !self.model.isGrantingPermissions &&
+            !self.model.isCapturingTextContext &&
+            self.windowPicker?.isInteractionActive != true &&
+            !self.isMenuActive
+    }
+
+    private func captureFocusedAppText() {
+        self.invalidateRecentsFetch()
+        self.model.captureFocusedAppText()
+    }
+
+    private func grantMissingPermissions() {
+        self.invalidateRecentsFetch()
+        self.model.grantMissingPermissions()
     }
 
     private func presentRecentSessionsMenu(rows: [SessionRow]) {
@@ -535,10 +584,56 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         }
         let windowPoint = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
         let contentPoint = contentView.convert(windowPoint, from: nil)
-        menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+        withExtendedLifetime(target) {
+            menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+        }
     }
 
-    private func startWindowPicker() {
+    private func showCaptureMenu() {
+        guard self.model.canCaptureWindow,
+              let panel,
+              let contentView = panel.contentView
+        else { return }
+
+        self.isMenuActive = true
+        self.removeDismissMonitors()
+        defer {
+            self.isMenuActive = false
+            if self.isVisible { self.installDismissMonitors() }
+            self.focusEditor()
+        }
+
+        let target = QuickChatCaptureMenuTarget { [weak self] action in
+            switch action {
+            case .window:
+                self?.startCapturePicker(area: false)
+            case .area:
+                self?.startCapturePicker(area: true)
+            }
+        }
+        let menu = NSMenu()
+        for (title, action) in [
+            (String(localized: "Capture Window…"), QuickChatCaptureMenuAction.window),
+            (String(localized: "Capture Area…"), QuickChatCaptureMenuAction.area),
+        ] {
+            let item = NSMenuItem(
+                title: title,
+                action: #selector(QuickChatCaptureMenuTarget.selectCapture(_:)),
+                keyEquivalent: "")
+            item.target = target
+            item.representedObject = action.rawValue
+            menu.addItem(item)
+        }
+        let windowPoint = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let contentPoint = contentView.convert(windowPoint, from: nil)
+        // Competing interaction: invalidate any in-flight recents fetch before blocking.
+        self.invalidateRecentsFetch()
+        withExtendedLifetime(target) {
+            menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+        }
+    }
+
+    private func startCapturePicker(area: Bool) {
         guard self.isVisible, self.model.canCaptureWindow else { return }
         if self.windowPicker == nil {
             self.windowPicker = QuickChatWindowPicker(
@@ -553,7 +648,13 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         guard let windowPicker = self.windowPicker else { return }
         // Competing interaction: a recents menu must not pop over the picker overlays.
         self.invalidateRecentsFetch()
-        Task { await windowPicker.begin() }
+        Task {
+            if area {
+                await windowPicker.beginArea()
+            } else {
+                await windowPicker.beginWindow()
+            }
+        }
     }
 
     private func pickerInteractionChanged(_ active: Bool) {
@@ -563,12 +664,18 @@ final class QuickChatController: NSObject, NSWindowDelegate {
             self.installDismissMonitors()
         }
         guard let panel else { return }
+        if active {
+            // Synchronous hide: overlays are clickable immediately, and a fast drag's
+            // capture (80ms settle) must never include a still-fading composer.
+            panel.alphaValue = 0
+            return
+        }
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.12
-            panel.animator().alphaValue = active ? 0.35 : 1
+            panel.animator().alphaValue = 1
         } completionHandler: { [weak self] in
             Task { @MainActor in
-                if active == false { self?.focusEditor() }
+                self?.focusEditor()
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -495,7 +495,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         // Competing interaction: invalidate any in-flight recents fetch before blocking.
         self.invalidateRecentsFetch()
         withExtendedLifetime(target) {
-            menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+            _ = menu.popUp(positioning: nil, at: contentPoint, in: contentView)
         }
     }
 
@@ -585,7 +585,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         let windowPoint = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
         let contentPoint = contentView.convert(windowPoint, from: nil)
         withExtendedLifetime(target) {
-            menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+            _ = menu.popUp(positioning: nil, at: contentPoint, in: contentView)
         }
     }
 
@@ -629,7 +629,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         // Competing interaction: invalidate any in-flight recents fetch before blocking.
         self.invalidateRecentsFetch()
         withExtendedLifetime(target) {
-            menu.popUp(positioning: nil, at: contentPoint, in: contentView)
+            _ = menu.popUp(positioning: nil, at: contentPoint, in: contentView)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
@@ -48,14 +48,19 @@ enum QuickChatFocusedTextCollector {
 
     static func collect(
         root: any QuickChatTextTreeNode,
-        limits: QuickChatTextCollectionLimits = .standard) -> QuickChatTextCollection
+        limits: QuickChatTextCollectionLimits = .standard,
+        deadline: ContinuousClock.Instant? = nil,
+        isCancelled: () -> Bool = { false }) -> QuickChatTextCollection
     {
         let maximumDepth = max(0, limits.maximumDepth)
         let maximumElements = max(1, limits.maximumElements)
         let maximumCharacters = max(1, limits.maximumCharacters)
         var stack: [(node: any QuickChatTextTreeNode, depth: Int)] = [(root, 0)]
         var visitedNodeIDs = Set<UInt64>()
-        var seenText = Set<String>()
+        // Only the parent/child echo is de-duplicated (an element repeating its parent's
+        // text); equal text from unrelated elements (table cells, repeated lines) is real
+        // document content and must be preserved.
+        var lastEmittedText: String?
         var rendered = ""
         var visitedElementCount = 0
         var textEntryCount = 0
@@ -63,6 +68,12 @@ enum QuickChatFocusedTextCollector {
         var wasTextTruncated = false
 
         traversal: while let next = stack.popLast() {
+            // Unresponsive AX targets can stall per-message; a wall-clock deadline and
+            // cooperative cancellation keep the walk bounded regardless of app health.
+            if isCancelled() || deadline.map({ ContinuousClock.now >= $0 }) == true {
+                wasStructurallyTruncated = true
+                break
+            }
             guard visitedNodeIDs.insert(next.node.identity).inserted else { continue }
             guard visitedElementCount < maximumElements else {
                 wasStructurallyTruncated = true
@@ -71,9 +82,10 @@ enum QuickChatFocusedTextCollector {
             visitedElementCount += 1
 
             for rawCandidate in [next.node.stringValue(), next.node.computedName()] {
-                guard let candidate = Self.normalized(rawCandidate), seenText.insert(candidate).inserted else {
+                guard let candidate = Self.normalized(rawCandidate), candidate != lastEmittedText else {
                     continue
                 }
+                lastEmittedText = candidate
                 let piece = rendered.isEmpty ? candidate : "\n\(candidate)"
                 let remaining = maximumCharacters + 1 - rendered.count
                 guard remaining > 0 else {
@@ -190,16 +202,29 @@ enum QuickChatFocusedTextCaptureService {
             return .failed(String(localized: "No focused window is available in \(appName)."))
         }
         let focusedWindow = unsafeDowncast(focusedWindowValue, to: AXUIElement.self)
+        // A hung target app would otherwise block each AX message for the system default
+        // (~6s); a short per-message timeout keeps worst-case walks near the deadline.
+        AXUIElementSetMessagingTimeout(appElement, 1.0)
+        AXUIElementSetMessagingTimeout(focusedWindow, 1.0)
         let root = QuickChatAXTextTreeNode(element: focusedWindow)
 
         // AX reads are synchronous and can be expensive. Keep the bounded walk off the
-        // main actor; this adapter never logs or persists attribute values.
-        let snapshot = await Task.detached(priority: .userInitiated) {
+        // main actor; this adapter never logs or persists attribute values. The walk
+        // itself checks cancellation and a 3s wall-clock deadline per iteration.
+        let walk = Task.detached(priority: .userInitiated) {
             let title = root.title()?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
                 ?? String(localized: "Focused Window")
-            let collection = QuickChatFocusedTextCollector.collect(root: root)
+            let collection = QuickChatFocusedTextCollector.collect(
+                root: root,
+                deadline: ContinuousClock.now.advanced(by: .seconds(3)),
+                isCancelled: { Task.isCancelled })
             return (title, collection)
-        }.value
+        }
+        let snapshot = await withTaskCancellationHandler {
+            await walk.value
+        } onCancel: {
+            walk.cancel()
+        }
         guard !Task.isCancelled else { return .cancelled }
         guard snapshot.1.textEntryCount > 0 else {
             return .failed(String(localized: "No readable text was found in \(appName)."))

--- a/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
@@ -10,7 +10,6 @@ struct QuickChatTextContext: Equatable, Sendable {
     var characterCount: Int {
         self.text.count
     }
-
 }
 
 struct QuickChatTextCollectionLimits: Equatable, Sendable {
@@ -41,6 +40,48 @@ protocol QuickChatTextTreeNode: Sendable {
     func stringValue() -> String?
     func computedName() -> String?
     func children(limit: Int) -> QuickChatTextTreeChildren
+}
+
+private enum QuickChatCaptureRaceResult: Sendable {
+    case snapshot(String, QuickChatTextCollection)
+    case timedOut
+    case cancelled
+}
+
+/// Synchronous one-shot arbitration lets a cancellation handler settle the AX race
+/// immediately, including when cancellation wins before the continuation is installed.
+private final class QuickChatCaptureRace: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: QuickChatCaptureRaceResult?
+    private var continuation: CheckedContinuation<QuickChatCaptureRaceResult, Never>?
+
+    func wait() async -> QuickChatCaptureRaceResult {
+        await withCheckedContinuation { continuation in
+            self.lock.lock()
+            if let result = self.result {
+                self.lock.unlock()
+                continuation.resume(returning: result)
+            } else {
+                self.continuation = continuation
+                self.lock.unlock()
+            }
+        }
+    }
+
+    @discardableResult
+    func resolve(_ result: QuickChatCaptureRaceResult) -> Bool {
+        self.lock.lock()
+        guard self.result == nil else {
+            self.lock.unlock()
+            return false
+        }
+        self.result = result
+        let continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        continuation?.resume(returning: result)
+        return true
+    }
 }
 
 enum QuickChatFocusedTextCollector {
@@ -114,8 +155,9 @@ enum QuickChatFocusedTextCollector {
             if childResult.wasTruncated {
                 wasStructurallyTruncated = true
             }
+            let descendantTexts = next.parentTexts + ownTexts.filter { !next.parentTexts.contains($0) }
             for child in childResult.nodes.reversed() {
-                stack.append((child, next.depth + 1, ownTexts))
+                stack.append((child, next.depth + 1, descendantTexts))
             }
         }
 
@@ -175,9 +217,12 @@ enum QuickChatFocusedTextCaptureService {
         }
 
         let hasPermission = await PermissionManager.status([.accessibility])[.accessibility] == true
+        guard !Task.isCancelled else { return .cancelled }
         guard hasPermission else {
             guard self.confirmAccessibilityRequest(appName: appName) else { return .cancelled }
+            guard !Task.isCancelled else { return .cancelled }
             let result = await PermissionManager.ensure([.accessibility], interactive: true)
+            guard !Task.isCancelled else { return .cancelled }
             guard result[.accessibility] == true else {
                 return .failed(String(localized: "Accessibility access is required to attach text from \(appName)."))
             }
@@ -190,6 +235,7 @@ enum QuickChatFocusedTextCaptureService {
         application: NSRunningApplication,
         appName: String) async -> QuickChatTextContextCaptureOutcome
     {
+        guard !Task.isCancelled else { return .cancelled }
         let appElement = AXUIElementCreateApplication(application.processIdentifier)
         // Bound the very first read too; the focused-window copy below otherwise waits
         // for the system default (~6s) on a hung target.
@@ -223,35 +269,43 @@ enum QuickChatFocusedTextCaptureService {
             return (title, collection)
         }
         // Hard outer bound: a hung target can stall individual AX reads past any
-        // cooperative check, so the wait itself races a timer and the walk is
-        // abandoned (cancelled, result discarded) on loss. The detached task may
-        // linger briefly on its current AX call; Quick Chat stays responsive.
-        let snapshot = await withTaskCancellationHandler {
-            await withTaskGroup(of: (String, QuickChatTextCollection)?.self) { group in
-                group.addTask { await walk.value }
-                group.addTask {
-                    try? await Task.sleep(for: .seconds(4))
-                    return nil
-                }
-                let first = await group.next() ?? nil
-                group.cancelAll()
-                return first
+        // cooperative check. A structured group would JOIN the losing child (and thus
+        // still wait for the walk), so the race is unstructured: first result wins the
+        // continuation, the abandoned walk is cancelled and its result discarded.
+        let race = QuickChatCaptureRace()
+        Task.detached {
+            let value = await walk.value
+            race.resolve(.snapshot(value.0, value.1))
+        }
+        let timeout = Task.detached {
+            try? await Task.sleep(for: .seconds(4))
+            if race.resolve(.timedOut) {
+                walk.cancel()
             }
+        }
+        let result = await withTaskCancellationHandler {
+            await race.wait()
         } onCancel: {
             walk.cancel()
+            race.resolve(.cancelled)
         }
-        guard !Task.isCancelled else { return .cancelled }
-        guard let snapshot else {
+        timeout.cancel()
+
+        switch result {
+        case .cancelled:
+            return .cancelled
+        case .timedOut:
             walk.cancel()
-            return .failed("\(appName) is not responding to Accessibility requests.")
+            return .failed(String(localized: "\(appName) is not responding to Accessibility requests."))
+        case let .snapshot(title, collection):
+            guard collection.textEntryCount > 0 else {
+                return .failed(String(localized: "No readable text was found in \(appName)."))
+            }
+            return .captured(QuickChatTextContext(
+                appName: appName,
+                windowTitle: title,
+                text: collection.text))
         }
-        guard snapshot.1.textEntryCount > 0 else {
-            return .failed(String(localized: "No readable text was found in \(appName)."))
-        }
-        return .captured(QuickChatTextContext(
-            appName: appName,
-            windowTitle: snapshot.0,
-            text: snapshot.1.text))
     }
 
     private static func confirmAccessibilityRequest(appName: String) -> Bool {

--- a/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
@@ -55,12 +55,8 @@ enum QuickChatFocusedTextCollector {
         let maximumDepth = max(0, limits.maximumDepth)
         let maximumElements = max(1, limits.maximumElements)
         let maximumCharacters = max(1, limits.maximumCharacters)
-        var stack: [(node: any QuickChatTextTreeNode, depth: Int)] = [(root, 0)]
+        var stack: [(node: any QuickChatTextTreeNode, depth: Int, parentTexts: [String])] = [(root, 0, [])]
         var visitedNodeIDs = Set<UInt64>()
-        // Only the parent/child echo is de-duplicated (an element repeating its parent's
-        // text); equal text from unrelated elements (table cells, repeated lines) is real
-        // document content and must be preserved.
-        var lastEmittedText: String?
         var rendered = ""
         var visitedElementCount = 0
         var textEntryCount = 0
@@ -81,11 +77,16 @@ enum QuickChatFocusedTextCollector {
             }
             visitedElementCount += 1
 
+            // Suppress only the parent/child echo (an element repeating its ancestor's
+            // text) and same-node repeats; equal text from siblings (table cells,
+            // repeated lines) is real document content and must be preserved.
+            var ownTexts: [String] = []
             for rawCandidate in [next.node.stringValue(), next.node.computedName()] {
-                guard let candidate = Self.normalized(rawCandidate), candidate != lastEmittedText else {
-                    continue
-                }
-                lastEmittedText = candidate
+                guard let candidate = Self.normalized(rawCandidate),
+                      !next.parentTexts.contains(candidate),
+                      !ownTexts.contains(candidate)
+                else { continue }
+                ownTexts.append(candidate)
                 let piece = rendered.isEmpty ? candidate : "\n\(candidate)"
                 let remaining = maximumCharacters + 1 - rendered.count
                 guard remaining > 0 else {
@@ -114,7 +115,7 @@ enum QuickChatFocusedTextCollector {
                 wasStructurallyTruncated = true
             }
             for child in childResult.nodes.reversed() {
-                stack.append((child, next.depth + 1))
+                stack.append((child, next.depth + 1, ownTexts))
             }
         }
 
@@ -190,6 +191,9 @@ enum QuickChatFocusedTextCaptureService {
         appName: String) async -> QuickChatTextContextCaptureOutcome
     {
         let appElement = AXUIElementCreateApplication(application.processIdentifier)
+        // Bound the very first read too; the focused-window copy below otherwise waits
+        // for the system default (~6s) on a hung target.
+        AXUIElementSetMessagingTimeout(appElement, 1.0)
         var focusedWindowValue: CFTypeRef?
         let focusedWindowError = AXUIElementCopyAttributeValue(
             appElement,
@@ -204,8 +208,6 @@ enum QuickChatFocusedTextCaptureService {
         let focusedWindow = unsafeDowncast(focusedWindowValue, to: AXUIElement.self)
         // A hung target app would otherwise block each AX message for the system default
         // (~6s); a short per-message timeout keeps worst-case walks near the deadline.
-        AXUIElementSetMessagingTimeout(appElement, 1.0)
-        AXUIElementSetMessagingTimeout(focusedWindow, 1.0)
         let root = QuickChatAXTextTreeNode(element: focusedWindow)
 
         // AX reads are synchronous and can be expensive. Keep the bounded walk off the
@@ -248,6 +250,13 @@ enum QuickChatFocusedTextCaptureService {
 
 private struct QuickChatAXTextTreeNode: QuickChatTextTreeNode, Sendable {
     let element: AXUIElement
+
+    init(element: AXUIElement) {
+        // Messaging timeouts are per element reference; every wrapped descendant needs
+        // its own or an unresponsive target stalls each read for the system default.
+        AXUIElementSetMessagingTimeout(element, 1.0)
+        self.element = element
+    }
 
     var identity: UInt64 {
         UInt64(CFHash(self.element))

--- a/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
@@ -1,0 +1,318 @@
+import AppKit
+@preconcurrency import ApplicationServices
+import Foundation
+
+struct QuickChatTextContext: Equatable, Sendable {
+    let appName: String
+    let windowTitle: String
+    let text: String
+
+    var characterCount: Int {
+        self.text.count
+    }
+
+}
+
+struct QuickChatTextCollectionLimits: Equatable, Sendable {
+    static let standard = QuickChatTextCollectionLimits(
+        maximumDepth: 12,
+        maximumElements: 800,
+        maximumCharacters: 20000)
+
+    let maximumDepth: Int
+    let maximumElements: Int
+    let maximumCharacters: Int
+}
+
+struct QuickChatTextCollection: Equatable, Sendable {
+    let text: String
+    let visitedElementCount: Int
+    let textEntryCount: Int
+    let wasTruncated: Bool
+}
+
+struct QuickChatTextTreeChildren: Sendable {
+    let nodes: [any QuickChatTextTreeNode]
+    let wasTruncated: Bool
+}
+
+protocol QuickChatTextTreeNode: Sendable {
+    var identity: UInt64 { get }
+    func stringValue() -> String?
+    func computedName() -> String?
+    func children(limit: Int) -> QuickChatTextTreeChildren
+}
+
+enum QuickChatFocusedTextCollector {
+    static let truncationMarker = String(localized: "… [truncated]")
+
+    static func collect(
+        root: any QuickChatTextTreeNode,
+        limits: QuickChatTextCollectionLimits = .standard) -> QuickChatTextCollection
+    {
+        let maximumDepth = max(0, limits.maximumDepth)
+        let maximumElements = max(1, limits.maximumElements)
+        let maximumCharacters = max(1, limits.maximumCharacters)
+        var stack: [(node: any QuickChatTextTreeNode, depth: Int)] = [(root, 0)]
+        var visitedNodeIDs = Set<UInt64>()
+        var seenText = Set<String>()
+        var rendered = ""
+        var visitedElementCount = 0
+        var textEntryCount = 0
+        var wasStructurallyTruncated = false
+        var wasTextTruncated = false
+
+        traversal: while let next = stack.popLast() {
+            guard visitedNodeIDs.insert(next.node.identity).inserted else { continue }
+            guard visitedElementCount < maximumElements else {
+                wasStructurallyTruncated = true
+                break
+            }
+            visitedElementCount += 1
+
+            for rawCandidate in [next.node.stringValue(), next.node.computedName()] {
+                guard let candidate = Self.normalized(rawCandidate), seenText.insert(candidate).inserted else {
+                    continue
+                }
+                let piece = rendered.isEmpty ? candidate : "\n\(candidate)"
+                let remaining = maximumCharacters + 1 - rendered.count
+                guard remaining > 0 else {
+                    wasTextTruncated = true
+                    break traversal
+                }
+                rendered.append(contentsOf: piece.prefix(remaining))
+                textEntryCount += 1
+                if piece.count >= remaining {
+                    wasTextTruncated = true
+                    break traversal
+                }
+            }
+
+            if next.depth >= maximumDepth {
+                let overflow = next.node.children(limit: 1)
+                if !overflow.nodes.isEmpty || overflow.wasTruncated {
+                    wasStructurallyTruncated = true
+                }
+                continue
+            }
+
+            let remainingElements = maximumElements - visitedElementCount
+            let childResult = next.node.children(limit: max(1, remainingElements))
+            if childResult.wasTruncated {
+                wasStructurallyTruncated = true
+            }
+            for child in childResult.nodes.reversed() {
+                stack.append((child, next.depth + 1))
+            }
+        }
+
+        if !stack.isEmpty {
+            wasStructurallyTruncated = true
+        }
+        let wasTruncated = wasStructurallyTruncated || wasTextTruncated
+        if wasTruncated {
+            rendered = Self.appendingTruncationMarker(to: rendered, maximumCharacters: maximumCharacters)
+        }
+        return QuickChatTextCollection(
+            text: rendered,
+            visitedElementCount: visitedElementCount,
+            textEntryCount: textEntryCount,
+            wasTruncated: wasTruncated)
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendingTruncationMarker(to text: String, maximumCharacters: Int) -> String {
+        guard maximumCharacters > self.truncationMarker.count else {
+            return String(self.truncationMarker.prefix(maximumCharacters))
+        }
+        let bodyLimit = maximumCharacters - Self.truncationMarker.count
+        return String(text.prefix(bodyLimit)) + Self.truncationMarker
+    }
+}
+
+enum QuickChatTextContextCaptureOutcome: Sendable {
+    case captured(QuickChatTextContext)
+    case failed(String)
+    case cancelled
+}
+
+@MainActor
+enum QuickChatFocusedTextCaptureService {
+    static func frontmostApplicationName() -> String {
+        NSWorkspace.shared.frontmostApplication?.localizedName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty ?? String(localized: "focused app")
+    }
+
+    static func capture() async -> QuickChatTextContextCaptureOutcome {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return .failed(String(localized: "No focused application is available."))
+        }
+        let appName = application.localizedName?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+            ?? application.bundleIdentifier
+            ?? String(localized: "Focused app")
+        guard application.processIdentifier != getpid(),
+              application.bundleIdentifier != Bundle.main.bundleIdentifier
+        else {
+            return .failed(String(localized: "Focus another app before attaching its text."))
+        }
+
+        let hasPermission = await PermissionManager.status([.accessibility])[.accessibility] == true
+        guard hasPermission else {
+            guard self.confirmAccessibilityRequest(appName: appName) else { return .cancelled }
+            let result = await PermissionManager.ensure([.accessibility], interactive: true)
+            guard result[.accessibility] == true else {
+                return .failed(String(localized: "Accessibility access is required to attach text from \(appName)."))
+            }
+            return await self.capture(application: application, appName: appName)
+        }
+        return await self.capture(application: application, appName: appName)
+    }
+
+    private static func capture(
+        application: NSRunningApplication,
+        appName: String) async -> QuickChatTextContextCaptureOutcome
+    {
+        let appElement = AXUIElementCreateApplication(application.processIdentifier)
+        var focusedWindowValue: CFTypeRef?
+        let focusedWindowError = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindowValue)
+        guard focusedWindowError == .success,
+              let focusedWindowValue,
+              CFGetTypeID(focusedWindowValue) == AXUIElementGetTypeID()
+        else {
+            return .failed(String(localized: "No focused window is available in \(appName)."))
+        }
+        let focusedWindow = unsafeDowncast(focusedWindowValue, to: AXUIElement.self)
+        let root = QuickChatAXTextTreeNode(element: focusedWindow)
+
+        // AX reads are synchronous and can be expensive. Keep the bounded walk off the
+        // main actor; this adapter never logs or persists attribute values.
+        let snapshot = await Task.detached(priority: .userInitiated) {
+            let title = root.title()?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+                ?? String(localized: "Focused Window")
+            let collection = QuickChatFocusedTextCollector.collect(root: root)
+            return (title, collection)
+        }.value
+        guard !Task.isCancelled else { return .cancelled }
+        guard snapshot.1.textEntryCount > 0 else {
+            return .failed(String(localized: "No readable text was found in \(appName)."))
+        }
+        return .captured(QuickChatTextContext(
+            appName: appName,
+            windowTitle: snapshot.0,
+            text: snapshot.1.text))
+    }
+
+    private static func confirmAccessibilityRequest(appName: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Allow OpenClaw to read text from \(appName)")
+        alert.informativeText = String(localized: "Attaching focused-window text uses macOS Accessibility access.")
+        alert.addButton(withTitle: String(localized: "Grant Access"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        // User-initiated confirmation owns the only path that may trigger the TCC prompt.
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+}
+
+private struct QuickChatAXTextTreeNode: QuickChatTextTreeNode, Sendable {
+    let element: AXUIElement
+
+    var identity: UInt64 {
+        UInt64(CFHash(self.element))
+    }
+
+    func stringValue() -> String? {
+        self.stringAttribute(kAXValueAttribute)
+    }
+
+    func computedName() -> String? {
+        let candidates = [
+            kAXTitleAttribute,
+            kAXValueAttribute,
+            kAXIdentifierAttribute,
+            kAXDescriptionAttribute,
+            kAXHelpAttribute,
+            kAXPlaceholderValueAttribute,
+        ]
+        for attribute in candidates {
+            if let value = self.stringAttribute(attribute)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty
+            {
+                return value
+            }
+        }
+        return self.stringAttribute(kAXRoleAttribute)?
+            .replacingOccurrences(of: "AX", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty
+    }
+
+    func children(limit: Int) -> QuickChatTextTreeChildren {
+        let attributes = [
+            kAXChildrenAttribute,
+            kAXVisibleChildrenAttribute,
+            "AXChildrenInNavigationOrder",
+            kAXRowsAttribute,
+            kAXContentsAttribute,
+        ]
+        let resolvedLimit = max(1, limit)
+        var nodes: [any QuickChatTextTreeNode] = []
+        var seen = Set<UInt64>()
+        var wasTruncated = false
+
+        for attribute in attributes {
+            var count: CFIndex = 0
+            guard AXUIElementGetAttributeValueCount(
+                self.element,
+                attribute as CFString,
+                &count) == .success,
+                count > 0
+            else { continue }
+            let remaining = resolvedLimit - nodes.count
+            guard remaining > 0 else {
+                wasTruncated = true
+                break
+            }
+            if count > remaining {
+                wasTruncated = true
+            }
+            var values: CFArray?
+            guard AXUIElementCopyAttributeValues(
+                self.element,
+                attribute as CFString,
+                0,
+                min(count, remaining),
+                &values) == .success,
+                let elements = values as? [AXUIElement]
+            else { continue }
+            for element in elements {
+                let node = QuickChatAXTextTreeNode(element: element)
+                if seen.insert(node.identity).inserted {
+                    nodes.append(node)
+                }
+            }
+        }
+        return QuickChatTextTreeChildren(nodes: nodes, wasTruncated: wasTruncated)
+    }
+
+    func title() -> String? {
+        self.stringAttribute(kAXTitleAttribute)
+    }
+
+    private func stringAttribute(_ attribute: String) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            self.element,
+            attribute as CFString,
+            &value) == .success
+        else { return nil }
+        return value as? String
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
@@ -222,12 +222,29 @@ enum QuickChatFocusedTextCaptureService {
                 isCancelled: { Task.isCancelled })
             return (title, collection)
         }
+        // Hard outer bound: a hung target can stall individual AX reads past any
+        // cooperative check, so the wait itself races a timer and the walk is
+        // abandoned (cancelled, result discarded) on loss. The detached task may
+        // linger briefly on its current AX call; Quick Chat stays responsive.
         let snapshot = await withTaskCancellationHandler {
-            await walk.value
+            await withTaskGroup(of: (String, QuickChatTextCollection)?.self) { group in
+                group.addTask { await walk.value }
+                group.addTask {
+                    try? await Task.sleep(for: .seconds(4))
+                    return nil
+                }
+                let first = await group.next() ?? nil
+                group.cancelAll()
+                return first
+            }
         } onCancel: {
             walk.cancel()
         }
         guard !Task.isCancelled else { return .cancelled }
+        guard let snapshot else {
+            walk.cancel()
+            return .failed("\(appName) is not responding to Accessibility requests.")
+        }
         guard snapshot.1.textEntryCount > 0 else {
             return .failed(String(localized: "No readable text was found in \(appName)."))
         }

--- a/apps/macos/Sources/OpenClaw/QuickChatModel.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatModel.swift
@@ -123,6 +123,8 @@ final class QuickChatModel {
     typealias PermissionStatusProvider = @MainActor ([Capability]) async -> [Capability: Bool]
     typealias PermissionGrantProvider = @MainActor ([Capability]) async -> [Capability: Bool]
     typealias ConnectionGateProvider = @MainActor () -> QuickChatConnectionGate
+    typealias FrontmostAppNameProvider = @MainActor () -> String
+    typealias TextContextCaptureProvider = @MainActor () async -> QuickChatTextContextCaptureOutcome
 
     static let trackedPermissions: [Capability] = [.notifications, .accessibility, .screenRecording]
 
@@ -149,6 +151,10 @@ final class QuickChatModel {
     private(set) var isGrantingPermissions = false
     private(set) var sendState: QuickChatSendState = .idle
     private(set) var isPresentationActive = false
+    private(set) var frontmostAppName = String(localized: "focused app")
+    private(set) var textContext: QuickChatTextContext?
+    private(set) var isCapturingTextContext = false
+    private(set) var textContextCaptureMessage: String?
     /// Route of the most recently accepted send; navigation reads this immutable value
     /// instead of sampling live routing state that an agent switch could move meanwhile.
     private(set) var lastAcceptedRoute: QuickChatRoutingTarget?
@@ -160,6 +166,8 @@ final class QuickChatModel {
     @ObservationIgnored private let permissionStatusProvider: PermissionStatusProvider
     @ObservationIgnored private let permissionGrantProvider: PermissionGrantProvider
     @ObservationIgnored private let connectionGateProvider: ConnectionGateProvider
+    @ObservationIgnored private let frontmostAppNameProvider: FrontmostAppNameProvider
+    @ObservationIgnored private let textContextCaptureProvider: TextContextCaptureProvider
     /// Invoked with the snapshotted route just before a send is dispatched, for every
     /// send path (text and capture); wires the reply consumer's pre-bind.
     @ObservationIgnored var onSendDispatched: ((QuickChatRoutingTarget) -> Void)?
@@ -172,6 +180,8 @@ final class QuickChatModel {
     @ObservationIgnored private var permissionPollTask: Task<Void, Never>?
     @ObservationIgnored private var retryIdentity: RetryIdentity?
     @ObservationIgnored private var capturePipelineID: UUID?
+    @ObservationIgnored private var textContextCaptureID: UUID?
+    @ObservationIgnored private var textContextCaptureTask: Task<Void, Never>?
 
     init(
         sessionKeyProvider: @escaping SessionKeyProvider = {
@@ -212,6 +222,12 @@ final class QuickChatModel {
             if appState.isPaused { return .paused }
             if ControlChannel.shared.state != .connected { return .disconnected }
             return .available
+        },
+        frontmostAppNameProvider: @escaping FrontmostAppNameProvider = {
+            QuickChatFocusedTextCaptureService.frontmostApplicationName()
+        },
+        textContextCaptureProvider: @escaping TextContextCaptureProvider = {
+            await QuickChatFocusedTextCaptureService.capture()
         })
     {
         self.sessionKeyProvider = sessionKeyProvider
@@ -221,6 +237,8 @@ final class QuickChatModel {
         self.permissionStatusProvider = permissionStatusProvider
         self.permissionGrantProvider = permissionGrantProvider
         self.connectionGateProvider = connectionGateProvider
+        self.frontmostAppNameProvider = frontmostAppNameProvider
+        self.textContextCaptureProvider = textContextCaptureProvider
     }
 
     var connectionGate: QuickChatConnectionGate {
@@ -241,18 +259,31 @@ final class QuickChatModel {
     }
 
     var canSend: Bool {
-        !self.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        (!self.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || self.textContext != nil) &&
             !self.sessionKey.isEmpty &&
             self.connectionGate == .available &&
+            !self.isCapturingTextContext &&
             self.sendState != .sending
     }
 
     var canCaptureWindow: Bool {
-        !self.sessionKey.isEmpty && self.connectionGate == .available && self.sendState != .sending
+        !self.sessionKey.isEmpty &&
+            self.connectionGate == .available &&
+            !self.isGrantingPermissions &&
+            !self.isCapturingTextContext &&
+            self.sendState != .sending
+    }
+
+    var canCaptureTextContext: Bool {
+        self.canCaptureWindow && !self.isCapturingTextContext
     }
 
     var canSelectRecentSession: Bool {
-        !self.sessionKey.isEmpty && self.connectionGate == .available && self.sendState != .sending
+        !self.sessionKey.isEmpty &&
+            self.connectionGate == .available &&
+            !self.isGrantingPermissions &&
+            !self.isCapturingTextContext &&
+            self.sendState != .sending
     }
 
     var messagePlaceholder: String {
@@ -276,6 +307,10 @@ final class QuickChatModel {
         self.isPresentationActive = true
         self.sessionKey = ""
         self.sendAgentID = nil
+        self.frontmostAppName = self.frontmostAppNameProvider()
+        self.textContext = nil
+        self.textContextCaptureMessage = nil
+        self.cancelTextContextCapture()
         self.targetSessionOverride = nil
         self.baseRoutingTarget = nil
         // The cached list stays displayable, but routing metadata must wait for the fresh
@@ -358,6 +393,46 @@ final class QuickChatModel {
         await self.performSend(messageOverride: nil, attachments: [])
     }
 
+    func captureFocusedAppText() {
+        guard self.canCaptureTextContext, self.isPresentationActive else { return }
+        let captureID = UUID()
+        let presentationID = self.presentationID
+        self.textContextCaptureID = captureID
+        self.isCapturingTextContext = true
+        self.textContextCaptureMessage = nil
+        self.textContextCaptureTask?.cancel()
+        self.textContextCaptureTask = Task { [weak self] in
+            guard let self else { return }
+            let outcome = await self.textContextCaptureProvider()
+            guard self.isCurrentPresentation(presentationID),
+                  self.textContextCaptureID == captureID,
+                  !Task.isCancelled
+            else { return }
+            self.textContextCaptureID = nil
+            self.textContextCaptureTask = nil
+            self.isCapturingTextContext = false
+            switch outcome {
+            case let .captured(context):
+                self.replaceTextContext(context)
+            case let .failed(message):
+                self.textContextCaptureMessage = message
+            case .cancelled:
+                break
+            }
+        }
+    }
+
+    func replaceTextContext(_ context: QuickChatTextContext) {
+        self.textContext = context
+        self.textContextCaptureMessage = nil
+        self.retryIdentity = nil
+    }
+
+    func clearTextContext() {
+        self.textContext = nil
+        self.retryIdentity = nil
+    }
+
     /// Holds the send state for the whole capture pipeline so typing/Return cannot race
     /// the screenshot send. Returns an ownership token (nil when a send is already active);
     /// detached processing can outlive cancellation, so every later pipeline mutation must
@@ -381,18 +456,23 @@ final class QuickChatModel {
     func failCapturePipeline(_ id: UUID) {
         guard self.capturePipelineID == id else { return }
         self.capturePipelineID = nil
-        self.sendState = .failed("Couldn't capture that window.")
+        self.sendState = .failed(String(localized: "Couldn't capture that image."))
     }
 
     /// Pre-pipeline capture failures (enumeration, no candidates). Never clobbers a held
     /// send state; those failures belong to their owning pipeline token.
     func setCaptureFailure() {
         guard self.sendState != .sending else { return }
-        self.sendState = .failed("Couldn't capture that window.")
+        self.sendState = .failed(String(localized: "Couldn't capture that image."))
     }
 
-    func sendWindowScreenshot(pipelineID: UUID, data: Data, appName: String, title: String) async -> Bool {
-        // Bind the pipeline to the route visible when the user clicked the window; an agent
+    func sendCapturedImage(
+        pipelineID: UUID,
+        data: Data,
+        label: String,
+        fileName: String) async -> Bool
+    {
+        // Bind the pipeline to the route visible when the user completed the selection; an agent
         // switch or re-presentation during processing must drop the capture, not reroute it.
         guard self.capturePipelineID == pipelineID,
               let presentationID = self.activePresentationID
@@ -405,10 +485,9 @@ final class QuickChatModel {
         }
         let draft = self.text
         let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let message = trimmedDraft.isEmpty
-            ? Self.defaultScreenshotCaption(appName: appName, title: title)
-            : trimmedDraft
-        let fileName = Self.screenshotFileName(appName: appName)
+        let baseMessage = trimmedDraft.isEmpty ? String(localized: "Screenshot: \(label)") : trimmedDraft
+        let textContext = self.textContext
+        let message = Self.assembleMessage(draft: baseMessage, context: textContext)
 
         let attachment: OpenClawChatAttachmentPayload
         do {
@@ -438,6 +517,7 @@ final class QuickChatModel {
             messageOverride: message,
             attachments: [attachment],
             draftOverride: draft,
+            textContextOverride: textContext,
             continuesCapturePipeline: true)
         if self.capturePipelineID == pipelineID {
             self.capturePipelineID = nil
@@ -463,6 +543,14 @@ final class QuickChatModel {
             agentID: nil)
     }
 
+    nonisolated static func assembleMessage(draft: String, context: QuickChatTextContext?) -> String {
+        let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let context else { return trimmedDraft }
+        let contextLabel = String(localized: "Context from \(context.appName) — \(context.windowTitle)")
+        let contextBlock = "[\(contextLabel)]\n\(context.text)"
+        return trimmedDraft.isEmpty ? contextBlock : "\(trimmedDraft)\n\n\(contextBlock)"
+    }
+
     nonisolated static func routingTarget(
         override: QuickChatSessionTargetOverride?,
         base: QuickChatRoutingTarget) -> QuickChatRoutingTarget
@@ -472,10 +560,6 @@ final class QuickChatModel {
         // agent owner as the selected base route when session scope is global.
         let agentID = override.key.lowercased() == "global" ? base.agentID : nil
         return QuickChatRoutingTarget(sessionKey: override.key, agentID: agentID)
-    }
-
-    nonisolated static func defaultScreenshotCaption(appName: String, title: String) -> String {
-        "Screenshot: \(appName) — \(title)"
     }
 
     nonisolated static func screenshotFileName(appName: String) -> String {
@@ -497,6 +581,11 @@ final class QuickChatModel {
         self.baseRoutingTarget = nil
         self.sessionKey = ""
         self.sendAgentID = nil
+        // Captured AX text is presentation-scoped: hiding the bar must erase it so a
+        // later recipient can never inherit stale focused-app context.
+        self.clearTextContext()
+        self.textContextCaptureMessage = nil
+        self.cancelTextContextCapture()
         // A dispatched chat.send may already be accepted; cancelling and retrying with a new UUID can duplicate it.
         self.cancelPermissionTask()
         self.cancelPermissionPolling()
@@ -508,6 +597,7 @@ final class QuickChatModel {
         self.retryIdentity = nil
         self.cancelPermissionTask()
         self.cancelPermissionPolling()
+        self.cancelTextContextCapture()
         if self.sendState == .sending { self.sendState = .idle }
     }
 
@@ -586,12 +676,14 @@ final class QuickChatModel {
         messageOverride: String?,
         attachments: [OpenClawChatAttachmentPayload],
         draftOverride: String? = nil,
+        textContextOverride: QuickChatTextContext? = nil,
         continuesCapturePipeline: Bool = false) async -> Bool
     {
         // The capture pipeline captured its draft before detached processing; edits made
         // meanwhile must survive, so the clear-decision compares against that original.
         let draft = draftOverride ?? self.text
-        let message = messageOverride ?? draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let textContext = textContextOverride ?? self.textContext
+        let message = messageOverride ?? Self.assembleMessage(draft: draft, context: textContext)
         guard !message.isEmpty, !self.sessionKey.isEmpty, self.connectionGate == .available else {
             // The capture pipeline unwinds its own held state after this returns false.
             return false
@@ -641,6 +733,9 @@ final class QuickChatModel {
             case .terminalSuccess, .inFlight:
                 self.retryIdentity = nil
                 self.lastAcceptedRoute = QuickChatRoutingTarget(sessionKey: sessionKey, agentID: agentID)
+                if self.textContext == textContext {
+                    self.textContext = nil
+                }
                 if self.text == draft {
                     self.sendState = .sent
                     self.text = ""
@@ -683,6 +778,13 @@ final class QuickChatModel {
         self.permissionTask?.cancel()
         self.permissionTask = nil
         self.isGrantingPermissions = false
+    }
+
+    private func cancelTextContextCapture() {
+        self.textContextCaptureTask?.cancel()
+        self.textContextCaptureTask = nil
+        self.textContextCaptureID = nil
+        self.isCapturingTextContext = false
     }
 
     private func recheckPermissions(id: UUID) async {

--- a/apps/macos/Sources/OpenClaw/QuickChatView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatView.swift
@@ -11,7 +11,9 @@ struct QuickChatView: View {
     let onSendAccepted: (Bool) -> Void
     let onShowAgentPicker: () -> Void
     let onShowRecentSessions: () -> Void
-    let onWindowScreenshot: () -> Void
+    let onCaptureTextContext: () -> Void
+    let onShowCaptureMenu: () -> Void
+    let onGrantPermissions: () -> Void
     let onContentHeightChange: (CGFloat) -> Void
     let onTextViewReady: (NSTextView) -> Void
 
@@ -27,9 +29,14 @@ struct QuickChatView: View {
             VStack(spacing: 0) {
                 self.inputRow
 
+                if let context = self.model.textContext {
+                    self.contextChip(context)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+
                 if let status = self.statusLine {
                     HStack {
-                        Text(status.message)
+                        Text(verbatim: status.message)
                             .font(.caption)
                             .foregroundStyle(status.isError ? Color.red : Color.orange)
                         Spacer()
@@ -53,6 +60,7 @@ struct QuickChatView: View {
         .frame(width: 620)
         .fixedSize(horizontal: false, vertical: true)
         .animation(.spring(duration: 0.25), value: self.model.shouldShowPermissionStrip)
+        .animation(.easeOut(duration: 0.14), value: self.model.textContext)
         .animation(.easeOut(duration: 0.14), value: self.statusLine?.message)
         .animation(.spring(duration: 0.28), value: self.replyBinding.route)
         .onGeometryChange(for: CGFloat.self) { proxy in
@@ -106,10 +114,27 @@ struct QuickChatView: View {
                 .disabled(!self.model.canSelectRecentSession)
                 .help("Continue a recent conversation")
                 .accessibilityLabel("Continue a recent conversation")
-            }
 
-            if self.model.sendState != .sending {
-                Button(action: self.onWindowScreenshot) {
+                Button(action: self.onCaptureTextContext) {
+                    Group {
+                        if self.model.isCapturingTextContext {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "doc.text")
+                                .font(.system(size: 16.5, weight: .medium))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.plain)
+                .disabled(!self.model.canCaptureTextContext)
+                .help(String(localized: "Attach text from \(self.model.frontmostAppName)"))
+                .accessibilityLabel(Text(verbatim: String(
+                    localized: "Attach text from \(self.model.frontmostAppName)")))
+
+                Button(action: self.onShowCaptureMenu) {
                     Image(systemName: "camera.viewfinder")
                         .font(.system(size: 16.5, weight: .medium))
                         .foregroundStyle(.secondary)
@@ -117,8 +142,8 @@ struct QuickChatView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!self.model.canCaptureWindow)
-                .help("Send a window screenshot")
-                .accessibilityLabel("Send a window screenshot")
+                .help("Capture a screenshot")
+                .accessibilityLabel("Capture a screenshot")
             }
 
             Button {
@@ -202,13 +227,13 @@ struct QuickChatView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Needs additional permissions")
                         .font(.caption.weight(.semibold))
-                    Text(self.model.missingPermissions.map(\.permissionDisplayName).joined(separator: ", "))
+                    Text(verbatim: self.model.missingPermissions.map(\.permissionDisplayName).joined(separator: ", "))
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
                 Button("Grant") {
-                    self.model.grantMissingPermissions()
+                    self.onGrantPermissions()
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
@@ -221,6 +246,29 @@ struct QuickChatView: View {
             }
             .padding(12)
         }
+    }
+
+    private func contextChip(_ context: QuickChatTextContext) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: "doc.text")
+                .foregroundStyle(Color.accentColor)
+            Text("\(context.appName) — \(context.windowTitle) (\(context.characterCount) chars)")
+                .font(.caption)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Button(action: self.model.clearTextContext) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove attached text context")
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 5)
+        .background(Color.accentColor.opacity(0.1), in: Capsule())
+        .padding(.horizontal, 14)
+        .padding(.bottom, 9)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func replyArea(viewModel: OpenClawChatViewModel) -> some View {
@@ -243,6 +291,9 @@ struct QuickChatView: View {
     private var statusLine: (message: String, isError: Bool)? {
         if case let .failed(message) = self.model.sendState {
             return (message, true)
+        }
+        if let message = self.model.textContextCaptureMessage {
+            return (message, false)
         }
         if let message = self.model.connectionStatusMessage {
             return (message, false)

--- a/apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift
@@ -72,6 +72,11 @@ enum QuickChatWindowPickerLogic {
     }
 }
 
+private enum QuickChatCapturePickerMode {
+    case window
+    case area
+}
+
 private final class QuickChatWindowPickerPanel: NSPanel {
     override var canBecomeKey: Bool {
         true
@@ -132,7 +137,15 @@ final class QuickChatWindowPicker {
         self.permissionGrantProvider = permissionGrantProvider
     }
 
-    func begin() async {
+    func beginWindow() async {
+        await self.begin(mode: .window)
+    }
+
+    func beginArea() async {
+        await self.begin(mode: .area)
+    }
+
+    private func begin(mode: QuickChatCapturePickerMode) async {
         guard !self.isInteractionActive, self.captureTask == nil, self.model.canCaptureWindow else { return }
         let operationID = UUID()
         self.operationID = operationID
@@ -141,11 +154,20 @@ final class QuickChatWindowPicker {
 
         guard await self.permissionStatusProvider() else {
             guard self.operationID == operationID else { return }
-            await self.requestScreenRecordingPermission()
+            await self.requestScreenRecordingPermission(mode: mode)
             // The modal alert suspends this task; a dismissal/reopen meanwhile owns the
             // interaction now, and finishing here would tear down the newer picker.
             guard self.operationID == operationID else { return }
             self.finishInteraction()
+            return
+        }
+
+        if mode == .area {
+            guard self.showAreaOverlays() else {
+                self.model.setCaptureFailure()
+                self.finishInteraction()
+                return
+            }
             return
         }
 
@@ -187,12 +209,14 @@ final class QuickChatWindowPicker {
         self.finishInteraction()
     }
 
-    private func requestScreenRecordingPermission() async {
+    private func requestScreenRecordingPermission(mode: QuickChatCapturePickerMode) async {
         let alert = NSAlert()
-        alert.messageText = "Allow OpenClaw to capture windows"
-        alert.informativeText = "Sending a window screenshot uses macOS Screen Recording access."
-        alert.addButton(withTitle: "Grant Access")
-        alert.addButton(withTitle: "Cancel")
+        alert.messageText = mode == .window
+            ? String(localized: "Allow OpenClaw to capture windows")
+            : String(localized: "Allow OpenClaw to capture a screen area")
+        alert.informativeText = String(localized: "Sending a screenshot uses macOS Screen Recording access.")
+        alert.addButton(withTitle: String(localized: "Grant Access"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
         // This alert is user-initiated; only its affirmative action may trigger TCC.
         if alert.runModal() == .alertFirstButtonReturn {
             await self.permissionGrantProvider()
@@ -284,6 +308,7 @@ final class QuickChatWindowPicker {
             panel.hidesOnDeactivate = false
             panel.isFloatingPanel = true
             panel.isExcludedFromWindowsMenu = true
+            panel.ignoresMouseEvents = false
             panel.contentView = NSHostingView(rootView: QuickChatWindowPickerView(
                 candidates: localCandidates,
                 onSelect: { [weak self] candidate in self?.select(candidate) },
@@ -292,6 +317,61 @@ final class QuickChatWindowPicker {
             panel.makeKeyAndOrderFront(nil)
         }
 
+        self.installEscapeMonitor()
+    }
+
+    private func showAreaOverlays() -> Bool {
+        self.tearDownOverlays()
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return false }
+
+        let displays = screens.compactMap { screen -> (NSScreen, CGRect)? in
+            guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+                return nil
+            }
+            let bounds = CGDisplayBounds(CGDirectDisplayID(number.uint32Value))
+            guard bounds.width > 0, bounds.height > 0 else { return nil }
+            return (screen, bounds)
+        }
+        guard displays.count == screens.count else { return false }
+
+        for (screen, displayBounds) in displays {
+            let screenFrame = screen.frame
+            let panel = QuickChatWindowPickerPanel(
+                contentRect: screenFrame,
+                styleMask: [.nonactivatingPanel, .borderless],
+                backing: .buffered,
+                defer: false)
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = false
+            panel.level = NSWindow.Level(rawValue: max(
+                NSWindow.Level.screenSaver.rawValue,
+                NSWindow.Level.floating.rawValue))
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+            panel.hidesOnDeactivate = false
+            panel.isFloatingPanel = true
+            panel.isExcludedFromWindowsMenu = true
+            panel.ignoresMouseEvents = false
+            panel.acceptsMouseMovedEvents = true
+            panel.contentView = QuickChatAreaPickerView(
+                frame: CGRect(origin: .zero, size: screenFrame.size),
+                onSelect: { [weak self] localRect in
+                    self?.selectArea(
+                        localRect: localRect,
+                        screenFrame: screenFrame,
+                        displayBounds: displayBounds)
+                },
+                onCancel: { [weak self] in self?.cancel() })
+            self.panels.append(panel)
+            panel.makeKeyAndOrderFront(nil)
+        }
+
+        self.installEscapeMonitor()
+        return true
+    }
+
+    private func installEscapeMonitor() {
         self.escapeMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard event.keyCode == 53 else { return event }
             Task { @MainActor in self?.cancel() }
@@ -336,11 +416,13 @@ final class QuickChatWindowPicker {
                     self.clearCaptureTask(for: operationID)
                     return
                 }
-                let accepted = await self.model.sendWindowScreenshot(
+                let accepted = await self.model.sendCapturedImage(
                     pipelineID: pipelineID,
                     data: result.imageData,
-                    appName: candidate.appName,
-                    title: candidate.title)
+                    label: QuickChatWindowPickerLogic.labelText(
+                        appName: candidate.appName,
+                        title: candidate.title),
+                    fileName: QuickChatModel.screenshotFileName(appName: candidate.appName))
                 guard accepted,
                       self.operationID == operationID,
                       self.model.activePresentationID == presentationID
@@ -362,6 +444,81 @@ final class QuickChatWindowPicker {
                 // Token-guarded: a stale operation's failure cannot touch a newer pipeline.
                 self.model.failCapturePipeline(pipelineID)
                 self.clearCaptureTask(for: operationID)
+            }
+        }
+    }
+
+    private func selectArea(localRect: CGRect, screenFrame: CGRect, displayBounds: CGRect) {
+        guard self.isInteractionActive, self.captureTask == nil,
+              let presentationID = self.model.activePresentationID,
+              let pipelineID = self.model.beginCapturePipeline()
+        else { return }
+        self.activePipelineID = pipelineID
+        let operationID = self.operationID
+        let appKitRect = CGRect(
+            x: screenFrame.minX + localRect.minX,
+            y: screenFrame.minY + localRect.minY,
+            width: localRect.width,
+            height: localRect.height)
+        let captureRect = QuickChatAreaPickerLogic.globalDisplayRect(
+            appKitRect: appKitRect,
+            screenFrame: screenFrame,
+            displayBounds: displayBounds)
+
+        // Keep the Quick Chat panel hidden while only the overlay windows disappear;
+        // restoring it before capture would put the bar into the selected screenshot.
+        self.tearDownOverlays()
+        self.captureTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: .milliseconds(80))
+                guard self.operationID == operationID,
+                      self.model.activePresentationID == presentationID,
+                      !Task.isCancelled
+                else {
+                    self.clearCaptureTask(for: operationID)
+                    return
+                }
+                let result = try await self.screenCaptureService.captureArea(captureRect)
+                guard self.operationID == operationID,
+                      self.model.activePresentationID == presentationID,
+                      !Task.isCancelled
+                else {
+                    self.clearCaptureTask(for: operationID)
+                    return
+                }
+                let accepted = await self.model.sendCapturedImage(
+                    pipelineID: pipelineID,
+                    data: result.imageData,
+                    label: String(localized: "Selected area"),
+                    fileName: "area-screenshot.jpg")
+                guard accepted,
+                      self.operationID == operationID,
+                      self.model.activePresentationID == presentationID
+                else {
+                    self.clearCaptureTask(for: operationID)
+                    if self.operationID == operationID {
+                        self.finishInteraction(invalidateOperation: false)
+                    }
+                    return
+                }
+                self.finishInteraction(invalidateOperation: false)
+                try? await Task.sleep(for: .seconds(0.45))
+                let stillCurrent = self.operationID == operationID &&
+                    self.model.activePresentationID == presentationID &&
+                    self.model.sendState == .sent
+                self.clearCaptureTask(for: operationID)
+                if stillCurrent {
+                    self.onSendAccepted()
+                }
+            } catch is CancellationError {
+                self.clearCaptureTask(for: operationID)
+            } catch {
+                self.model.failCapturePipeline(pipelineID)
+                self.clearCaptureTask(for: operationID)
+                if self.operationID == operationID {
+                    self.finishInteraction(invalidateOperation: false)
+                }
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/QuickChatWindowPickerView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatWindowPickerView.swift
@@ -20,7 +20,7 @@ struct QuickChatWindowPickerView: View {
                         .fill(Color.accentColor.opacity(isHovered ? 0.16 : 0.04))
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .stroke(Color.accentColor.opacity(isHovered ? 0.95 : 0.62), lineWidth: isHovered ? 3 : 2)
-                    Text(QuickChatWindowPickerLogic.labelText(
+                    Text(verbatim: QuickChatWindowPickerLogic.labelText(
                         appName: candidate.appName,
                         title: candidate.title))
                         .font(.callout.weight(.medium))

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
@@ -153,6 +153,49 @@ struct QuickChatControllerTests {
         controller.stop()
     }
 
+    @Test func `resign key keeps bar visible while capturing focused text`() async {
+        let latch = TextCaptureLatch()
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentsProvider: {
+                AgentsListResult(
+                    defaultid: "main",
+                    mainkey: "main",
+                    scope: AnyCodable("per-agent"),
+                    agents: [AgentSummary(id: "main", name: "Main")])
+            },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _, _, _ in "ok" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            permissionGrantProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available },
+            textContextCaptureProvider: { await latch.wait() })
+        let controller = QuickChatController(enableUI: false, model: model, monitoringEnabled: false)
+        controller.present()
+        guard let id = model.activePresentationID else {
+            Issue.record("expected active presentation")
+            return
+        }
+        await model.refreshForPresentation(id: id)
+
+        model.captureFocusedAppText()
+        #expect(model.isCapturingTextContext)
+        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        #expect(controller.isVisible)
+
+        latch.finish(.cancelled)
+        while model.isCapturingTextContext {
+            await Task.yield()
+        }
+        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        #expect(!controller.isVisible)
+        controller.stop()
+    }
+
     @Test func `quick chat setting defaults true and hydrates false`() async {
         await TestIsolation.withUserDefaultsValues([quickChatEnabledKey: nil]) {
             #expect(AppState(preview: true).quickChatEnabled)
@@ -229,6 +272,25 @@ private final class GrantLatch {
     func finish() {
         self.finished = true
         self.continuation?.resume()
+        self.continuation = nil
+    }
+}
+
+@MainActor
+private final class TextCaptureLatch {
+    private var continuation: CheckedContinuation<QuickChatTextContextCaptureOutcome, Never>?
+    private var outcome: QuickChatTextContextCaptureOutcome?
+
+    func wait() async -> QuickChatTextContextCaptureOutcome {
+        if let outcome { return outcome }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish(_ outcome: QuickChatTextContextCaptureOutcome) {
+        self.outcome = outcome
+        self.continuation?.resume(returning: outcome)
         self.continuation = nil
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
@@ -1,0 +1,114 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+struct QuickChatFocusedTextCollectorTests {
+    @Test func `collector de-duplicates string values and computed names`() {
+        let child = FakeTextNode(id: 2, stringValue: "same", computedName: "other")
+        let root = FakeTextNode(id: 1, stringValue: "same", computedName: "same", children: [child])
+
+        let result = QuickChatFocusedTextCollector.collect(root: root)
+
+        #expect(result.text == "same\nother")
+        #expect(result.textEntryCount == 2)
+        #expect(!result.wasTruncated)
+    }
+
+    @Test func `collector enforces depth cap`() {
+        let deepest = FakeTextNode(id: 3, stringValue: "too deep")
+        let child = FakeTextNode(id: 2, stringValue: "child", children: [deepest])
+        let root = FakeTextNode(id: 1, stringValue: "root", children: [child])
+
+        let result = QuickChatFocusedTextCollector.collect(
+            root: root,
+            limits: QuickChatTextCollectionLimits(
+                maximumDepth: 1,
+                maximumElements: 20,
+                maximumCharacters: 100))
+
+        #expect(result.text.contains("root"))
+        #expect(result.text.contains("child"))
+        #expect(!result.text.contains("too deep"))
+        #expect(result.text.hasSuffix(QuickChatFocusedTextCollector.truncationMarker))
+        #expect(result.visitedElementCount == 2)
+    }
+
+    @Test func `collector enforces element cap`() {
+        let children = (2...12).map { FakeTextNode(id: UInt64($0), stringValue: "item \($0)") }
+        let root = FakeTextNode(id: 1, stringValue: "root", children: children)
+
+        let result = QuickChatFocusedTextCollector.collect(
+            root: root,
+            limits: QuickChatTextCollectionLimits(
+                maximumDepth: 12,
+                maximumElements: 3,
+                maximumCharacters: 100))
+
+        #expect(result.visitedElementCount == 3)
+        #expect(result.wasTruncated)
+        #expect(result.text.hasSuffix(QuickChatFocusedTextCollector.truncationMarker))
+    }
+
+    @Test func `collector enforces character cap with marker`() {
+        let root = FakeTextNode(id: 1, stringValue: String(repeating: "a", count: 200))
+
+        let result = QuickChatFocusedTextCollector.collect(
+            root: root,
+            limits: QuickChatTextCollectionLimits(
+                maximumDepth: 12,
+                maximumElements: 800,
+                maximumCharacters: 40))
+
+        #expect(result.text.count == 40)
+        #expect(result.text.hasSuffix(QuickChatFocusedTextCollector.truncationMarker))
+        #expect(result.wasTruncated)
+    }
+
+    @Test func `collector treats the exact sentinel character as truncation`() {
+        let root = FakeTextNode(id: 1, stringValue: String(repeating: "a", count: 41))
+
+        let result = QuickChatFocusedTextCollector.collect(
+            root: root,
+            limits: QuickChatTextCollectionLimits(
+                maximumDepth: 12,
+                maximumElements: 800,
+                maximumCharacters: 40))
+
+        #expect(result.text.count == 40)
+        #expect(result.text.hasSuffix(QuickChatFocusedTextCollector.truncationMarker))
+        #expect(result.wasTruncated)
+    }
+}
+
+private final class FakeTextNode: QuickChatTextTreeNode, Sendable {
+    let identity: UInt64
+    let storedStringValue: String?
+    let storedComputedName: String?
+    let childNodes: [FakeTextNode]
+
+    init(
+        id: UInt64,
+        stringValue: String? = nil,
+        computedName: String? = nil,
+        children: [FakeTextNode] = [])
+    {
+        self.identity = id
+        self.storedStringValue = stringValue
+        self.storedComputedName = computedName
+        self.childNodes = children
+    }
+
+    func stringValue() -> String? {
+        self.storedStringValue
+    }
+
+    func computedName() -> String? {
+        self.storedComputedName
+    }
+
+    func children(limit: Int) -> QuickChatTextTreeChildren {
+        QuickChatTextTreeChildren(
+            nodes: Array(self.childNodes.prefix(limit)),
+            wasTruncated: self.childNodes.count > limit)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Suite(.serialized)
 struct QuickChatFocusedTextCollectorTests {
-    @Test func `collector de-duplicates string values and computed names`() {
+    @Test func `collector collapses adjacent parent-child echoes`() {
         let child = FakeTextNode(id: 2, stringValue: "same", computedName: "other")
         let root = FakeTextNode(id: 1, stringValue: "same", computedName: "same", children: [child])
 
@@ -12,6 +12,35 @@ struct QuickChatFocusedTextCollectorTests {
         #expect(result.text == "same\nother")
         #expect(result.textEntryCount == 2)
         #expect(!result.wasTruncated)
+    }
+
+    @Test func `collector preserves equal text from distinct elements`() {
+        let cells = (2...4).map { FakeTextNode(id: UInt64($0), stringValue: "42") }
+        let root = FakeTextNode(id: 1, stringValue: "table", children: cells)
+
+        let result = QuickChatFocusedTextCollector.collect(root: root)
+
+        #expect(result.text == "table\n42\n42\n42")
+        #expect(result.textEntryCount == 4)
+    }
+
+    @Test func `collector honors cancellation and deadline`() {
+        let children = (2...40).map { FakeTextNode(id: UInt64($0), stringValue: "item \($0)") }
+        let root = FakeTextNode(id: 1, stringValue: "root", children: children)
+
+        var calls = 0
+        let cancelled = QuickChatFocusedTextCollector.collect(root: root, isCancelled: {
+            calls += 1
+            return calls > 3
+        })
+        #expect(cancelled.visitedElementCount < children.count)
+        #expect(cancelled.wasTruncated)
+
+        let expired = QuickChatFocusedTextCollector.collect(
+            root: root,
+            deadline: ContinuousClock.now.advanced(by: .seconds(-1)))
+        #expect(expired.visitedElementCount == 0)
+        #expect(expired.wasTruncated)
     }
 
     @Test func `collector enforces depth cap`() {

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
@@ -24,6 +24,17 @@ struct QuickChatFocusedTextCollectorTests {
         #expect(result.textEntryCount == 4)
     }
 
+    @Test func `collector suppresses echoes from any ancestor`() {
+        let grandchild = FakeTextNode(id: 3, stringValue: "same")
+        let child = FakeTextNode(id: 2, stringValue: "same", computedName: "middle", children: [grandchild])
+        let root = FakeTextNode(id: 1, stringValue: "same", children: [child])
+
+        let result = QuickChatFocusedTextCollector.collect(root: root)
+
+        #expect(result.text == "same\nmiddle")
+        #expect(result.textEntryCount == 2)
+    }
+
     @Test func `collector honors cancellation and deadline`() {
         let children = (2...40).map { FakeTextNode(id: UInt64($0), stringValue: "item \($0)") }
         let root = FakeTextNode(id: 1, stringValue: "root", children: children)

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatModelTests.swift
@@ -211,6 +211,34 @@ struct QuickChatModelTests {
         #expect(!model.shouldShowPermissionStrip)
     }
 
+    @Test func `capture controls stay disabled while granting permissions`() async {
+        let latch = PermissionGrantLatch()
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentsProvider: { Self.agentsResult(defaultID: "main", agentIDs: ["main"]) },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _, _, _ in "ok" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, $0 != .accessibility) })
+            },
+            permissionGrantProvider: { capabilities in
+                await latch.wait()
+                return Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available })
+        await self.prepare(model)
+
+        model.grantMissingPermissions()
+
+        #expect(model.isGrantingPermissions)
+        #expect(!model.canCaptureWindow)
+        #expect(!model.canCaptureTextContext)
+        latch.finish()
+        while model.isGrantingPermissions {
+            await Task.yield()
+        }
+    }
+
     @Test func `routing target follows scope contract`() {
         #expect(QuickChatModel.routingTarget(
             scope: "global",
@@ -317,7 +345,7 @@ struct QuickChatModelTests {
         #expect(sentRoute == QuickChatRoutingTarget(sessionKey: "global", agentID: "work"))
     }
 
-    @Test func `agent display parses avatar forms and monogram`() throws {
+    @Test func `agent display parses avatar forms and monogram`() {
         let imageData = Data([0x89, 0x50, 0x4E, 0x47])
         let dataSummary = AgentSummary(
             id: "molty",
@@ -391,11 +419,11 @@ struct QuickChatModelTests {
                 Data(
                     base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
         let pipelineID = try #require(model.beginCapturePipeline())
-        let send = Task { await model.sendWindowScreenshot(
+        let send = Task { await model.sendCapturedImage(
             pipelineID: pipelineID,
             data: png,
-            appName: "Safari",
-            title: "Docs") }
+            label: "Safari — Docs",
+            fileName: "window-safari.jpg") }
         while !latch.started {
             await Task.yield()
         }
@@ -462,17 +490,70 @@ struct QuickChatModelTests {
                     base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
 
         let pipelineID = try #require(model.beginCapturePipeline())
-        #expect(await model.sendWindowScreenshot(
+        #expect(await model.sendCapturedImage(
             pipelineID: pipelineID,
             data: png,
-            appName: "Safari",
-            title: "Docs"))
+            label: "Safari — Docs",
+            fileName: "window-safari.jpg"))
         #expect(receivedMessage == "Screenshot: Safari — Docs")
         #expect(receivedAttachments.count == 1)
         #expect(receivedAttachments[0].type == "file")
         #expect(receivedAttachments[0].mimeType == "image/jpeg")
         #expect(receivedAttachments[0].fileName == "window-safari.jpg")
         #expect(!receivedAttachments[0].content.hasPrefix("data:"))
+    }
+
+    @Test func `message assembly appends context block`() {
+        let context = QuickChatTextContext(
+            appName: "Safari",
+            windowTitle: "Docs",
+            text: "Selected text")
+
+        #expect(QuickChatModel.assembleMessage(draft: "Question", context: context) == """
+        Question
+
+        [Context from Safari — Docs]
+        Selected text
+        """)
+        #expect(QuickChatModel.assembleMessage(draft: "  ", context: context) == """
+        [Context from Safari — Docs]
+        Selected text
+        """)
+    }
+
+    @Test func `accepted send clears attached context`() async {
+        var receivedMessage: String?
+        let model = self.makeModel(sendHandler: { _, _, message, _, _ in
+            receivedMessage = message
+            return "ok"
+        })
+        await self.prepare(model)
+        model.replaceTextContext(QuickChatTextContext(
+            appName: "Notes",
+            windowTitle: "Plan",
+            text: "Ship it"))
+
+        #expect(model.canSend)
+        #expect(await model.send())
+        #expect(receivedMessage == """
+        [Context from Notes — Plan]
+        Ship it
+        """)
+        #expect(model.textContext == nil)
+    }
+
+    @Test func `context replaces and clears on hide`() async {
+        let model = self.makeModel()
+        await self.prepare(model)
+        let first = QuickChatTextContext(appName: "One", windowTitle: "First", text: "old")
+        let second = QuickChatTextContext(appName: "Two", windowTitle: "Second", text: "new")
+
+        model.replaceTextContext(first)
+        model.replaceTextContext(second)
+        #expect(model.textContext == second)
+
+        model.endPresentation()
+        #expect(model.textContext == nil)
     }
 
     @Test func `permission strip tracks missing permissions and session dismissal`() async {
@@ -553,6 +634,25 @@ private enum FakeSendError: LocalizedError {
 @MainActor
 private final class GrantFlag {
     var value = false
+}
+
+@MainActor
+private final class PermissionGrantLatch {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var finished = false
+
+    func wait() async {
+        if self.finished { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish() {
+        self.finished = true
+        self.continuation?.resume()
+        self.continuation = nil
+    }
 }
 
 @MainActor

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatViewSmokeTests.swift
@@ -32,7 +32,9 @@ struct QuickChatViewSmokeTests {
             onSendAccepted: { _ in },
             onShowAgentPicker: {},
             onShowRecentSessions: {},
-            onWindowScreenshot: {},
+            onCaptureTextContext: {},
+            onShowCaptureMenu: {},
+            onGrantPermissions: {},
             onContentHeightChange: { _ in },
             onTextViewReady: { _ in })
 

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatWindowPickerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatWindowPickerTests.swift
@@ -49,6 +49,43 @@ struct QuickChatWindowPickerTests {
         #expect(QuickChatWindowPickerLogic.labelText(appName: "Safari", title: "Safari") == "Safari")
     }
 
+    @Test func `area selection normalizes drags from every corner`() throws {
+        let expected = CGRect(x: 20, y: 30, width: 80, height: 60)
+        let corners = [
+            (CGPoint(x: 20, y: 30), CGPoint(x: 100, y: 90)),
+            (CGPoint(x: 100, y: 30), CGPoint(x: 20, y: 90)),
+            (CGPoint(x: 20, y: 90), CGPoint(x: 100, y: 30)),
+            (CGPoint(x: 100, y: 90), CGPoint(x: 20, y: 30)),
+        ]
+
+        for (start, end) in corners {
+            #expect(try #require(QuickChatAreaPickerLogic.normalizedSelection(from: start, to: end)) == expected)
+        }
+    }
+
+    @Test func `area selection rejects either tiny dimension`() {
+        #expect(QuickChatAreaPickerLogic.normalizedSelection(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 7.9, y: 40)) == nil)
+        #expect(QuickChatAreaPickerLogic.normalizedSelection(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 40, y: 7.9)) == nil)
+        #expect(QuickChatAreaPickerLogic.normalizedSelection(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 8, y: 8)) != nil)
+    }
+
+    @Test func `area coordinates convert between appkit and global display spaces`() {
+        let screenFrame = CGRect(x: -1440, y: 200, width: 1440, height: 900)
+        let displayBounds = CGRect(x: -1440, y: -200, width: 1440, height: 900)
+        let appKitSelection = CGRect(x: -1400, y: 900, width: 400, height: 100)
+
+        #expect(QuickChatAreaPickerLogic.globalDisplayRect(
+            appKitRect: appKitSelection,
+            screenFrame: screenFrame,
+            displayBounds: displayBounds) == CGRect(x: -1400, y: -100, width: 400, height: 100))
+    }
+
     private func input(
         id: Int,
         processID: Int32,

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -26,7 +26,9 @@ Click the history button to choose from the five most recently updated sessions 
 
 Command-Return opens the conversation of the agent that received the send, including when session scope is global.
 
-The camera button starts a window screenshot: every visible window gets a labeled overlay, and clicking one captures it and sends it (with any typed text as the caption) to the selected agent. The first use asks for macOS Screen Recording access. Escape or clicking empty space cancels.
+The camera button opens a menu for **Capture Window…** or **Capture Area…**. Window capture labels every visible window; area capture dims each display while you drag a region and shows its live size. The selected screenshot is sent to the chosen agent with any typed text as its caption. The first use asks for macOS Screen Recording access. Escape, clicking empty space, or clicking without a meaningful area drag cancels.
+
+Use the document-text button to attach text from the focused app's focused window. Quick Chat shows the result as a removable context chip rather than placing the captured text in the composer; sending appends the chip's text to the outgoing message and then clears it. This requires macOS Accessibility permission. Attached text also clears whenever Quick Chat closes, so context from one presentation cannot leak into a later send.
 
 Disable the feature entirely with **Settings → General → Quick Chat**; the same section hosts the shortcut recorder.
 


### PR DESCRIPTION
## What Problem This Solves

The macOS Quick Chat could attach a whole window screenshot but nothing more precise, and it had no way to hand the agent the text you're actually looking at. Region capture is table stakes across quick bars; focused-app text context is cheaper, sharper, and more actionable than pixels.

## Why This Change Was Made

- **Drag-select region capture**: the camera button becomes a native two-item menu (Capture Window… / Capture Area…). The area flow raises per-screen overlay panels with crosshair drag, outside-dim, a live size badge, and Esc/tiny-drag cancel; on mouse-up the overlays tear down first (matching the window picker's settle), the bar is hidden synchronously (a fast drag must never capture a fading composer), and the selection converts from AppKit bottom-left space to the top-left global display coordinates Peekaboo's `captureArea` expects (conversion verified against the pinned Peekaboo 3.9.3 source, ScreenCaptureKit and legacy paths). The image rides the existing capture pipeline (ownership tokens, off-main processing, same attachment path).
- **Focused-app text context**: a doc-text button captures the frontmost app's focused-window text via a bounded Accessibility walk (the bar is a nonactivating panel, so the user's app stays frontmost). Bounds are real, not aspirational: depth/element/char caps, ancestry-scoped echo suppression that preserves repeated sibling content, per-element AX messaging timeouts, cooperative cancellation, and a hard outer race that abandons a hung walk (structured groups join cancelled children — the race is deliberately unstructured, commented). The result is a removable context chip; on send the text is appended as a labeled context block, and the chip clears on send and on hide so stale context can't leak. Accessibility-only permission, user-initiated prompt, no AX content logged or persisted.

## User Impact

Capture exactly the region you mean, or hand the agent the text of the app you're working in, straight from the bar. Docs updated (`docs/platforms/mac/webchat.md`).

## Evidence

- `swift build` (release) green; SwiftFormat/SwiftLint clean; `git diff --check` clean.
- New tests: region normalization (corner-agnostic drags, tiny-drag cancel, multi-display conversion), collector bounding (depth/element/char caps, truncation marker, sibling preservation, cancellation, expired deadline), chip lifecycle, message assembly.
- Structured second-model review over five rounds: blur-race, dedup-semantics, timeout-coverage, structured-join, and fade-race findings all fixed with regression coverage; final round clean ("patch is correct").
- Live interaction screenshots follow in a PR comment during the CI window.
