### PR TITLE
fix(release): force isolated gateway shutdown

### DIFF
--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -484,7 +484,7 @@ export async function runInstallerFreshSuite(
         logLanePhase(lane, "gateway-stop-managed");
         await runInstalledCli({
           cliPath: freshShell.cliPath,
-          args: ["gateway", "stop"],
+          args: ["gateway", "stop", "--force"],
           env,
           cwd: lane.homeDir,
           logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed.log"),

--- a/scripts/lib/cross-os-release-checks/runtime.ts
+++ b/scripts/lib/cross-os-release-checks/runtime.ts
@@ -109,7 +109,7 @@ export async function exerciseManagedGatewayLifecycle(
   logLanePhase(params.lane, "gateway-stop");
   await runInstalledCli({
     cliPath: params.cliPath,
-    args: ["gateway", "stop"],
+    args: ["gateway", "stop", "--force"],
     env: params.env,
     cwd: params.lane.homeDir,
     logPath: `${params.logPrefix}-stop.log`,

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -793,6 +793,18 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(args.at(-2)).toBe("--timeout");
   });
 
+  it("forces shutdown of the isolated managed gateways owned by release checks", () => {
+    const source = [
+      "scripts/lib/cross-os-release-checks/lanes.ts",
+      "scripts/lib/cross-os-release-checks/runtime.ts",
+    ]
+      .map((filePath) => readFileSync(filePath, "utf8"))
+      .join("\n");
+
+    expect(source.match(/args: \["gateway", "stop", "--force"\]/g)).toHaveLength(2);
+    expect(source).not.toContain('args: ["gateway", "stop"]');
+  });
+
   it("keeps cross-OS live smoke agent turns on GPT-5-safe timeouts and minimal context", () => {
     const source = [
       "scripts/lib/cross-os-release-checks/agent.ts",


### PR DESCRIPTION
## Summary

- pass `--force` when cross-OS release checks stop their own isolated managed gateways
- cover both lifecycle and manual-fallback shutdown paths with a regression assertion

## Proof

- `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts` (109 passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Fixes the Windows installer-fresh failure in Full Release Validation run 29644160635.
