### PR TITLE
fix(config): restore redacted array values by item identity

### DIFF
--- a/src/config/redact-snapshot.array-identity.test.ts
+++ b/src/config/redact-snapshot.array-identity.test.ts
@@ -266,6 +266,36 @@ describe("restoreRedactedValues — identity-keyed object arrays", () => {
   });
 });
 
+// Identity semantics: the restoration identity is the visible unique id exactly
+// as the client sends it back. Config entries are addressed by id rather than by
+// position — the schema gives every entry an `id`, lookups and per-agent state
+// resolve by that id, and config writes locate a row by finding its id — so an
+// item's array position is not its identity. (Uniqueness is conventional, not
+// schema-enforced; this module falls back to positional restore when an original
+// array violates it.) The complementary half of the contract — an id that was
+// not in the original inherits nothing — is covered by the fail-closed block
+// below.
+describe("restoreRedactedValues — identity semantics", () => {
+  const hints = { "rows[].mark": { sensitive: true } } as unknown as ConfigUiHints;
+  const original = {
+    rows: [
+      { id: "alpha", mark: "mark-alpha" },
+      { id: "bravo", mark: "mark-bravo" },
+    ],
+  };
+
+  it("restores values for the authoritative id when an original id is reused", () => {
+    const redacted = redactConfigObject(original, hints) as typeof original;
+    const sentinel = redacted.rows[0]?.mark;
+    // Final array holds a single item carrying the original id `alpha`.
+    const res = restoreRedactedValues({ rows: [{ id: "alpha", mark: sentinel }] }, original, hints);
+    expect(res.ok).toBe(true);
+    expect((res.result as typeof original).rows).toEqual([{ id: "alpha", mark: "mark-alpha" }]);
+    // The value belonging to a different id is not transferred.
+    expect(JSON.stringify(res.result)).not.toContain("mark-bravo");
+  });
+});
+
 describe("restoreRedactedValues — identity-keyed fail-closed edges", () => {
   const original = agentsConfig([
     { id: "alpha", mark: "mark-alpha" },

--- a/src/config/redact-snapshot.array-identity.test.ts
+++ b/src/config/redact-snapshot.array-identity.test.ts
@@ -1,0 +1,485 @@
+// Covers identity-based restoration of redacted values inside config object
+// arrays: removing, reordering, or inserting rows must restore each retained
+// row's own redacted values (matched by stable `id`) instead of following array
+// position. Arrays without a stable id keep positional restoration.
+//
+// The sensitive leaf is named `mark` here (marked sensitive purely through the
+// authored hints) rather than a real credential key: sensitivity in restore is
+// driven by the hint path, not the field name, so the identity logic is
+// exercised identically while the fixtures carry no secret-shaped values. The
+// real production path this protects is e.g. `agents.list[].memorySearch.remote.apiKey`.
+import { describe, expect, it } from "vitest";
+import type { ConfigUiHints } from "../shared/config-ui-hints-types.js";
+import { createRedactedArrayOriginalResolver } from "./redact-snapshot.array-identity.js";
+import { redactConfigObject, REDACTED_SENTINEL, restoreRedactedValues } from "./redact-snapshot.js";
+import { buildConfigSchema } from "./schema.js";
+
+const AGENT_MARK_HINTS = {
+  "agents.list[].mark": { sensitive: true },
+} as unknown as ConfigUiHints;
+
+const NESTED_MARK_HINTS = {
+  "agents.list[].telemetry.remote.mark": { sensitive: true },
+} as unknown as ConfigUiHints;
+
+type AgentEntry = { id?: string; mark?: unknown; label?: string };
+
+function agentsConfig(list: AgentEntry[]): { agents: { list: AgentEntry[] } } {
+  return { agents: { list } };
+}
+
+/** Builds the edited snapshot a client returns: the sensitive `mark` shown as the sentinel. */
+function redactMarks(list: AgentEntry[]): AgentEntry[] {
+  return list.map((entry) =>
+    "mark" in entry ? { ...entry, mark: REDACTED_SENTINEL } : { ...entry },
+  );
+}
+
+function restoreAgents(
+  incoming: unknown,
+  original: unknown,
+  hints: ConfigUiHints = AGENT_MARK_HINTS,
+) {
+  return restoreRedactedValues(incoming, original, hints);
+}
+
+// Mirrors production: the original item's id as the client receives it.
+const RAW_ID = (item: unknown): string | undefined => {
+  const id = (item as { id?: unknown } | null)?.id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+};
+const resolverFor = (
+  original: unknown[],
+  incoming: unknown[],
+  visibleIdOf: (item: unknown) => string | undefined = RAW_ID,
+) => createRedactedArrayOriginalResolver(original, incoming, visibleIdOf);
+
+describe("createRedactedArrayOriginalResolver", () => {
+  it("is identity-keyed when every original item has a unique string id", () => {
+    expect(resolverFor([{ id: "a" }, { id: "b" }], [{ id: "b" }]).identityKeyed).toBe(true);
+  });
+
+  it("is not identity-keyed when an item is missing an id", () => {
+    expect(resolverFor([{ id: "a" }, { label: "x" }], []).identityKeyed).toBe(false);
+  });
+
+  it("is not identity-keyed when original ids are duplicated", () => {
+    expect(resolverFor([{ id: "a" }, { id: "a" }], []).identityKeyed).toBe(false);
+  });
+
+  it("is not identity-keyed for empty, bare-string, or empty-id arrays", () => {
+    expect(resolverFor([], []).identityKeyed).toBe(false);
+    expect(resolverFor(["x", "y"], []).identityKeyed).toBe(false);
+    expect(resolverFor([{ id: "" }], []).identityKeyed).toBe(false);
+  });
+
+  it("resolves a retained row to its own original after a delete, not by position", () => {
+    const original = [{ id: "a" }, { id: "b" }];
+    expect(resolverFor(original, [{ id: "b" }]).resolve({ id: "b" }, 0)).toBe(original[1]);
+  });
+
+  it("restores bare (whole-item redacted) rows positionally, not by identity", () => {
+    // Items themselves sensitive -> incoming rows are bare sentinels with no id;
+    // keep the pre-existing positional original so unchanged saves are not lost.
+    const original = [{ id: "a" }, { id: "b" }];
+    const resolver = resolverFor(original, [REDACTED_SENTINEL, REDACTED_SENTINEL]);
+    expect(resolver.resolve(REDACTED_SENTINEL, 1)).toBe(original[1]);
+  });
+
+  it("stays positional when the id is redacted away", () => {
+    // Id not client-visible -> identity cannot apply, so the array round-trips
+    // positionally (unchanged saves are not rejected).
+    const original = [{ id: "a" }, { id: "b" }];
+    const resolver = resolverFor(
+      original,
+      [{ id: REDACTED_SENTINEL }, { id: REDACTED_SENTINEL }],
+      () => REDACTED_SENTINEL,
+    );
+    expect(resolver.identityKeyed).toBe(false);
+    expect(resolver.resolve({ id: REDACTED_SENTINEL }, 1)).toBe(original[1]);
+  });
+
+  it("keys on whatever visible id the redactor reports, not the stored id", () => {
+    // Identity applies to the id the client actually receives; production
+    // supplies that via the redactor (see the redact -> restore cases below).
+    const original = [{ id: "a" }, { id: "b" }];
+    const resolver = resolverFor(original, [{ id: "shown-b" }], (item) => `shown-${RAW_ID(item)}`);
+    expect(resolver.identityKeyed).toBe(true);
+    expect(resolver.resolve({ id: "shown-b" }, 0)).toBe(original[1]);
+  });
+
+  it("follows identity through a reorder", () => {
+    const original = [{ id: "a" }, { id: "b" }];
+    const resolver = resolverFor(original, [{ id: "b" }, { id: "a" }]);
+    expect(resolver.resolve({ id: "b" }, 0)).toBe(original[1]);
+    expect(resolver.resolve({ id: "a" }, 1)).toBe(original[0]);
+  });
+
+  it("resolves inserted, renamed, and duplicated ids to no original", () => {
+    const original = [{ id: "a" }, { id: "b" }];
+    const inserted = resolverFor(original, [{ id: "a" }, { id: "c" }, { id: "b" }]);
+    expect(inserted.resolve({ id: "c" }, 1)).toBeUndefined();
+    const renamed = resolverFor(original, [{ id: "a2" }, { id: "b" }]);
+    expect(renamed.resolve({ id: "a2" }, 0)).toBeUndefined();
+    const dup = resolverFor(original, [{ id: "a" }, { id: "a" }]);
+    expect(dup.resolve({ id: "a" }, 0)).toBeUndefined();
+  });
+
+  it("falls back to positional resolution for non-identity arrays", () => {
+    const original = ["x", "y"];
+    expect(resolverFor(original, [REDACTED_SENTINEL]).resolve(REDACTED_SENTINEL, 0)).toBe("x");
+  });
+});
+
+describe("restoreRedactedValues — identity-keyed object arrays", () => {
+  const original = agentsConfig([
+    { id: "alpha", mark: "mark-alpha" },
+    { id: "bravo", mark: "mark-bravo" },
+    { id: "charlie", mark: "mark-charlie" },
+  ]);
+
+  it("keeps each retained row's own value when the first row is deleted", () => {
+    const incoming = agentsConfig(
+      redactMarks([
+        { id: "bravo", mark: undefined },
+        { id: "charlie", mark: undefined },
+      ]),
+    );
+    const res = restoreAgents(incoming, original);
+    expect(res.ok).toBe(true);
+    const list = (res.result as typeof original).agents.list;
+    expect(list.map((a) => [a.id, a.mark])).toEqual([
+      ["bravo", "mark-bravo"],
+      ["charlie", "mark-charlie"],
+    ]);
+    // The deleted row's value must not survive on any retained row.
+    expect(JSON.stringify(list)).not.toContain("mark-alpha");
+  });
+
+  it("keeps own values when a middle row is deleted", () => {
+    const incoming = agentsConfig(
+      redactMarks([
+        { id: "alpha", mark: undefined },
+        { id: "charlie", mark: undefined },
+      ]),
+    );
+    const list = (restoreAgents(incoming, original).result as typeof original).agents.list;
+    expect(list.map((a) => a.mark)).toEqual(["mark-alpha", "mark-charlie"]);
+  });
+
+  it("keeps own values when the last row is deleted", () => {
+    const incoming = agentsConfig(
+      redactMarks([
+        { id: "alpha", mark: undefined },
+        { id: "bravo", mark: undefined },
+      ]),
+    );
+    const list = (restoreAgents(incoming, original).result as typeof original).agents.list;
+    expect(list.map((a) => a.mark)).toEqual(["mark-alpha", "mark-bravo"]);
+  });
+
+  it("follows identity through a reorder", () => {
+    const incoming = agentsConfig(
+      redactMarks([
+        { id: "charlie", mark: undefined },
+        { id: "alpha", mark: undefined },
+        { id: "bravo", mark: undefined },
+      ]),
+    );
+    const list = (restoreAgents(incoming, original).result as typeof original).agents.list;
+    expect(list.map((a) => [a.id, a.mark])).toEqual([
+      ["charlie", "mark-charlie"],
+      ["alpha", "mark-alpha"],
+      ["bravo", "mark-bravo"],
+    ]);
+  });
+
+  it("preserves an explicitly entered replacement value", () => {
+    const incoming = agentsConfig([
+      { id: "alpha", mark: "mark-rotated" },
+      { id: "bravo", mark: REDACTED_SENTINEL },
+      { id: "charlie", mark: REDACTED_SENTINEL },
+    ]);
+    const list = (restoreAgents(incoming, original).result as typeof original).agents.list;
+    expect(list.map((a) => a.mark)).toEqual(["mark-rotated", "mark-bravo", "mark-charlie"]);
+  });
+
+  it("restores an inserted row's real value and leaves existing rows intact", () => {
+    const incoming = agentsConfig([
+      { id: "alpha", mark: REDACTED_SENTINEL },
+      { id: "delta", mark: "mark-delta" },
+      { id: "bravo", mark: REDACTED_SENTINEL },
+      { id: "charlie", mark: REDACTED_SENTINEL },
+    ]);
+    const list = (restoreAgents(incoming, original).result as typeof original).agents.list;
+    expect(list.map((a) => [a.id, a.mark])).toEqual([
+      ["alpha", "mark-alpha"],
+      ["delta", "mark-delta"],
+      ["bravo", "mark-bravo"],
+      ["charlie", "mark-charlie"],
+    ]);
+  });
+
+  it("restores multiple redacted fields on the same identity", () => {
+    const multiOriginal = {
+      agents: {
+        list: [
+          { id: "alpha", mark: "mark-alpha", note: "note-alpha" },
+          { id: "bravo", mark: "mark-bravo", note: "note-bravo" },
+        ],
+      },
+    };
+    const hints = {
+      "agents.list[].mark": { sensitive: true },
+      "agents.list[].note": { sensitive: true },
+    } as unknown as ConfigUiHints;
+    const incoming = {
+      agents: { list: [{ id: "bravo", mark: REDACTED_SENTINEL, note: REDACTED_SENTINEL }] },
+    };
+    const res = restoreRedactedValues(incoming, multiOriginal, hints);
+    expect(res.ok).toBe(true);
+    expect((res.result as typeof multiOriginal).agents.list[0]).toEqual({
+      id: "bravo",
+      mark: "mark-bravo",
+      note: "note-bravo",
+    });
+  });
+
+  it("restores a deeply nested sensitive field by identity after a delete", () => {
+    // Mirrors the real production path agents.list[].memorySearch.remote.apiKey.
+    const deepOriginal = {
+      agents: {
+        list: [
+          { id: "alpha", telemetry: { remote: { mark: "deep-alpha" } } },
+          { id: "bravo", telemetry: { remote: { mark: "deep-bravo" } } },
+        ],
+      },
+    };
+    const incoming = {
+      agents: { list: [{ id: "bravo", telemetry: { remote: { mark: REDACTED_SENTINEL } } }] },
+    };
+    const res = restoreRedactedValues(incoming, deepOriginal, NESTED_MARK_HINTS);
+    expect(res.ok).toBe(true);
+    const list = (res.result as typeof deepOriginal).agents.list;
+    expect(list[0]?.telemetry.remote.mark).toBe("deep-bravo");
+    expect(JSON.stringify(list)).not.toContain("deep-alpha");
+  });
+});
+
+describe("restoreRedactedValues — identity-keyed fail-closed edges", () => {
+  const original = agentsConfig([
+    { id: "alpha", mark: "mark-alpha" },
+    { id: "bravo", mark: "mark-bravo" },
+  ]);
+
+  it("fails closed when a renamed row still shows a redacted value", () => {
+    const incoming = agentsConfig([
+      { id: "alpha-renamed", mark: REDACTED_SENTINEL },
+      { id: "bravo", mark: REDACTED_SENTINEL },
+    ]);
+    const res = restoreAgents(incoming, original);
+    expect(res.ok).toBe(false);
+    // The failure surfaces no restored value material.
+    expect(JSON.stringify(res)).not.toContain("mark-alpha");
+    expect(JSON.stringify(res)).not.toContain("mark-bravo");
+  });
+
+  it("fails closed on a duplicated id in the edited array", () => {
+    const incoming = agentsConfig([
+      { id: "alpha", mark: REDACTED_SENTINEL },
+      { id: "alpha", mark: REDACTED_SENTINEL },
+    ]);
+    expect(restoreAgents(incoming, original).ok).toBe(false);
+  });
+
+  it("does not migrate a deleted row's value onto a renamed row", () => {
+    const incoming = agentsConfig([{ id: "renamed", mark: REDACTED_SENTINEL }]);
+    const res = restoreAgents(incoming, original);
+    expect(res.ok).toBe(false);
+    expect(JSON.stringify(res)).not.toContain("mark-alpha");
+  });
+
+  it("fails closed when a retained row drops its id but keeps a redacted value", () => {
+    // A client that does not round-trip `id` cannot be identity-matched; the
+    // save is rejected rather than guessing which original the row is.
+    const incoming = agentsConfig([
+      { mark: REDACTED_SENTINEL },
+      { id: "bravo", mark: "mark-bravo" },
+    ]);
+    const res = restoreAgents(incoming, original);
+    expect(res.ok).toBe(false);
+    expect(JSON.stringify(res)).not.toContain("mark-alpha");
+  });
+});
+
+describe("restoreRedactedValues — non-regression", () => {
+  it("leaves an unchanged two-item array identical", () => {
+    const original = agentsConfig([
+      { id: "alpha", mark: "mark-alpha" },
+      { id: "bravo", mark: "mark-bravo" },
+    ]);
+    const incoming = agentsConfig(redactMarks(original.agents.list));
+    const res = restoreAgents(incoming, original);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(original);
+  });
+
+  it("keeps positional behavior for object arrays without a stable id", () => {
+    // No `id` field -> not identity-keyed -> legacy positional restore.
+    const original = {
+      agents: {
+        list: [
+          { name: "one", mark: "mark-one" },
+          { name: "two", mark: "mark-two" },
+        ],
+      },
+    };
+    const incoming = { agents: { list: [{ name: "two", mark: REDACTED_SENTINEL }] } };
+    const res = restoreRedactedValues(incoming, original, AGENT_MARK_HINTS);
+    expect(res.ok).toBe(true);
+    // Legacy positional restore pulls index 0 (documents unchanged behavior).
+    expect((res.result as typeof original).agents.list[0]?.mark).toBe("mark-one");
+  });
+
+  it("preserves env-var placeholders through restore unchanged", () => {
+    const original = agentsConfig([
+      { id: "alpha", mark: "${ALPHA_MARK}" },
+      { id: "bravo", mark: "mark-bravo" },
+    ]);
+    // Env placeholders are never redacted, so the client returns them verbatim.
+    const incoming = agentsConfig([
+      { id: "bravo", mark: REDACTED_SENTINEL },
+      { id: "alpha", mark: "${ALPHA_MARK}" },
+    ]);
+    const list = (restoreAgents(incoming, original).result as typeof original).agents.list;
+    expect(list.map((a) => [a.id, a.mark])).toEqual([
+      ["bravo", "mark-bravo"],
+      ["alpha", "${ALPHA_MARK}"],
+    ]);
+  });
+
+  it("round-trips an unchanged array whose id field is itself redaction-backed", () => {
+    // Both `id` and `mark` sensitive: the edited snapshot masks each id, so
+    // identity cannot apply; positional restore keeps the unchanged save working.
+    const idAndMarkHints = {
+      "agents.list[].id": { sensitive: true },
+      "agents.list[].mark": { sensitive: true },
+    } as unknown as ConfigUiHints;
+    const original = agentsConfig([
+      { id: "alpha", mark: "mark-alpha" },
+      { id: "bravo", mark: "mark-bravo" },
+    ]);
+    const incoming = agentsConfig([
+      { id: REDACTED_SENTINEL, mark: REDACTED_SENTINEL },
+      { id: REDACTED_SENTINEL, mark: REDACTED_SENTINEL },
+    ]);
+    const res = restoreRedactedValues(incoming, original, idAndMarkHints);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(original);
+  });
+
+  // Restore must agree with what the real redactor actually emits, not with an
+  // assumption about it. These drive redactConfigObject directly. In both hint
+  // shapes the ids themselves redact away, so they prove unchanged saves keep
+  // working via positional restore (identity coverage is the production-hints
+  // case above, where ids stay visible).
+  describe.each([
+    ["explicit id hint", { "rows[].id": { sensitive: true }, "rows[].mark": { sensitive: true } }],
+    ["wildcard hint", { "rows[].*": { sensitive: true } }],
+  ])("redact -> restore agreement, ids redact away (%s)", (_label, hintSpec) => {
+    it("round-trips an unchanged array", () => {
+      const hints = hintSpec as unknown as ConfigUiHints;
+      const original = {
+        rows: [
+          { id: "row-alpha", mark: "mark-alpha" },
+          { id: "row-bravo", mark: "mark-bravo" },
+        ],
+      };
+      const redacted = redactConfigObject(original, hints);
+      const res = restoreRedactedValues(redacted, original, hints);
+      expect(res.ok).toBe(true);
+      expect(res.result).toEqual(original);
+    });
+  });
+
+  it("keeps each agent's own secret on the real production schema hints", () => {
+    // Highest-value symmetry case: real uiHints + real redactor, on the shipped
+    // agents.list surface. Values are built indirectly so the fixture carries no
+    // literal secret-shaped assignment.
+    const hints = buildConfigSchema().uiHints;
+    const secretFor = (id: string) => `value-for-${id}`;
+    const original = {
+      agents: {
+        list: ["alpha", "bravo"].map((id) => ({
+          id,
+          memorySearch: { remote: { apiKey: secretFor(id) } },
+        })),
+      },
+    };
+    const redacted = redactConfigObject(original, hints) as typeof original;
+    // The client never receives the real values.
+    expect(JSON.stringify(redacted)).not.toContain(secretFor("alpha"));
+    // Unchanged round-trip is accepted and lossless.
+    const unchanged = restoreRedactedValues(redacted, original, hints);
+    expect(unchanged.ok).toBe(true);
+    expect(unchanged.result).toEqual(original);
+    // Deleting the first row must not move its value onto the retained row.
+    const afterDelete = restoreRedactedValues(
+      { agents: { list: [redacted.agents.list[1]] } },
+      original,
+      hints,
+    );
+    expect(afterDelete.ok).toBe(true);
+    const list = (afterDelete.result as typeof original).agents.list;
+    expect(list.map((a) => [a.id, a.memorySearch.remote.apiKey])).toEqual([
+      ["bravo", secretFor("bravo")],
+    ]);
+    expect(JSON.stringify(list)).not.toContain(secretFor("alpha"));
+  });
+
+  it("degrades to positional when an explicitly-sensitive id is redacted, env placeholder included", () => {
+    // A hinted-sensitive id is replaced even when it is an env placeholder (the
+    // placeholder escape only covers the plain-string branch), so the ids are
+    // not client-visible and the array must fall back to positional restore.
+    const hints = {
+      "rows[].id": { sensitive: true },
+      "rows[].mark": { sensitive: true },
+    } as unknown as ConfigUiHints;
+    const original = {
+      rows: [
+        { id: "${ALPHA_ID}", mark: "mark-alpha" },
+        { id: "${BRAVO_ID}", mark: "mark-bravo" },
+      ],
+    };
+    const redacted = redactConfigObject(original, hints) as typeof original;
+    expect(redacted.rows.map((r) => r.id)).toEqual([REDACTED_SENTINEL, REDACTED_SENTINEL]);
+    // Unchanged round-trip still succeeds losslessly via positional restore.
+    const res = restoreRedactedValues(redacted, original, hints);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(original);
+  });
+
+  it("round-trips an array whose name makes its id pattern-sensitive (ids redact away)", () => {
+    // `secretStores[].id` matches SENSITIVE_PATTERNS via the path, so the
+    // redactor hides the id even without an explicit hint; restore must agree.
+    const hints = { "secretStores[].mark": { sensitive: true } } as unknown as ConfigUiHints;
+    const original = {
+      secretStores: [
+        { id: "store-alpha", mark: "mark-alpha" },
+        { id: "store-bravo", mark: "mark-bravo" },
+      ],
+    };
+    const redacted = redactConfigObject(original, hints);
+    const res = restoreRedactedValues(redacted, original, hints);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(original);
+  });
+
+  it("leaves primitive arrays and nested structures untouched", () => {
+    const original = { tags: ["a", "b"], nested: { list: [{ id: "x", note: "keep" }] } };
+    const incoming = { tags: ["a", "b"], nested: { list: [{ id: "x", note: "keep" }] } };
+    const res = restoreRedactedValues(incoming, original, AGENT_MARK_HINTS);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(original);
+  });
+});

--- a/src/config/redact-snapshot.array-identity.test.ts
+++ b/src/config/redact-snapshot.array-identity.test.ts
@@ -266,36 +266,6 @@ describe("restoreRedactedValues — identity-keyed object arrays", () => {
   });
 });
 
-// Identity semantics: the restoration identity is the visible unique id exactly
-// as the client sends it back. Config entries are addressed by id rather than by
-// position — the schema gives every entry an `id`, lookups and per-agent state
-// resolve by that id, and config writes locate a row by finding its id — so an
-// item's array position is not its identity. (Uniqueness is conventional, not
-// schema-enforced; this module falls back to positional restore when an original
-// array violates it.) The complementary half of the contract — an id that was
-// not in the original inherits nothing — is covered by the fail-closed block
-// below.
-describe("restoreRedactedValues — identity semantics", () => {
-  const hints = { "rows[].mark": { sensitive: true } } as unknown as ConfigUiHints;
-  const original = {
-    rows: [
-      { id: "alpha", mark: "mark-alpha" },
-      { id: "bravo", mark: "mark-bravo" },
-    ],
-  };
-
-  it("restores values for the authoritative id when an original id is reused", () => {
-    const redacted = redactConfigObject(original, hints) as typeof original;
-    const sentinel = redacted.rows[0]?.mark;
-    // Final array holds a single item carrying the original id `alpha`.
-    const res = restoreRedactedValues({ rows: [{ id: "alpha", mark: sentinel }] }, original, hints);
-    expect(res.ok).toBe(true);
-    expect((res.result as typeof original).rows).toEqual([{ id: "alpha", mark: "mark-alpha" }]);
-    // The value belonging to a different id is not transferred.
-    expect(JSON.stringify(res.result)).not.toContain("mark-bravo");
-  });
-});
-
 describe("restoreRedactedValues — identity-keyed fail-closed edges", () => {
   const original = agentsConfig([
     { id: "alpha", mark: "mark-alpha" },
@@ -447,8 +417,13 @@ describe("restoreRedactedValues — non-regression", () => {
       },
     };
     const redacted = redactConfigObject(original, hints) as typeof original;
-    // The client never receives the real values.
-    expect(JSON.stringify(redacted)).not.toContain(secretFor("alpha"));
+    // Every entry must actually be redacted: the client never receives real
+    // values, and the delete case below only proves identity restoration if the
+    // retained entry was redacted too.
+    expect(redacted.agents.list.map((a) => a.memorySearch.remote.apiKey)).toEqual([
+      REDACTED_SENTINEL,
+      REDACTED_SENTINEL,
+    ]);
     // Unchanged round-trip is accepted and lossless.
     const unchanged = restoreRedactedValues(redacted, original, hints);
     expect(unchanged.ok).toBe(true);
@@ -484,6 +459,60 @@ describe("restoreRedactedValues — non-regression", () => {
     const redacted = redactConfigObject(original, hints) as typeof original;
     expect(redacted.rows.map((r) => r.id)).toEqual([REDACTED_SENTINEL, REDACTED_SENTINEL]);
     // Unchanged round-trip still succeeds losslessly via positional restore.
+    const res = restoreRedactedValues(redacted, original, hints);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(original);
+  });
+
+  it("keeps each hook mapping's own value on the real production schema hints", () => {
+    // Second real trigger path for the resolver (hooks.mappings[] carries an id
+    // and a redaction-backed descendant), locking that it gains no new semantics.
+    const hints = buildConfigSchema().uiHints;
+    const valueFor = (id: string) => `value-for-${id}`;
+    const original = {
+      hooks: { mappings: ["first", "second"].map((id) => ({ id, sessionKey: valueFor(id) })) },
+    };
+    const redacted = redactConfigObject(original, hints) as typeof original;
+    // Every entry must actually be redacted, otherwise the delete case below
+    // could pass without exercising identity-based restoration at all.
+    expect(redacted.hooks.mappings.map((m) => m.sessionKey)).toEqual([
+      REDACTED_SENTINEL,
+      REDACTED_SENTINEL,
+    ]);
+    const unchanged = restoreRedactedValues(redacted, original, hints);
+    expect(unchanged.ok).toBe(true);
+    expect(unchanged.result).toEqual(original);
+    // Removing the first entry leaves the retained entry with its own value.
+    const afterDelete = restoreRedactedValues(
+      { hooks: { mappings: [redacted.hooks.mappings[1]] } },
+      original,
+      hints,
+    );
+    expect(afterDelete.ok).toBe(true);
+    const mappings = (afterDelete.result as typeof original).hooks.mappings;
+    expect(mappings.map((m) => [m.id, m.sessionKey])).toEqual([["second", valueFor("second")]]);
+    expect(JSON.stringify(mappings)).not.toContain(valueFor("first"));
+  });
+
+  it("keeps hook mappings positional when only some entries carry an id", () => {
+    // hooks.mappings[].id is optional, so a real config can mix entries with and
+    // without ids. That array is not identity-keyed and must keep the existing
+    // positional behavior rather than matching partially.
+    const hints = buildConfigSchema().uiHints;
+    const valueFor = (id: string) => `value-for-${id}`;
+    const original = {
+      hooks: {
+        mappings: [
+          { id: "first", sessionKey: valueFor("first") },
+          { sessionKey: valueFor("second") },
+        ],
+      },
+    };
+    const redacted = redactConfigObject(original, hints) as typeof original;
+    expect(redacted.hooks.mappings.map((m) => m.sessionKey)).toEqual([
+      REDACTED_SENTINEL,
+      REDACTED_SENTINEL,
+    ]);
     const res = restoreRedactedValues(redacted, original, hints);
     expect(res.ok).toBe(true);
     expect(res.result).toEqual(original);

--- a/src/config/redact-snapshot.array-identity.ts
+++ b/src/config/redact-snapshot.array-identity.ts
@@ -71,24 +71,21 @@ interface RedactedArrayOriginalResolver {
 
 /**
  * Builds a resolver mapping each edited array item to the original item it may
- * restore redacted values from. Identity-keyed arrays match by `id`; unmatched,
- * renamed, or duplicated ids resolve to `undefined` so redacted placeholders
- * fail closed. Non-identity arrays resolve positionally, preserving existing
- * behaviour.
+ * restore redacted values from.
  *
- * Whether the array is identity-keyed is decided from the authoritative original
- * array, so a client cannot flip the whole array to positional by crafting an
- * `id`. (A client can still send a bare value for one row, which resolves that
- * row positionally — unchanged from before this indirection.) `visibleIdOf`
- * returns an original item's id
- * as the client receives it — the redactor's own output, so redaction rules are
- * never re-implemented here. Ids that redact away collapse to one sentinel key,
- * which reads as duplicate and keeps the array positional (unchanged saves are
- * not rejected). Otherwise identity applies per row only to object rows that
- * carry an id: a bare value (a whole-item redaction sentinel, or a sensitive
- * string array element) has no identity and restores positionally, exactly as
- * before; an object row missing or duplicating an `id` resolves to no original
- * so its redacted fields fail closed.
+ * An identity lookup is built only when the authoritative original array yields a
+ * unique, non-empty, client-visible id for every item. `visibleIdOf` reports each
+ * id as the redactor renders it, so redaction rules are never re-implemented
+ * here, and ids that redact away collapse to a single key and read as ambiguous.
+ * When identity cannot be established that way, the array resolves positionally
+ * and the caller's existing behaviour is untouched.
+ *
+ * With identity established, an object row matches its original by id, while a
+ * row whose id is missing, duplicated or absent from the original resolves to no
+ * original so its redacted placeholders fail closed rather than inheriting
+ * another row's value; a bare value carries no id and resolves positionally. The
+ * resolver only selects which original a row may draw from — values the client
+ * submitted explicitly are never replaced.
  */
 export function createRedactedArrayOriginalResolver(
   originalArray: unknown[],

--- a/src/config/redact-snapshot.array-identity.ts
+++ b/src/config/redact-snapshot.array-identity.ts
@@ -62,7 +62,7 @@ function findDuplicateStableIds(items: unknown[]): Set<string> {
   return duplicates;
 }
 
-export interface RedactedArrayOriginalResolver {
+interface RedactedArrayOriginalResolver {
   /** True when the original array is unambiguously keyed by a unique string `id`. */
   readonly identityKeyed: boolean;
   /** Resolves the original item that `incomingItem` may restore redacted values from. */

--- a/src/config/redact-snapshot.array-identity.ts
+++ b/src/config/redact-snapshot.array-identity.ts
@@ -1,0 +1,119 @@
+// Identity resolution for restoring redacted values inside config arrays.
+//
+// Redacted snapshots replace sensitive values with a sentinel and restore the
+// real value from the original config when a client saves an edited snapshot.
+// For object arrays the restore used to follow array position, so removing or
+// reordering a row could restore a different row's original value into a
+// retained row. When every original item carries a unique, non-empty string
+// `id`, this module matches edited items to their original by that identity
+// instead, and refuses to resolve ambiguous edits (renamed, inserted, or
+// duplicated ids) so redacted placeholders fail closed rather than inheriting a
+// neighbouring item's value. Arrays without a stable id keep positional matching.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+/** Returns an item's stable identity when it is an object with a non-empty string `id`. */
+function stableStringId(item: unknown): string | undefined {
+  if (!isRecord(item)) {
+    return undefined;
+  }
+  const id = item.id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+/**
+ * Indexes original items by the id the client actually receives, i.e. the id as
+ * it appears after redaction (`visibleIdOf`). Returns null unless every item
+ * yields a unique, non-empty visible id, so bare-value arrays, arrays with
+ * missing or duplicate ids, and arrays whose ids redact to the same sentinel all
+ * stay positional.
+ */
+function buildStableIdIdentityIndex(
+  originalArray: unknown[],
+  visibleIdOf: (item: unknown) => string | undefined,
+): Map<string, unknown> | null {
+  if (originalArray.length === 0) {
+    return null;
+  }
+  const index = new Map<string, unknown>();
+  for (const item of originalArray) {
+    const visibleId = visibleIdOf(item);
+    if (visibleId === undefined || index.has(visibleId)) {
+      return null;
+    }
+    index.set(visibleId, item);
+  }
+  return index;
+}
+
+/** Collects ids that appear more than once, which are ambiguous to restore. */
+function findDuplicateStableIds(items: unknown[]): Set<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const item of items) {
+    const id = stableStringId(item);
+    if (id === undefined) {
+      continue;
+    }
+    if (seen.has(id)) {
+      duplicates.add(id);
+    }
+    seen.add(id);
+  }
+  return duplicates;
+}
+
+export interface RedactedArrayOriginalResolver {
+  /** True when the original array is unambiguously keyed by a unique string `id`. */
+  readonly identityKeyed: boolean;
+  /** Resolves the original item that `incomingItem` may restore redacted values from. */
+  resolve(incomingItem: unknown, index: number): unknown;
+}
+
+/**
+ * Builds a resolver mapping each edited array item to the original item it may
+ * restore redacted values from. Identity-keyed arrays match by `id`; unmatched,
+ * renamed, or duplicated ids resolve to `undefined` so redacted placeholders
+ * fail closed. Non-identity arrays resolve positionally, preserving existing
+ * behaviour.
+ *
+ * Whether the array is identity-keyed is decided from the authoritative original
+ * array, so a client cannot flip the whole array to positional by crafting an
+ * `id`. (A client can still send a bare value for one row, which resolves that
+ * row positionally — unchanged from before this indirection.) `visibleIdOf`
+ * returns an original item's id
+ * as the client receives it — the redactor's own output, so redaction rules are
+ * never re-implemented here. Ids that redact away collapse to one sentinel key,
+ * which reads as duplicate and keeps the array positional (unchanged saves are
+ * not rejected). Otherwise identity applies per row only to object rows that
+ * carry an id: a bare value (a whole-item redaction sentinel, or a sensitive
+ * string array element) has no identity and restores positionally, exactly as
+ * before; an object row missing or duplicating an `id` resolves to no original
+ * so its redacted fields fail closed.
+ */
+export function createRedactedArrayOriginalResolver(
+  originalArray: unknown[],
+  incomingArray: unknown[],
+  visibleIdOf: (item: unknown) => string | undefined,
+): RedactedArrayOriginalResolver {
+  const identityIndex = buildStableIdIdentityIndex(originalArray, visibleIdOf);
+  if (!identityIndex) {
+    return {
+      identityKeyed: false,
+      resolve: (_incomingItem, index) => originalArray[index],
+    };
+  }
+  const duplicateIncomingIds = findDuplicateStableIds(incomingArray);
+  return {
+    identityKeyed: true,
+    resolve: (incomingItem, index) => {
+      if (!isRecord(incomingItem)) {
+        return originalArray[index];
+      }
+      const id = stableStringId(incomingItem);
+      if (id === undefined || duplicateIncomingIds.has(id)) {
+        return undefined;
+      }
+      return identityIndex.get(id);
+    },
+  };
+}

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -8,6 +8,7 @@ import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ConfigUiHints } from "../shared/config-ui-hints-types.js";
+import { createRedactedArrayOriginalResolver } from "./redact-snapshot.array-identity.js";
 import {
   replaceSensitiveValuesInRaw,
   shouldFallbackToStructuredRawRedaction,
@@ -616,17 +617,56 @@ function maybeRestoreSecretRefId(params: {
   return { handled: true, value: { ...incomingObj, id: originalObj.id } };
 }
 
+/**
+ * Returns an original array item's `id` as the client receives it, by running
+ * the id through the redactor itself. Restoring by identity only works against
+ * the value the client can send back, and the redaction rules (hint paths, the
+ * `*` wildcard, pattern fallback, explicit non-sensitive hints, env
+ * placeholders, URL scrubbing, and sensitive-primitive handling) are far too
+ * subtle to re-implement here: any divergence would either fail unchanged saves
+ * closed or silently drop back to positional restore. Ids that redact away all
+ * collapse to the same sentinel, which the caller reads as ambiguous.
+ */
+function createArrayVisibleIdReader(params: {
+  path: string;
+  lookup?: Set<string>;
+  hints?: ConfigUiHints;
+}): (item: unknown) => string | undefined {
+  return (item) => {
+    if (!isObjectRecord(item) || typeof item.id !== "string" || item.id.length === 0) {
+      return undefined;
+    }
+    const probe = params.lookup
+      ? redactObjectWithLookup({ id: item.id }, params.lookup, params.path, [], params.hints ?? {})
+      : redactObjectGuessing({ id: item.id }, params.path, [], params.hints);
+    const visibleId = isObjectRecord(probe) ? probe.id : undefined;
+    return typeof visibleId === "string" && visibleId.length > 0 ? visibleId : undefined;
+  };
+}
+
 function mapRedactedArray(params: {
   incoming: unknown[];
   original: unknown;
   path: string;
-  mapItem: (item: unknown, index: number, originalArray: unknown[]) => unknown;
+  // Returns an original item's `id` as the client receives it (post-redaction),
+  // so identity matching compares against what can actually be sent back.
+  visibleIdOf: (item: unknown) => string | undefined;
+  mapItem: (item: unknown, index: number, resolvedOriginal: unknown) => unknown;
 }): unknown[] {
   const originalArray = Array.isArray(params.original) ? params.original : [];
-  if (params.incoming.length < originalArray.length) {
+  const resolver = createRedactedArrayOriginalResolver(
+    originalArray,
+    params.incoming,
+    params.visibleIdOf,
+  );
+  if (!resolver.identityKeyed && params.incoming.length < originalArray.length) {
+    // Only positional arrays truncate here; identity-keyed arrays match removed
+    // and reordered rows by id, so a shorter array is not a lossy truncation.
     log.warn(`Redacted config array key ${params.path} has been truncated`);
   }
-  return params.incoming.map((item, index) => params.mapItem(item, index, originalArray));
+  return params.incoming.map((item, index) =>
+    params.mapItem(item, index, resolver.resolve(item, index)),
+  );
 }
 
 function toObjectRecord(value: unknown): Record<string, unknown> {
@@ -649,18 +689,17 @@ function toRestoreArrayContext(
 
 function restoreArrayItemWithLookup(params: {
   item: unknown;
-  index: number;
-  originalArray: unknown[];
+  original: unknown;
   lookup: Set<string>;
   path: string;
   hints: ConfigUiHints;
 }): unknown {
   if (params.item === REDACTED_SENTINEL) {
-    return params.originalArray[params.index];
+    return params.original;
   }
   return restoreRedactedValuesWithLookup(
     params.item,
-    params.originalArray[params.index],
+    params.original,
     params.lookup,
     params.path,
     params.hints,
@@ -669,8 +708,7 @@ function restoreArrayItemWithLookup(params: {
 
 function restoreArrayItemWithGuessing(params: {
   item: unknown;
-  index: number;
-  originalArray: unknown[];
+  original: unknown;
   path: string;
   hints?: ConfigUiHints;
 }): unknown {
@@ -679,14 +717,9 @@ function restoreArrayItemWithGuessing(params: {
     isSensitivePath(params.path) &&
     params.item === REDACTED_SENTINEL
   ) {
-    return params.originalArray[params.index];
+    return params.original;
   }
-  return restoreRedactedValuesGuessing(
-    params.item,
-    params.originalArray[params.index],
-    params.path,
-    params.hints,
-  );
+  return restoreRedactedValuesGuessing(params.item, params.original, params.path, params.hints);
 }
 
 function restoreGuessingArray(
@@ -699,11 +732,11 @@ function restoreGuessingArray(
     incoming,
     original,
     path,
-    mapItem: (item, index, originalArray) =>
+    visibleIdOf: createArrayVisibleIdReader({ path, hints }),
+    mapItem: (item, _index, resolvedOriginal) =>
       restoreArrayItemWithGuessing({
         item,
-        index,
-        originalArray,
+        original: resolvedOriginal,
         path,
         hints,
       }),
@@ -780,10 +813,12 @@ function restoreRedactedValuesWithLookup(
 
   const arrayContext = toRestoreArrayContext(incoming, prefix);
   if (arrayContext) {
-    // Note: If the user removed an item in the middle of the array,
-    // we have no way of knowing which one. In this case, the last
-    // element(s) get(s) chopped off. Not good, so please don't put
-    // sensitive string array in the config...
+    // Object arrays whose items carry a unique string `id` are matched by
+    // identity (see mapRedactedArray), so removing or reordering a row restores
+    // each retained row's own values. Arrays without that stable identity (e.g.
+    // bare sensitive string arrays) still restore positionally: if the user
+    // removed a middle item we cannot tell which one, so the last element(s)
+    // get chopped off — avoid putting bare sensitive string arrays in config.
     const { incoming: incomingArray, path } = arrayContext;
     if (!lookup.has(path)) {
       // Keep behavior symmetric with object fallback: if hints miss the path,
@@ -794,11 +829,11 @@ function restoreRedactedValuesWithLookup(
       incoming: incomingArray,
       original,
       path,
-      mapItem: (item, index, originalArray) =>
+      visibleIdOf: createArrayVisibleIdReader({ path, lookup, hints }),
+      mapItem: (item, _index, resolvedOriginal) =>
         restoreArrayItemWithLookup({
           item,
-          index,
-          originalArray,
+          original: resolvedOriginal,
           lookup,
           path,
           hints,
@@ -865,10 +900,12 @@ function restoreRedactedValuesGuessing(
 
   const arrayContext = toRestoreArrayContext(incoming, prefix);
   if (arrayContext) {
-    // Note: If the user removed an item in the middle of the array,
-    // we have no way of knowing which one. In this case, the last
-    // element(s) get(s) chopped off. Not good, so please don't put
-    // sensitive string array in the config...
+    // Object arrays whose items carry a unique string `id` are matched by
+    // identity (see mapRedactedArray), so removing or reordering a row restores
+    // each retained row's own values. Arrays without that stable identity (e.g.
+    // bare sensitive string arrays) still restore positionally: if the user
+    // removed a middle item we cannot tell which one, so the last element(s)
+    // get chopped off — avoid putting bare sensitive string arrays in config.
     const { incoming: incomingArray, path } = arrayContext;
     return restoreGuessingArray(incomingArray, original, path, hints);
   }


### PR DESCRIPTION
Closes #110658

## What Problem This Solves

Fixes an issue where operators editing config in the Control UI would silently get one entry's value saved onto a different entry when they removed or reordered a row in an object array such as `agents.list`.

Fields backed by a secret are shown as a redaction placeholder and restored from the saved config on save. That restore paired each edited row with the original row **by array position**, so deleting the first of two agents saved the retained agent with the deleted agent's `memorySearch.remote.apiKey`. The UI reported "Saved" and there was no error — the mismatch only showed up later in the durable config. Reordering produced the same class of mismatch, with values staying in their old positions instead of following their rows.

## Why This Change Was Made

Restore now follows **item identity** rather than array position. When every original item in an array carries a unique, non-empty `id` that the client can actually see, items are matched by that `id`, so removing or reordering a row restores each retained row's own value.

The identity an item is keyed by is taken from the redactor itself — each original `id` is run through the same redaction the client received, and the result is the lookup key. That avoids re-implementing (and drifting from) the redaction rules, which cover hint paths, `*` wildcards, pattern matching, explicit non-sensitive hints, env placeholders and URL scrubbing. When ids are not client-visible they all collapse to the same placeholder, which reads as ambiguous and keeps the array on the existing positional behavior, so those configs round-trip exactly as before.

Edits that cannot be resolved to the same identity — a renamed, duplicated or dropped `id` on a row that still shows a placeholder — fail closed rather than substituting another row's value. Arrays without a usable identity (bare values, id-less objects, duplicate ids) are untouched. No schema, protocol, storage or migration changes.

## User Impact

- Deleting or reordering a row in an id-keyed config array no longer copies another row's value onto a retained row.
- **Compatibility-sensitive:** renaming a row's `id` while a field on that row still shows the placeholder now fails the save instead of silently keeping the pre-rename value. This affects only the ambiguous edit and is safer than the previous silent substitution.

## Scope

This patch guarantees that redacted values are not moved between rows by array position:

- deleting a row while retaining another row with its own unchanged unique id restores only that row's values
- reordering rows with distinct unchanged unique ids restores each row's own values
- a previously unseen id inherits nothing
- duplicate, missing or otherwise ambiguous ids fail closed
- arrays without a usable identity keep the existing positional behavior

The resolver only engages where an array's items already carry a stable id: `agents.list[]`, `hooks.mappings[]` (its id is optional, so mixed entries stay positional), and `models.providers.*.models[]` (only when URL scrubbing actually rewrites the value). The `tools.media.*` model arrays have no item id and are unaffected.

### Not in scope

Reusing an id that belonged to another original row is unchanged by this patch. The final config payload does not encode row continuity separately from the id, so defining reject-versus-adopt behavior for that case requires a separate product decision. This branch does not make it.

## Evidence

Real Control UI against an isolated Gateway (dedicated port, isolated state dir, synthetic values, no external requests), on this branch and on unpatched `main` with the same harness:

| journey | unpatched `main` | this branch |
|---|---|---|
| delete `alpha`, save, reload | "Saved" — `bravo` gets **`synthetic-alpha`** | "Saved" — `bravo` keeps `synthetic-bravo` |
| reorder `[alpha, bravo]` → `[bravo, alpha]` | values stay in old positions | each id keeps its own value |
| rename `bravo` → `charlie` (placeholder kept) | "Saved" — pre-rename value silently retained | "Save failed", durable config unchanged, nothing bound to `charlie` |
| edit a non-secret field only | unchanged | "Saved", both values retained |

No browser console errors in any journey.

Tests (`src/config/redact-snapshot.array-identity.test.ts`): delete first/middle/last, reorder, insert, id rename, duplicate id, missing id, single/multiple/nested fields, explicit replacement preserved, env placeholders, and positional non-regression for id-less, bare-value and duplicate-id arrays. Several drive the real redactor end-to-end, including one on the real `buildConfigSchema().uiHints` for the shipped `agents.list` surface, so redact and restore are asserted to agree rather than assumed to.

Local: `src/config` suite 197 files / 2606 tests pass, `tsgo:core` and test types clean, lint and format clean.

### Journey transcript (isolated Gateway, synthetic values)

Real Control UI (Settings → Advanced → Raw) against a Gateway started on a dedicated port with an isolated state directory. Each journey: load config → edit → Save → full page reload → re-read durable config. Values are synthetic; no provider or network request was made — the runtime check stops at credential selection.

Client always receives placeholders, never values:

```
{"agents":{"list":[
  {"id":"alpha","memorySearch":{"remote":{"apiKey":"__OPENCLAW_REDACTED__"}}},
  {"id":"bravo","memorySearch":{"remote":{"apiKey":"__OPENCLAW_REDACTED__"}}}]}}
```

**Delete** — remove the `alpha` row, Save, reload:

```
before   alpha=synthetic-alpha, bravo=synthetic-bravo
action   delete row alpha -> Save -> reload
after    bravo=synthetic-bravo          (this branch)
after    bravo=synthetic-alpha          (unpatched main, same harness)
```

**Reorder** — `[alpha, bravo]` → `[bravo, alpha]`, Save, reload:

```
before   alpha=synthetic-alpha, bravo=synthetic-bravo
action   reorder -> Save -> reload
after    bravo=synthetic-bravo, alpha=synthetic-alpha
```

**Unseen-id rename fail-closed** — change `bravo` to `charlie` leaving the placeholder:

```
action   bravo -> charlie -> Save
UI       "Save failed"
gateway  Cannot un-redact config key agents.list[].memorySearch.remote.apiKey as it doesn't have any value
gateway  config.set errorCode=INVALID_REQUEST errorMessage=Sentinel value "__OPENCLAW_REDACTED__" in key agents.list[].memorySearch.remote.apiKey is not valid as real data
after    alpha=synthetic-alpha, bravo=synthetic-bravo   (durable config unchanged; nothing bound to charlie)
```

**Unchanged ids, metadata-only edit** — add a `name` to `alpha`, Save, reload:

```
after    alpha(name set)=synthetic-alpha, bravo=synthetic-bravo
```

No browser console errors in any journey.

