### PR TITLE
docs(troubleshooting): add recovery runbook for plugin install metadata conflict after update

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4066,6 +4066,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Command ladder
   - H2: After an update
+  - H2: Plugin install metadata conflict after an update
   - H2: Split brain installs and newer config guard
   - H2: Protocol mismatch after rollback
   - H2: Skill symlink skipped as path escape

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -45,6 +45,44 @@ Look for:
 - `plugin load failed: dependency tree corrupted; run openclaw doctor --fix` under Channels: the channel config still exists, but plugin registration failed before the channel could load.
 - Provider 401s after re-auth: `openclaw doctor --fix` checks for stale per-agent OAuth auth shadows and removes old copies so all agents resolve the current shared profile.
 
+## Plugin install metadata conflict after an update
+
+Use when the gateway restarts in a loop after an update (or `openclaw doctor` keeps nagging after one), and logs show a legacy state migration warning naming one or more plugins:
+
+```
+[state-migrations] Legacy state migration warnings:
+- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: brave, discord
+[openclaw] Reason: OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
+```
+
+Older releases recorded plugin installs in `~/.openclaw/plugins/installs.json`. The shared SQLite state store is now authoritative. When the legacy file disagrees with the SQLite records (for example, it still lists plugin versions from before the update), the startup migration refuses to archive it and reports the conflict on every start. On 2026.7.1 this blocked gateway readiness and caused a restart loop; 2026.7.1-1 and later downgrade it to a non-blocking note, but the warning returns on every `openclaw doctor` run until the conflict is resolved.
+
+```bash
+openclaw plugins list
+ls -la ~/.openclaw/plugins/installs.json
+```
+
+<Steps>
+  <Step title="Verify the SQLite side is correct">
+    Confirm every plugin named in the warning appears in `openclaw plugins list` at the version you expect (current, not pre-update). If a plugin is missing or stale there, stop: the legacy file may be your only good record. Repair the install first.
+  </Step>
+  <Step title="Archive the legacy file">
+    Move it aside so the migration no longer sees two sources of truth. Move, do not delete:
+
+    ```bash
+    mv ~/.openclaw/plugins/installs.json ~/.openclaw/plugins/installs.json.migrated-$(date +%Y%m%d)
+    ```
+
+  </Step>
+  <Step title="Confirm the warning is gone">
+    Rerun `openclaw doctor` and `openclaw gateway status`. The conflict note should no longer appear. If you are stuck on 2026.7.1 itself, where this conflict blocks readiness entirely, update to 2026.7.1-1 or later first; those releases downgrade the conflict to a note so the gateway starts and you can do the cleanup from a running system.
+  </Step>
+</Steps>
+
+<Warning>
+Do not archive the legacy file while the two records still disagree and the SQLite side is the wrong one. The migration leaves both in place on conflict precisely so you can pick the correct survivor.
+</Warning>
+
 ## Split brain installs and newer config guard
 
 Use when a gateway service unexpectedly stops after an update, or logs show one `openclaw` binary is older than the version that last wrote `openclaw.json`.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -58,24 +58,28 @@ Use when the gateway restarts in a loop after an update (or `openclaw doctor` ke
 Older releases recorded plugin installs in `~/.openclaw/plugins/installs.json`. The shared SQLite state store is now authoritative. When the legacy file disagrees with the SQLite records (for example, it still lists plugin versions from before the update), the startup migration refuses to archive it and reports the conflict on every start. On 2026.7.1 this blocked gateway readiness and caused a restart loop; 2026.7.1-1 and later downgrade it to a non-blocking note, but the warning returns on every `openclaw doctor` run until the conflict is resolved.
 
 ```bash
+openclaw plugins registry
 openclaw plugins list
 ls -la ~/.openclaw/plugins/installs.json
 ```
 
 <Steps>
-  <Step title="Verify the SQLite side is correct">
-    Confirm every plugin named in the warning appears in `openclaw plugins list` at the version you expect (current, not pre-update). If a plugin is missing or stale there, stop: the legacy file may be your only good record. Repair the install first.
+  <Step title="Verify the authoritative record">
+    Inspect the persisted plugin registry with `openclaw plugins registry`. It reports the registry state and the current versus persisted enabled counts, and prints its own repair command (`openclaw plugins registry --refresh`) when the persisted record is stale. Then confirm every plugin named in the warning appears in `openclaw plugins list` at the version you expect (current, not pre-update). If the registry reports a stale or incomplete record, or a plugin is missing, stop and repair the install first: until the authoritative record is proven complete, the legacy file may still hold the only good copy of that metadata.
   </Step>
   <Step title="Archive the legacy file">
-    Move it aside so the migration no longer sees two sources of truth. Move, do not delete:
+    Move it aside so the migration no longer sees two sources of truth. This is a rename in place: nothing is deleted, and restoring the original filename undoes it completely.
 
     ```bash
-    mv ~/.openclaw/plugins/installs.json ~/.openclaw/plugins/installs.json.migrated-$(date +%Y%m%d)
+    mv ~/.openclaw/plugins/installs.json        ~/.openclaw/plugins/installs.json.migrated-$(date +%Y%m%d)
     ```
 
   </Step>
   <Step title="Confirm the warning is gone">
     Rerun `openclaw doctor` and `openclaw gateway status`. The conflict note should no longer appear. If you are stuck on 2026.7.1 itself, where this conflict blocks readiness entirely, update to 2026.7.1-1 or later first; those releases downgrade the conflict to a note so the gateway starts and you can do the cleanup from a running system.
+  </Step>
+  <Step title="Verify plugin state after recovery">
+    Compare the enabled counts in `openclaw plugins list` against what you saw before archiving, run `openclaw plugins doctor` for load issues, and confirm your plugin configuration and any `plugins.allow` entries are still present in the config. Manual remediation around this conflict has been reported to coincide with dropped plugin configuration and allowlist entries; catching that here beats discovering it on the next restart.
   </Step>
 </Steps>
 


### PR DESCRIPTION
## What Problem This Solves

After updating to 2026.7.1, gateways that still have a pre-SQLite-era `~/.openclaw/plugins/installs.json` crash-loop on startup with `conflicting plugin install metadata` (#92811, #107727, #107841, #108374). On 2026.7.1-1 and later the same conflict is non-fatal but resurfaces on every `openclaw doctor` run until resolved. The docs currently cover neither the warning nor its recovery: the phrase appears nowhere in `docs/`. This PR adds a symptom-based troubleshooting runbook next to the existing "Split brain installs and newer config guard" section: verify the persisted registry is the authoritative record, archive the legacy file (a rename in place, nothing deleted), confirm the warning clears, and verify plugin state after recovery.

## Evidence

From a real 2026.6.11 to 2026.7.1 upgrade on 2026-07-18 UTC (Ubuntu 24.04, npm global install; hostname redacted).

Crash loop on plain 2026.7.1, repeating every ~9 seconds from 23:27 to 23:47 ET:

```
Jul 17 23:27:01 [host] node[2983736]: [state-migrations] Legacy state migration warnings:
Jul 17 23:27:01 [host] node[2983736]: - Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: brave, discord
Jul 17 23:27:01 [host] node[2983736]: [openclaw] Reason: OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
```

Updating to 2026.7.1-1 (23:52 ET) started cleanly with the same conflict reported under "Legacy state migration notes:" instead of blocking readiness, matching the behavior documented in the new section.

Recovery, as documented in the runbook, on the same install: the legacy file (mtime June 1, recording plugin versions `2026.5.22` from before the update) was archived by rename after the SQLite side was verified. Results:

- `openclaw doctor` after archiving: zero `conflicting` lines (previously on every run; verified again today by an independent re-check)
- `openclaw plugins list` before and after: `Plugins (55/72 enabled)`, unchanged
- `openclaw plugins registry` on this install reports registry state, current vs persisted enabled counts, and its `--refresh` repair path, which is exactly the verification the new Step 1 documents

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)