### PR TITLE
fix(cli): bound dns-cli subprocess probes with timeout

### DIFF
--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -1,8 +1,13 @@
-// Regression: dns-cli subprocess probes (DNS lookup + sudo tee) must be bounded
-// by a timeout so a hung binary cannot block `openclaw dns setup`.
-import { afterEach, describe, expect, it, vi } from "vitest";
+// Regression: the dns setup brew-prefix probe must be bounded by a SIGKILL-backed
+// timeout so a hung binary cannot block `openclaw dns setup`, while long-running
+// setup steps (install/restart/sudo writes) stay unbounded.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
+const testState = vi.hoisted(() => ({ zonePath: "" }));
 
 vi.mock("node:child_process", async () => {
   const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
@@ -13,7 +18,7 @@ vi.mock("node:child_process", async () => {
 
 vi.mock("../infra/widearea-dns.js", async () => {
   return {
-    getWideAreaZonePath: () => "/tmp/openclaw-dns-test.zone",
+    getWideAreaZonePath: () => testState.zonePath,
     normalizeWideAreaDomain: (d: string) => d,
     resolveWideAreaDiscoveryDomain: () => "openclaw.internal.",
   };
@@ -30,56 +35,74 @@ vi.mock("../config/config.js", async () => {
   return { getRuntimeConfig: () => ({}) };
 });
 
-import os from "node:os";
 import { Command } from "commander";
+import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import { registerDnsCli } from "./dns-cli.js";
 
+function spawnOk(stdout = "") {
+  return { stdout, stderr: "", pid: 1, output: [], status: 0, signal: null };
+}
+
+function isBrewPrefixProbe(call: unknown[]): boolean {
+  const args = call[1] as string[] | undefined;
+  return call[0] === "brew" && args?.[0] === "--prefix";
+}
+
 describe("dns-cli probe bounds", () => {
+  let brewPrefix: string;
+
+  beforeEach(() => {
+    // A real writable temp prefix lets the un-mocked fs writes (Corefile, conf.d,
+    // zone bootstrap) succeed on Linux CI without touching sudo paths.
+    brewPrefix = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-dns-cli-test-"));
+    testState.zonePath = path.join(brewPrefix, "test.zone");
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "brew" && args?.[0] === "--prefix") {
+        return spawnOk(`${brewPrefix}\n`);
+      }
+      return spawnOk();
+    });
+  });
+
   afterEach(() => {
+    fs.rmSync(brewPrefix, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
-  it("passes a timeout to spawned dns setup subprocesses", async () => {
-    vi.spyOn(os, "platform").mockReturnValue("darwin");
-    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "brew" && args?.[0] === "--prefix") {
-        return {
-          stdout: "/opt/homebrew",
-          stderr: "",
-          pid: 1,
-          output: [],
-          status: 0,
-          signal: null,
-        };
-      }
-      return {
-        stdout: "",
-        stderr: "",
-        pid: 1,
-        output: [],
-        status: 0,
-        signal: null,
-      };
-    });
-
+  async function runDnsSetupApply(): Promise<void> {
     const program = new Command();
     program.exitOverride();
     registerDnsCli(program);
+    // The action gates on process.platform; os.platform() is not consulted.
+    await withMockedPlatform("darwin", () =>
+      program.parseAsync([
+        "node",
+        "openclaw",
+        "dns",
+        "setup",
+        "--domain",
+        "openclaw.internal",
+        "--apply",
+      ]),
+    );
+  }
 
-    await program.parseAsync([
-      "node",
-      "openclaw",
-      "dns",
-      "setup",
-      "--domain",
-      "openclaw.internal",
-      "--apply",
-    ]);
+  it("bounds the brew prefix probe with a SIGKILL-backed timeout", async () => {
+    await runDnsSetupApply();
 
-    const spawned = spawnSyncMock.mock.calls;
-    expect(spawned.length).toBeGreaterThan(0);
-    for (const call of spawned) {
-      expect(call[2]?.timeout).toBeGreaterThan(0);
+    const probeCall = spawnSyncMock.mock.calls.find(isBrewPrefixProbe);
+    expect(probeCall).toBeDefined();
+    expect(probeCall?.[2]).toMatchObject({ timeout: 15_000, killSignal: "SIGKILL" });
+  });
+
+  it("leaves long-running setup subprocesses unbounded", async () => {
+    await runDnsSetupApply();
+
+    const nonProbeCalls = spawnSyncMock.mock.calls.filter((call) => !isBrewPrefixProbe(call));
+    expect(nonProbeCalls.length).toBeGreaterThan(0);
+    for (const call of nonProbeCalls) {
+      expect(call[2]?.timeout).toBeUndefined();
     }
   });
 });

--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -30,8 +30,8 @@ vi.mock("../config/config.js", async () => {
   return { getRuntimeConfig: () => ({}) };
 });
 
-import { Command } from "commander";
 import os from "node:os";
+import { Command } from "commander";
 import { registerDnsCli } from "./dns-cli.js";
 
 describe("dns-cli probe bounds", () => {
@@ -66,12 +66,20 @@ describe("dns-cli probe bounds", () => {
     program.exitOverride();
     registerDnsCli(program);
 
-    await program.parseAsync(["node", "openclaw", "dns", "setup", "--domain", "openclaw.internal", "--apply"]);
+    await program.parseAsync([
+      "node",
+      "openclaw",
+      "dns",
+      "setup",
+      "--domain",
+      "openclaw.internal",
+      "--apply",
+    ]);
 
     const spawned = spawnSyncMock.mock.calls;
     expect(spawned.length).toBeGreaterThan(0);
-    for (const [, , opts] of spawned) {
-      expect(opts?.timeout).toBeGreaterThan(0);
+    for (const call of spawned) {
+      expect(call[2]?.timeout).toBeGreaterThan(0);
     }
   });
 });

--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -1,0 +1,77 @@
+// Regression: dns-cli subprocess probes (DNS lookup + sudo tee) must be bounded
+// by a timeout so a hung binary cannot block `openclaw dns setup`.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeChildProcessSpawnSync(spawnSyncMock, () =>
+    vi.importActual<typeof import("node:child_process")>("node:child_process"),
+  );
+});
+
+vi.mock("../infra/widearea-dns.js", async () => {
+  return {
+    getWideAreaZonePath: () => "/tmp/openclaw-dns-test.zone",
+    normalizeWideAreaDomain: (d: string) => d,
+    resolveWideAreaDiscoveryDomain: () => "openclaw.internal.",
+  };
+});
+
+vi.mock("../infra/tailnet.js", async () => {
+  return {
+    pickPrimaryTailnetIPv4: () => "100.64.0.1",
+    pickPrimaryTailnetIPv6: () => undefined,
+  };
+});
+
+vi.mock("../config/config.js", async () => {
+  return { getRuntimeConfig: () => ({}) };
+});
+
+import { Command } from "commander";
+import os from "node:os";
+import { registerDnsCli } from "./dns-cli.js";
+
+describe("dns-cli probe bounds", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes a timeout to spawned dns setup subprocesses", async () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "brew" && args?.[0] === "--prefix") {
+        return {
+          stdout: "/opt/homebrew",
+          stderr: "",
+          pid: 1,
+          output: [],
+          status: 0,
+          signal: null,
+        };
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        pid: 1,
+        output: [],
+        status: 0,
+        signal: null,
+      };
+    });
+
+    const program = new Command();
+    program.exitOverride();
+    registerDnsCli(program);
+
+    await program.parseAsync(["node", "openclaw", "dns", "setup", "--domain", "openclaw.internal", "--apply"]);
+
+    const spawned = spawnSyncMock.mock.calls;
+    expect(spawned.length).toBeGreaterThan(0);
+    for (const [, , opts] of spawned) {
+      expect(opts?.timeout).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -15,13 +15,18 @@ import {
 } from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
 
-type RunOpts = { allowFailure?: boolean; inherit?: boolean };
+type RunOpts = { allowFailure?: boolean; inherit?: boolean; timeoutMs?: number };
 
 function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
-    timeout: 15_000,
+    // Timeout stays opt-in: install/restart/sudo-write steps may legitimately run
+    // long, so only fast probes pass a deadline. SIGKILL guarantees a
+    // signal-resistant hung probe still dies at the deadline.
+    ...(opts?.timeoutMs === undefined
+      ? {}
+      : { timeout: opts.timeoutMs, killSignal: "SIGKILL" as const }),
   });
   if (res.error) {
     throw res.error;
@@ -52,7 +57,6 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
-    timeout: 15_000,
   });
   if (res.error) {
     throw res.error;
@@ -89,7 +93,8 @@ function zoneFileNeedsBootstrap(zonePath: string): boolean {
 }
 
 function detectBrewPrefix(): string {
-  const out = run("brew", ["--prefix"]);
+  // A hung brew shim can block setup indefinitely; bound only this fast probe.
+  const out = run("brew", ["--prefix"], { timeoutMs: 15_000 });
   const prefix = out.trim();
   if (!prefix) {
     throw new Error("failed to resolve Homebrew prefix");

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -21,6 +21,7 @@ function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    timeout: 15_000,
   });
   if (res.error) {
     throw res.error;
@@ -51,6 +52,7 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
+    timeout: 15_000,
   });
   if (res.error) {
     throw res.error;


### PR DESCRIPTION
## What Problem This Solves

The `brew --prefix` capability probe in `dns-cli.ts` uses `spawnSync` without a timeout. A hung DNS tool shim can block `openclaw dns setup --apply` indefinitely before setup even starts.

## Why This Change Was Made

Prevents indefinite hangs from a misbehaving `brew` probe during DNS setup, without changing the behavior of legitimate long-running setup steps.

## User Impact

No functional change for normal setups. The `brew --prefix` probe is now bounded by a 15s SIGKILL-backed deadline, so a hung (even signal-resistant) probe terminates and the CLI exits with a clear error instead of blocking forever. Install, service restart, and sudo file-write steps keep their previous unbounded wait.

## Evidence

Real environment: macOS (Darwin 24.6.0 arm64), Node v24.18.0, pnpm 11.2.2. Both runs use a real built CLI (`pnpm install && pnpm build`, launched via `node openclaw.mjs`). A controlled hung `brew` shim (`#!/bin/sh` + `exec sleep 3600`) is placed first on `PATH`, so `dns setup --apply` blocks inside the real `brew --prefix` probe in `run()`. The test machine has no Tailscale, so a `NODE_OPTIONS=--import` preload injects a fake `100.64.0.1` interface entry to pass the command's tailnet-IP gate; that gate is unrelated to this change and no production code was modified for the harness. State is isolated via `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` pointing at a scratch dir.

Exact command:

```sh
node openclaw.mjs dns setup --domain openclaw.internal --apply
```

Before (upstream/main @ 28069db63aa, same harness): the CLI prints the setup plan, then blocks inside the hung probe and never returns; the outer guard kills it after 40s.

```
Tailscale admin (DNS → Nameservers):
- Add nameserver: 100.64.0.1
- Restrict to domain (Split DNS): openclaw.internal
---- result ----
elapsed_seconds=41
exit_code=137
verdict=CLI STILL BLOCKED after 40s guard; killed by harness (unbounded hang)
```

After (this PR @ d41b4ffa10b): the probe's 15s deadline fires, `spawnSync brew ETIMEDOUT` is reported, and the CLI exits with a clear error instead of blocking (~3s CLI startup + 15s timeout = 18s). `ps` afterwards shows no leftover `sleep 3600` process, i.e. SIGKILL reaped the hung probe.

```
Tailscale admin (DNS → Nameservers):
- Add nameserver: 100.64.0.1
- Restrict to domain (Split DNS): openclaw.internal
[openclaw] Could not start the CLI.
[openclaw] Reason: spawnSync brew ETIMEDOUT
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
---- result ----
elapsed_seconds=18
exit_code=1
leftover hung brew/sleep processes: (none)
verdict=CLI returned on its own after 18s; hung probe SIGKILLed, nothing leaked
```

Regression tests (`pnpm test src/cli/dns-cli.test.ts`):

```
✓ |cli| src/cli/dns-cli.test.ts (2 tests) 62ms
  ✓ bounds the brew prefix probe with a SIGKILL-backed timeout
  ✓ leaves long-running setup subprocesses unbounded
Test Files  1 passed (1)
     Tests  2 passed (2)
```

What was not tested: full CoreDNS install end-to-end (requires Homebrew + sudo + a real Tailscale interface on the host); the bounded-probe behavior this PR changes is covered by the controlled hung-subprocess run above, and the unbounded behavior of install/restart/sudo steps is covered by the focused test.
