### PR TITLE
fix(discord): Activity token requests stop hanging on stalled bodies

### DIFF
--- a/extensions/discord/src/activities/http.test.ts
+++ b/extensions/discord/src/activities/http.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { createServer, request as createHttpRequest, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -37,6 +37,7 @@ async function startServer(
     vendorAssetPath?: string;
     readVendorAsset?: (assetPath: string) => Promise<Buffer>;
     logError?: (message: string) => void;
+    bodyTimeoutMs?: number;
   } = {},
 ): Promise<string> {
   const route = createDiscordActivityHttpHandler({
@@ -59,6 +60,39 @@ async function startServer(
   });
   const address = server.address() as AddressInfo;
   return `http://127.0.0.1:${address.port}`;
+}
+
+async function observeStalledTokenRequest(
+  base: string,
+  clientTimeoutMs: number,
+): Promise<"server-terminated" | "client-timeout"> {
+  return await new Promise((resolve) => {
+    const request = createHttpRequest(`${base}/discord/activity/api/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    let settled = false;
+    const finish = (outcome: "server-terminated" | "client-timeout") => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(outcome);
+    };
+    const timer = setTimeout(() => {
+      finish("client-timeout");
+      request.end();
+    }, clientTimeoutMs);
+    request.on("response", (response) => {
+      response.resume();
+      response.on("end", () => finish("server-terminated"));
+      response.on("close", () => finish("server-terminated"));
+    });
+    request.on("error", () => finish("server-terminated"));
+    request.on("close", () => finish("server-terminated"));
+    request.write('{"code":"');
+  });
 }
 
 function guardedJsonFetch(params?: {
@@ -124,6 +158,12 @@ function fetchInputUrl(input: string | URL | Request): string {
 }
 
 describe("Discord Activity HTTP OAuth", () => {
+  it("terminates stalled token request bodies within the read timeout", async () => {
+    const base = await startServer(createActivityTestRuntime(), { bodyTimeoutMs: 25 });
+
+    await expect(observeStalledTokenRequest(base, 1_000)).resolves.toBe("server-terminated");
+  });
+
   it("exchanges a code, creates a session, and uses it on the widget endpoint", async () => {
     const runtime = createActivityTestRuntime();
     const widgetId = await createWidget(runtime);

--- a/extensions/discord/src/activities/http.ts
+++ b/extensions/discord/src/activities/http.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { resolveRequestClientIp } from "openclaw/plugin-sdk/webhook-ingress";
+import {
+  readJsonBodyWithLimit,
+  WEBHOOK_BODY_READ_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import { parseDiscordActivityCustomId } from "../component-custom-id.js";
 import {
   DISCORD_TOKEN_URL,
@@ -39,6 +43,7 @@ type DiscordActivityHttpDeps = {
   now?: () => number;
   readVendorAsset?: (assetPath: string) => Promise<Buffer>;
   logError?: (message: string) => void;
+  bodyTimeoutMs?: number;
 };
 
 function setCommonHeaders(res: ServerResponse): void {
@@ -77,27 +82,6 @@ function notFound(res: ServerResponse, widgetDocument = false): true {
     "text/plain; charset=utf-8",
     widgetDocument ? { "Content-Security-Policy": DISCORD_ACTIVITY_WIDGET_CSP } : undefined,
   );
-}
-
-async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown> | null> {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of req) {
-    const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += data.byteLength;
-    if (total > BODY_MAX_BYTES) {
-      return null;
-    }
-    chunks.push(data);
-  }
-  try {
-    const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
-  } catch {
-    return null;
-  }
 }
 
 function readHeader(req: IncomingMessage, name: string): string | undefined {
@@ -140,6 +124,9 @@ export function createDiscordActivityHttpHandler(deps: DiscordActivityHttpDeps):
   const limiter = new TokenRateLimiter(deps.now ?? Date.now);
   const readVendorAsset = deps.readVendorAsset ?? ((assetPath: string) => fs.readFile(assetPath));
   const reportError = deps.logError ?? logError;
+  // The OAuth code body is unauthenticated and tiny. Reuse the pre-auth webhook budget so a
+  // stalled upload cannot retain a Gateway handler indefinitely.
+  const bodyTimeoutMs = deps.bodyTimeoutMs ?? WEBHOOK_BODY_READ_DEFAULTS.preAuth.timeoutMs;
   let vendorAsset: Promise<Buffer> | undefined;
   let pendingLaunchFailureLogged = false;
 
@@ -167,7 +154,21 @@ export function createDiscordActivityHttpHandler(deps: DiscordActivityHttpDeps):
     if (!account) {
       return respondJson(res, 503, { error: "Discord Activities is not fully configured" });
     }
-    const body = await readJsonBody(req);
+    const bodyResult = await readJsonBodyWithLimit(req, {
+      maxBytes: BODY_MAX_BYTES,
+      timeoutMs: bodyTimeoutMs,
+      emptyObjectOnEmpty: true,
+    });
+    if (!bodyResult.ok && bodyResult.code === "REQUEST_BODY_TIMEOUT") {
+      return respondJson(res, 408, { error: "request body timeout" });
+    }
+    const body =
+      bodyResult.ok &&
+      bodyResult.value &&
+      typeof bodyResult.value === "object" &&
+      !Array.isArray(bodyResult.value)
+        ? (bodyResult.value as Record<string, unknown>)
+        : null;
     const code = typeof body?.code === "string" ? body.code.trim() : "";
     if (!code) {
       return respondJson(res, 401, { error: "invalid authorization code" });


### PR DESCRIPTION
Related: #107442

## What Problem This Solves

Fixes an issue where a client that starts the Discord Activity OAuth token request but never finishes its JSON body can keep the plugin HTTP handler open indefinitely.

The route already capped the body at 8 KiB, but its `for await` reader had no time bound. A stalled upload therefore retained a Gateway request handler until the client or an outer network layer eventually disconnected.

## Why This Change Was Made

The Activity token route now uses the existing public Plugin SDK request-body guard with the same 8 KiB cap and the shared 5-second pre-auth read budget. The helper owns timer cleanup, connection-close handling, and stream destruction on timeout. Normal malformed or missing OAuth codes retain the existing 401 response; a body-read timeout is classified as 408 when the socket is still writable.

This PR was rebuilt from current `main`. The earlier client-side Activity shell deadline change and its test are not present in the current head; this diff contains only the independent server-side request-body fix.

## User Impact

Discord Activity launches no longer leave an OpenClaw Gateway handler waiting forever when the token upload stalls. Normal completed token exchanges, account selection, rate limiting, session creation, and widget delivery are unchanged.

## Evidence

Current-main red proof reproduces the unbounded live HTTP request; the final rebased head passes the focused regression, the full Discord Activities test directory, formatting, and path lint. The logs below are from the commands actually run for this diff.

### Current-main failure proof

The regression test runs a real localhost Node HTTP server, starts a chunked `POST /discord/activity/api/token`, writes a partial JSON body, and deliberately never ends it. On `origin/main` at `a54a292d62c`, the server did not terminate the request before the 1-second client watchdog. The final pre-push `origin/main` (`9e0780c5a0b`) did not change the Activity HTTP files or their bounded-body helper, so the before behavior remains patch-identical:

```text
$ node scripts/run-vitest.mjs extensions/discord/src/activities/http.test.ts

RUN  v4.1.10

❯ |extension-discord| extensions/discord/src/activities/http.test.ts (32 tests | 1 failed) 6390ms
    × terminates stalled token request bodies within the read timeout 5317ms

FAIL  |extension-discord| extensions/discord/src/activities/http.test.ts > Discord Activity HTTP OAuth > terminates stalled token request bodies within the read timeout
AssertionError: expected 'client-timeout' to be 'server-terminated'

Expected: "server-terminated"
Received: "client-timeout"

Test Files  1 failed (1)
Tests       1 failed | 31 passed (32)
Duration    20.03s

[test] failed 1 Vitest shard in 28.09s
```

### Focused green proof on the final rebased head

```text
$ node scripts/run-vitest.mjs extensions/discord/src/activities/http.test.ts

RUN  v4.1.10

Test Files  1 passed (1)
Tests       32 passed (32)
Duration    7.43s

[test] passed 1 Vitest shard in 15.40s
```

### Adjacent Discord Activities suite

```text
$ node scripts/run-vitest.mjs extensions/discord/src/activities

RUN  v4.1.10

Test Files  6 passed (6)
Tests       64 passed (64)
Duration    22.91s
```

### Formatting and lint

```text
$ ./node_modules/.bin/oxfmt --check extensions/discord/src/activities/http.ts extensions/discord/src/activities/http.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 153ms on 2 files using 8 threads.

$ ./node_modules/.bin/oxlint extensions/discord/src/activities/http.ts extensions/discord/src/activities/http.test.ts
# passed with no diagnostics

$ git diff --check origin/main...HEAD
# passed with no output
```

### Contract and owner-boundary checks

- Runtime entry point: the Discord plugin registers `/discord/activity` through its plugin-owned HTTP route.
- Canonical callee: `readJsonBodyWithLimit` in the public `openclaw/plugin-sdk/webhook-request-guards` subpath.
- Shared contract: pre-auth webhook body reads default to 5 seconds; timeout and connection-close paths remove listeners, clear the timer, and destroy the request stream without emitting an unhandled destroy error.
- Sibling usage checked: Mattermost, Telegram, and Nostr already route inbound bodies through the same bounded helper.
- Alternative rejected: a Gateway-global timeout would change every plugin route and is not present today; the Discord Activity route owns this tiny unauthenticated OAuth body.

### Broader gate and review notes

`node scripts/check-changed.mjs` correctly selected extension production/test checks, but remote delegation could not start because this host has no `blacksmith` executable and its direct AWS Crabbox broker is not logged in. The trusted-source local fallback then reached existing `packages/net-policy/src/ip.ts` type errors (`benchmarking`, `orchid2`, and the IPv4/IPv6 union call); those files are unchanged from `origin/main` and outside this diff. Focused runtime tests, the complete Activities suite, path lint, formatting, and diff checks are green; PR CI remains the broad type/build gate.

Fresh structured autoreview was attempted twice with the repository helper and the default Codex/Sol configuration. Both attempts ended in an engine failure before returning a verdict. An equivalent manual review covered the changed module, route registration caller, public SDK callee and tests, sibling inbound-body implementations, current-main behavior, and the final diff; no actionable in-scope finding remained.

### Submission guards

```text
origin/main: 9e0780c5a0b685cbb2fc54d6e4a9af01071e8a39
same-path open PRs: 0
symptom/symbol competing open PRs: 0
author open PRs in openclaw/openclaw: 16 (< 20)
```

Not exercised: a credentialed Discord Activity client. The defect is below the Discord client boundary and is reproduced against the actual plugin HTTP server/socket path without mocks; no Discord credential is needed to prove the stalled request is released.
