### PR TITLE
fix(diagnostics-otel): ignore blank protocol env overrides

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -210,6 +210,7 @@ const PROTO_KEY = "__proto__";
 const MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS = 128 * 1024;
 const OTEL_TRUNCATED_SUFFIX_MAX_CHARS = 20;
 const ORIGINAL_OPENCLAW_OTEL_PRELOADED = process.env.OPENCLAW_OTEL_PRELOADED;
+const ORIGINAL_OTEL_EXPORTER_OTLP_PROTOCOL = process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
 const ORIGINAL_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
 const ORIGINAL_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
   process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
@@ -563,6 +564,7 @@ describe("diagnostics-otel service", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
     delete process.env.OPENCLAW_OTEL_PRELOADED;
+    delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
     delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
     telemetryState.counters.clear();
     telemetryState.histograms.clear();
@@ -597,6 +599,11 @@ describe("diagnostics-otel service", () => {
       delete process.env.OPENCLAW_OTEL_PRELOADED;
     } else {
       process.env.OPENCLAW_OTEL_PRELOADED = ORIGINAL_OPENCLAW_OTEL_PRELOADED;
+    }
+    if (ORIGINAL_OTEL_EXPORTER_OTLP_PROTOCOL === undefined) {
+      delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
+    } else {
+      process.env.OTEL_EXPORTER_OTLP_PROTOCOL = ORIGINAL_OTEL_EXPORTER_OTLP_PROTOCOL;
     }
     if (ORIGINAL_OTEL_SEMCONV_STABILITY_OPT_IN === undefined) {
       delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
@@ -1222,6 +1229,44 @@ describe("diagnostics-otel service", () => {
       capture.spy.mockRestore();
       await service.stop?.(ctx);
     }
+  });
+
+  test("ignores blank OTLP protocol env overrides", async () => {
+    process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "   ";
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    if (ctx.config.diagnostics?.otel) {
+      delete ctx.config.diagnostics.otel.protocol;
+    }
+
+    try {
+      await service.start(ctx);
+
+      expect(traceExporterCtor).toHaveBeenCalledOnce();
+      expect(metricExporterCtor).toHaveBeenCalledOnce();
+      expect(ctx.logger.warn).not.toHaveBeenCalledWith(
+        "diagnostics-otel: unsupported protocol    ",
+      );
+    } finally {
+      await service.stop?.(ctx);
+    }
+  });
+
+  test("preserves nonblank OTLP protocol env overrides", async () => {
+    process.env.OTEL_EXPORTER_OTLP_PROTOCOL = " http/protobuf ";
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    if (ctx.config.diagnostics?.otel) {
+      delete ctx.config.diagnostics.otel.protocol;
+    }
+
+    await service.start(ctx);
+
+    expect(traceExporterCtor).not.toHaveBeenCalled();
+    expect(metricExporterCtor).not.toHaveBeenCalled();
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "diagnostics-otel: unsupported protocol  http/protobuf ",
+    );
   });
 
   test("exports trusted security events as stdout JSONL logs", async () => {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -129,7 +129,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      const protocol = otel.protocol ?? process.env.OTEL_EXPORTER_OTLP_PROTOCOL ?? "http/protobuf";
+      const envProtocol = process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
+      const protocol = otel.protocol ?? (envProtocol?.trim() ? envProtocol : "http/protobuf");
       if (otlpSignals.length > 0 && protocol !== "http/protobuf") {
         emitForSignals(otlpSignals, {
           exporter: "diagnostics-otel",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the diagnostics OpenTelemetry plugin could lose all configured OTLP telemetry when `OTEL_EXPORTER_OTLP_PROTOCOL` was present but blank and no plugin-level protocol was set. The blank value was treated as an unsupported protocol, so service startup returned before creating exporters.

## Why This Change Was Made

Blank protocol environment values are now treated as absent while explicit plugin configuration and the exact value of every nonblank environment override remain unchanged. This avoids changing which nonblank protocol strings are accepted while restoring the existing `http/protobuf` default for blank values.

## User Impact

Blank or whitespace-only protocol environment values no longer disable OTLP traces, metrics, or logs. Explicit and nonblank unsupported protocol values keep their previous behavior.

## Evidence

On Node `v24.18.0`, I drove the real exported `createDiagnosticsOtelService()` with traces enabled and `OTEL_EXPORTER_OTLP_PROTOCOL='   '`. The same production-entry command produced this result on unmodified `upstream/main` (`f98bcb7fa73`):

```json
{
  "exporterEvents": [
    { "signal": "traces", "status": "failure", "reason": "unsupported_protocol" }
  ],
  "logs": [["warn", "diagnostics-otel: unsupported protocol    "]]
}
```

After this change, the service passed the protocol gate and reported the real exporter lifecycle as started:

```json
{
  "exporterEvents": [
    { "signal": "traces", "status": "started", "reason": "configured" }
  ],
  "logs": []
}
```

Focused validation:

```text
node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts
Test Files  1 passed (1)
Tests       110 passed (110)
```

Replacing only `service.ts` with the real `upstream/main` version made the new blank-protocol test fail because both exporter constructors had zero calls. `CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --staged` also passed, including extension/test type checks, targeted lint, formatting, plugin boundaries, and import-cycle checks. Final autoreview reported no accepted/actionable findings.

No live OTLP collector delivery was tested; the defect and fix occur during the real service startup protocol gate, before any collector request.

AI-assisted: Codex helped implement and review the change; the production-entry proof and validation commands above were run manually.
