### PR TITLE
test(feishu): align delivery trace with turn plan

### DIFF
--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -16,7 +16,6 @@ import {
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeAll, describe, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
-import type { ReplyPayload } from "./reply-dispatcher-runtime-api.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -1,7 +1,7 @@
 // Feishu delivery trace goldens: replayable wire-level lifecycle recordings.
 //
-// IN events are fed straight into the reply-dispatcher wiring (the options
-// createReplyDispatcherWithTyping receives plus replyOptions callbacks); OUT
+// IN events are fed straight into the reply-dispatcher plan (dispatcherOptions,
+// delivery, and replyOptions callbacks); OUT
 // events are recorded at the mocked Lark SDK client and the mocked CardKit
 // HTTP fetch, so streaming-card entity calls are captured at the wire seam.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
@@ -25,19 +25,11 @@ type CreateFeishuReplyDispatcher =
 type StreamingStartBackoffMap =
   typeof import("./reply-dispatcher-state.js").streamingStartBackoffUntilByAccount;
 
-type FeishuDispatcherOptions = {
-  onReplyStart?: () => Promise<void> | void;
-  onIdle?: () => Promise<void> | void;
-  onCleanup?: () => void;
-  deliver: (payload: ReplyPayload, info: { kind: string }) => Promise<void> | void;
-};
-
 type FeishuTraceState = {
   recordWireCall: (call: RecordedWireCall) => void;
   account: ResolvedFeishuAccount | null;
   larkClient: unknown;
   cardKitFetch: typeof fetch | null;
-  dispatcherOptions: FeishuDispatcherOptions | null;
   messageCount: number;
   reactionCount: number;
   cardCount: number;
@@ -51,7 +43,6 @@ const traceState = vi.hoisted(
     account: null,
     larkClient: null,
     cardKitFetch: null,
-    dispatcherOptions: null,
     messageCount: 0,
     reactionCount: 0,
     cardCount: 0,
@@ -84,17 +75,6 @@ vi.mock("./client.js", async (importOriginal) => {
         throw new Error("trace Lark client not initialized");
       }
       return traceState.larkClient;
-    },
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createReplyDispatcherWithTyping: (options: FeishuDispatcherOptions) => {
-      traceState.dispatcherOptions = options;
-      return { dispatcher: {}, replyOptions: {}, markDispatchIdle: () => {} };
     },
   };
 });
@@ -161,7 +141,6 @@ afterAll(() => {
   vi.doUnmock("./client.js");
   vi.doUnmock("./runtime.js");
   vi.doUnmock("./streaming-card.js");
-  vi.doUnmock("openclaw/plugin-sdk/reply-runtime");
   vi.resetModules();
 });
 
@@ -169,7 +148,6 @@ afterEach(() => {
   traceState.account = null;
   traceState.larkClient = null;
   traceState.cardKitFetch = null;
-  traceState.dispatcherOptions = null;
   traceState.wireFaults = [];
   streamingStartBackoffUntilByAccount.clear();
 });
@@ -378,27 +356,24 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
     sendTarget: "oc-trace-chat",
     replyToMessageId: "om-inbound",
   });
-  const options = traceState.dispatcherOptions;
-  if (!options) {
-    throw new Error("dispatcher options were not captured");
-  }
+  const { dispatcherOptions, delivery, replyOptions } = created;
 
   return async (step: DeliveryTraceInStep) => {
     switch (step.kind) {
       case "reply-start":
-        await options.onReplyStart?.();
+        await dispatcherOptions.onReplyStart?.();
         break;
       case "partial":
-        created.replyOptions.onPartialReply?.({ text: step.text });
+        replyOptions.onPartialReply?.({ text: step.text });
         break;
       case "block-final":
-        await options.deliver({ text: step.text }, { kind: "block" });
+        await delivery.deliver({ text: step.text }, { kind: "block" });
         break;
       case "tool-progress":
-        created.replyOptions.onToolStart?.({ name: step.name, phase: step.phase });
+        replyOptions.onToolStart?.({ name: step.name, phase: step.phase });
         break;
       case "final":
-        await options.deliver(
+        await delivery.deliver(
           {
             ...(step.text !== undefined ? { text: step.text } : {}),
             ...(step.mediaUrls ? { mediaUrls: step.mediaUrls } : {}),
@@ -411,8 +386,8 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
         // An aborted run stops emitting payloads; closeout happens on idle.
         break;
       case "idle":
-        await options.onIdle?.();
-        options.onCleanup?.();
+        await dispatcherOptions.onIdle?.();
+        dispatcherOptions.onCleanup?.();
         break;
       case "wire-fault":
         if (step.fault !== "rate-limit") {


### PR DESCRIPTION
## What Problem This Solves

Feishu's delivery-trace harness still models the retired reply dispatcher factory. After the channel inbound-turn refactor, `createFeishuReplyDispatcher()` returns a plan with `dispatcherOptions`, `delivery`, and `replyOptions`; the stale mock leaves every trace scenario without a delivery adapter.

## Change

- Drive the trace harness from the current dispatcher plan directly.
- Remove the obsolete reply-runtime mock and its test-only state.

No production Feishu behavior changes.

## Validation

- `node scripts/run-vitest.mjs extensions/feishu/src/delivery-trace.test.ts` (5 passed)
- `pnpm exec oxfmt --check --threads=1 extensions/feishu/src/delivery-trace.test.ts`
- `git diff --check`

This unblocks the unrelated Feishu media preview PR #98458, whose changed-file CI shard exercises this trace suite.