### PR TITLE
fix(push): ignore blank timeout env overrides

### DIFF
--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -144,6 +144,29 @@ describe("push-apns.relay", () => {
       });
     });
 
+    it("uses the configured timeout when the env override is blank", () => {
+      const resolved = resolveApnsRelayConfigFromEnv(
+        {
+          OPENCLAW_APNS_RELAY_BASE_URL: "https://relay.example.com",
+          OPENCLAW_APNS_RELAY_TIMEOUT_MS: "   ",
+        } as NodeJS.ProcessEnv,
+        {
+          push: {
+            apns: {
+              relay: {
+                timeoutMs: 2500,
+              },
+            },
+          },
+        },
+      );
+
+      expectRelayConfig(resolved, {
+        baseUrl: "https://relay.example.com",
+        timeoutMs: 2500,
+      });
+    });
+
     it("allows loopback http URLs for alternate truthy env values", () => {
       const resolved = resolveApnsRelayConfigFromEnv({
         OPENCLAW_APNS_RELAY_BASE_URL: "http://[::1]:8787",

--- a/src/infra/push-apns.relay.ts
+++ b/src/infra/push-apns.relay.ts
@@ -249,7 +249,7 @@ export function resolveApnsRelayConfigFromEnv(
     value: {
       baseUrl: normalizedBaseUrl.value,
       timeoutMs: normalizeTimeoutMs(
-        env.OPENCLAW_APNS_RELAY_TIMEOUT_MS ?? configuredRelay?.timeoutMs,
+        normalizeNonEmptyString(env.OPENCLAW_APNS_RELAY_TIMEOUT_MS) ?? configuredRelay?.timeoutMs,
       ),
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a blank `OPENCLAW_APNS_RELAY_TIMEOUT_MS` silently overrode `gateway.push.apns.relay.timeoutMs`. A configured timeout such as `2500` was replaced with the global `10000` millisecond default, changing relay request timing without a startup error.

## Why This Change Was Made

The environment value is normalized before choosing between the existing env and config sources. Nonblank env precedence, timeout parsing and clamping, the public config shape, and the `10000` millisecond default are unchanged.

## User Impact

Operators can rely on their configured APNs relay timeout when the environment variable is blank, while valid environment overrides continue to win.

## Evidence

On Node `v24.18.0`, I invoked the real exported `resolveApnsRelayConfigFromEnv()` with a blank env override and configured timeout `2500`. Unmodified `upstream/main` (`f98bcb7fa73`) returned the wrong timeout:

```json
{
  "ok": true,
  "value": {
    "baseUrl": "https://relay.example.com",
    "timeoutMs": 10000
  }
}
```

After this change, the same production resolver preserves all three precedence states:

```json
{
  "blankEnv": {
    "ok": true,
    "value": { "baseUrl": "https://relay.example.com", "timeoutMs": 2500 }
  },
  "nonblankEnv": {
    "ok": true,
    "value": { "baseUrl": "https://relay.example.com", "timeoutMs": 1000 }
  },
  "bothAbsent": {
    "ok": true,
    "value": { "baseUrl": "https://relay.example.com", "timeoutMs": 10000 }
  }
}
```

The nonblank `999` env value is intentionally clamped by the existing minimum to `1000`.

Focused validation:

```text
node scripts/run-vitest.mjs src/infra/push-apns.relay.test.ts
Test Files  1 passed (1)
Tests       23 passed (23)
```

Replacing only `push-apns.relay.ts` with the real `upstream/main` version made the new blank-override test fail with `received 10000, expected 2500`. `CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --staged` also passed, including core/core-test type checks, targeted lint, formatting, runtime guards, and import-cycle checks. Autoreview reported no accepted/actionable findings.

No live APNs relay request was sent; the source precedence and timeout value are fully resolved before network I/O.

AI-assisted: Codex helped implement and review the change; the production-entry proof and validation commands above were run manually.
