### PR TITLE
fix(ios): shrink the chat "Jump to latest" pill to a compact icon button

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -37274,16 +37274,8 @@
       "id": "native.apple.99df7de891c8235f"
     },
     {
-      "kind": "ui-call",
-      "line": 618,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
-      "source": "Jump to latest",
-      "surface": "apple",
-      "id": "native.apple.f84b674ad395b694"
-    },
-    {
       "kind": "ui-modifier",
-      "line": 629,
+      "line": 631,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -37291,7 +37283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 649,
+      "line": 651,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -37299,7 +37291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1036,
+      "line": 1038,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -37307,7 +37299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1059,
+      "line": 1061,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -37315,7 +37307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1080,
+      "line": 1082,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -37323,7 +37315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1090,
+      "line": 1092,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -37331,7 +37323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1092,
+      "line": 1094,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -37339,7 +37331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1158,
+      "line": 1160,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -37347,7 +37339,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1238,
+      "line": 1240,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -23299,11 +23299,6 @@
       "translated": "استمع"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "الانتقال إلى الأحدث"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "الانتقال إلى أحدث رد"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -23299,11 +23299,6 @@
       "translated": "Zuhören"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Zum neuesten springen"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Zur neuesten Antwort springen"

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -23299,11 +23299,6 @@
       "translated": "Escuchar"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Ir a lo más reciente"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Ir a la respuesta más reciente"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -23299,11 +23299,6 @@
       "translated": "گوش دادن"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "پرش به آخرین مورد"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "پرش به آخرین پاسخ"

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -23299,11 +23299,6 @@
       "translated": "Écouter"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Aller au plus récent"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Aller à la réponse la plus récente"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -23299,11 +23299,6 @@
       "translated": "सुनें"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "नवीनतम पर जाएँ"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "नवीनतम उत्तर पर जाएँ"

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -23299,11 +23299,6 @@
       "translated": "Dengarkan"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Lompat ke terbaru"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Lompat ke balasan terbaru"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -23299,11 +23299,6 @@
       "translated": "Ascolta"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Vai all'ultimo"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Vai all'ultima risposta"

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -23299,11 +23299,6 @@
       "translated": "聞く"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "最新に移動"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "最新の返信に移動"

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -23299,11 +23299,6 @@
       "translated": "듣기"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "최신 항목으로 이동"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "최신 답글로 이동"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -23299,11 +23299,6 @@
       "translated": "Luisteren"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Naar nieuwste springen"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Naar nieuwste antwoord springen"

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -23299,11 +23299,6 @@
       "translated": "Słuchaj"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Przejdź do najnowszych"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Przejdź do najnowszej odpowiedzi"

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -23299,11 +23299,6 @@
       "translated": "Ouvir"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Ir para a mais recente"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Ir para a resposta mais recente"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -23299,11 +23299,6 @@
       "translated": "Слушать"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Перейти к последнему"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Перейти к последнему ответу"

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -23299,11 +23299,6 @@
       "translated": "Lyssna"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Hoppa till senaste"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Hoppa till senaste svar"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -23299,11 +23299,6 @@
       "translated": "ฟัง"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "ข้ามไปยังล่าสุด"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "ข้ามไปยังการตอบกลับล่าสุด"

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -23299,11 +23299,6 @@
       "translated": "Dinle"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "En yeniye atla"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "En yeni yanıta atla"

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -23299,11 +23299,6 @@
       "translated": "Слухати"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Перейти до останнього"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Перейти до останньої відповіді"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -23299,11 +23299,6 @@
       "translated": "Nghe"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "Chuyển đến mới nhất"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "Chuyển đến phản hồi mới nhất"

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -23299,11 +23299,6 @@
       "translated": "聆听"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "跳转到最新"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "跳转到最新回复"

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -23299,11 +23299,6 @@
       "translated": "聆聽"
     },
     {
-      "id": "native.apple.f84b674ad395b694",
-      "source": "Jump to latest",
-      "translated": "跳至最新內容"
-    },
-    {
       "id": "native.apple.429d825201b2cb85",
       "source": "Jump to latest reply",
       "translated": "跳至最新回覆"

--- a/apps/ios/Tests/Info.plist
+++ b/apps/ios/Tests/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenClawTests</string>
+	<string>OpenClawLogicTests</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -615,17 +615,19 @@ public struct OpenClawChatView: View {
             self.hasNewerContentBelow = false
             self.moveScrollPosition(to: self.scrollerBottomID)
         } label: {
-            Label("Jump to latest", systemImage: "arrow.down")
-                .font(OpenClawChatTypography.body(size: 16, weight: .semibold, relativeTo: .callout))
-                .padding(.horizontal, 13)
-                .padding(.vertical, 8)
+            Image(systemName: "arrow.down")
+                .font(.system(size: 15, weight: .semibold))
+                .frame(width: 36, height: 36)
+                .background(
+                    Circle()
+                        .fill(OpenClawChatTheme.subtleCard)
+                        .shadow(color: .black.opacity(0.16), radius: 8, y: 3))
+                // Padding keeps a ~44pt tap target around the compact visual circle.
+                .padding(4)
+                .contentShape(Circle())
         }
         .buttonStyle(.plain)
         .foregroundStyle(OpenClawChatTheme.assistantText)
-        .background(
-            Capsule()
-                .fill(OpenClawChatTheme.subtleCard)
-                .shadow(color: .black.opacity(0.16), radius: 10, y: 4))
         .accessibilityLabel("Jump to latest reply")
     }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the chat reader's "Jump to latest" pill covered a full line of conversation text on iOS. The wide labeled capsule (icon + "Jump to latest" at 16pt semibold) floats over the transcript whenever the reader scrolls up, and on phone-width screens it obscured message content and drew far more attention than a scroll affordance needs.

## Why This Change Was Made

The affordance only needs to communicate "newer content below"; a compact icon button does that with a fraction of the footprint. The button is now an icon-only 36pt circle (SF Symbol `arrow.down`) with the same `subtleCard` fill and shadow treatment, matching the familiar chat-app pattern for scroll-to-bottom. A 4pt padding ring keeps the hit target at ~44pt. The accessibility label stays `Jump to latest reply`, so VoiceOver and the existing live-gateway UI test (`OpenClawSnapshotUITests`, which taps `app.buttons["Jump to latest reply"]`) are unaffected.

The view is shared chat UI (`OpenClawChatUI`), so the macOS quick chat gets the same compact button.

Removing the visible label retires the `Jump to latest` string: `pnpm native:i18n:sync` pruned it from the native inventory and the iOS string catalog (the `apps/ios/Tests/Info.plist` display-name line is that sync's own generated-artifact drift, aligned here so the next sync run is clean).

## User Impact

iOS (and macOS quick chat) users who scroll up in a conversation now see a small circular ↓ button instead of a wide labeled pill, leaving the transcript readable underneath. Tap behavior, appearance conditions, and accessibility are unchanged.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-ios-jump-to-latest/before.png" width="380" alt="Before: wide Jump to latest pill covering a line of chat text" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-ios-jump-to-latest/after.png" width="380" alt="After: compact circular arrow button" /> |

## Evidence

- Screenshots above captured on the iPhone 17 simulator (iOS 26.5) via the screenshot-fixture chat (`--openclaw-screenshot-mode`): seeded a scrollable conversation, swiped down to leave the live edge, and grabbed the frame with the overlay visible — identical recipe for both builds (HEAD vs. this branch).
- A scratch XCUITest driving that flow passed against both builds, asserting `app.buttons["Jump to latest reply"]` still appears after scrolling up and disappears after tap-through — the unchanged accessibility contract the shipped live-gateway E2E relies on.
- `swiftformat --lint --config config/swiftformat` clean on the changed file; `git diff --check` clean.
- `node scripts/native-app-i18n.ts sync --write` regenerated the inventory/catalog artifacts included here (string removal only; no new translations needed).
