### PR TITLE
feat(ui): add reactive OpenClaw health nudges

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -10510,6 +10510,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Gateway host status
   - H2: Language support
   - H2: Appearance themes
+  - H2: OpenClaw system care
   - H2: Manage plugins
   - H2: Apps and extensions
   - H2: Sidebar navigation

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -117,6 +117,10 @@ Appearance also has a Text size setting. It applies to chat text, composer text,
 
 Theme, theme mode, text size, language, and chat display preferences sync through the gateway config (`ui.prefs`), so they follow you across devices and agents can change them through the approval gate — connected clients apply changes live via the gateway's `config.changed` notice. Each browser keeps a local mirror for instant boot; clients that cannot write config (viewer scope, offline) keep changes device-local. See [Configuration reference](/gateway/configuration-reference#ui).
 
+## OpenClaw system care
+
+Open **OpenClaw** in the sidebar to talk to the system setup and repair agent. Outside onboarding, this page can show at most one dismissible event chip per visit. It stays silent for routine Gateway traffic and reacts only to health snapshots that report a disabled configuration reloader, a configured channel disconnect/degradation, a failed channel probe, or unavailable channel credentials. A newer event replaces the pending chip only when it is more severe; dismissing or using the chip silences event prompts for that visit. Clicking the chip sends its diagnosis question as a real `openclaw.chat` message, so the transcript records the request and OpenClaw performs the diagnosis. Onboarding never shows these event chips.
+
 ## Manage plugins
 
 Open **Plugins** in the sidebar, or use `/settings/plugins` relative to the

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -1,0 +1,177 @@
+// Control UI tests cover event-reactive custodian presence against a mocked Gateway.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const uiProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "custodian-event-nudge",
+);
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function settleUi(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
+describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("shows one consequential nudge and sends its canonical message", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(uiProofArtifactDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+      methodResponses: {
+        "openclaw.chat": {
+          sessionId: "e2e-custodian",
+          reply: "I'm watching the system.",
+          action: "none",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}custodian`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(1);
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "01-before-event.png"),
+        });
+      }
+
+      await gateway.emitGatewayEvent("config.changed", {
+        hash: "config-hash",
+        path: "/tmp/openclaw.json",
+        ts: Date.now(),
+      });
+      await settleUi(page);
+      expect(await page.locator(".custodian__nudge").count()).toBe(0);
+
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: { configured: true, connected: false, running: true },
+        },
+      });
+
+      const nudge = page.getByRole("button", {
+        name: "Telegram just disconnected — ask me what happened",
+      });
+      await nudge.waitFor();
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "02-disconnected-nudge.png"),
+        });
+      }
+
+      await nudge.click();
+      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
+      const requests = await gateway.getRequests("openclaw.chat");
+      expect(requests[1]?.params).toMatchObject({
+        message: "what happened with telegram?",
+        sessionId: "e2e-custodian",
+      });
+      await page.getByText("what happened with telegram?", { exact: true }).waitFor();
+      expect(await nudge.count()).toBe(0);
+
+      await gateway.emitGatewayEvent("health", {
+        configReload: { hotReloadStatus: "disabled" },
+      });
+      await settleUi(page);
+      expect(await page.locator(".custodian__nudge").count()).toBe(0);
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "03-message-sent.png"),
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("stays silent during onboarding", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+      methodResponses: {
+        "openclaw.chat": {
+          sessionId: "e2e-onboarding-custodian",
+          reply: "Let's finish setup.",
+          action: "none",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}custodian?onboarding=1`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: { configured: true, connected: false, running: true },
+        },
+      });
+      await settleUi(page);
+      expect(await page.locator(".custodian__nudge").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1866,6 +1866,14 @@ export const en: TranslationMap = {
     requestFailed: "OpenClaw could not reply. Try again.",
     connectionChanged: "The Gateway connection changed. Retry to continue this setup.",
     unsupportedGateway: "Update the Gateway to continue setup with OpenClaw.",
+    nudge: {
+      configReload: "Configuration reload stopped — ask me what happened",
+      channelAuth: "{channel} authentication degraded — ask me what happened",
+      channelDisconnected: "{channel} just disconnected — ask me what happened",
+      channelDegraded: "{channel} is degraded — ask me what happened",
+      channelFallback: "A channel",
+      dismiss: "Dismiss this update",
+    },
   },
   mcpServers: {
     add: "Add server",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -697,6 +697,34 @@ describe("custodian page", () => {
     expect(page.querySelector(".custodian__nudge")).toBeNull();
   });
 
+  it("does not report a recovered channel with a retained error", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: {
+          telegram: {
+            configured: true,
+            enabled: true,
+            running: true,
+            healthState: "healthy",
+            lastError: "connection closed during the previous run",
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+  });
+
   it("reports a channel that fails before its first start", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -729,6 +729,72 @@ describe("custodian page", () => {
     expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
   });
 
+  it("reports a failed restart after an earlier clean stop", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: {
+            configured: true,
+            enabled: true,
+            running: false,
+            restartPending: false,
+            reconnectAttempts: 0,
+            healthState: "not-running",
+            lastStopAt: 1_700_000_000_000,
+            lastStartAt: 1_700_000_001_000,
+            lastError: "failed to initialize transport",
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
+  });
+
+  it("reports a current failed probe for an intentionally stopped channel", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: {
+            configured: true,
+            enabled: true,
+            running: false,
+            restartPending: false,
+            reconnectAttempts: 0,
+            healthState: "not-running",
+            lastStopAt: 1_700_000_001_000,
+            lastStartAt: 1_700_000_000_000,
+            probe: { ok: false },
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
+  });
+
   it("shows a channel disconnect from the aggregate health row", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -685,12 +685,48 @@ describe("custodian page", () => {
             running: false,
             connected: false,
             healthState: "not-running",
+            restartPending: false,
+            reconnectAttempts: 0,
+            lastStopAt: 1_700_000_000_000,
+            lastError: "connection closed during the previous run",
           },
         },
       },
     });
     await page.updateComplete;
     expect(page.querySelector(".custodian__nudge")).toBeNull();
+  });
+
+  it("reports a channel that fails before its first start", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: {
+            configured: true,
+            enabled: true,
+            running: false,
+            connected: false,
+            restartPending: false,
+            reconnectAttempts: 0,
+            healthState: "not-running",
+            lastError: "failed to initialize transport",
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
   });
 
   it("shows a channel disconnect from the aggregate health row", async () => {

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -1,7 +1,11 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type {
+  GatewayBrowserClient,
+  GatewayEventFrame,
+  GatewayEventListener,
+} from "../../api/gateway.ts";
 import type {
   ApplicationContext,
   ApplicationGateway,
@@ -26,6 +30,7 @@ type ContextHarness = {
   setGatewayToken: (token: string) => void;
   setGatewayBootstrapToken: (bootstrapToken: string) => void;
   setGatewayDeviceToken: (deviceToken: string) => void;
+  emitGatewayEvent: (event: Pick<GatewayEventFrame, "event" | "payload">) => void;
 };
 
 function createContext(request: ReturnType<typeof vi.fn>): ContextHarness {
@@ -46,6 +51,7 @@ function createContext(request: ReturnType<typeof vi.fn>): ContextHarness {
     lastErrorCode: null,
   };
   const listeners = new Set<(snapshot: ApplicationGatewaySnapshot) => void>();
+  const eventListeners = new Set<GatewayEventListener>();
   const connection = {
     gatewayUrl: "ws://gateway.test/control",
     token: "",
@@ -60,6 +66,10 @@ function createContext(request: ReturnType<typeof vi.fn>): ContextHarness {
     subscribe: (listener: (snapshot: ApplicationGatewaySnapshot) => void) => {
       listeners.add(listener);
       return () => listeners.delete(listener);
+    },
+    subscribeEvents: (listener: GatewayEventListener) => {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
     },
   } as unknown as ApplicationGateway;
   const context = {
@@ -91,6 +101,11 @@ function createContext(request: ReturnType<typeof vi.fn>): ContextHarness {
           ? { ...snapshot.hello, auth: { ...snapshot.hello.auth, deviceToken } }
           : snapshot.hello,
       };
+    },
+    emitGatewayEvent: (event) => {
+      for (const listener of eventListeners) {
+        listener(event as GatewayEventFrame);
+      }
     },
   };
 }
@@ -592,6 +607,275 @@ describe("custodian page", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(request.mock.calls[1]?.[1]).not.toHaveProperty("welcomeVariant");
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "status" });
+  });
+
+  it("shows a channel-error nudge but ignores routine events", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({ event: "tick", payload: { ts: Date.now() } });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: {
+          telegram: {
+            enabled: false,
+            accounts: {
+              default: {
+                configured: true,
+                enabled: false,
+                running: true,
+                connected: false,
+              },
+            },
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: {
+            enabled: false,
+            accounts: {
+              default: { configured: true, enabled: false, connected: false },
+              work: { configured: true, enabled: true, running: true, connected: false },
+            },
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
+      "Telegram just disconnected",
+    );
+  });
+
+  it("does not report an intentionally stopped channel as disconnected", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: {
+          telegram: {
+            configured: true,
+            enabled: true,
+            running: false,
+            connected: false,
+            healthState: "not-running",
+          },
+        },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+  });
+
+  it("shows a channel disconnect from the aggregate health row", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: { configured: true, running: true, connected: false },
+        },
+      },
+    });
+    await page.updateComplete;
+
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
+      "Telegram just disconnected",
+    );
+  });
+
+  it("clears a pending event nudge when the gateway identity changes", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent, setGatewaySnapshot, setGatewayUrl } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { telegram: { configured: true, running: true, connected: false } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).not.toBeNull();
+
+    setGatewayUrl("ws://gateway-b.test/control");
+    setGatewaySnapshot({
+      client: { request } as unknown as GatewayBrowserClient,
+      connected: true,
+      reconnecting: false,
+    });
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+
+    emitGatewayEvent({
+      event: "health",
+      payload: { configReload: { hotReloadStatus: "disabled" }, channels: {} },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
+      "Configuration reload stopped",
+    );
+  });
+
+  it("dismisses event nudges for the rest of the page visit", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { telegram: { configured: true, running: true, connected: false } },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-dismiss")!.click();
+    await page.updateComplete;
+
+    emitGatewayEvent({
+      event: "health",
+      payload: { configReload: { hotReloadStatus: "disabled" }, channels: {} },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("replaces a pending nudge only with a more severe event", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: { telegram: { configured: true, healthState: "stale-socket" } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, healthState: "stale-socket" } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, running: true, connected: false } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
+      "Discord just disconnected",
+    );
+  });
+
+  it("sends a real message when an event nudge is clicked", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: {
+          telegram: { configured: true, tokenStatus: "configured_unavailable" },
+        },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      message: "what happened with telegram authentication?",
+    });
+    expect(page.textContent).toContain("what happened with telegram authentication?");
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+  });
+
+  it("never shows event nudges during onboarding", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Welcome.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: true });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: { configReload: { hotReloadStatus: "disabled" }, channels: {} },
+    });
+    await page.updateComplete;
+
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
   });
 
   it("starts a fresh welcome when onboarding mode changes", async () => {

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -13,6 +13,7 @@ import { searchForSession } from "../../lib/sessions/navigation.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/custodian.css";
+import { classifyCustodianEventNudge, type CustodianEventNudge } from "./event-nudge.ts";
 import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
 
 const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
@@ -56,6 +57,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   @state() private answeredQuestions = new Set<string>();
   @state() private activeClient: GatewayBrowserClient | null = null;
   @state() private chatAvailable = false;
+  @state() private eventNudge: CustodianEventNudge | null = null;
 
   private sessionId = createSessionId();
   private requestEpoch = 0;
@@ -64,14 +66,29 @@ export class CustodianPage extends OpenClawLightDomElement {
   private sessionScopeKey: string | null = null;
   private sessionStarted = false;
   private lastHelloDeviceToken = "";
+  private eventNudgeClosed = false;
   private readonly subscriptions = new SubscriptionsController(this).watch(
     () => this.context?.gateway,
     (gateway, notify) => gateway.subscribe(notify),
+  );
+  private readonly eventSubscriptions = new SubscriptionsController(this).effect(
+    () => this.context?.gateway,
+    (gateway) =>
+      gateway.subscribeEvents((event) => {
+        if (this.onboarding || this.eventNudgeClosed) {
+          return;
+        }
+        const next = classifyCustodianEventNudge(event);
+        if (next && (!this.eventNudge || next.severity > this.eventNudge.severity)) {
+          this.eventNudge = next;
+        }
+      }),
   );
 
   override disconnectedCallback(): void {
     this.requestEpoch += 1;
     this.subscriptions.clear();
+    this.eventSubscriptions.clear();
     super.disconnectedCallback();
   }
 
@@ -128,6 +145,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     if (scopeChanged) {
       this.sessionScopeKey = scopeKey;
       this.sessionStarted = false;
+      this.eventNudge = null;
       this.clearConversation();
     } else if (requestWasPending) {
       this.error = t("custodian.connectionChanged");
@@ -251,6 +269,35 @@ export class CustodianPage extends OpenClawLightDomElement {
     });
   }
 
+  private sendEventNudge(): void {
+    const nudge = this.eventNudge;
+    if (!nudge) {
+      return;
+    }
+    this.eventNudge = null;
+    this.eventNudgeClosed = true;
+    this.send(nudge.message);
+  }
+
+  private dismissEventNudge(): void {
+    this.eventNudge = null;
+    this.eventNudgeClosed = true;
+  }
+
+  private eventNudgeText(nudge: CustodianEventNudge): string {
+    if (nudge.kind === "config-reload") {
+      return t("custodian.nudge.configReload");
+    }
+    const channel = nudge.channelLabel ?? t("custodian.nudge.channelFallback");
+    if (nudge.kind === "channel-auth") {
+      return t("custodian.nudge.channelAuth", { channel });
+    }
+    if (nudge.kind === "channel-disconnected") {
+      return t("custodian.nudge.channelDisconnected", { channel });
+    }
+    return t("custodian.nudge.channelDegraded", { channel });
+  }
+
   private dismissQuestion(message: CustodianMessage): void {
     const questionId = message.question?.id;
     if (!questionId) {
@@ -327,6 +374,26 @@ export class CustodianPage extends OpenClawLightDomElement {
         </header>
 
         <div class="custodian__messages" aria-live="polite">
+          ${!this.onboarding && this.eventNudge
+            ? html`<div class="custodian__nudge" role="status">
+                <button
+                  class="custodian__nudge-action"
+                  type="button"
+                  ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
+                  @click=${() => this.sendEventNudge()}
+                >
+                  ${this.eventNudgeText(this.eventNudge)}
+                </button>
+                <button
+                  class="custodian__nudge-dismiss"
+                  type="button"
+                  aria-label=${t("custodian.nudge.dismiss")}
+                  @click=${() => this.dismissEventNudge()}
+                >
+                  ×
+                </button>
+              </div>`
+            : nothing}
           ${this.messages.map((message) => {
             const questionKey = message.question ? `${message.id}:${message.question.id}` : "";
             const showQuestion =

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -64,20 +64,7 @@ function classifyChannelAccount(
       message: `what happened with ${canonical}?`,
     };
   }
-  if (healthState === "not-running" && account.running === false) {
-    const reconnectAttempts =
-      typeof account.reconnectAttempts === "number" ? account.reconnectAttempts : 0;
-    if (
-      account.restartPending === false &&
-      typeof account.lastStopAt === "number" &&
-      reconnectAttempts < 10
-    ) {
-      // server-channels only leaves this low-count, non-retrying shape after a clean/manual stop.
-      // Startup failures lack lastStopAt; post-start failures retry, terminate, or reach 10 attempts.
-      return null;
-    }
-  }
-  if (typeof account.lastError === "string" && account.lastError.trim()) {
+  if (hasFailedProbe(account)) {
     return {
       severity: 3,
       kind: "channel-degraded",
@@ -85,7 +72,23 @@ function classifyChannelAccount(
       message: `what happened with ${canonical}?`,
     };
   }
-  if (hasFailedProbe(account)) {
+  if (healthState === "not-running" && account.running === false) {
+    const reconnectAttempts =
+      typeof account.reconnectAttempts === "number" ? account.reconnectAttempts : 0;
+    const lastStartAt = typeof account.lastStartAt === "number" ? account.lastStartAt : undefined;
+    const lastStopAt = typeof account.lastStopAt === "number" ? account.lastStopAt : undefined;
+    if (
+      account.restartPending === false &&
+      lastStopAt !== undefined &&
+      (lastStartAt === undefined || lastStopAt >= lastStartAt) &&
+      reconnectAttempts < 10
+    ) {
+      // server-channels only leaves this low-count, non-retrying shape after a clean/manual stop.
+      // A newer start timestamp means a pre-handoff startup failed after an earlier clean stop.
+      return null;
+    }
+  }
+  if (typeof account.lastError === "string" && account.lastError.trim()) {
     return {
       severity: 3,
       kind: "channel-degraded",

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -88,7 +88,12 @@ function classifyChannelAccount(
       return null;
     }
   }
-  if (typeof account.lastError === "string" && account.lastError.trim()) {
+  if (
+    account.connected !== true &&
+    healthState !== "healthy" &&
+    typeof account.lastError === "string" &&
+    account.lastError.trim()
+  ) {
     return {
       severity: 3,
       kind: "channel-degraded",

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -1,0 +1,150 @@
+import type { GatewayEventFrame } from "../../api/gateway.ts";
+
+export type CustodianEventNudge = {
+  severity: 1 | 2 | 3;
+  kind: "channel-auth" | "channel-degraded" | "channel-disconnected" | "config-reload";
+  channelLabel?: string;
+  message: string;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+const CONSEQUENTIAL_CHANNEL_STATES = new Set([
+  "disconnected",
+  "stale-socket",
+  "stuck",
+  "terminal-disconnect",
+]);
+const CHANNEL_AUTH_STATUS_KEYS = [
+  "tokenStatus",
+  "botTokenStatus",
+  "appTokenStatus",
+  "signingSecretStatus",
+  "userTokenStatus",
+] as const;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function hasUnavailableAuth(account: UnknownRecord): boolean {
+  return CHANNEL_AUTH_STATUS_KEYS.some((key) => account[key] === "configured_unavailable");
+}
+
+function hasFailedProbe(account: UnknownRecord): boolean {
+  return asRecord(account.probe)?.ok === false;
+}
+
+function classifyChannelAccount(
+  channelId: string,
+  label: string,
+  account: UnknownRecord,
+): CustodianEventNudge | null {
+  if (account.configured === false || account.enabled === false) {
+    return null;
+  }
+  const canonical = channelId.toLowerCase();
+  if (hasUnavailableAuth(account)) {
+    return {
+      severity: 3,
+      kind: "channel-auth",
+      channelLabel: label,
+      message: `what happened with ${canonical} authentication?`,
+    };
+  }
+  const healthState =
+    typeof account.healthState === "string" ? account.healthState.trim().toLowerCase() : undefined;
+  if (healthState === "terminal-disconnect") {
+    return {
+      severity: 3,
+      kind: "channel-degraded",
+      channelLabel: label,
+      message: `what happened with ${canonical}?`,
+    };
+  }
+  if (typeof account.lastError === "string" && account.lastError.trim()) {
+    return {
+      severity: 3,
+      kind: "channel-degraded",
+      channelLabel: label,
+      message: `what happened with ${canonical}?`,
+    };
+  }
+  if (hasFailedProbe(account)) {
+    return {
+      severity: 3,
+      kind: "channel-degraded",
+      channelLabel: label,
+      message: `what happened with ${canonical}?`,
+    };
+  }
+  if (account.connected === false && account.running === true) {
+    return {
+      severity: 2,
+      kind: "channel-disconnected",
+      channelLabel: label,
+      message: `what happened with ${canonical}?`,
+    };
+  }
+  if (healthState && CONSEQUENTIAL_CHANNEL_STATES.has(healthState)) {
+    return {
+      severity: 1,
+      kind: "channel-degraded",
+      channelLabel: label,
+      message: `what happened with ${canonical}?`,
+    };
+  }
+  return null;
+}
+
+function classifyHealth(payload: unknown): CustodianEventNudge | null {
+  const health = asRecord(payload);
+  if (!health) {
+    return null;
+  }
+  if (asRecord(health.configReload)?.hotReloadStatus === "disabled") {
+    return {
+      severity: 3,
+      kind: "config-reload",
+      message: "what happened with configuration reload?",
+    };
+  }
+  const channels = asRecord(health.channels);
+  if (!channels) {
+    return null;
+  }
+  const labels = asRecord(health.channelLabels);
+  let best: CustodianEventNudge | null = null;
+  for (const [channelId, channelValue] of Object.entries(channels)) {
+    const channel = asRecord(channelValue);
+    if (!channel) {
+      continue;
+    }
+    const label = typeof labels?.[channelId] === "string" ? labels[channelId] : channelId;
+    const accounts = asRecord(channel.accounts);
+    const accountCandidates = accounts
+      ? Object.values(accounts)
+          .map(asRecord)
+          .filter((value) => value !== null)
+      : [];
+    // The channel-level record duplicates the preferred account. Per-account
+    // rows are authoritative when present and may have different enabled state.
+    const candidates = accountCandidates.length > 0 ? accountCandidates : [channel];
+    for (const account of candidates) {
+      const nudge = classifyChannelAccount(channelId, label, account);
+      if (nudge && (!best || nudge.severity > best.severity)) {
+        best = nudge;
+      }
+    }
+  }
+  return best;
+}
+
+/** Only Gateway health failures produce presence nudges; success/info events stay silent. */
+export function classifyCustodianEventNudge(
+  event: Pick<GatewayEventFrame, "event" | "payload">,
+): CustodianEventNudge | null {
+  return event.event === "health" ? classifyHealth(event.payload) : null;
+}

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -64,6 +64,19 @@ function classifyChannelAccount(
       message: `what happened with ${canonical}?`,
     };
   }
+  if (healthState === "not-running" && account.running === false) {
+    const reconnectAttempts =
+      typeof account.reconnectAttempts === "number" ? account.reconnectAttempts : 0;
+    if (
+      account.restartPending === false &&
+      typeof account.lastStopAt === "number" &&
+      reconnectAttempts < 10
+    ) {
+      // server-channels only leaves this low-count, non-retrying shape after a clean/manual stop.
+      // Startup failures lack lastStopAt; post-start failures retry, terminate, or reach 10 attempts.
+      return null;
+    }
+  }
   if (typeof account.lastError === "string" && account.lastError.trim()) {
     return {
       severity: 3,

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -51,6 +51,7 @@ function createContext(): ApplicationContext {
       password: "",
     },
     subscribe: () => () => undefined,
+    subscribeEvents: () => () => undefined,
   } as unknown as ApplicationGateway;
   return { gateway } as unknown as ApplicationContext;
 }

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -67,6 +67,60 @@
   width: min(680px, 90%);
 }
 
+.custodian__nudge {
+  display: flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 4px;
+  max-width: min(680px, 96%);
+  padding: 4px 5px 4px 12px;
+  border: 1px solid color-mix(in srgb, var(--warn) 42%, var(--border));
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--warn) 9%, var(--bg-elevated));
+  color: var(--text);
+}
+
+.custodian__nudge-action,
+.custodian__nudge-dismiss {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.custodian__nudge-action {
+  padding: 5px 2px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.custodian__nudge-action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.custodian__nudge-dismiss {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.custodian__nudge-action:focus-visible,
+.custodian__nudge-dismiss:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.custodian__nudge-dismiss:hover {
+  background: var(--bg-hover);
+  color: var(--text-strong);
+}
+
 .custodian__message--assistant {
   align-self: flex-start;
 }


### PR DESCRIPTION
## What Problem This Solves

The permanent OpenClaw custodian page was passive when a consequential system problem arrived. Operators had to notice the failure elsewhere and manually decide what to ask, while routine Gateway traffic made a broad reactive assistant too noisy.

## Why This Change Was Made

This adds one restrained, dismissible nudge per normal custodian-page visit. Only consequential `health` snapshots qualify: configuration hot-reload disabled, configured/enabled channel credentials unavailable, explicit channel errors or failed probes, terminal disconnects, active channel disconnects, and the concrete degraded lifecycle states `disconnected`, `stale-socket`, and `stuck`. Routine events such as `config.changed`, disabled accounts, and intentionally stopped channels remain silent. Higher-severity failures may replace a pending chip; dismissal or use silences the visit. Gateway identity changes clear a pending chip so it cannot cross operators or servers.

Clicking the chip sends a canonical diagnosis question through the existing `openclaw.chat` path and records it as a real user transcript message. Onboarding mode never subscribes visibly to these nudges.

AI-assisted by Codex. No changelog edit per the phase work order.

### Phase 6 server study / bounded follow-up proposal

The server deliverable was studied but intentionally stopped at the work order's depth gate:

- Inbound `/openclaw` handling already enters `src/auto-reply/reply/commands-system-agent.ts`; existing commands use deterministic rescue via `src/system-agent/rescue-message.ts`.
- A conversational `/openclaw ask <request>` can be routed there to `openclaw.chat` with the existing host-owned delegation fields from `src/gateway/server-methods/system-agent.ts`, and the normal reply pipeline preserves the source thread.
- The hard agent-down seam is the final generic external failure in `src/auto-reply/reply/agent-runner-error-handler.ts`.
- A safe fallback cannot be only a bounded reply hook: cancellation must reach the underlying in-process `openclaw.chat` inference. Today `SystemAgentChatEngine.handle` and the system-agent turn runner do not own an `AbortSignal`; merely racing the Gateway promise leaves inference running and can mutate a stable delegation session after the source turn was stopped.

Proposed follow-up: add turn-owned cancellation from `openclaw.chat` through the system-agent session queue, `SystemAgentChatEngine.handle`, and the embedded/CLI system-agent turn. Then add `/openclaw ask <request>` with source delegation, and invoke one disposable/cancellable diagnosis from the final generic channel failure. The returned copy must direct the user to the routable command, for example `Ask me to fix it with /openclaw ask fix it`, and reserved system-agent IDs must bypass the fallback to prevent loops.

## User Impact

Operators can notice one meaningful health incident while already talking to OpenClaw and ask for diagnosis with one click, without fake assistant transcript content or recurring Clippy-style prompts.

## Evidence

- Unit: `node scripts/run-vitest.mjs ui/src/pages/custodian/custodian-page.test.ts` — 27 passed.
- Mocked Gateway browser E2E: consequential event -> one chip -> real second `openclaw.chat` request; routine events and onboarding stay silent — 2 passed.
- Source-blind behavior contract: 5 observable clauses passed; anti-cheat probes verified the real Gateway request, once-per-visit silence, routine-event silence, and onboarding isolation.
- Visual proof captured locally: before event, disconnect chip, real-message transcript, plus browser video. Sanitized synthetic fixtures only; images will be attached to this PR.
- Exact-head heavy gates on Blacksmith Testbox: `pnpm tsgo`, `pnpm tsgo:ui`, `pnpm check:test-types`, targeted oxlint, `pnpm deadcode:exports` (0), i18n baseline/verify, docs MDX, format check, and `git diff --check` all passed. [Testbox hydration run](https://github.com/openclaw/openclaw/actions/runs/29646057346).
- Fresh branch autoreview: clean, no accepted/actionable findings.
