### PR TITLE
ci(ui): raise startup CSS gzip budget to 44 KiB

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -13,7 +13,7 @@ export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze({
   startupJsRequests: 18,
   startupCssRequests: 1,
   startupJsGzipBytes: 310 * KIB,
-  startupCssGzipBytes: 42 * KIB,
+  startupCssGzipBytes: 44 * KIB,
   largestJsGzipBytes: 215 * KIB,
   largestCssGzipBytes: 42 * KIB,
 });


### PR DESCRIPTION
## What Problem This Solves

Control UI startup CSS on `main` crossed its 42 KiB gzip budget (it sat at 41.1 KiB earlier today; the Settings → MCP management UI #110654 and session unarchive flows #110605 added startup CSS). Main's own QA Smoke run 29643357786 fails the bundle check, so every PR is blocked at the ci-gate - same boundary-race class as this morning's startup JS crossing.

## Why This Change Was Made

Raise `startupCssGzipBytes` from 42 to 44 KiB, following the small-increment budget precedent (`a3804782dc9`, and the JS-side resolution #110528). The recent Control UI perf work (#110623, #110628) targeted JS; there is no CSS trim in flight, and a red main blocks all landings. 2 KiB headroom keeps the creep guard tight.

## User Impact

CI-only.

## Evidence

- Failure reproduced on main's own QA Smoke run 29643357786 and on unrelated PR #110666 (state-module refactor, zero UI changes): four profiles fail the startup CSS budget check.
- One-line constant change; `git diff --check` clean.
