### PR TITLE
fix(macOS): bound sysctl/sw_vers presence probes with timeout

### DIFF
--- a/src/infra/system-presence.test.ts
+++ b/src/infra/system-presence.test.ts
@@ -1,7 +1,61 @@
 // Covers in-memory system presence merging and expiry behavior.
+import os from "node:os";
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => {
+  const fn = vi.fn();
+  // Safe default so the module-level initSelfPresence() probe at import time
+  // (which runs a real sysctl/sw_vers on darwin) never produces an undefined
+  // stdout that would break normalizeOptionalString.
+  fn.mockReturnValue({
+    stdout: "",
+    stderr: "",
+    pid: 1,
+    output: [],
+    status: 0,
+    signal: null,
+  });
+  return fn;
+});
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeChildProcessSpawnSync(spawnSyncMock, () =>
+    vi.importActual<typeof import("node:child_process")>("node:child_process"),
+  );
+});
+
 import { listSystemPresence, updateSystemPresence, upsertPresence } from "./system-presence.js";
+
+describe("system-presence macOS probe bounds", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes a timeout to the sysctl and sw_vers presence probes", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    spawnSyncMock.mockReturnValue({
+      stdout: "MacBookPro18,1\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    // initSelfPresence runs at import; re-trigger by forcing a repopulate path.
+    upsertPresence(randomUUID(), { host: "probe-host", mode: "ui", reason: "connect" });
+
+    const probedCommands = spawnSyncMock.mock.calls
+      .filter(([cmd]) => cmd === "sysctl" || cmd === "sw_vers")
+      .map(([, , opts]) => opts);
+    expect(probedCommands.length).toBeGreaterThan(0);
+    for (const opts of probedCommands) {
+      expect(opts?.timeout).toBeGreaterThan(0);
+    }
+  });
+});
 
 describe("system-presence", () => {
   afterEach(() => {

--- a/src/infra/system-presence.test.ts
+++ b/src/infra/system-presence.test.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from "node:crypto";
 // Covers in-memory system presence merging and expiry behavior.
 import os from "node:os";
-import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => {
@@ -26,14 +26,12 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { listSystemPresence, updateSystemPresence, upsertPresence } from "./system-presence.js";
-
 describe("system-presence macOS probe bounds", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("passes a timeout to the sysctl and sw_vers presence probes", () => {
+  it("passes a timeout to the sysctl and sw_vers presence probes", async () => {
     vi.spyOn(os, "platform").mockReturnValue("darwin");
     spawnSyncMock.mockReturnValue({
       stdout: "MacBookPro18,1\n",
@@ -44,18 +42,25 @@ describe("system-presence macOS probe bounds", () => {
       signal: null,
     });
 
-    // initSelfPresence runs at import; re-trigger by forcing a repopulate path.
+    vi.resetModules();
+    const { upsertPresence } = await import("./system-presence.js");
+
     upsertPresence(randomUUID(), { host: "probe-host", mode: "ui", reason: "connect" });
 
     const probedCommands = spawnSyncMock.mock.calls
       .filter(([cmd]) => cmd === "sysctl" || cmd === "sw_vers")
-      .map(([, , opts]) => opts);
+      .map((call) => call[2]);
     expect(probedCommands.length).toBeGreaterThan(0);
     for (const opts of probedCommands) {
       expect(opts?.timeout).toBeGreaterThan(0);
+      // Enforceable termination: a child that traps SIGTERM must still be
+      // reaped, so the probe uses SIGKILL rather than relying on SIGTERM.
+      expect(opts?.killSignal).toBe("SIGKILL");
     }
   });
 });
+
+import { listSystemPresence, updateSystemPresence, upsertPresence } from "./system-presence.js";
 
 describe("system-presence", () => {
   afterEach(() => {

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -61,6 +61,8 @@ function initSelfPresence() {
       const res = spawnSync("sysctl", ["-n", "hw.model"], {
         encoding: "utf-8",
         timeout: DARWIN_SYSTEM_PROBE_TIMEOUT_MS,
+        // SIGKILL guarantees the probe is reaped even if the child traps
+        // SIGTERM; a bare timeout would otherwise leave spawnSync waiting.
         killSignal: "SIGKILL",
       });
       const out = normalizeOptionalString(res.stdout) ?? "";


### PR DESCRIPTION
## What Problem This Solves

The macOS presence probes in `initSelfPresence` (`sysctl -n hw.model` and `sw_vers -productVersion`) run synchronously at gateway startup with no timeout. A hung or misbehaving binary could block the entire process.

## Why This Change Was Made

Aligns with the existing pattern in the codebase (Alix-007 style) of bounding all sync subprocess probes to prevent hangs.

## User Impact

No behavior change for normal operations. A hung binary will now be terminated after 5s instead of blocking indefinitely.

## Evidence

**Code changes:**
- `src/infra/system-presence.ts:60,69` — added `timeout: 5_000` to both `spawnSync` calls.

**Regression test:**
- `src/infra/system-presence.test.ts` — verifies timeout parameter is passed.
- Test now uses dynamic import after Darwin mock to ensure Linux CI validates the timeout option.

**Real macOS behavior proof:**
```
=== macOS Presence Probe Timeout Test ===
Platform: darwin
Testing bounded sysctl probe with 5s timeout...

sysctl -n hw.model:
  stdout: Mac16,12
  elapsed: 4 ms
  timeout: 5000ms (bound applied)
  status: 0

sw_vers -productVersion:
  stdout: 15.7.7
  elapsed: 9 ms
  timeout: 5000ms (bound applied)
  status: 0

=== Verification ===
✓ Both probes completed within timeout bound
✓ timeout: 5_000 parameter present in spawnSync options
✓ Probes successfully return model and version on macOS
```

**Environment tested:**
- Platform: darwin (macOS)
- macOS Version: 15.7.7
- Model: Mac16,12

**What was not tested:**
- Hung/misbehaving binary scenario (would require intentionally breaking `sysctl` or `sw_vers`)

**Impact:**
- Normal operations: No change (probes complete in <10ms)
- Hung binary scenario: Process will terminate after 5s instead of blocking indefinitely


### Real behavior proof (enforceable timeout termination)

`spawnSync` with a bare `timeout` does NOT guarantee termination: a child that traps SIGTERM keeps `spawnSync` waiting past the deadline. This PR adds `killSignal: "SIGKILL"` so the OS reaps a stuck probe.

Reproduced against a child that ignores SIGTERM (`trap '' TERM; sleep 30`):

```
[enforceable-with-SIGKILL]  PASS
  -> signal=SIGKILL status=null elapsed=2005ms
```

The probe returns at exactly the 2s timeout with `signal=SIGKILL`, confirming an unkillable-by-SIGTERM child is forcibly reaped. Both `sysctl` and `sw_vers` probes now set `timeout: 5000, killSignal: "SIGKILL"`; the regression test asserts `killSignal === "SIGKILL"` on both. `git diff --check` clean.
