### PR TITLE
fix(security): bound hashFileContentsSync in approval script operand reads

### DIFF
--- a/src/node-host/invoke-agent-cli-claude-handler.ts
+++ b/src/node-host/invoke-agent-cli-claude-handler.ts
@@ -84,7 +84,7 @@ export async function handleClaudeCliNodeInvoke(params: {
     return;
   }
   const approvalCommand = [claudePath, ...request.argv];
-  const preparedApproval = buildSystemRunApprovalPlan({
+  const preparedApproval = await buildSystemRunApprovalPlan({
     command: approvalCommand,
     ...(request.cwd ? { cwd: request.cwd } : {}),
     ...(request.agentId ? { agentId: request.agentId } : {}),

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -1162,23 +1162,22 @@ describe("hardenApprovedExecutionPaths", () => {
   });
 });
 
-it("rejects mutable file operand exceeding 8 MiB size cap", () => {
+it("accepts mutable file operand larger than 8 MiB using chunked hashing", () => {
   const tmp = createFixtureDir("openclaw-oversize-script-");
   const scriptPath = path.join(tmp, "huge.js");
   // Create a file just over the 8 MiB cap (8 MiB + 1 byte)
   const oversizedBytes = 8 * 1024 * 1024 + 1;
   const buf = Buffer.alloc(oversizedBytes, "x");
   fs.writeFileSync(scriptPath, buf);
-  expect(
-    resolveMutableFileOperandSnapshotSync({
-      argv: ["node", "huge.js"],
-      cwd: tmp,
-      shellCommand: null,
-    }),
-  ).toEqual({
-    ok: false,
-    message: "SYSTEM_RUN_DENIED: approval script operand is too large or not a regular file",
+  const snapshot = resolveMutableFileOperandSnapshotSync({
+    argv: ["node", "huge.js"],
+    cwd: tmp,
+    shellCommand: null,
   });
+  expect(snapshot.ok).toBe(true);
+  if (snapshot.ok && snapshot.snapshot) {
+    expect(snapshot.snapshot.sha256).toBe(sha256FileSync(scriptPath));
+  }
 });
 
 it("accepts mutable file operand exactly at 8 MiB size cap", () => {

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -5,12 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { formatExecCommand } from "../infra/system-run-command.js";
-import { withEnv } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildSystemRunApprovalPlan,
   hardenApprovedExecutionPaths,
   revalidateApprovedMutableFileOperand,
-  resolveMutableFileOperandSnapshotSync,
+  resolveMutableFileOperandSnapshot,
 } from "./invoke-system-run-plan.js";
 
 type PathTokenSetup = {
@@ -142,11 +142,11 @@ function writeFakeRuntimeBin(binDir: string, binName: string) {
   }
 }
 
-function withFakeRuntimeBins<T>(params: {
+async function withFakeRuntimeBins<T>(params: {
   binNames: string[];
   tmpPrefix?: string;
-  run: () => T;
-}): T {
+  run: () => Promise<T>;
+}): Promise<T> {
   void params.tmpPrefix;
   for (const binName of params.binNames) {
     if (sharedRuntimeBins.has(binName)) {
@@ -155,7 +155,7 @@ function withFakeRuntimeBins<T>(params: {
     writeFakeRuntimeBin(sharedRuntimeBinDir, binName);
     sharedRuntimeBins.add(binName);
   }
-  return withEnv(
+  return await withEnvAsync(
     { PATH: `${sharedRuntimeBinDir}${path.delimiter}${process.env.PATH ?? ""}` },
     params.run,
   );
@@ -194,7 +194,7 @@ function resolveNativeBinaryFixturePath(): string {
   throw new Error("expected a native binary fixture path");
 }
 
-function expectShellPayloadApprovalDenied(params: {
+async function expectShellPayloadApprovalDenied(params: {
   tmpPrefix: string;
   fileName: string;
   body: string;
@@ -206,7 +206,7 @@ function expectShellPayloadApprovalDenied(params: {
   const scriptPath = path.join(tmp, params.fileName);
   fs.writeFileSync(scriptPath, params.body);
   fs.chmodSync(scriptPath, 0o755);
-  const prepared = buildSystemRunApprovalPlan({
+  const prepared = await buildSystemRunApprovalPlan({
     command: ["/bin/sh", "-lc", scriptPath],
     rawCommand: scriptPath,
     cwd: tmp,
@@ -214,8 +214,8 @@ function expectShellPayloadApprovalDenied(params: {
   expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
 }
 
-function expectMutableFileOperandApprovalPlan(fixture: ScriptOperandFixture, cwd: string) {
-  const prepared = buildSystemRunApprovalPlan({
+async function expectMutableFileOperandApprovalPlan(fixture: ScriptOperandFixture, cwd: string) {
+  const prepared = await buildSystemRunApprovalPlan({
     command: fixture.command,
     cwd,
   });
@@ -237,19 +237,19 @@ function writeScriptOperandFixture(fixture: ScriptOperandFixture) {
   }
 }
 
-function withScriptOperandPlanFixture<T>(
+async function withScriptOperandPlanFixture<T>(
   params: {
     tmpPrefix: string;
     fixture?: RuntimeFixture;
     afterWrite?: (fixture: ScriptOperandFixture, tmp: string) => void;
   },
-  run: (fixture: ScriptOperandFixture, tmp: string) => T,
-) {
+  run: (fixture: ScriptOperandFixture, tmp: string) => Promise<T>,
+): Promise<T> {
   const tmp = createFixtureDir(params.tmpPrefix);
   const fixture = createScriptOperandFixture(tmp, params.fixture);
   writeScriptOperandFixture(fixture);
   params.afterWrite?.(fixture, tmp);
-  return run(fixture, tmp);
+  return await run(fixture, tmp);
 }
 
 const DENIED_RUNTIME_APPROVAL = {
@@ -257,21 +257,21 @@ const DENIED_RUNTIME_APPROVAL = {
   message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
 } as const;
 
-function runNamedCase(name: string, run: () => void) {
+async function runNamedCase(name: string, run: () => void | Promise<void>) {
   try {
-    run();
+    await run();
   } catch (error) {
     throw new Error(`case failed: ${name}`, { cause: error });
   }
 }
 
-function expectRuntimeApprovalDenied(command: string[], cwd: string) {
-  const prepared = buildSystemRunApprovalPlan({ command, cwd });
+async function expectRuntimeApprovalDenied(command: string[], cwd: string) {
+  const prepared = await buildSystemRunApprovalPlan({ command, cwd });
   expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
 }
 
-function expectApprovalPlanWithoutMutableOperand(command: string[], cwd: string) {
-  const prepared = buildSystemRunApprovalPlan({ command, cwd });
+async function expectApprovalPlanWithoutMutableOperand(command: string[], cwd: string) {
+  const prepared = await buildSystemRunApprovalPlan({ command, cwd });
   expect(prepared.ok).toBe(true);
   if (!prepared.ok) {
     throw new Error("unreachable");
@@ -395,7 +395,7 @@ const unsafeRuntimeInvocationCases: UnsafeRuntimeInvocationCase[] = [
   },
 ];
 
-describe("hardenApprovedExecutionPaths", () => {
+describe("hardenApprovedExecutionPaths", async () => {
   const cases: HardeningCase[] = [
     {
       name: "preserves shell-wrapper argv during approval hardening",
@@ -451,15 +451,15 @@ describe("hardenApprovedExecutionPaths", () => {
     },
   ];
 
-  it.runIf(process.platform !== "win32")("handles approval hardening cases", () => {
+  it.runIf(process.platform !== "win32")("handles approval hardening cases", async () => {
     for (const testCase of cases) {
-      runNamedCase(testCase.name, () => {
+      await runNamedCase(testCase.name, async () => {
         const tmp = createFixtureDir("openclaw-approval-hardening-");
         let pathToken: PathTokenSetup | null = null;
 
-        const checkCase = () => {
+        const checkCase = async () => {
           if (testCase.mode === "build-plan") {
-            const prepared = buildSystemRunApprovalPlan({
+            const prepared = await buildSystemRunApprovalPlan({
               command: testCase.argv,
               cwd: tmp,
             });
@@ -502,7 +502,7 @@ describe("hardenApprovedExecutionPaths", () => {
           const link = path.join(binDir, "poccmd");
           fs.symlinkSync("/bin/echo", link);
           pathToken = { expected: fs.realpathSync(link) };
-          return withEnv(
+          return await withEnvAsync(
             { PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
             checkCase,
           );
@@ -657,13 +657,13 @@ describe("hardenApprovedExecutionPaths", () => {
     },
   ];
 
-  it("captures mutable runtime operands in approval plans", () => {
+  it("captures mutable runtime operands in approval plans", async () => {
     const tmp = createFixtureDir("openclaw-approval-script-plan-");
-    withFakeRuntimeBins({
+    await withFakeRuntimeBins({
       binNames: uniqueRuntimeBinNames(mutableOperandCases),
-      run: () => {
+      run: async () => {
         for (const runtimeCase of mutableOperandCases) {
-          runNamedCase(runtimeCase.name, () => {
+          await runNamedCase(runtimeCase.name, async () => {
             if (runtimeCase.skipOnWin32 && process.platform === "win32") {
               return;
             }
@@ -675,30 +675,30 @@ describe("hardenApprovedExecutionPaths", () => {
               fs.writeFileSync(shimPath, "#!/usr/bin/env node\nconsole.log('shim')\n");
               fs.chmodSync(shimPath, 0o755);
             }
-            expectMutableFileOperandApprovalPlan(fixture, tmp);
+            await expectMutableFileOperandApprovalPlan(fixture, tmp);
           });
         }
       },
     });
   });
 
-  it("captures mutable shell script operands in approval plans", () => {
-    withScriptOperandPlanFixture(
+  it("captures mutable shell script operands in approval plans", async () => {
+    await withScriptOperandPlanFixture(
       {
         tmpPrefix: "openclaw-approval-script-plan-",
       },
-      (fixture, tmp) => {
-        expectMutableFileOperandApprovalPlan(fixture, tmp);
+      async (fixture, tmp) => {
+        await expectMutableFileOperandApprovalPlan(fixture, tmp);
       },
     );
   });
 
-  it("handles shell payloads that invoke absolute-path native binaries", () => {
+  it("handles shell payloads that invoke absolute-path native binaries", async () => {
     if (process.platform === "win32") {
       return;
     }
     const binaryPath = resolveNativeBinaryFixturePath();
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["/bin/sh", "-lc", binaryPath],
       rawCommand: binaryPath,
       cwd: process.cwd(),
@@ -714,7 +714,7 @@ describe("hardenApprovedExecutionPaths", () => {
     expect(prepared.plan.mutableFileOperand).toBeUndefined();
   });
 
-  it("recognizes native binary headers across short positional reads", () => {
+  it("recognizes native binary headers across short positional reads", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -738,7 +738,7 @@ describe("hardenApprovedExecutionPaths", () => {
       return realReadSync(fd, buffer, offset, cappedLength, position);
     }) as typeof fs.readSync);
     try {
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: ["/bin/sh", "-lc", binaryPath],
         rawCommand: binaryPath,
         cwd: process.cwd(),
@@ -755,7 +755,7 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
-  it("keeps fail-closed behavior for relative native-binary shell payloads", () => {
+  it("keeps fail-closed behavior for relative native-binary shell payloads", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -764,7 +764,7 @@ describe("hardenApprovedExecutionPaths", () => {
     const relativeBinaryPath = path.join(tmp, "tool");
     fs.copyFileSync(binaryPath, relativeBinaryPath);
     fs.chmodSync(relativeBinaryPath, 0o755);
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["/bin/sh", "-lc", "./tool"],
       rawCommand: "./tool",
       cwd: tmp,
@@ -772,7 +772,7 @@ describe("hardenApprovedExecutionPaths", () => {
     expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
   });
 
-  it("keeps fail-closed behavior for writable absolute native-binary shell payloads", () => {
+  it("keeps fail-closed behavior for writable absolute native-binary shell payloads", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -781,7 +781,7 @@ describe("hardenApprovedExecutionPaths", () => {
     const copiedBinaryPath = path.join(tmp, "tool");
     fs.copyFileSync(binaryPath, copiedBinaryPath);
     fs.chmodSync(copiedBinaryPath, 0o755);
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["/bin/sh", "-lc", copiedBinaryPath],
       rawCommand: copiedBinaryPath,
       cwd: tmp,
@@ -789,7 +789,7 @@ describe("hardenApprovedExecutionPaths", () => {
     expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
   });
 
-  it("keeps fail-closed behavior for owner-controlled read-only absolute binaries", () => {
+  it("keeps fail-closed behavior for owner-controlled read-only absolute binaries", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -799,7 +799,7 @@ describe("hardenApprovedExecutionPaths", () => {
       fs.copyFileSync(resolveNativeBinaryFixturePath(), binaryPath);
       fs.chmodSync(binaryPath, 0o555);
       fs.chmodSync(tmp, 0o555);
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: ["/bin/sh", "-lc", binaryPath],
         rawCommand: binaryPath,
         cwd: tmp,
@@ -810,7 +810,7 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
-  it("keeps fail-closed behavior for symlinked binaries with writable targets", () => {
+  it("keeps fail-closed behavior for symlinked binaries with writable targets", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -827,7 +827,7 @@ describe("hardenApprovedExecutionPaths", () => {
       fs.chmodSync(targetBinaryPath, 0o755);
       fs.symlinkSync(targetBinaryPath, symlinkPath);
       fs.chmodSync(stableDir, 0o555);
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: ["/bin/sh", "-lc", symlinkPath],
         rawCommand: symlinkPath,
         cwd: tmp,
@@ -838,7 +838,7 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
-  it("keeps fail-closed behavior for mutable or ambiguous shell payload files", () => {
+  it("keeps fail-closed behavior for mutable or ambiguous shell payload files", async () => {
     for (const testCase of [
       {
         tmpPrefix: "openclaw-shell-script-binding-",
@@ -861,11 +861,11 @@ describe("hardenApprovedExecutionPaths", () => {
         body: "SAFE\u0000maybe-binary\n",
       },
     ]) {
-      expectShellPayloadApprovalDenied(testCase);
+      await expectShellPayloadApprovalDenied(testCase);
     }
   });
 
-  it("keeps fail-closed behavior when the shell payload probe stops seeing a file", () => {
+  it("keeps fail-closed behavior when the shell payload probe stops seeing a file", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -886,7 +886,7 @@ describe("hardenApprovedExecutionPaths", () => {
       return realStatSync(pathLike, options);
     });
     try {
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: ["/bin/sh", "-lc", scriptPath],
         rawCommand: scriptPath,
         cwd: tmp,
@@ -897,26 +897,26 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
-  it("rejects unsafe runtime invocation forms", () => {
-    withFakeRuntimeBins({
+  it("rejects unsafe runtime invocation forms", async () => {
+    await withFakeRuntimeBins({
       binNames: [...new Set(unsafeRuntimeInvocationCases.map((testCase) => testCase.binName))],
-      run: () => {
+      run: async () => {
         for (const testCase of unsafeRuntimeInvocationCases) {
-          runNamedCase(testCase.name, () => {
+          await runNamedCase(testCase.name, async () => {
             const tmp = createFixtureDir(testCase.tmpPrefix);
             testCase.setup?.(tmp);
-            expectRuntimeApprovalDenied(testCase.command, tmp);
+            await expectRuntimeApprovalDenied(testCase.command, tmp);
           });
         }
       },
     });
   });
 
-  it("detects rewritten script operands for pnpm dlx approval plans", () => {
-    withFakeRuntimeBins({
+  it("detects rewritten script operands for pnpm dlx approval plans", async () => {
+    await withFakeRuntimeBins({
       binNames: ["pnpm", "tsx"],
-      run: () => {
-        withScriptOperandPlanFixture(
+      run: async () => {
+        await withScriptOperandPlanFixture(
           {
             tmpPrefix: "openclaw-pnpm-dlx-approval-",
             fixture: {
@@ -927,8 +927,8 @@ describe("hardenApprovedExecutionPaths", () => {
               expectedArgvIndex: 3,
             },
           },
-          (fixture, tmp) => {
-            const prepared = buildSystemRunApprovalPlan({
+          async (fixture, tmp) => {
+            const prepared = await buildSystemRunApprovalPlan({
               command: fixture.command,
               cwd: tmp,
             });
@@ -942,7 +942,7 @@ describe("hardenApprovedExecutionPaths", () => {
             }
             fs.writeFileSync(fixture.scriptPath, 'console.log("PWNED");\n');
             expect(
-              revalidateApprovedMutableFileOperand({
+              await revalidateApprovedMutableFileOperand({
                 snapshot: mutableFileOperand,
                 argv: prepared.plan.argv,
                 cwd: prepared.plan.cwd ?? tmp,
@@ -954,14 +954,14 @@ describe("hardenApprovedExecutionPaths", () => {
     });
   });
 
-  it("does not bind pnpm dlx shell-mode commands to a mutable file operand", () => {
-    withFakeRuntimeBins({
+  it("does not bind pnpm dlx shell-mode commands to a mutable file operand", async () => {
+    await withFakeRuntimeBins({
       binNames: ["pnpm", "tsx"],
-      run: () => {
+      run: async () => {
         const tmp = createFixtureDir("openclaw-pnpm-dlx-shell-mode-");
         fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE");\n');
         expect(
-          resolveMutableFileOperandSnapshotSync({
+          await resolveMutableFileOperandSnapshot({
             argv: ["pnpm", "dlx", "--shell-mode", "tsx ./run.ts"],
             cwd: tmp,
             shellCommand: null,
@@ -971,10 +971,10 @@ describe("hardenApprovedExecutionPaths", () => {
     });
   });
 
-  it("allows pnpm dlx package binaries that do not bind mutable local files", () => {
-    withFakeRuntimeBins({
+  it("allows pnpm dlx package binaries that do not bind mutable local files", async () => {
+    await withFakeRuntimeBins({
       binNames: ["pnpm", "eslint"],
-      run: () => {
+      run: async () => {
         const casesResult = [
           {
             prefix: "openclaw-pnpm-dlx-package-bin-",
@@ -1007,17 +1007,17 @@ describe("hardenApprovedExecutionPaths", () => {
         for (const testCase of casesResult) {
           const tmp = createFixtureDir(testCase.prefix);
           testCase.setup?.(tmp);
-          expectApprovalPlanWithoutMutableOperand(testCase.command, tmp);
+          await expectApprovalPlanWithoutMutableOperand(testCase.command, tmp);
         }
       },
     });
   });
 
-  it("treats -- as the end of pnpm dlx option parsing", () => {
-    withFakeRuntimeBins({
+  it("treats -- as the end of pnpm dlx option parsing", async () => {
+    await withFakeRuntimeBins({
       binNames: ["pnpm", "tsx"],
-      run: () => {
-        withScriptOperandPlanFixture(
+      run: async () => {
+        await withScriptOperandPlanFixture(
           {
             tmpPrefix: "openclaw-pnpm-dlx-double-dash-",
             fixture: {
@@ -1028,15 +1028,15 @@ describe("hardenApprovedExecutionPaths", () => {
               expectedArgvIndex: 4,
             },
           },
-          (fixture, tmp) => {
-            expectMutableFileOperandApprovalPlan(fixture, tmp);
+          async (fixture, tmp) => {
+            await expectMutableFileOperandApprovalPlan(fixture, tmp);
           },
         );
       },
     });
   });
 
-  it("captures the real shell script operand after value-taking shell flags", () => {
+  it("captures the real shell script operand after value-taking shell flags", async () => {
     const casesValue = [
       {
         name: "separate set option",
@@ -1083,12 +1083,12 @@ describe("hardenApprovedExecutionPaths", () => {
     ];
 
     for (const testCase of casesValue) {
-      runNamedCase(testCase.name, () => {
+      await runNamedCase(testCase.name, async () => {
         const tmp = createFixtureDir("openclaw-shell-option-value-");
         const scriptPath = path.join(tmp, "run.sh");
         fs.writeFileSync(scriptPath, "#!/bin/sh\necho SAFE\n");
         fs.writeFileSync(path.join(tmp, testCase.decoyName), "decoy\n");
-        const snapshot = resolveMutableFileOperandSnapshotSync({
+        const snapshot = await resolveMutableFileOperandSnapshot({
           argv: testCase.argv,
           cwd: tmp,
           shellCommand: null,
@@ -1106,7 +1106,7 @@ describe("hardenApprovedExecutionPaths", () => {
         }
         fs.writeFileSync(scriptPath, "#!/bin/sh\necho CHANGED\n");
         expect(
-          revalidateApprovedMutableFileOperand({
+          await revalidateApprovedMutableFileOperand({
             snapshot: snapshot.snapshot,
             argv: testCase.argv,
             cwd: tmp,
@@ -1116,7 +1116,7 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
-  it("captures fish script operands with plus-prefixed filenames", () => {
+  it("captures fish script operands with plus-prefixed filenames", async () => {
     const casesLocal = [
       {
         name: "plus-prefixed fish script",
@@ -1129,11 +1129,11 @@ describe("hardenApprovedExecutionPaths", () => {
     ];
 
     for (const testCase of casesLocal) {
-      runNamedCase(testCase.name, () => {
+      await runNamedCase(testCase.name, async () => {
         const tmp = createFixtureDir("openclaw-fish-plus-script-");
         const scriptPath = path.join(tmp, "+setup.fish");
         fs.writeFileSync(scriptPath, "echo SAFE\n");
-        const snapshot = resolveMutableFileOperandSnapshotSync({
+        const snapshot = await resolveMutableFileOperandSnapshot({
           argv: testCase.argv,
           cwd: tmp,
           shellCommand: null,
@@ -1151,7 +1151,7 @@ describe("hardenApprovedExecutionPaths", () => {
         }
         fs.writeFileSync(scriptPath, "echo CHANGED\n");
         expect(
-          revalidateApprovedMutableFileOperand({
+          await revalidateApprovedMutableFileOperand({
             snapshot: snapshot.snapshot,
             argv: testCase.argv,
             cwd: tmp,
@@ -1162,14 +1162,14 @@ describe("hardenApprovedExecutionPaths", () => {
   });
 });
 
-it("accepts mutable file operand larger than 8 MiB using chunked hashing", () => {
+it("accepts mutable file operand larger than 8 MiB using chunked hashing", async () => {
   const tmp = createFixtureDir("openclaw-oversize-script-");
   const scriptPath = path.join(tmp, "huge.js");
   // Create a file just over the 8 MiB cap (8 MiB + 1 byte)
   const oversizedBytes = 8 * 1024 * 1024 + 1;
   const buf = Buffer.alloc(oversizedBytes, "x");
   fs.writeFileSync(scriptPath, buf);
-  const snapshot = resolveMutableFileOperandSnapshotSync({
+  const snapshot = await resolveMutableFileOperandSnapshot({
     argv: ["node", "huge.js"],
     cwd: tmp,
     shellCommand: null,
@@ -1180,14 +1180,14 @@ it("accepts mutable file operand larger than 8 MiB using chunked hashing", () =>
   }
 });
 
-it("accepts mutable file operand exactly at 8 MiB size cap", () => {
+it("accepts mutable file operand exactly at 8 MiB size cap", async () => {
   const tmp = createFixtureDir("openclaw-boundary-script-");
   const scriptPath = path.join(tmp, "ok.js");
   // Create a file exactly at the 8 MiB cap
   const exactBytes = 8 * 1024 * 1024;
   const buf = Buffer.alloc(exactBytes, "x");
   fs.writeFileSync(scriptPath, buf);
-  const snapshot = resolveMutableFileOperandSnapshotSync({
+  const snapshot = await resolveMutableFileOperandSnapshot({
     argv: ["node", "ok.js"],
     cwd: tmp,
     shellCommand: null,

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -1161,4 +1161,41 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 });
+
+it("rejects mutable file operand exceeding 8 MiB size cap", () => {
+  const tmp = createFixtureDir("openclaw-oversize-script-");
+  const scriptPath = path.join(tmp, "huge.js");
+  // Create a file just over the 8 MiB cap (8 MiB + 1 byte)
+  const oversizedBytes = 8 * 1024 * 1024 + 1;
+  const buf = Buffer.alloc(oversizedBytes, "x");
+  fs.writeFileSync(scriptPath, buf);
+  expect(
+    resolveMutableFileOperandSnapshotSync({
+      argv: ["node", "huge.js"],
+      cwd: tmp,
+      shellCommand: null,
+    }),
+  ).toEqual({
+    ok: false,
+    message: "SYSTEM_RUN_DENIED: approval script operand is too large or not a regular file",
+  });
+});
+
+it("accepts mutable file operand exactly at 8 MiB size cap", () => {
+  const tmp = createFixtureDir("openclaw-boundary-script-");
+  const scriptPath = path.join(tmp, "ok.js");
+  // Create a file exactly at the 8 MiB cap
+  const exactBytes = 8 * 1024 * 1024;
+  const buf = Buffer.alloc(exactBytes, "x");
+  fs.writeFileSync(scriptPath, buf);
+  const snapshot = resolveMutableFileOperandSnapshotSync({
+    argv: ["node", "ok.js"],
+    cwd: tmp,
+    shellCommand: null,
+  });
+  expect(snapshot.ok).toBe(true);
+  if (snapshot.ok && snapshot.snapshot) {
+    expect(snapshot.snapshot.sha256).toBe(sha256FileSync(scriptPath));
+  }
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -272,27 +272,22 @@ function shouldPinExecutableForApproval(params: {
 // Hash arbitrarily large regular script operands without loading the whole
 // file into memory. This keeps the approval hot path bounded while preserving
 // the existing approval contract for large scripts.
-const APPROVAL_SCRIPT_HASH_CHUNK_BYTES = 64 * 1024;
-
-function hashFileContentsSync(filePath: string): string {
-  const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+async function hashFileContents(filePath: string): Promise<string> {
+  const handle = await fs.promises.open(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
   try {
-    const stat = fs.fstatSync(fd);
+    const stat = await handle.stat();
     if (!stat.isFile()) {
       throw new Error(`Not a regular file: ${filePath}`);
     }
     const hash = crypto.createHash("sha256");
-    const chunk = Buffer.alloc(APPROVAL_SCRIPT_HASH_CHUNK_BYTES);
-    let bytesRead: number;
-    do {
-      bytesRead = fs.readSync(fd, chunk, 0, chunk.length, null);
-      if (bytesRead > 0) {
-        hash.update(chunk.subarray(0, bytesRead));
-      }
-    } while (bytesRead > 0);
-    return hash.digest("hex");
+    const stream = handle.createReadStream();
+    return await new Promise<string>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer) => hash.update(chunk));
+      stream.on("end", () => resolve(hash.digest("hex")));
+      stream.on("error", reject);
+    });
   } finally {
-    fs.closeSync(fd);
+    await handle.close().catch(() => {});
   }
 }
 
@@ -752,12 +747,15 @@ function resolveMutableFileOperandIndex(argv: string[], cwd: string | undefined)
   return genericIndex === null ? null : unwrapped.baseIndex + genericIndex;
 }
 
-function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | undefined): boolean {
+async function shellPayloadNeedsStableBinding(
+  shellCommand: string,
+  cwd: string | undefined,
+): Promise<boolean> {
   const argv = splitShellArgs(shellCommand);
   if (!argv || argv.length === 0) {
     return false;
   }
-  const snapshot = resolveMutableFileOperandSnapshotSync({
+  const snapshot = await resolveMutableFileOperandSnapshot({
     argv,
     cwd,
     shellCommand: null,
@@ -782,19 +780,19 @@ function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | unde
   return isLikelyScriptLikePathSync(resolvedPath);
 }
 
-function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
+async function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
   argv: string[];
   shellCommand: string | null;
   cwd: string | undefined;
-}): boolean {
+}): Promise<boolean> {
   const unwrapped = unwrapArgvForMutableOperand(params.argv);
   if (unwrapped.opaqueMultiplexerSeen) {
     return true;
   }
   if (params.shellCommand !== null) {
-    return shellPayloadNeedsStableBinding(params.shellCommand, params.cwd);
+    return await shellPayloadNeedsStableBinding(params.shellCommand, params.cwd);
   }
-  if (pnpmDlxInvocationNeedsFailClosedBinding(params.argv, params.cwd)) {
+  if (await pnpmDlxInvocationNeedsFailClosedBinding(params.argv, params.cwd)) {
     return true;
   }
   const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
@@ -807,7 +805,10 @@ function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
   return isMutableScriptRunner(executable);
 }
 
-function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
+async function pnpmDlxInvocationNeedsFailClosedBinding(
+  argv: string[],
+  cwd: string | undefined,
+): Promise<boolean> {
   if (normalizePackageManagerExecToken(argv[0] ?? "") !== "pnpm") {
     return false;
   }
@@ -849,7 +850,10 @@ function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | u
   return false;
 }
 
-function pnpmDlxTailNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
+async function pnpmDlxTailNeedsFailClosedBinding(
+  argv: string[],
+  cwd: string | undefined,
+): Promise<boolean> {
   let idx = 0;
   while (idx < argv.length) {
     const token = readTrimmedArgToken(argv, idx);
@@ -886,8 +890,11 @@ function pnpmDlxTailNeedsFailClosedBinding(argv: string[], cwd: string | undefin
   return true;
 }
 
-function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined): boolean {
-  const snapshot = resolveMutableFileOperandSnapshotSync({
+async function pnpmDlxTailMayNeedStableBinding(
+  argv: string[],
+  cwd: string | undefined,
+): Promise<boolean> {
+  const snapshot = await resolveMutableFileOperandSnapshot({
     argv,
     cwd,
     shellCommand: null,
@@ -896,15 +903,17 @@ function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined
 }
 
 /** Captures file identity for a mutable script operand that approval is bound to. */
-export function resolveMutableFileOperandSnapshotSync(params: {
+export async function resolveMutableFileOperandSnapshot(params: {
   argv: string[];
   cwd: string | undefined;
   shellCommand: string | null;
-}): { ok: true; snapshot: SystemRunApprovalFileOperand | null } | { ok: false; message: string } {
+}): Promise<
+  { ok: true; snapshot: SystemRunApprovalFileOperand | null } | { ok: false; message: string }
+> {
   const argvIndex = resolveMutableFileOperandIndex(params.argv, params.cwd);
   if (argvIndex === null) {
     if (
-      requiresStableInterpreterApprovalBindingWithShellCommand({
+      await requiresStableInterpreterApprovalBindingWithShellCommand({
         argv: params.argv,
         shellCommand: params.shellCommand,
         cwd: params.cwd,
@@ -944,7 +953,7 @@ export function resolveMutableFileOperandSnapshotSync(params: {
   }
   let sha256: string;
   try {
-    sha256 = hashFileContentsSync(realPath);
+    sha256 = await hashFileContents(realPath);
   } catch {
     return {
       ok: false,
@@ -1029,11 +1038,11 @@ export function revalidateApprovedCwdSnapshot(params: { snapshot: ApprovedCwdSna
   return sameFileIdentity(params.snapshot.stat, current.snapshot.stat);
 }
 
-export function revalidateApprovedMutableFileOperand(params: {
+export async function revalidateApprovedMutableFileOperand(params: {
   snapshot: SystemRunApprovalFileOperand;
   argv: string[];
   cwd: string | undefined;
-}): boolean {
+}): Promise<boolean> {
   const operand = params.argv[params.snapshot.argvIndex]?.trim();
   if (!operand) {
     return false;
@@ -1049,7 +1058,7 @@ export function revalidateApprovedMutableFileOperand(params: {
     return false;
   }
   try {
-    return hashFileContentsSync(realPath) === params.snapshot.sha256;
+    return (await hashFileContents(realPath)) === params.snapshot.sha256;
   } catch {
     return false;
   }
@@ -1149,13 +1158,13 @@ export function hardenApprovedExecutionPaths(params: {
   };
 }
 
-export function buildSystemRunApprovalPlan(params: {
+export async function buildSystemRunApprovalPlan(params: {
   command?: unknown;
   rawCommand?: unknown;
   cwd?: unknown;
   agentId?: unknown;
   sessionKey?: unknown;
-}): { ok: true; plan: SystemRunApprovalPlan } | { ok: false; message: string } {
+}): Promise<{ ok: true; plan: SystemRunApprovalPlan } | { ok: false; message: string }> {
   const command = resolveSystemRunCommandRequest({
     command: params.command,
     rawCommand: params.rawCommand,
@@ -1186,7 +1195,7 @@ export function buildSystemRunApprovalPlan(params: {
     command.previewText?.trim() && command.previewText.trim() !== commandText
       ? command.previewText.trim()
       : null;
-  const mutableFileOperand = resolveMutableFileOperandSnapshotSync({
+  const mutableFileOperand = await resolveMutableFileOperandSnapshot({
     argv: hardening.argv,
     cwd: hardening.cwd,
     shellCommand: command.shellPayload,

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -31,7 +31,6 @@ import {
   PNPM_OPTIONS_WITH_VALUE,
   unwrapKnownPackageManagerExecInvocation,
 } from "../infra/package-manager-exec-wrapper.js";
-import { readRegularFileSync } from "../infra/regular-file.js";
 import {
   advancePosixInlineOptionScan,
   POSIX_INLINE_COMMAND_FLAGS,
@@ -270,17 +269,31 @@ function shouldPinExecutableForApproval(params: {
   return (params.wrapperChain?.length ?? 0) === 0;
 }
 
-// Cap at 8 MiB — script operands are code files, not data dumps.
-// Larger files should not be fingerprinted for approval; the operator
-// must rewrite argv to avoid the unbounded-read OOM vector.
-const MAX_APPROVAL_SCRIPT_FILE_BYTES = 8 * 1024 * 1024;
+// Hash arbitrarily large regular script operands without loading the whole
+// file into memory. This keeps the approval hot path bounded while preserving
+// the existing approval contract for large scripts.
+const APPROVAL_SCRIPT_HASH_CHUNK_BYTES = 64 * 1024;
 
 function hashFileContentsSync(filePath: string): string {
-  const { buffer } = readRegularFileSync({
-    filePath,
-    maxBytes: MAX_APPROVAL_SCRIPT_FILE_BYTES,
-  });
-  return crypto.createHash("sha256").update(buffer).digest("hex");
+  const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) {
+      throw new Error(`Not a regular file: ${filePath}`);
+    }
+    const hash = crypto.createHash("sha256");
+    const chunk = Buffer.alloc(APPROVAL_SCRIPT_HASH_CHUNK_BYTES);
+    let bytesRead: number;
+    do {
+      bytesRead = fs.readSync(fd, chunk, 0, chunk.length, null);
+      if (bytesRead > 0) {
+        hash.update(chunk.subarray(0, bytesRead));
+      }
+    } while (bytesRead > 0);
+    return hash.digest("hex");
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 function looksLikePathToken(token: string): boolean {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -31,6 +31,7 @@ import {
   PNPM_OPTIONS_WITH_VALUE,
   unwrapKnownPackageManagerExecInvocation,
 } from "../infra/package-manager-exec-wrapper.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import {
   advancePosixInlineOptionScan,
   POSIX_INLINE_COMMAND_FLAGS,
@@ -269,8 +270,17 @@ function shouldPinExecutableForApproval(params: {
   return (params.wrapperChain?.length ?? 0) === 0;
 }
 
+// Cap at 8 MiB — script operands are code files, not data dumps.
+// Larger files should not be fingerprinted for approval; the operator
+// must rewrite argv to avoid the unbounded-read OOM vector.
+const MAX_APPROVAL_SCRIPT_FILE_BYTES = 8 * 1024 * 1024;
+
 function hashFileContentsSync(filePath: string): string {
-  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+  const { buffer } = readRegularFileSync({
+    filePath,
+    maxBytes: MAX_APPROVAL_SCRIPT_FILE_BYTES,
+  });
+  return crypto.createHash("sha256").update(buffer).digest("hex");
 }
 
 function looksLikePathToken(token: string): boolean {
@@ -919,12 +929,21 @@ export function resolveMutableFileOperandSnapshotSync(params: {
       message: "SYSTEM_RUN_DENIED: approval requires a file script operand",
     };
   }
+  let sha256: string;
+  try {
+    sha256 = hashFileContentsSync(realPath);
+  } catch {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval script operand is too large or not a regular file",
+    };
+  }
   return {
     ok: true,
     snapshot: {
       argvIndex,
       path: realPath,
-      sha256: hashFileContentsSync(realPath),
+      sha256,
     },
   };
 }

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -46,7 +46,7 @@ type MockedSendInvokeResult = Mock<HandleSystemRunInvokeOptions["sendInvokeResul
 type MockedSendExecFinishedEvent = Mock<HandleSystemRunInvokeOptions["sendExecFinishedEvent"]>;
 type MockedSendNodeEvent = Mock<HandleSystemRunInvokeOptions["sendNodeEvent"]>;
 
-describe("handleSystemRunInvoke mac app exec host routing", () => {
+describe("handleSystemRunInvoke mac app exec host routing", async () => {
   let sharedFixtureRoot = "";
   let sharedOpenClawHome = "";
   let sharedRuntimeBinDir = "";
@@ -112,12 +112,14 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     return executablePath;
   }
 
-  function createStrictInlineEvalApprovalPlan(prefix: string): SystemRunApprovalPlan {
+  async function createStrictInlineEvalApprovalPlan(
+    prefix: string,
+  ): Promise<SystemRunApprovalPlan> {
     const tempDir = createFixtureDir(prefix);
     const executablePath = createTempExecutable({ dir: tempDir, name: "gawk" });
     const scriptPath = path.join(tempDir, "library.awk");
     fs.writeFileSync(scriptPath, "{ print }\n");
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: [executablePath, "-f", scriptPath, '--source=BEGIN{print "safe"}'],
       sessionKey: "agent:main:main",
     });
@@ -565,7 +567,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     let systemRunPlan = params.systemRunPlan;
     if (forwardsDelayedApproval && params.prepareDelayedApprovalPlan !== false) {
       if (!systemRunPlan) {
-        const prepared = buildSystemRunApprovalPlan({
+        const prepared = await buildSystemRunApprovalPlan({
           command,
           rawCommand: params.rawCommand,
           cwd: params.cwd,
@@ -691,7 +693,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       }));
       const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
       const runCommand = vi.fn(async () => createLocalRunResult("auto-reviewed"));
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: [executablePath],
         cwd: tmp,
       });
@@ -811,7 +813,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         risk: "low",
       }));
       const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
         cwd: tmp,
       });
@@ -857,7 +859,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         risk: "medium",
       }));
       const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: [executablePath],
         cwd: tmp,
       });
@@ -1337,7 +1339,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         },
       ]) {
         const { cwd, message } = testCase.setup();
-        const prepared = buildSystemRunApprovalPlan({
+        const prepared = await buildSystemRunApprovalPlan({
           command: ["./run.sh"],
           cwd,
         });
@@ -1386,7 +1388,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     fs.writeFileSync(script, "#!/bin/sh\necho SAFE\n");
     fs.chmodSync(script, 0o755);
     const canonicalCwd = fs.realpathSync(tmp);
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["./run.sh"],
       cwd: tmp,
       sessionKey: "agent:main:main",
@@ -1435,7 +1437,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       if (process.platform !== "win32") {
         fs.chmodSync(fixture.scriptPath, 0o755);
       }
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: fixture.command,
         cwd: tmp,
       });
@@ -1513,7 +1515,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     if (process.platform !== "win32") {
       fs.chmodSync(fixture.scriptPath, 0o755);
     }
-    const prepared = buildSystemRunApprovalPlan({ command: fixture.command, cwd: tmp });
+    const prepared = await buildSystemRunApprovalPlan({ command: fixture.command, cwd: tmp });
     expect(prepared.ok).toBe(true);
     if (!prepared.ok) {
       throw new Error("unreachable");
@@ -1551,7 +1553,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         const tmp = createFixtureDir("openclaw-approval-tsx-script-drift-");
         const fixture = createRuntimeScriptOperandFixture({ tmp, runtime: "tsx" });
         fs.writeFileSync(fixture.scriptPath, fixture.initialBody);
-        const prepared = buildSystemRunApprovalPlan({
+        const prepared = await buildSystemRunApprovalPlan({
           command: fixture.command,
           cwd: tmp,
         });
@@ -1583,7 +1585,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           runtime: "tsx",
         });
         fs.writeFileSync(missingBindingFixture.scriptPath, missingBindingFixture.initialBody);
-        const missingBindingPrepared = buildSystemRunApprovalPlan({
+        const missingBindingPrepared = await buildSystemRunApprovalPlan({
           command: missingBindingFixture.command,
           cwd: missingBindingTmp,
         });
@@ -2155,7 +2157,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("treats authenticated auto-review provenance as marker-only one-shot authority", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2200,7 +2202,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("rejects forwarded auto-review when current ask policy tightens to always", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2245,7 +2247,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("rejects forwarded auto-review when persisted security tightens to allowlist", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2293,7 +2295,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("rejects forwarded auto-review when persisted ask tightens from off to on-miss", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2341,7 +2343,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("rejects forwarded auto-review when current security policy tightens to deny", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2383,7 +2385,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   it("does not let forwarded auto-review authorize security audit suppression edits", async () => {
     const tmp = createFixtureDir("openclaw-forwarded-auto-review-suppression-");
     const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
       cwd: tmp,
       sessionKey: "agent:main:main",
@@ -2420,7 +2422,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("preserves exact-plan forwarded auto-review for strict inline eval", async () => {
-    const plan = createStrictInlineEvalApprovalPlan("openclaw-forwarded-inline-");
+    const plan = await createStrictInlineEvalApprovalPlan("openclaw-forwarded-inline-");
     setRuntimeConfigSnapshot({ tools: { exec: { strictInlineEval: true } } });
     try {
       await withTempApprovalsHome({
@@ -2486,7 +2488,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("revalidates timeout fallback against the current askFallback policy", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2577,7 +2579,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("requires a prepared policy snapshot for forwarded delayed approval", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2610,7 +2612,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         defaults: { security: "full", ask: "always", askFallback: "deny" },
       },
       run: async () => {
-        const prepared = buildSystemRunApprovalPlan({
+        const prepared = await buildSystemRunApprovalPlan({
           command: ["echo", "ok"],
           sessionKey: "agent:main:main",
         });
@@ -2653,7 +2655,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         defaults: { security: "full", ask: "off", askFallback: "deny" },
       },
       run: async () => {
-        const prepared = buildSystemRunApprovalPlan({
+        const prepared = await buildSystemRunApprovalPlan({
           command: ["echo", "ok"],
           sessionKey: "agent:main:main",
         });
@@ -2700,7 +2702,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         },
       },
       run: async () => {
-        const prepared = buildSystemRunApprovalPlan({
+        const prepared = await buildSystemRunApprovalPlan({
           command: ["echo", "ok"],
           agentId: "main",
           sessionKey: "agent:main:main",
@@ -2772,7 +2774,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("applies marker-only full timeout fallback without another prompt", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2812,7 +2814,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     "permits a durable exact-command approval under allowlist timeout fallback",
     async () => {
       const tempDir = createFixtureDir("openclaw-fallback-durable-");
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: ["/bin/sh", "-c", "/bin/ls"],
         cwd: tempDir,
         sessionKey: "agent:main:main",
@@ -2867,7 +2869,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     "rejects allowlist timeout fallback when its durable source is removed before commit",
     async () => {
       const tempDir = createFixtureDir("openclaw-fallback-durable-revoked-");
-      const prepared = buildSystemRunApprovalPlan({
+      const prepared = await buildSystemRunApprovalPlan({
         command: ["/bin/sh", "-c", "/bin/ls"],
         cwd: tempDir,
         sessionKey: "agent:main:main",
@@ -2929,7 +2931,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   );
 
   it("preserves source-only fallback across the authenticated Mac app bridge", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -2965,7 +2967,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("preserves marker-only auto-review across the authenticated Mac app bridge", async () => {
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
       sessionKey: "agent:main:main",
     });
@@ -3003,7 +3005,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("does not let timeout fallback satisfy strict inline review", async () => {
-    const plan = createStrictInlineEvalApprovalPlan("openclaw-fallback-inline-");
+    const plan = await createStrictInlineEvalApprovalPlan("openclaw-fallback-inline-");
     setRuntimeConfigSnapshot({ tools: { exec: { strictInlineEval: true } } });
     try {
       await withTempApprovalsHome({
@@ -3035,7 +3037,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   it("does not let timeout fallback authorize security audit suppression edits", async () => {
     const tmp = createFixtureDir("openclaw-timeout-fallback-suppression-");
     const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
       cwd: tmp,
       sessionKey: "agent:main:main",
@@ -3072,7 +3074,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   it("keeps audit suppression edits approval-gated under allowlist fallback from full/off", async () => {
     const tmp = createFixtureDir("openclaw-timeout-fallback-full-off-suppression-");
     const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
       cwd: tmp,
       sessionKey: "agent:main:main",
@@ -3144,7 +3146,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
             dir: tempDir,
             name: "python3.13",
           });
-          const prepared = buildSystemRunApprovalPlan({
+          const prepared = await buildSystemRunApprovalPlan({
             command: [executablePath, "-c", "print('hi')"],
           });
 
@@ -3237,7 +3239,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           });
           const makefilePath = path.join(tempDir, "Makefile");
           fs.writeFileSync(makefilePath, "all:\n\t@echo inline-eval-ok\n");
-          const prepared = buildSystemRunApprovalPlan({
+          const prepared = await buildSystemRunApprovalPlan({
             command: [executablePath, "-f", makefilePath],
             cwd: tempDir,
           });
@@ -3371,7 +3373,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       const commandName = "check_mail.cmd";
       const command = ["env", "FOO=bar", "cmd.exe", "/d", "/s", "/c", `${commandName} --limit 5`];
       const ordinaryPattern = "*";
-      const prepared = buildSystemRunApprovalPlan({ command, cwd: tempDir });
+      const prepared = await buildSystemRunApprovalPlan({ command, cwd: tempDir });
       expect(prepared.ok).toBe(true);
       if (!prepared.ok) {
         throw new Error("unreachable");
@@ -3450,7 +3452,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
 
     const tempDir = createFixtureDir("openclaw-shell-wrapper-allow-");
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["/bin/sh", "-c", "/bin/ls"],
       cwd: tempDir,
     });
@@ -3502,7 +3504,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
 
     const tempDir = createFixtureDir("openclaw-shell-wrapper-redundant-grant-");
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["/bin/sh", "-c", "cd ."],
       cwd: tempDir,
     });
@@ -3568,7 +3570,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
 
     const tempDir = createFixtureDir("openclaw-shell-wrapper-revoked-");
-    const prepared = buildSystemRunApprovalPlan({
+    const prepared = await buildSystemRunApprovalPlan({
       command: ["/bin/sh", "-c", "/bin/ls"],
       cwd: tempDir,
     });

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -61,7 +61,7 @@ import {
   hardenApprovedExecutionPaths,
   revalidateApprovedCwdSnapshot,
   revalidateApprovedMutableFileOperand,
-  resolveMutableFileOperandSnapshotSync,
+  resolveMutableFileOperandSnapshot,
   type ApprovedCwdSnapshot,
 } from "./invoke-system-run-plan.js";
 import type {
@@ -879,11 +879,11 @@ async function revalidateSystemRunApprovedPathBindings(
   }
   if (
     phase.approvalPlan?.mutableFileOperand &&
-    !revalidateApprovedMutableFileOperand({
+    !(await revalidateApprovedMutableFileOperand({
       snapshot: phase.approvalPlan.mutableFileOperand,
       argv: phase.argv,
       cwd: phase.cwd,
-    })
+    }))
   ) {
     logWarn(`security: system.run approval script drift blocked (runId=${phase.runId})`);
     await sendSystemRunDenied(opts, phase.execution, {
@@ -903,7 +903,7 @@ async function executeSystemRunPhase(
     return;
   }
   const expectedMutableFileOperand = phase.approvalPlan
-    ? resolveMutableFileOperandSnapshotSync({
+    ? await resolveMutableFileOperandSnapshot({
         argv: phase.argv,
         cwd: phase.cwd,
         shellCommand: phase.shellPayload,

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -730,7 +730,7 @@ async function dispatchInvoke(
         decodeParams<SystemRunPrepareParams>(frame.paramsJSON),
         frame.nodeId,
       );
-      const prepared = buildSystemRunApprovalPlan(params);
+      const prepared = await buildSystemRunApprovalPlan(params);
       if (!prepared.ok) {
         await sendErrorResult(client, frame, "INVALID_REQUEST", prepared.message);
         return;


### PR DESCRIPTION
## What Problem This Solves

`hashFileContentsSync` in `src/node-host/invoke-system-run-plan.ts` reads the entire file synchronously into memory with no size limit to compute a SHA-256 hash for approval fingerprinting. A user who runs `node ./10GB-script.js` as a `system.run` operand would cause Node to block the event loop and OOM the process before approval is even evaluated.

This is a security OOM/availability vector on the **hot approval path**:
- Called every `system.run` to fingerprint the script operand for approval binding
- Called again on every revalidation before execution
- File path is derived from user-supplied CLI argv — an attacker who controls the workspace can trivially OOM or stall the runtime

## Why This Change Was Made

Unbounded synchronous `readFileSync` on user-controlled paths is a known OOM vector. The fix must bound memory usage without changing the existing approval contract for large script operands. Asynchronous streaming SHA-256 satisfies both goals: it caps per-chunk memory and yields the event loop, while still supporting arbitrarily large approved scripts.

## What Changed

**`src/node-host/invoke-system-run-plan.ts`:**
- Renamed `hashFileContentsSync` → `hashFileContents` and made it asynchronous.
- Uses `fs.promises.open(..., O_RDONLY | O_NOFOLLOW)`, `handle.createReadStream()`, and `crypto.createHash("sha256")` so the hash is computed chunk-by-chunk without loading the whole file.
- Renamed `resolveMutableFileOperandSnapshotSync` → `resolveMutableFileOperandSnapshot` and made it asynchronous.
- Made `revalidateApprovedMutableFileOperand` asynchronous.
- Made `buildSystemRunApprovalPlan` asynchronous.
- Kept the existing error handling: a non-regular file or symlink (via `O_NOFOLLOW`) still returns a clean `SYSTEM_RUN_DENIED` message.

**Callers updated to await the async boundary:**
- `src/node-host/invoke.ts`
- `src/node-host/invoke-agent-cli-claude-handler.ts`
- `src/node-host/invoke-system-run.ts`

**Tests updated:**
- `src/node-host/invoke-system-run-plan.test.ts`
- `src/node-host/invoke-system-run.test.ts`

## User Impact

| Before | After |
|--------|-------|
| `node ./10GB-script.js` -> OOM, process killed | `node ./10GB-script.js` -> hashed asynchronously, approval binding preserved |
| `node ./4MB-script.js` -> works (unchanged) | `node ./4MB-script.js` -> works (unchanged) |
| Error from non-regular operand -> unhandled exception | Error -> proper `SYSTEM_RUN_DENIED` message |

The change is additive from a behavior perspective for legitimate large scripts; only the internal hashing boundary becomes async.

## Evidence (head SHA: `345759cee3b`)

### Focused Tests — all pass ✓

```
$ node scripts/run-vitest.mjs src/node-host/invoke-system-run-plan.test.ts src/node-host/invoke-system-run.test.ts

 ✓ |unit-fast-isolated| src/node-host/invoke-system-run-plan.test.ts (20 tests)
 ✓ |unit-fast-isolated| src/node-host/invoke-system-run.test.ts (72 tests)

Test Files  2 passed (2)
     Tests  92 passed (92)
```

### Terminal Proof — large operand approval + revalidation at current head

The transcript below executes the actual checked-in production modules at `345759cee3b` against a real 32 MiB script file.

```
$ node --import tsx/esm prove-110712-async-hash.mjs

=== 1. Large operand approval plan ===
plan.ok: true
mutableFileOperand.path: /tmp/oc-approval-hash-g4tlhp/big-script.js
mutableFileOperand.argvIndex: 1
mutableFileOperand.sha256 (prefix): 5e478e0aff2a4e45...

=== 2. Verify hash matches crypto.hash ===
expected: 5e478e0aff2a4e45...
actual:   5e478e0aff2a4e45...
match: true

=== 3. Revalidation succeeds before execution ===
revalidate: true

=== 4. Snapshot helper directly ===
snapshot.ok: true
snapshot.sha256 (prefix): 5e478e0aff2a4e45...
```

The proof runner imports `buildSystemRunApprovalPlan`, `revalidateApprovedMutableFileOperand`, and `resolveMutableFileOperandSnapshot` directly from `src/node-host/invoke-system-run-plan.ts` and invokes them against real files. No inlined copies or mocks.
