### PR TITLE
fix(install): honor shared timeout during curl connection setup

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -140,8 +140,10 @@ download_file() {
     detect_downloader
   fi
   if [[ "$DOWNLOADER" == "curl" ]]; then
-    # Bound post-connect stalls without imposing a total download duration.
+    # Bound connection setup and post-connect stalls without imposing a
+    # total download duration.
     curl -fsSL --proto '=https' --tlsv1.2 \
+      --connect-timeout 20 \
       --speed-limit 1 --speed-time 30 \
       --retry 3 --retry-delay 1 --retry-connrefused \
       -o "$output" "$url"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -118,15 +118,18 @@ download_file() {
         detect_downloader
     fi
     if [[ "$DOWNLOADER" == "curl" ]]; then
+        # Bound connection setup and post-connect stalls without imposing a
+        # total download duration.
         if [[ "$redirect_mode" == "deny" ]]; then
             curl -fsSL --max-redirs 0 --proto '=https' --tlsv1.2 \
+                --connect-timeout 20 \
                 --speed-limit 1 --speed-time 30 \
                 --retry 3 --retry-delay 1 --retry-connrefused \
                 -o "$output" "$url"
             return
         fi
-        # Bound post-connect stalls without imposing a total download duration.
         curl -fsSL --proto '=https' --tlsv1.2 \
+            --connect-timeout 20 \
             --speed-limit 1 --speed-time 30 \
             --retry 3 --retry-delay 1 --retry-connrefused \
             -o "$output" "$url"

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -236,8 +236,8 @@ describe("install-cli.sh", () => {
     `);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--connect-timeout 20");
     expect(result.stdout).toContain("--speed-limit 1 --speed-time 30");
-    expect(result.stdout).not.toContain("--connect-timeout");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -166,6 +166,7 @@ describe("install.sh", () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("curl=-fsSL --max-redirs 0");
+      expect(result.stdout).toContain("--connect-timeout 20");
       expect(result.stdout).toContain("wget=-q --max-redirect=0");
       expect(result.stdout).toContain("managed-mode=deny");
     } finally {
@@ -188,8 +189,8 @@ describe("install.sh", () => {
     `);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--connect-timeout 20");
     expect(result.stdout).toContain("--speed-limit 1 --speed-time 30");
-    expect(result.stdout).not.toContain("--connect-timeout");
     expect(result.stdout).not.toContain("--max-redirs");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");


### PR DESCRIPTION
## What Problem This Solves

Makes curl connection setup honor the installers’ shared network-timeout budget, which was previously wired only to transfer-stall handling and wget. Curl’s ordinary connection default is already 300 seconds, so this is policy consistency and configurable-budget wiring—not a new faster default or a claim that ordinary curl waits forever.

## User Impact

Unix installs and upgrades apply the existing installer network-timeout budget to each curl connection attempt. Slow downloads that continue making progress still have no total-duration deadline. Retries, transfer-stall grace, HTTPS/TLS restrictions, redirect-denied managed-script downloads, and wget behavior are unchanged.

## Why This Change Was Made

The existing low-speed settings only cover the transfer phase. All three curl branches now also use `--connect-timeout "$UPDATE_NETWORK_TIMEOUT_SECONDS"`, following the same configured budget already used by the installers (currently 300 seconds).

**Maintainer decision:** use the existing shared timeout policy for curl connection setup; do not introduce the earlier proposed hard-coded 20-second cutoff. This resolves the prior review's separate-default concern. The original work by @xydigit-zt is preserved in the branch ancestry, with current main merged into that branch.

## Evidence

- Current-composition checks: **20 affected installer download tests passed**, including configured/default budgets, timeout propagation, and redirect policy. Node 24.20.0, repository-pinned pnpm 12.4.0, independent dependency installation.
- Exact-source review: **no P0–P2 findings** on the four-file correction.
- Both final `download_file` helpers are byte-identical to the previously exercised candidate: **24 real transport cases passed** for controlled DNS/TCP/TLS stalls, slow progress, redirects, and TLS/HTTPS rejection. Those results are historical helper-level evidence, not fresh current-head CI; the unchanged transport proof and full historical 363-test suite were not replayed.
- Native original-head review, guard, and artifact validation passed. Current-composition maintained checks **passed**: formatting, repository/dependency guards, root-test types, script/full-tree dead-export scans, script lint, and changed-test type-aware lint. Exact-head CI is linked below; refreshed native review is in progress. The completed external source review found no introduced code defect and accepted the shared-policy decision; the evidence requested by that review is included below.

No operator installer execution or release downloads were performed for these checks. The change is confined to the download helpers and their existing test files. The older 20-second/30-second measurements remain historical discussion evidence and do not describe this updated head.


## Inspectable retained transport evidence

These are the **existing September 15 results**, not newly executed current-head tests. The fixture sets `UPDATE_NETWORK_TIMEOUT_SECONDS=1` in the helper caller to make the shared-budget distinction observable. Ordinary shipped policy remains 300 seconds. Baseline watchdog exits at nine seconds do **not** establish an unbounded default; they show that the old curl helper ignored the fixture’s one-second shared budget. The candidate uses it for connection setup while preserving slow progress, retries, redirect policy and HTTPS/TLS verification.

Source binding (SHA-256 of the exact extracted `download_file` function bytes, including its final newline):

| Revision | Source path | Helper SHA-256 |
| --- | --- | --- |
| baseline | `scripts/install.sh` | `45da2c20e78435ef7d919b264f0abfaeaac085dcae9da1fec23517e4debacf46` |
| baseline | `scripts/install-cli.sh` | `279f5a972b16a2eaee60ca544a867baa653a49689da85f0a4959aca765beb0af` |
| candidate | `scripts/install.sh` | `f369c4694da5430a27d0eb6a86c9575aecfa29963a8370ac52cf1033f6cf34d5` |
| candidate | `scripts/install-cli.sh` | `3d61860bafb773bb72d230a6eb29641785adbfe1aa453b969ba5542f99ce509c` |

The historical baseline helpers are exact substrings of integration base `afc27e774fdad72872e16d49ca2fdbb667c2779f`; candidate helpers are exact substrings of published head `d5ac97491ad784394f685a86a8c0b9a8dba5a70e`. Full-script differences from the historical files consist only of the current-main pnpm fallback update (12.3.4 → 12.4.0), outside these helpers. Current test files match the historically formatted candidate byte-for-byte. The original raw stdout SHA-256 is `d8edecadbb9144ec0eba7ad991d234fe21ee6934fb892b124ee950a2385fb79b`; local verification of these bindings did not execute transport tests.

Pinned candidate source: [install.sh](https://github.com/openclaw/openclaw/blob/d5ac97491ad784394f685a86a8c0b9a8dba5a70e/scripts/install.sh#L150), [install-cli.sh](https://github.com/openclaw/openclaw/blob/d5ac97491ad784394f685a86a8c0b9a8dba5a70e/scripts/install-cli.sh#L175). [Current-head CI](https://github.com/openclaw/openclaw/actions/runs/35153299181).

Observed environment: `curl 8.18.0 (x86_64-pc-linux-gnu) libcurl/8.18.0 OpenSSL/3.5.5 zlib/1.3.1 brotli/1.2.0 zstd/1.5.7 libidn2/2.3.8 libpsl/0.21.2 libssh2/1.11.1 nghttp2/1.68.0 librtmp/2.3 mit-krb5/1.22.1 OpenLDAP/2.6.10`. The original helper-only fixture ran in a private Linux network/mount namespace with loopback DNS silence, TCP packet drop, and a TLS ClientHello sink; a separate local HTTPS server supplied slow-progress and redirect controls. No installer entry point or release server was executed.

<details>
<summary>All 24 retained case records (unchanged timing, exit, counters and diagnostics)</summary>

```jsonl
{"kind": "case", "revision": "baseline", "helper": "install", "mode": "follow", "case": "dns", "exit": -15, "watchdogStopped": true, "elapsedSeconds": 9.011, "stderr": "", "outputBytes": 0, "dnsQueries": 2, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "baseline", "helper": "install", "mode": "follow", "case": "tcp", "exit": -15, "watchdogStopped": true, "elapsedSeconds": 9.01, "stderr": "", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "baseline", "helper": "install", "mode": "follow", "case": "tls", "exit": -15, "watchdogStopped": true, "elapsedSeconds": 9.011, "stderr": "", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 1, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "dns", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.015, "stderr": "curl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\n", "outputBytes": 0, "dnsQueries": 8, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "tcp", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.017, "stderr": "curl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "tls", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.022, "stderr": "curl: (28) Connection timed out after 1003 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 4, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "slow", "exit": 0, "watchdogStopped": false, "elapsedSeconds": 2.015, "stderr": "", "outputBytes": 12, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": ["/slow"], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "redirect", "exit": 0, "watchdogStopped": false, "elapsedSeconds": 2.015, "stderr": "", "outputBytes": 12, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": ["/redirect", "/slow"], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "tls-verification", "exit": 60, "watchdogStopped": false, "elapsedSeconds": 0.016, "stderr": "curl: (60) SSL certificate OpenSSL verify result: self-signed certificate (18)\nMore details here: https://curl.se/docs/sslcerts.html\n\ncurl failed to verify the legitimacy of the server and therefore could not\nestablish a secure connection to it. To learn more about this situation and\nhow to fix it, please visit the webpage mentioned above.\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "follow", "case": "http-denied", "exit": 1, "watchdogStopped": false, "elapsedSeconds": 0.008, "stderr": "curl: (1) Protocol \"http\" disabled\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "dns", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.015, "stderr": "curl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\n", "outputBytes": 0, "dnsQueries": 8, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "tcp", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.017, "stderr": "curl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "tls", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.022, "stderr": "curl: (28) Connection timed out after 1002 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 4, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "slow", "exit": 0, "watchdogStopped": false, "elapsedSeconds": 2.014, "stderr": "", "outputBytes": 12, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": ["/slow"], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "redirect", "exit": 47, "watchdogStopped": false, "elapsedSeconds": 0.012, "stderr": "curl: (47) Maximum (0) redirects followed\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": ["/redirect"], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "tls-verification", "exit": 60, "watchdogStopped": false, "elapsedSeconds": 0.015, "stderr": "curl: (60) SSL certificate OpenSSL verify result: self-signed certificate (18)\nMore details here: https://curl.se/docs/sslcerts.html\n\ncurl failed to verify the legitimacy of the server and therefore could not\nestablish a secure connection to it. To learn more about this situation and\nhow to fix it, please visit the webpage mentioned above.\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install", "mode": "deny", "case": "http-denied", "exit": 1, "watchdogStopped": false, "elapsedSeconds": 0.007, "stderr": "curl: (1) Protocol \"http\" disabled\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "dns", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.014, "stderr": "curl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\ncurl: (28) Resolving timed out after 1000 milliseconds\n", "outputBytes": 0, "dnsQueries": 8, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "tcp", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.017, "stderr": "curl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "tls", "exit": 28, "watchdogStopped": false, "elapsedSeconds": 7.021, "stderr": "curl: (28) Connection timed out after 1003 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\ncurl: (28) Connection timed out after 1001 milliseconds\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 4, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "slow", "exit": 0, "watchdogStopped": false, "elapsedSeconds": 2.014, "stderr": "", "outputBytes": 12, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": ["/slow"], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "redirect", "exit": 0, "watchdogStopped": false, "elapsedSeconds": 2.015, "stderr": "", "outputBytes": 12, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": ["/redirect", "/slow"], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "tls-verification", "exit": 60, "watchdogStopped": false, "elapsedSeconds": 0.015, "stderr": "curl: (60) SSL certificate OpenSSL verify result: self-signed certificate (18)\nMore details here: https://curl.se/docs/sslcerts.html\n\ncurl failed to verify the legitimacy of the server and therefore could not\nestablish a secure connection to it. To learn more about this situation and\nhow to fix it, please visit the webpage mentioned above.\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "case", "revision": "candidate", "helper": "install-cli", "mode": "follow", "case": "http-denied", "exit": 1, "watchdogStopped": false, "elapsedSeconds": 0.008, "stderr": "curl: (1) Protocol \"http\" disabled\n", "outputBytes": 0, "dnsQueries": 0, "tlsClientHellos": 0, "httpRequests": [], "pass": true}
{"kind": "tcp-drop-counter", "output": "Chain OUTPUT (policy ACCEPT 332 packets, 88364 bytes)\n    pkts      bytes target     prot opt in     out     source               destination         \n      19     1140 DROP       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:43585\n"}
{"kind": "summary", "cases": 24, "failures": 0, "installerExecuted": false, "releaseFetches": 0, "dependencyGraphs": 0}
```

</details>

<details>
<summary>Original helper-only fixture source (not rerun)</summary>

The extracted baseline/candidate helper files and their SHA-256 bindings above supplied the fixture. The original invocation was `sudo -n unshare --net --mount --propagation private python3 transport-proof.py` in the disposable Linux proof environment. Host/controller paths, capacity probes and transient process/network-namespace IDs are omitted from this presentation; the following fixture body is unchanged.

```python
#!/usr/bin/env python3
"""Run only extracted installer download_file bodies in a private network namespace."""
import hashlib, http.server, json, os, pathlib, signal, socket, ssl, subprocess, threading, time
root = pathlib.Path(__file__).resolve().parent
results = []
def emit(event):
    results.append(event)
    print(json.dumps(event), flush=True)
    (root / "transport-results.json").write_text(json.dumps(results, indent=2)+"\n")
def command(args, **kw):
    return subprocess.run(args, check=True, capture_output=True, text=True, **kw)
emit({"kind":"environment","curl":command(["curl","--version"]).stdout,"netns":os.readlink("/proc/self/ns/net"),"pid":os.getpid(),"source":json.loads((root/"helper-bindings.json").read_text())})
command(["ip","link","set","lo","up"])
(root/"resolv.conf").write_text("nameserver 127.0.0.1\noptions timeout:30 attempts:1\n")
command(["mount","--bind",str(root/"resolv.conf"),"/etc/resolv.conf"])
dns_events=[]
dns = socket.socket(socket.AF_INET,socket.SOCK_DGRAM);dns.bind(("127.0.0.1",53))
def dns_loop():
    while True:
        packet,peer=dns.recvfrom(4096); dns_events.append({"bytes":len(packet),"at":time.monotonic()})
threading.Thread(target=dns_loop,daemon=True).start()
tls_events=[];tls_sockets=[]
stall=socket.socket();stall.bind(("127.0.0.1",0));stall.listen()
def tls_loop():
    while True:
        conn,peer=stall.accept();tls_sockets.append(conn)
        data=conn.recv(4096);tls_events.append({"bytes":len(data),"clientHello":data[:1]==b"\x16"})
threading.Thread(target=tls_loop,daemon=True).start()
tcp=socket.socket();tcp.bind(("127.0.0.1",0));tcp.listen()
tcp_port=tcp.getsockname()[1]
command(["iptables","-A","OUTPUT","-p","tcp","--dport",str(tcp_port),"-j","DROP"])
command(["openssl","req","-x509","-newkey","rsa:2048","-nodes","-keyout",str(root/"key.pem"),"-out",str(root/"cert.pem"),"-days","1","-subj","/CN=127.0.0.1","-addext","subjectAltName=IP:127.0.0.1"])
http_events=[]
class Handler(http.server.BaseHTTPRequestHandler):
    def log_message(self,*args): pass
    def do_GET(self):
        http_events.append(self.path)
        if self.path=="/redirect":
            self.send_response(302);self.send_header("Location","/slow");self.send_header("Content-Length","0");self.end_headers();return
        self.send_response(200);self.send_header("Content-Length","12");self.end_headers()
        try:
            for _ in range(6):
                self.wfile.write(b"ok");self.wfile.flush();time.sleep(0.4)
        except (BrokenPipeError,ConnectionResetError): pass
http=http.server.ThreadingHTTPServer(("127.0.0.1",0),Handler)
ctx=ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER);ctx.minimum_version=ssl.TLSVersion.TLSv1_2
ctx.load_cert_chain(root/"cert.pem",root/"key.pem");http.socket=ctx.wrap_socket(http.socket,server_side=True)
threading.Thread(target=http.serve_forever,daemon=True).start()
https=f"https://127.0.0.1:{http.server_port}"
env={k:v for k,v in os.environ.items() if k in ["PATH","LANG"]}
env.update({"HOME":str(root/"home"),"CURL_CA_BUNDLE":str(root/"cert.pem"),"NO_PROXY":"*","BASH_ENV":"","ENV":""})
(root/"home").mkdir(exist_ok=True)
def run_helper(revision,helper,mode,case,url,expected,deadline=11,ca=True):
    out=root/f"{revision}-{helper}-{mode}-{case}.data"
    body=(root/f"{revision}-{helper}.sh").read_text()
    script="set -eu\nDOWNLOADER=curl\nUPDATE_NETWORK_TIMEOUT_SECONDS=1\n"+body+'\ndownload_file "$1" "$2" "$3"\n'
    begin=time.monotonic();dns_before=len(dns_events);tls_before=len(tls_events);http_before=len(http_events)
    child_env=env.copy()
    if not ca:child_env.pop("CURL_CA_BUNDLE")
    p=subprocess.Popen(["/bin/bash","--noprofile","--norc","-c",script,"proof",url,str(out),mode],env=child_env,stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True,start_new_session=True)
    killed=False
    try:stdout,stderr=p.communicate(timeout=deadline)
    except subprocess.TimeoutExpired:
        killed=True;os.killpg(p.pid,signal.SIGTERM);stdout,stderr=p.communicate(timeout=3)
    elapsed=time.monotonic()-begin
    row={"kind":"case","revision":revision,"helper":helper,"mode":mode,"case":case,"exit":p.returncode,"watchdogStopped":killed,"elapsedSeconds":round(elapsed,3),"stderr":stderr,"outputBytes":out.stat().st_size if out.exists() else 0,"dnsQueries":len(dns_events)-dns_before,"tlsClientHellos":sum(e["clientHello"] for e in tls_events[tls_before:]),"httpRequests":http_events[http_before:]}
    if expected=="baseline-stall":
        ok=killed
    elif expected=="timeout":
        ok=not killed and p.returncode==28 and 0.7<elapsed<10
    elif expected=="slow":
        ok=not killed and p.returncode==0 and elapsed>1.5 and out.read_bytes()==b"ok"*6
    else:ok=not killed and p.returncode==expected
    if case=="dns":ok=ok and row["dnsQueries"]>0
    if case=="tls":ok=ok and row["tlsClientHellos"]>0
    row["pass"]=ok;emit(row)
    return ok
failures=0
urls={"dns":"https://stall.invalid/file","tcp":f"https://127.0.0.1:{tcp_port}/file","tls":f"https://127.0.0.1:{stall.getsockname()[1]}/file"}
for case,url in urls.items():
    failures+=not run_helper("baseline","install","follow",case,url,"baseline-stall",deadline=9)
for helper,mode in [("install","follow"),("install","deny"),("install-cli","follow")]:
    for case,url in urls.items():
        failures+=not run_helper("candidate",helper,mode,case,url,"timeout")
    failures+=not run_helper("candidate",helper,mode,"slow",https+"/slow","slow")
    failures+=not run_helper("candidate",helper,mode,"redirect",https+"/redirect",47 if mode=="deny" else "slow")
    failures+=not run_helper("candidate",helper,mode,"tls-verification",https+"/slow",60,ca=False)
    failures+=not run_helper("candidate",helper,mode,"http-denied",https.replace("https:","http:")+"/slow",1)
emit({"kind":"tcp-drop-counter","output":command(["iptables","-nvxL","OUTPUT"]).stdout})
emit({"kind":"summary","cases":sum(x.get("kind")=="case" for x in results),"failures":failures,"installerExecuted":False,"releaseFetches":0,"dependencyGraphs":0})
raise SystemExit(1 if failures else 0)
```

</details>
