### PR TITLE
fix(acp): stop client setup hanging on unresponsive servers

### DIFF
--- a/src/acp/client.setup-timeout.test.ts
+++ b/src/acp/client.setup-timeout.test.ts
@@ -1,0 +1,135 @@
+/** Real-process regression tests for bounded ACP client session setup. */
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { runAcpClientInteractive } from "./client.js";
+
+const SETUP_TIMEOUT_MS = 500;
+const FIXTURE_SELF_CLEANUP_MS = 2_000;
+
+const tempDirs = createTrackedTempDirs();
+const trackedPids = new Set<number>();
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    // Node defines signal 0 as a cross-platform existence probe, including on Windows.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessAlive(pid) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
+  expect(isProcessAlive(pid)).toBe(false);
+}
+
+async function createHungAcpServer(
+  phase: "initialization" | "session creation",
+): Promise<{ cwd: string; pidFile: string }> {
+  const cwd = await tempDirs.make("openclaw-acp-client-setup-timeout-");
+  const pidFile = path.join(cwd, "pids.json");
+  const script = `
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+  stdio: "ignore",
+});
+fs.writeFileSync(
+  path.join(process.cwd(), "pids.json"),
+  JSON.stringify({ serverPid: process.pid, descendantPid: descendant.pid }),
+);
+
+if (${JSON.stringify(phase)} === "session creation") {
+  readline.createInterface({ input: process.stdin }).on("line", (line) => {
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      process.stdout.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: { protocolVersion: 1 },
+        }) + "\\n",
+      );
+    }
+  });
+} else {
+  process.stdin.resume();
+}
+
+setTimeout(() => {
+  try {
+    descendant.kill("SIGKILL");
+  } catch {}
+  process.exit(23);
+}, ${String(FIXTURE_SELF_CLEANUP_MS)});
+`;
+  await writeFile(path.join(cwd, "acp"), script, "utf8");
+  return { cwd, pidFile };
+}
+
+async function expectBoundedSetupFailure(phase: "initialization" | "session creation") {
+  const fixture = await createHungAcpServer(phase);
+  const startedAt = Date.now();
+  let error: unknown;
+  try {
+    // The ACP client prepends "acp" to custom server args, so Node executes cwd/acp.
+    await runAcpClientInteractive({
+      cwd: fixture.cwd,
+      serverCommand: process.execPath,
+      setupTimeoutMs: SETUP_TIMEOUT_MS,
+    });
+  } catch (caught) {
+    error = caught;
+  }
+
+  const pids = JSON.parse(await readFile(fixture.pidFile, "utf8")) as {
+    serverPid: number;
+    descendantPid: number;
+  };
+  trackedPids.add(pids.serverPid);
+  trackedPids.add(pids.descendantPid);
+
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toBe(
+    `ACP client setup timed out during ${phase} after ${String(SETUP_TIMEOUT_MS)}ms`,
+  );
+  expect(Date.now() - startedAt).toBeLessThan(FIXTURE_SELF_CLEANUP_MS);
+  // POSIX owns a detached process group; Windows uses the canonical taskkill /T path.
+  await waitForProcessExit(pids.serverPid);
+  await waitForProcessExit(pids.descendantPid);
+}
+
+afterEach(async () => {
+  for (const pid of trackedPids) {
+    if (isProcessAlive(pid)) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already exited.
+      }
+    }
+  }
+  trackedPids.clear();
+  await tempDirs.cleanup();
+});
+
+describe("ACP client setup deadline", () => {
+  it("bounds an initialize request when the ACP server never responds", async () => {
+    await expectBoundedSetupFailure("initialization");
+  });
+
+  it("shares the deadline with session creation and cleans up the server tree", async () => {
+    await expectBoundedSetupFailure("session creation");
+  });
+});

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -15,6 +15,11 @@ import {
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import {
+  shouldDetachChildForProcessTree,
+  signalChildProcessTree,
+} from "../process/child-process-tree.js";
+import { killProcessTree } from "../process/kill-tree.js";
+import {
   buildAcpClientStripKeys,
   resolveAcpClientSpawnEnv,
   resolveAcpClientSpawnInvocation,
@@ -27,6 +32,7 @@ type AcpClientOptions = {
   serverCommand?: string;
   serverArgs?: string[];
   serverVerbose?: boolean;
+  setupTimeoutMs?: number;
   verbose?: boolean;
 };
 
@@ -35,6 +41,58 @@ type AcpClientHandle = {
   agent: ChildProcess;
   sessionId: string;
 };
+
+const ACP_CLIENT_SETUP_TIMEOUT_MS = 30_000;
+const ACP_CLIENT_TERMINATION_GRACE_MS = 500;
+const ACP_CLIENT_FORCE_KILL_WAIT_MS = 500;
+
+type AcpClientSetupPhase = "initialization" | "session creation";
+
+function isAgentRunning(agent: ChildProcess): boolean {
+  return agent.exitCode === null && agent.signalCode === null;
+}
+
+function waitForAgentClose(agent: ChildProcess, timeoutMs: number): Promise<void> {
+  if (!isAgentRunning(agent)) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      agent.off("close", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, timeoutMs);
+    agent.once("close", finish);
+  });
+}
+
+async function terminateAcpAgent(agent: ChildProcess): Promise<void> {
+  if (!isAgentRunning(agent)) {
+    return;
+  }
+
+  try {
+    agent.stdin?.end();
+  } catch {
+    // Best-effort pipe cleanup before terminating the owned process tree.
+  }
+
+  if (agent.pid) {
+    killProcessTree(agent.pid, {
+      graceMs: ACP_CLIENT_TERMINATION_GRACE_MS,
+      detached: shouldDetachChildForProcessTree(),
+    });
+  } else {
+    agent.kill("SIGTERM");
+  }
+
+  await waitForAgentClose(agent, ACP_CLIENT_TERMINATION_GRACE_MS + ACP_CLIENT_FORCE_KILL_WAIT_MS);
+  if (isAgentRunning(agent)) {
+    signalChildProcessTree(agent, "SIGKILL");
+    await waitForAgentClose(agent, ACP_CLIENT_FORCE_KILL_WAIT_MS);
+  }
+}
 
 function toArgs(value: string[] | string | undefined): string[] {
   if (!value) {
@@ -138,6 +196,7 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
   const agent = spawn(spawnInvocation.command, spawnInvocation.args, {
     stdio: ["pipe", "pipe", "inherit"],
     cwd,
+    detached: shouldDetachChildForProcessTree(),
     env: spawnEnv,
     shell: spawnInvocation.shell,
     windowsHide: spawnInvocation.windowsHide,
@@ -163,27 +222,60 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
     stream,
   );
 
-  log("initializing");
-  await client.initialize({
-    protocolVersion: PROTOCOL_VERSION,
-    clientCapabilities: {
-      fs: { readTextFile: true, writeTextFile: true },
-      terminal: true,
-    },
-    clientInfo: { name: "openclaw-acp-client", version: "1.0.0" },
-  });
+  const setupTimeoutMs = opts.setupTimeoutMs ?? ACP_CLIENT_SETUP_TIMEOUT_MS;
+  let setupPhase: AcpClientSetupPhase = "initialization";
+  let setupTimer: NodeJS.Timeout | undefined;
+  try {
+    // One deadline covers both setup RPCs so a slow initialize cannot consume a fresh
+    // full timeout before session creation. Closing the child is required because the
+    // ACP SDK's request cancellation remains cooperative when a peer stops responding.
+    const setupTimeout = new Promise<never>((_resolve, reject) => {
+      setupTimer = setTimeout(() => {
+        reject(
+          new Error(
+            `ACP client setup timed out during ${setupPhase} after ${String(setupTimeoutMs)}ms`,
+          ),
+        );
+      }, setupTimeoutMs);
+    });
+    const setup = (async () => {
+      log("initializing");
+      await client.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          terminal: true,
+        },
+        clientInfo: { name: "openclaw-acp-client", version: "1.0.0" },
+      });
 
-  log("creating session");
-  const session = await client.newSession({
-    cwd,
-    mcpServers: [],
-  });
+      setupPhase = "session creation";
+      log("creating session");
+      return await client.newSession({
+        cwd,
+        mcpServers: [],
+      });
+    })();
+    // Terminating a timed-out agent rejects the still-pending SDK request after the race settles.
+    void setup.catch(() => {});
 
-  return {
-    client,
-    agent,
-    sessionId: session.sessionId,
-  };
+    const session = await Promise.race([setup, setupTimeout]);
+
+    return {
+      client,
+      agent,
+      sessionId: session.sessionId,
+    };
+  } catch (err) {
+    await terminateAcpAgent(agent).catch((cleanupErr: unknown) => {
+      log(`setup cleanup failed: ${String(cleanupErr)}`);
+    });
+    throw err;
+  } finally {
+    if (setupTimer) {
+      clearTimeout(setupTimer);
+    }
+  }
 }
 
 /** Starts the terminal prompt loop for a local ACP client session. */
@@ -194,6 +286,31 @@ export async function runAcpClientInteractive(opts: AcpClientOptions = {}): Prom
     input: process.stdin,
     output: process.stdout,
   });
+
+  // The server runs in its own process group so setup failures can terminate descendants.
+  // Handle terminal shutdown while the event loop is live; Windows tree cleanup starts taskkill.
+  const shutdownSignals = [
+    { signal: "SIGHUP", exitCode: 129 },
+    { signal: "SIGINT", exitCode: 130 },
+    { signal: "SIGTERM", exitCode: 143 },
+  ] as const;
+  const shutdownHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = [];
+  const removeShutdownHandlers = () => {
+    for (const { signal, handler } of shutdownHandlers) {
+      process.off(signal, handler);
+    }
+  };
+  for (const { signal, exitCode } of shutdownSignals) {
+    const handler = () => {
+      removeShutdownHandlers();
+      signalChildProcessTree(agent, "SIGTERM");
+      rl.close();
+      process.exit(exitCode);
+    };
+    process.once(signal, handler);
+    shutdownHandlers.push({ signal, handler });
+  }
+  agent.once("exit", removeShutdownHandlers);
 
   console.log("OpenClaw ACP client");
   console.log(`Session: ${sessionId}`);
@@ -208,7 +325,8 @@ export async function runAcpClientInteractive(opts: AcpClientOptions = {}): Prom
           return;
         }
         if (text === "exit" || text === "quit") {
-          agent.kill();
+          removeShutdownHandlers();
+          signalChildProcessTree(agent, "SIGTERM");
           rl.close();
           process.exit(0);
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw acp client` could wait forever when the spawned ACP server accepted its stdio connection but stopped responding during `initialize` or `session/new`.

## Why This Change Was Made

The ACP client now applies one 30-second deadline across both setup RPCs. If setup fails or reaches that deadline, the client terminates the owned server process tree, preserves the original setup error, and reports which setup phase timed out. Interactive prompt RPC behavior is intentionally unchanged.

The server is spawned in an owned process group on POSIX so descendants cannot survive setup cleanup. Interactive `SIGHUP`, `SIGINT`, and `SIGTERM` shutdowns forward termination while the event loop is still active; Windows uses the repository's canonical `taskkill /T` path.

## User Impact

`openclaw acp client` now exits with a clear error instead of hanging indefinitely when a local or custom ACP server becomes unresponsive during startup. Failed setup also no longer leaves the spawned server or its descendants running.

## Evidence

The regression was demonstrated red against the pre-fix implementation, then green with real stdio child processes for both setup phases. Focused ACP tests, formatting, lint, diff validation, and the final independent autoreview were also completed.

### Red regression proof

The fixture server self-terminates after 2 seconds only to keep the pre-fix test bounded. Before the fix, both requests waited until that fallback exit and returned the SDK's connection-close error instead of the expected 500ms setup deadline:

```text
$ node scripts/run-vitest.mjs src/acp/client.setup-timeout.test.ts

src/acp/client.setup-timeout.test.ts (2 tests | 2 failed) 4998ms

Expected: "ACP client setup timed out during initialization after 500ms"
Received: "ACP connection closed"

Expected: "ACP client setup timed out during session creation after 500ms"
Received: "ACP connection closed"

Test Files  1 failed (1)
Tests       2 failed (2)
```

### Green focused proof

The regression uses real Node child processes. One fixture never answers `initialize`; the other answers `initialize` and then drops `session/new`. Both record a server PID and descendant PID, and the assertions verify that both processes are gone after the deadline.

```text
$ node scripts/run-vitest.mjs src/acp/client.setup-timeout.test.ts src/acp/client.test.ts

Test Files  1 passed (1)
Tests       57 passed (57)

Test Files  1 passed (1)
Tests       2 passed (2)

[test] passed 2 Vitest shards in 22.23s
```

Additional checks:

```text
$ node scripts/run-oxlint.mjs --openclaw-focused-config --tsconfig config/tsconfig/oxlint.core.json src/acp/client.ts src/acp/client.setup-timeout.test.ts
# passed with no diagnostics

$ git diff --check
# passed

$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine pi --model deepseek/deepseek-v4-flash --thinking high --no-web-search
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.95)
```

`check:changed` passed its conflict-marker, formatting, dependency-pin, Plugin SDK API, deprecated-API, plugin-boundary, package-patch, and temp-directory checks. Its core typecheck then stopped on three diagnostics in unchanged `packages/net-policy/src/ip.ts` (`benchmarking`, `orchid2`, and a mixed IPv4/IPv6 overload); the touched ACP files and dependency manifests do not differ from the latest main for that failure. This partial run is not presented as a passing full changed gate; PR CI remains authoritative.

AI-assisted: yes. I reviewed the implementation, dependency behavior, process ownership, tests, and reviewer findings before submission.
