### PR TITLE
fix(macOS): bound sw_vers diagnostic probe with timeout

### DIFF
--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -94,4 +94,24 @@ describe("resolveOsSummary", () => {
     }
     expect(resolveOsSummary()).toEqual(expected);
   });
+
+  it("passes a timeout to the sw_vers probe so a hung binary cannot block startup", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "release").mockReturnValue("24.0.0");
+    vi.spyOn(os, "arch").mockReturnValue("arm64");
+    spawnSyncMock.mockReturnValue({
+      stdout: " 15.4 \n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    resolveOsSummary();
+
+    const swVersCall = spawnSyncMock.mock.calls.find(([cmd]) => cmd === "sw_vers");
+    expect(swVersCall).toBeDefined();
+    expect(swVersCall?.[2]?.timeout).toBeGreaterThan(0);
+  });
 });

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -13,7 +13,7 @@ type OsSummary = {
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
 function macosVersion(): string {
-  const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
+  const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8", timeout: 5_000 });
   const out = normalizeOptionalString(res.stdout) ?? "";
   return out || os.release();
 }


### PR DESCRIPTION
## What Problem This Solves

The macOS diagnostic probe in `resolveOsSummary` (`sw_vers -productVersion`) runs synchronously with no timeout. A hung binary could block OS label resolution used in logs and diagnostics.

## Why This Change Was Made

Consistent with the codebase pattern of bounding sync subprocess probes.

## User Impact

No visible change for normal operations. A hung `sw_vers` will be terminated after 5s.

## Evidence

- `src/infra/os-summary.ts:16` — added `timeout: 5_000`.
- Regression test in `src/infra/os-summary.test.ts` verifies timeout is passed.