### PR TITLE
fix: pause hidden session catalog polling

### DIFF
--- a/ui/src/components/app-sidebar-session-data.ts
+++ b/ui/src/components/app-sidebar-session-data.ts
@@ -175,18 +175,24 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
 
   override updated() {
     this.syncSessionsScrollObserver();
-    const snapshot = this.context?.gateway.snapshot;
     if (this.context) {
       this.synchronizeSessionCatalogAgent(this.expandedAgentId());
     }
     if (
-      !sessionCatalogListClient(snapshot, this.connected) ||
+      !this.visibleSessionCatalogClient() ||
       this.sessionCatalogLive.timer ||
       this.sessionCatalogLive.requestGeneration === this.sessionCatalogGeneration
     ) {
       return;
     }
     void this.refreshSessionCatalogs();
+  }
+
+  private visibleSessionCatalogClient(): GatewayBrowserClient | null {
+    if (document.visibilityState === "hidden") {
+      return null;
+    }
+    return sessionCatalogListClient(this.context?.gateway.snapshot, this.connected);
   }
 
   private synchronizeSessionCatalogAgent(agentId: string) {
@@ -265,7 +271,9 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
   }
 
   private async refreshSessionCatalogs() {
-    const client = sessionCatalogListClient(this.context?.gateway.snapshot, this.connected);
+    // Hidden pages resume through the coalesced activation handler. Starting
+    // here without a timer makes catalog state updates poll at request latency.
+    const client = this.visibleSessionCatalogClient();
     if (!client) {
       return;
     }

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
@@ -101,6 +101,61 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
+  it("stays paused through a Gateway reconnect while the tab is hidden", async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = "visible";
+    const visibilitySpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockImplementation(() => visibility);
+    try {
+      const foregroundRequest = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(catalogPage([]))
+        .mockReturnValue(foregroundRequest.promise);
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledTimes(1);
+
+      visibility = "hidden";
+      document.dispatchEvent(new Event("visibilitychange"));
+      gateway.publish({ connected: false, reconnecting: true, hello: null });
+      await sidebar.updateComplete;
+      gateway.publish({
+        connected: true,
+        reconnecting: false,
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(request).toHaveBeenCalledTimes(1);
+
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(request).toHaveBeenCalledTimes(2);
+      foregroundRequest.resolve(catalogPage([]));
+      await vi.advanceTimersByTimeAsync(0);
+    } finally {
+      visibilitySpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not poll an older Gateway that does not advertise session catalogs", async () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SessionsCatalogListResult } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { catalogPage, createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
+import {
+  catalogPage,
+  createGatewayHarness,
+  createSessions,
+  deferred,
+  mountSidebar,
+} from "../app-sidebar.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session catalog pagination", () => {
@@ -29,6 +36,56 @@ describe("AppSidebar session catalog pagination", () => {
 
       visibility = "hidden";
       document.dispatchEvent(new Event("visibilitychange"));
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(49);
+      expect(request).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(request).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      visibilitySpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stays paused when an in-flight catalog refresh finishes in a hidden tab", async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = "visible";
+    const visibilitySpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockImplementation(() => visibility);
+    try {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockReturnValueOnce(pending.promise)
+        .mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledTimes(1);
+
+      visibility = "hidden";
+      document.dispatchEvent(new Event("visibilitychange"));
+      pending.resolve(catalogPage([]));
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(request).toHaveBeenCalledTimes(1);
+
       visibility = "visible";
       document.dispatchEvent(new Event("visibilitychange"));
       globalThis.dispatchEvent(new Event("focus"));


### PR DESCRIPTION
## What Problem This Solves

Hidden Control UI tabs can repeatedly call `sessions.catalog.list` at request latency after an in-flight refresh completes or the Gateway reconnects.

The existing page-activation handler respects `document.visibilityState`, but refreshes initiated by component updates and request completion bypass that check. This creates unnecessary network activity, CPU usage, and continuous Gateway logs.

Closes #110701.

## Changes

- Apply the same visibility check to every session catalog refresh entry point.
- Prevent completed requests and Gateway reconnects from restarting catalog polling while the page is hidden.
- Preserve the existing coalesced refresh when the page becomes visible again.
- Add regression coverage for in-flight completion and reconnect behavior while hidden.

## Evidence

- Reproduced the request loop with the Control UI hidden during catalog refresh and Gateway restart.
- Confirmed the hidden page remains idle after an in-flight request completes.
- Confirmed a reconnect while hidden does not restart polling.
- Confirmed returning to the page triggers one coalesced refresh.
- Added focused regression tests for both hidden-page failure paths.