### PR TITLE
fix(litellm): guard loopback hostname auto-allow with isIP to prevent DNS SSRF bypass

### DIFF
--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -254,7 +254,9 @@ describe("litellm image generation provider", () => {
     const cases = [
       "http://localhost:4000",
       "http://127.0.0.1:4000",
+      "http://127.255.255.254:4000",
       "http://[::1]:4000",
+      "http://[0:0:0:0:0:0:0:1]:4000",
       "http://host.docker.internal:4000",
       "https://localhost:4000",
     ] as const;
@@ -283,6 +285,7 @@ describe("litellm image generation provider", () => {
       "https://192.168.5.10:4000",
       "http://printer.local:4000",
       "http://proxy.internal:4000",
+      "http://127.evil.com:4000",
       "https://metadata.google.internal",
     ] as const;
     for (const baseUrl of cases) {
@@ -303,33 +306,36 @@ describe("litellm image generation provider", () => {
     }
   });
 
-  it("honors explicit private-network opt-in for a LAN LiteLLM proxy", async () => {
-    mockGeneratedPngResponse();
+  it.each(["http://192.168.5.10:4000", "http://127.evil.com:4000"])(
+    "honors explicit private-network opt-in for %s",
+    async (baseUrl) => {
+      mockGeneratedPngResponse();
 
-    const provider = buildLitellmImageGenerationProvider();
-    await provider.generateImage({
-      provider: "litellm",
-      model: "gpt-image-2",
-      prompt: "x",
-      cfg: {
-        models: {
-          providers: {
-            litellm: {
-              baseUrl: "http://192.168.5.10:4000",
-              request: { allowPrivateNetwork: true },
-              models: [],
+      const provider = buildLitellmImageGenerationProvider();
+      await provider.generateImage({
+        provider: "litellm",
+        model: "gpt-image-2",
+        prompt: "x",
+        cfg: {
+          models: {
+            providers: {
+              litellm: {
+                baseUrl,
+                request: { allowPrivateNetwork: true },
+                models: [],
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expectFields(mockObjectArg(resolveProviderHttpRequestConfigMock), {
-      allowPrivateNetwork: undefined,
-      request: { allowPrivateNetwork: true },
-    });
-    expect(mockObjectArg(postJsonRequestMock).allowPrivateNetwork).toBe(true);
-  });
+      expectFields(mockObjectArg(resolveProviderHttpRequestConfigMock), {
+        allowPrivateNetwork: undefined,
+        request: { allowPrivateNetwork: true },
+      });
+      expect(mockObjectArg(postJsonRequestMock).allowPrivateNetwork).toBe(true);
+    },
+  );
 
   it("does not allow private network for public hosts that embed private strings in the URL", async () => {
     // Must not be fooled by an attacker-controlled URL that mentions

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -63,9 +63,8 @@ function isAutoAllowedLitellmHostname(hostname: string): boolean {
   ) {
     return true;
   }
-  // Only literal IPv4 loopback addresses qualify — DNS hostnames like
-  // 127.evil.com must not auto-bypass the allowPrivateNetwork opt-in.
-  if (lowered === "127.0.0.1" || (isIP(lowered) === 4 && lowered.startsWith("127."))) {
+  // Only IPv4 literals may use the 127/8 loopback exemption.
+  if (isIP(lowered) === 4 && lowered.startsWith("127.")) {
     return true;
   }
   if (lowered === "::1" || lowered === "0:0:0:0:0:0:0:1") {

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 // Litellm provider module implements model/runtime integration.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -62,7 +63,9 @@ function isAutoAllowedLitellmHostname(hostname: string): boolean {
   ) {
     return true;
   }
-  if (lowered === "127.0.0.1" || lowered.startsWith("127.")) {
+  // Only literal IPv4 loopback addresses qualify — DNS hostnames like
+  // 127.evil.com must not auto-bypass the allowPrivateNetwork opt-in.
+  if (lowered === "127.0.0.1" || (isIP(lowered) === 4 && lowered.startsWith("127."))) {
     return true;
   }
   if (lowered === "::1" || lowered === "0:0:0:0:0:0:0:1") {


### PR DESCRIPTION
## What Problem This Solves

LiteLLM image generation automatically permits private-network access for loopback-style endpoints. The previous `127.` prefix check also matched DNS hostnames such as `127.evil.com`, allowing an attacker-controlled public hostname to receive the loopback exemption without the operator's explicit `allowPrivateNetwork` opt-in.

## Why This Change Was Made

The provider now applies the `127/8` exemption only when Node's `net.isIP` confirms that the parsed hostname is an IPv4 literal. This keeps endpoint ownership local to the LiteLLM provider and leaves the shared SSRF policy unchanged. Provider-level regression coverage exercises the canonical image-generation request path, including the explicit opt-in fallback.

The surrounding audit found no second unfixed instance in the same LiteLLM path: Slack and policy helpers already validate literal IPv4 input, the Nostr socket check receives a resolved peer address rather than a URL hostname, and the analogous Codex WebSocket authentication issue is tracked separately in #110692.

## User Impact

Literal `127/8`, `localhost`, IPv6 loopback, and `host.docker.internal` LiteLLM endpoints remain automatic. A DNS hostname beginning with `127.` now needs the existing `models.providers.litellm.request.allowPrivateNetwork` opt-in, as other non-loopback private endpoints already do.

## Evidence

- `node scripts/run-vitest.mjs extensions/litellm/image-generation-provider.test.ts` — 1 file passed, 12 tests passed.
- `node scripts/check-changed.mjs -- extensions/litellm/image-generation-provider.ts extensions/litellm/image-generation-provider.test.ts` — all extension typecheck, test-typecheck, lint, formatting, dependency, boundary, database-first, and import-cycle gates passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29665469639
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.
- Node 26.5.0 `net.isIP` probe classified `127.0.0.1` and `127.255.255.255` as IPv4 literals, while classifying `127.evil.com` as not an IP literal.

Fix and tests improved by the OpenClaw maintainer team; original security report and patch by @lsr911.
