### PR TITLE
perf(ui): keep lazy-page CSS out of the Control UI entry stylesheet

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -13,7 +13,7 @@ export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze({
   startupJsRequests: 18,
   startupCssRequests: 1,
   startupJsGzipBytes: 310 * KIB,
-  startupCssGzipBytes: 42 * KIB,
+  startupCssGzipBytes: 38 * KIB,
   largestJsGzipBytes: 215 * KIB,
   largestCssGzipBytes: 42 * KIB,
 });

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -4,6 +4,7 @@
 // Drawn in the smooth OpenClaw lobster style (see the dreams scene and
 // icons.lobster). Look and personality are seeded per session + page load so
 // every new session hatches a slightly different lobster.
+import "../styles/lobster-pet.css";
 import { expectDefined } from "@openclaw/normalization-core";
 import { html, LitElement, nothing, svg, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";

--- a/ui/src/pages/about/view.ts
+++ b/ui/src/pages/about/view.ts
@@ -1,3 +1,4 @@
+import "../../styles/lobster-pet.css";
 import { expectDefined } from "@openclaw/normalization-core";
 import { html, nothing, type TemplateResult } from "lit";
 import type { ControlUiBuildInfo } from "../../build-info.ts";

--- a/ui/src/pages/agents/memory/view.ts
+++ b/ui/src/pages/agents/memory/view.ts
@@ -1,4 +1,5 @@
 // Control UI view renders dreaming screen content.
+import "../../../styles/lobster-pet.css";
 import { expectDefined } from "@openclaw/normalization-core";
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -1,3 +1,4 @@
+import "../../styles/approval.css";
 import { consume } from "@lit/context";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing, type PropertyValues } from "lit";

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1,3 +1,5 @@
+import "../../styles/config.css";
+import "../../styles/config-quick.css";
 import { consume } from "@lit/context";
 import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, type PropertyValues } from "lit";

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1,4 +1,5 @@
 // Control UI view renders config screen content.
+import "../../styles/lobster-pet.css";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import type { QueueMode } from "../../../../src/auto-reply/reply/queue/types.js";

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -1,3 +1,4 @@
+import "../../styles/config-quick.css";
 import { consume } from "@lit/context";
 import { html, nothing, svg } from "lit";
 import { state } from "lit/decorators.js";

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3,11 +3,8 @@
 @import "./styles/layout.css";
 @import "./styles/layout.mobile.css";
 @import "./styles/components.css";
-@import "./styles/approval.css";
-@import "./styles/config.css";
-@import "./styles/config-quick.css";
+@import "./styles/approval-boot.css";
 @import "./styles/settings.css";
-@import "./styles/lobster-pet.css";
 @import "@create-markdown/preview/themes/system.css";
 
 /* Contract read by stale-chunk-reload.ts to detect a failed entry stylesheet load.

--- a/ui/src/styles/approval-boot.css
+++ b/ui/src/styles/approval-boot.css
@@ -1,0 +1,49 @@
+openclaw-approval-page {
+  display: block;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100svh;
+  overflow: hidden;
+}
+
+.approval-page {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: minmax(0, 720px);
+  grid-template-rows: max-content max-content;
+  grid-auto-rows: max-content;
+  height: 100%;
+  min-height: 100vh;
+  min-height: 100svh;
+  align-content: start;
+  align-content: safe center;
+  justify-content: center;
+  place-items: center;
+  gap: 18px;
+  overflow: hidden auto;
+  padding: max(32px, var(--safe-area-top)) max(22px, var(--safe-area-right))
+    max(24px, var(--safe-area-bottom)) max(22px, var(--safe-area-left));
+  background: var(--bg);
+  color: var(--text);
+}
+
+@media (display-mode: standalone) {
+  openclaw-approval-page {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .approval-page {
+    min-height: 100%;
+  }
+}
+
+.approval-page--booting {
+  align-content: center;
+  color: var(--muted);
+}
+
+/* Only the shell's pre-hydration booting state lives here; the full approval
+ * page styles load with the lazy page chunk (see approval-page.ts). */

--- a/ui/src/styles/approval.css
+++ b/ui/src/styles/approval.css
@@ -1,49 +1,5 @@
-openclaw-approval-page {
-  display: block;
-  height: 100vh;
-  height: 100dvh;
-  min-height: 100vh;
-  min-height: 100svh;
-  overflow: hidden;
-}
-
-.approval-page {
-  position: relative;
-  isolation: isolate;
-  display: grid;
-  grid-template-columns: minmax(0, 720px);
-  grid-template-rows: max-content max-content;
-  grid-auto-rows: max-content;
-  height: 100%;
-  min-height: 100vh;
-  min-height: 100svh;
-  align-content: start;
-  align-content: safe center;
-  justify-content: center;
-  place-items: center;
-  gap: 18px;
-  overflow: hidden auto;
-  padding: max(32px, var(--safe-area-top)) max(22px, var(--safe-area-right))
-    max(24px, var(--safe-area-bottom)) max(22px, var(--safe-area-left));
-  background: var(--bg);
-  color: var(--text);
-}
-
-@media (display-mode: standalone) {
-  openclaw-approval-page {
-    height: 100%;
-    min-height: 0;
-  }
-
-  .approval-page {
-    min-height: 100%;
-  }
-}
-
-.approval-page--booting {
-  align-content: center;
-  color: var(--muted);
-}
+/* Full approval-page styles; loaded with the lazy page chunk. The shell boot
+ * subset lives in approval-boot.css and must stay in the entry stylesheet. */
 
 .approval-page__backdrop {
   position: fixed;


### PR DESCRIPTION
## What Problem This Solves

Main is red on every push since `74880cb`: all four QA Smoke CI profiles fail the Control UI performance gate with "startup CSS gzip: 42.0 KiB exceeds 42.0 KiB" (run 29643357786). Bisected by building `ui/` at each commit: no single culprit — #110605 (+0.21 KiB) and #110654 (+0.14 KiB) tipped a budget that was already 97% full.

The structural cause: the entry stylesheet (`ui/src/styles.css`) aggregates `approval.css`, `config.css`, `config-quick.css`, and `lobster-pet.css` even though every consumer is a lazy route chunk (pages own `route.ts` dynamic imports) or a lazily defined element (`lobster-pet.ts` is already `import()`ed by the sidebar).

## Why This Change Was Made

Move each stylesheet to its owning lazy module — the established pattern (chat, agents, cron pages already import their own CSS). The shell's pre-hydration approval booting state (`app-host.ts` renders `.approval-page--booting` before the lazy page loads) keeps its subset in the entry via the new `approval-boot.css`. Consumer map verified by selector-leak grep: `config-quick.css` also feeds `profile-page.ts` (lazy), `lobster-pet.css` classes are used by about/memory/config views (all lazy) — each gets its own import.

Startup CSS drops **42.0 → 36.0 KiB gzip**; the budget tightens 42 → 38 KiB to lock in the recovery, matching the startup-JS precedent (#110528: lazy-load + tighten). Total CSS grows 2.4 KiB from per-chunk duplication — the intended trade for startup weight.

## User Impact

Main CI green again; Control UI first paint ships 6 KiB less CSS; the budget gate keeps future page styles from silently re-filling the entry.

## Evidence

- `node scripts/check-control-ui-performance.mjs` after `vite build`: startup CSS 36.0 KiB / 38.0 limit, one request, no violations (before: 42.0/42.0 violation reproduced locally).
- Bisect table (entry CSS gzip, local build): f98bcb7 41.63 → 39ddf71 41.84 → 74880cb 41.98 KiB.
- Full `vitest.ui.config.ts` run: no new failures (the only failing suites are the three storage tests already proven to fail identically on clean main under local Node 26).
- Selector-leak audit for every moved stylesheet; `.approval-page--booting` shell dependency handled via the boot subset split.
- Codex autoreview: running on this bundle; will be clean before landing.
