### PR TITLE
fix(thread-ownership): ignore blank forwarder URL env overrides

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -139,6 +139,49 @@ describe("thread-ownership plugin", () => {
       );
     });
 
+    it("uses the default forwarder URL when the env override is blank", async () => {
+      process.env.SLACK_FORWARDER_URL = "   ";
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toBeUndefined();
+      expectOwnershipFetchCall(
+        0,
+        "http://slack-forwarder:8750/api/v1/ownership/C123/1234.5678",
+        "test-agent",
+      );
+    });
+
+    it("keeps live plugin config ahead of the env override", async () => {
+      configFile = {
+        ...configFile,
+        plugins: {
+          entries: {
+            "thread-ownership": {
+              config: {
+                forwarderUrl: "http://config-forwarder:8750",
+              },
+            },
+          },
+        },
+      };
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toBeUndefined();
+      expectOwnershipFetchCall(
+        0,
+        "http://config-forwarder:8750/api/v1/ownership/C123/1234.5678",
+        "test-agent",
+      );
+    });
+
     it("prefers shared conversationId over non-canonical Slack target shapes", async () => {
       vi.mocked(globalThis.fetch).mockResolvedValue(
         new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -96,7 +96,7 @@ export default definePluginEntry({
         currentConfig,
         forwarderUrl: (
           pluginCfg.forwarderUrl ??
-          process.env.SLACK_FORWARDER_URL ??
+          normalizeOptionalString(process.env.SLACK_FORWARDER_URL) ??
           "http://slack-forwarder:8750"
         ).replace(/\/$/, ""),
         abTestChannels: new Set(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack thread ownership coordination silently failed open when `SLACK_FORWARDER_URL` was present but blank and the plugin had no configured forwarder URL. The blank value produced an invalid request URL, so no ownership claim reached the existing default forwarder.

## Why This Change Was Made

The environment override is normalized before the existing config → env → default precedence is applied. Live plugin config, nonblank environment overrides, SSRF policy, and the existing fail-open decision are unchanged.

## User Impact

Thread replies can again claim ownership through the default `http://slack-forwarder:8750` service when the environment override is blank.

## Evidence

On Node `v24.18.0`, I registered the real plugin entry and invoked its real `message_sending` hook with `SLACK_FORWARDER_URL='   '`. The only stub was the HTTP transport, used to capture the pre-network URL and body. On unmodified `upstream/main` (`f98bcb7fa73`), no request reached that seam and the plugin logged:

```json
{
  "requested": [],
  "result": null,
  "warnings": [
    "thread-ownership: ownership check failed (Error: Invalid URL: must be http or https), allowing send"
  ]
}
```

After this change, the same production hook issued the expected ownership claim without warnings:

```json
{
  "requested": [
    {
      "url": "http://slack-forwarder:8750/api/v1/ownership/C123/1234.5678",
      "method": "POST",
      "body": "{\"agent_id\":\"proof-agent\"}"
    }
  ],
  "result": null,
  "warnings": []
}
```

Focused validation:

```text
node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts
Test Files  1 passed (1)
Tests       23 passed (23)
```

Replacing only `index.ts` with the real `upstream/main` version made the new blank-override test fail because the ownership fetch was never called. `CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --staged` also passed, including extension/test type checks, targeted lint, formatting, plugin boundaries, and import-cycle checks. Autoreview reported no accepted/actionable findings.

No live Slack or forwarder deployment was used; URL selection fails before network I/O, and the proof drives the production hook while stubbing only its transport boundary.

AI-assisted: Codex helped implement and review the change; the production-entry proof and validation commands above were run manually.
