### PR TITLE
fix(ci): bound Mantis Slack desktop smoke runner IP lookup

### DIFF
--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -266,7 +266,8 @@ jobs:
           require_var OPENCLAW_QA_CONVEX_SECRET_CI
           require_var CRABBOX_COORDINATOR_TOKEN
           if [[ -z "${CRABBOX_LEASE_ID:-}" && "$CRABBOX_PROVIDER" == "aws" ]]; then
-            runner_ip="$(curl -fsS https://checkip.amazonaws.com | tr -d '[:space:]')"
+            # Bound the public IP lookup so a stalled metadata endpoint cannot wedge AWS SSH ingress setup.
+            runner_ip="$(curl -fsS --connect-timeout 10 --max-time 30 https://checkip.amazonaws.com | tr -d '[:space:]')"
             if [[ -z "$runner_ip" ]]; then
               echo "Could not resolve GitHub runner public IPv4 for AWS SSH ingress." >&2
               exit 1

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -294,6 +294,14 @@ describe("ci workflow guards", () => {
     );
   });
 
+  it("bounds the runner public IP lookup in Mantis Slack desktop smoke", () => {
+    const workflow = readFileSync(".github/workflows/mantis-slack-desktop-smoke.yml", "utf8");
+
+    expect(workflow).toContain(
+      "runner_ip=\"$(curl -fsS --connect-timeout 10 --max-time 30 https://checkip.amazonaws.com | tr -d '[:space:]')\"",
+    );
+  });
+
   it("runs dependency policy guards in PR CI preflight", () => {
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
     const preflightGuards = workflow.slice(


### PR DESCRIPTION
## What Problem This Solves

In `mantis-slack-desktop-smoke.yml`, the AWS SSH ingress setup resolves the GitHub runner's public IPv4 via `curl -fsS https://checkip.amazonaws.com`. This call has no connect or total timeout. If the metadata/lookup endpoint stalls, the smoke job hangs indefinitely instead of failing fast, blocking AWS SSH ingress setup for the entire Mantis Slack desktop smoke run.

This mirrors the same "bound the external lookup so a stalled endpoint cannot wedge setup" pattern used elsewhere in the Mantis CI surface.

## Why This Change Was Made

`checkip.amazonaws.com` is an external dependency outside OpenClaw's control. An unbounded `curl` there turns a transient third-party slowdown into an indefinite CI hang. Adding `--connect-timeout 10 --max-time 30` (the same bounds already used for sibling Mantis lookups) makes the failure deterministic and fast.

## User Impact

No user-facing behavior change. CI-only: the Mantis Slack desktop smoke workflow now fails fast with a clear empty-IP error instead of hanging when the public IP lookup endpoint is slow or unresponsive.

## Evidence

Real environment: macOS (Darwin 24.6.0 arm64), `curl 8.7.1`. The exact workflow lookup pipeline was executed verbatim in bash (`runner_ip="$(curl -fsS <flags> <endpoint> | tr -d '[:space:]')"`), comparing the after-fix line (this PR, with bounds) against the before-fix line (current `main`, no flags). Where a stalled endpoint was needed, the URL was swapped for a controlled stand-in as noted; the flags and pipeline are exactly the workflow's.

1. Production endpoint sanity — after-fix line against the real `https://checkip.amazonaws.com`:

```
curl pipeline rc=0 runner_ip='103.151.172.151'
elapsed_seconds=1
verdict=returned on its own after 1s
```

2. Stalled connect — endpoint swapped for unroutable TEST-NET-1 (`https://192.0.2.1`, proxy env stripped):

```
# after-fix (this PR):
elapsed_seconds=11   runner_ip=''   verdict=returned on its own after 11s     # --connect-timeout 10 fired
# before-fix (main, unbounded):
elapsed_seconds=76   runner_ip=''   verdict=returned on its own after 76s     # only the OS TCP timeout saved it
```

3. Stalled mid-transfer — endpoint swapped for a local server that accepts the connection and then never sends a byte:

```
# after-fix (this PR):
elapsed_seconds=31   runner_ip=''   verdict=returned on its own after 31s     # --max-time 30 fired
# before-fix (main, unbounded):
exit_code=137
verdict=STILL BLOCKED after 60s guard; killed by harness (unbounded hang)
```

In all bounded cases the workflow continues immediately with an empty `runner_ip`, which the existing guard turns into a clear error instead of a multi-minute or indefinite stall.

Regression test (from this PR): `test/scripts/ci-workflow-guards.test.ts` asserts the bounded lookup line is present in the workflow:

```
RUN  v4.1.8
Test Files  1 passed (1)
     Tests  22 passed (22)
```

What was not tested: live AWS SSH ingress provisioning end-to-end (requires credentialed AWS runner); the bounded lookup line itself was executed verbatim against real and controlled stalled endpoints as shown above.
