### PR TITLE
fix(nostr): profile imports no longer crash on invalid fields

### DIFF
--- a/extensions/nostr/src/nostr-profile-import.test.ts
+++ b/extensions/nostr/src/nostr-profile-import.test.ts
@@ -150,6 +150,10 @@ describe("nostr-profile-import", () => {
         content: { name: 123, about: "valid" },
       },
       {
+        case: "a wrong URL field type",
+        content: { name: "valid", picture: 123 },
+      },
+      {
         case: "an overlong field",
         content: { name: "a".repeat(257), about: "valid" },
       },

--- a/extensions/nostr/src/nostr-profile-import.test.ts
+++ b/extensions/nostr/src/nostr-profile-import.test.ts
@@ -137,6 +137,26 @@ describe("nostr-profile-import", () => {
         sourceRelay: "wss://relay.example",
       });
     });
+
+    it("rejects profile objects with invalid field types", async () => {
+      mockState.subscribeMany.mockImplementation((_relays, _filter, params) => {
+        params.onevent?.(
+          createProfileEvent({ content: JSON.stringify({ name: 123, about: "valid" }) }),
+        );
+        params.oneose?.();
+      });
+
+      await expect(
+        importProfileFromRelays({
+          pubkey: "a".repeat(64),
+          relays: ["wss://relay.example"],
+        }),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: "Profile event content has invalid fields",
+        sourceRelay: "wss://relay.example",
+      });
+    });
   });
 
   describe("mergeProfiles", () => {

--- a/extensions/nostr/src/nostr-profile-import.test.ts
+++ b/extensions/nostr/src/nostr-profile-import.test.ts
@@ -46,6 +46,20 @@ function createProfileEvent(overrides: Partial<Event> = {}): Event {
   };
 }
 
+function respondWithProfileContent(content: unknown): void {
+  mockState.subscribeMany.mockImplementation((_relays, _filter, params) => {
+    params.onevent?.(createProfileEvent({ content: JSON.stringify(content) }));
+    params.oneose?.();
+  });
+}
+
+function importDefaultProfile() {
+  return importProfileFromRelays({
+    pubkey: "a".repeat(64),
+    relays: ["wss://relay.example"],
+  });
+}
+
 describe("nostr-profile-import", () => {
   beforeEach(() => {
     mockState.close.mockReset();
@@ -121,41 +135,50 @@ describe("nostr-profile-import", () => {
     });
 
     it("rejects profile content that is not a JSON object", async () => {
-      mockState.subscribeMany.mockImplementation((_relays, _filter, params) => {
-        params.onevent?.(createProfileEvent({ content: "null" }));
-        params.oneose?.();
-      });
+      respondWithProfileContent(null);
 
-      await expect(
-        importProfileFromRelays({
-          pubkey: "a".repeat(64),
-          relays: ["wss://relay.example"],
-        }),
-      ).resolves.toMatchObject({
+      await expect(importDefaultProfile()).resolves.toMatchObject({
         ok: false,
         error: "Profile event content must be a JSON object",
         sourceRelay: "wss://relay.example",
       });
     });
 
-    it("rejects profile objects with invalid field types", async () => {
-      mockState.subscribeMany.mockImplementation((_relays, _filter, params) => {
-        params.onevent?.(
-          createProfileEvent({ content: JSON.stringify({ name: 123, about: "valid" }) }),
-        );
-        params.oneose?.();
-      });
+    it.each([
+      {
+        case: "a wrong field type",
+        content: { name: 123, about: "valid" },
+      },
+      {
+        case: "an overlong field",
+        content: { name: "a".repeat(257), about: "valid" },
+      },
+      {
+        case: "a wrong field type alongside an unsafe URL",
+        content: { name: "valid", about: 123, picture: "https://127.0.0.1/avatar.png" },
+      },
+    ])("rejects the whole profile for $case", async ({ content }) => {
+      respondWithProfileContent(content);
 
-      await expect(
-        importProfileFromRelays({
-          pubkey: "a".repeat(64),
-          relays: ["wss://relay.example"],
-        }),
-      ).resolves.toMatchObject({
+      await expect(importDefaultProfile()).resolves.toMatchObject({
         ok: false,
         error: "Profile event content has invalid fields",
         sourceRelay: "wss://relay.example",
       });
+    });
+
+    it("drops unknown fields and unsafe URLs from an otherwise valid profile", async () => {
+      respondWithProfileContent({
+        name: "valid",
+        picture: "https://127.0.0.1/avatar.png",
+        website: "https://example.com",
+        custom: "ignored",
+      });
+
+      const result = await importDefaultProfile();
+
+      expect(result).toMatchObject({ ok: true, sourceRelay: "wss://relay.example" });
+      expect(result.profile).toStrictEqual({ name: "valid", website: "https://example.com" });
     });
   });
 

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -187,7 +187,8 @@ export async function importProfileFromRelays(
     // Convert to our profile format
     const profile = contentToProfile(content);
 
-    // Sanitize URLs from imported profile to prevent SSRF when auto-merging
+    // Drop unsafe URLs before schema validation so an otherwise valid profile remains importable.
+    // Other invalid known fields reject the event atomically instead of silently changing its data.
     const sanitizedProfile = sanitizeProfileUrls(profile);
     const validatedProfile = NostrProfileSchema.safeParse(sanitizedProfile);
     if (!validatedProfile.success) {

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -7,7 +7,7 @@
 
 import { SimplePool, type Event } from "nostr-tools";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import type { NostrProfile } from "./config-schema.js";
+import { type NostrProfile, NostrProfileSchema } from "./config-schema.js";
 import { contentToProfile, type ProfileContent } from "./nostr-profile-core.js";
 import { validateUrlSafety } from "./nostr-profile-url-safety.js";
 
@@ -189,10 +189,19 @@ export async function importProfileFromRelays(
 
     // Sanitize URLs from imported profile to prevent SSRF when auto-merging
     const sanitizedProfile = sanitizeProfileUrls(profile);
+    const validatedProfile = NostrProfileSchema.safeParse(sanitizedProfile);
+    if (!validatedProfile.success) {
+      return {
+        ok: false,
+        error: "Profile event content has invalid fields",
+        relaysQueried,
+        sourceRelay: bestEvent.relay,
+      };
+    }
 
     return {
       ok: true,
-      profile: sanitizedProfile,
+      profile: validatedProfile.data,
       event: {
         id: bestEvent.event.id,
         pubkey: bestEvent.event.pubkey,


### PR DESCRIPTION
Related: #110330

## What Problem This Solves

Fixes an issue where users importing a Nostr profile would receive an internal server error when the newest signed kind 0 event contained an invalid type or exceeded a local field limit.

## Why This Change Was Made

NIP-01 defines kind 0 content as a stringified metadata object. The import boundary now validates the converted profile with the canonical `NostrProfileSchema` after URL sanitation, so malformed known fields reject the event atomically before optional auto-merge and config persistence. Unknown metadata remains ignored, unsafe URLs remain deliberately omitted, and relay selection, merge precedence, and the profile schema itself are unchanged.

Reference: https://github.com/nostr-protocol/nips/blob/master/01.md#kinds

## User Impact

Malformed Nostr metadata no longer crashes profile import. Users receive the existing structured import failure for wrong types and overlong fields; valid profiles still import, with unknown fields stripped and unsafe URLs removed.

## Evidence

- `node scripts/run-vitest.mjs extensions/nostr/src/nostr-profile-import.test.ts` — 15 tests passed. Coverage includes wrong scalar and URL-field types, the 256-character name cap, a mixed unsafe-URL/wrong-type event, unknown-key stripping, and unsafe-URL removal.
- `node scripts/check-changed.mjs -- extensions/nostr/src/nostr-profile-import.ts extensions/nostr/src/nostr-profile-import.test.ts` — passed all selected extension production/test typechecks, formatting, lint, dependency, plugin-boundary, database-first, and import-cycle gates on Blacksmith Testbox.
- Hosted changed-surface proof: https://github.com/openclaw/openclaw/actions/runs/29666109541
- Maintainer autoreview — clean after directly pinning the sanitation-before-validation type boundary.
- The contributor's public-relay before/after proof remains representative: the prior path returned HTTP 500, while the repaired path returned HTTP 200 with `ok: false` and `Profile event content has invalid fields`.
