### PR TITLE
test(shared): add unit tests for safe-record defensive guards

### DIFF
--- a/src/shared/safe-record.test.ts
+++ b/src/shared/safe-record.test.ts
@@ -29,16 +29,12 @@ describe("isRecordWithoutThrowing", () => {
     expect(isRecordWithoutThrowing(true)).toBe(false);
   });
 
-  it("survives a throwing Proxy", () => {
-    const hostile = new Proxy(
-      {},
-      {
-        get() {
-          throw new Error("boom");
-        },
-      },
-    );
-    expect(isRecordWithoutThrowing(hostile)).toBe(false);
+  it("survives a revoked Proxy", () => {
+    // Array.isArray/typeof on a revoked Proxy throws TypeError; the guard must
+    // catch it instead of letting it escape to callers.
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    expect(isRecordWithoutThrowing(proxy)).toBe(false);
   });
 });
 
@@ -55,6 +51,16 @@ describe("readRecordValue", () => {
     expect(readRecordValue(null, "key")).toBeUndefined();
     expect(readRecordValue("string", "key")).toBeUndefined();
   });
+
+  it("returns undefined when the property getter throws", () => {
+    const hostile = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("boom");
+      },
+      enumerable: true,
+    });
+    expect(readRecordValue(hostile, "name")).toBeUndefined();
+  });
 });
 
 describe("copyArrayEntries", () => {
@@ -69,6 +75,30 @@ describe("copyArrayEntries", () => {
 
   it("handles empty array", () => {
     expect(copyArrayEntries([])).toEqual([]);
+  });
+
+  it("returns empty array when the length getter throws", () => {
+    const hostile = new Proxy([1, 2, 3], {
+      get(target, prop) {
+        if (prop === "length") {
+          throw new Error("boom");
+        }
+        return Reflect.get(target, prop);
+      },
+    });
+    expect(copyArrayEntries(hostile)).toEqual([]);
+  });
+
+  it("skips entries whose index access throws", () => {
+    const hostile = new Proxy([1, 2, 3], {
+      get(target, prop) {
+        if (prop === "length") {
+          return Reflect.get(target, prop);
+        }
+        throw new Error("boom");
+      },
+    });
+    expect(copyArrayEntries(hostile)).toEqual([]);
   });
 });
 
@@ -86,5 +116,28 @@ describe("copyRecordEntries", () => {
   it("returns empty array for non-record input", () => {
     expect(copyRecordEntries(null)).toEqual([]);
     expect(copyRecordEntries("string")).toEqual([]);
+  });
+
+  it("returns empty array when the ownKeys trap throws", () => {
+    const hostile = new Proxy(
+      { a: { v: 1 } },
+      {
+        ownKeys() {
+          throw new Error("boom");
+        },
+      },
+    );
+    expect(copyRecordEntries(hostile)).toEqual([]);
+  });
+
+  it("skips entries whose value getter throws but keeps the rest", () => {
+    const hostile = { good: { v: 1 } };
+    Object.defineProperty(hostile, "bad", {
+      get() {
+        throw new Error("boom");
+      },
+      enumerable: true,
+    });
+    expect(copyRecordEntries(hostile)).toEqual([["good", { v: 1 }]]);
   });
 });

--- a/src/shared/safe-record.test.ts
+++ b/src/shared/safe-record.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  copyArrayEntries,
+  copyRecordEntries,
+  isRecordWithoutThrowing,
+  readRecordValue,
+} from "./safe-record.js";
+
+describe("isRecordWithoutThrowing", () => {
+  it("returns true for plain objects", () => {
+    expect(isRecordWithoutThrowing({ a: 1 })).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isRecordWithoutThrowing(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isRecordWithoutThrowing(undefined)).toBe(false);
+  });
+
+  it("returns false for arrays", () => {
+    expect(isRecordWithoutThrowing([1, 2, 3])).toBe(false);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isRecordWithoutThrowing("string")).toBe(false);
+    expect(isRecordWithoutThrowing(42)).toBe(false);
+    expect(isRecordWithoutThrowing(true)).toBe(false);
+  });
+
+  it("survives a throwing Proxy", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("boom");
+        },
+      },
+    );
+    expect(isRecordWithoutThrowing(hostile)).toBe(false);
+  });
+});
+
+describe("readRecordValue", () => {
+  it("reads an existing property", () => {
+    expect(readRecordValue({ name: "test" }, "name")).toBe("test");
+  });
+
+  it("returns undefined for missing property", () => {
+    expect(readRecordValue({ name: "test" }, "missing")).toBeUndefined();
+  });
+
+  it("returns undefined for non-record input", () => {
+    expect(readRecordValue(null, "key")).toBeUndefined();
+    expect(readRecordValue("string", "key")).toBeUndefined();
+  });
+});
+
+describe("copyArrayEntries", () => {
+  it("copies array elements", () => {
+    expect(copyArrayEntries([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty array for non-array", () => {
+    expect(copyArrayEntries("string")).toEqual([]);
+    expect(copyArrayEntries(null)).toEqual([]);
+  });
+
+  it("handles empty array", () => {
+    expect(copyArrayEntries([])).toEqual([]);
+  });
+});
+
+describe("copyRecordEntries", () => {
+  it("copies nested record entries", () => {
+    const entries = copyRecordEntries({ a: { v: 1 }, b: { v: 2 } });
+    expect(entries).toHaveLength(2);
+  });
+
+  it("skips non-record values", () => {
+    const entries = copyRecordEntries({ a: { v: 1 }, b: "string", c: 42 });
+    expect(entries).toHaveLength(1);
+  });
+
+  it("returns empty array for non-record input", () => {
+    expect(copyRecordEntries(null)).toEqual([]);
+    expect(copyRecordEntries("string")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`isRecordWithoutThrowing`, `readRecordValue`, `copyArrayEntries`, and `copyRecordEntries` are exported defensive guards against hostile objects with 0% test coverage.

## Why This Change Was Made

Adds a Vitest suite covering happy paths plus every guarded operation: revoked `Proxy` (`Array.isArray`/`typeof` throws), throwing property getter, throwing `length` getter, throwing index access, throwing `ownKeys` trap, and partial copy when one value getter throws. A mutation check (all four `try/catch` guards stripped from `src/shared/safe-record.ts`) fails exactly the 6 hostile-input tests, confirming each test reaches the guard it names.

## Evidence

```
$ node --import tsx --input-type=module -e "
import { isRecordWithoutThrowing, readRecordValue, copyArrayEntries, copyRecordEntries } from './src/shared/safe-record.ts';
const { proxy, revoke } = Proxy.revocable({}, {}); revoke();
console.log('revoked proxy:', JSON.stringify(isRecordWithoutThrowing(proxy)));
const hostGet = Object.defineProperty({}, 'name', { get() { throw new Error('boom'); }, enumerable: true });
console.log('throwing get:', JSON.stringify(readRecordValue(hostGet, 'name')));
const badLen = new Proxy([1,2,3], { get(t,p){ if(p==='length') throw new Error('boom'); return Reflect.get(t,p); } });
console.log('throwing length:', JSON.stringify(copyArrayEntries(badLen)));
const hostKeys = new Proxy({a:{v:1}}, { ownKeys() { throw new Error('boom'); } });
console.log('throwing ownKeys:', JSON.stringify(copyRecordEntries(hostKeys)));
"

revoked proxy: false
throwing get: undefined
throwing length: []
throwing ownKeys: []

All four guarded helpers return safe defaults on hostile input.

$ npx vitest run src/shared/safe-record.test.ts --reporter=verbose
 Test Files  1 passed (1)
      Tests  20 passed (20)

Mutation check (guards stripped from src/shared/safe-record.ts):
      Tests  6 failed | 14 passed (20)
→ the 6 failures are exactly the hostile-input tests, one per guarded operation.
```
