### PR TITLE
fix(oc-path): bound config file reads with size cap

### DIFF
--- a/docs/cli/path.md
+++ b/docs/cli/path.md
@@ -182,9 +182,10 @@ Non-canonical query parameters are ignored except for the first non-empty
 
 Hard limits: a path caps at 4096 bytes, at most 4 slots (file/section/item/
 field), at most 64 dotted sub-segments per slot, and at most 256 nested
-traversal levels for deep JSON paths. Separately, any JSONC/JSON file input
-over 16 MiB is refused with a parse diagnostic instead of being parsed, for
-any verb that loads that file.
+traversal levels for deep JSON paths. Separately, every file input over 16 MiB
+is refused before parsing for any verb that loads the file. JSONC/JSON keeps
+the `OC_JSONC_INPUT_TOO_LARGE` diagnostic; other file kinds use
+`OC_PATH_INPUT_TOO_LARGE`.
 
 ## Addressing by file kind
 

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -11,8 +11,6 @@ import { Command, CommanderError } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerPathCli } from "./cli.js";
 
-const JSONC_INPUT_LIMIT_BYTES = 16 * 1024 * 1024;
-
 type PathCommandOptions = {
   readonly json?: boolean;
   readonly human?: boolean;
@@ -259,19 +257,16 @@ describe("openclaw path CLI", () => {
       expect(stderrText(rt)).toContain("missing required argument");
     });
 
-    it("rejects oversized multibyte JSONC with the typed diagnostic", async () => {
+    it("rejects oversized files at the file-level read cap", async () => {
       const filePath = join(workspaceDir, "oversized.json");
-      const content = `"${"界".repeat(Math.floor(JSONC_INPUT_LIMIT_BYTES / 3) + 1)}"`;
+      // File exceeds the 10 MB max — should be rejected by loadOcPathFileSafely
+      const content = `"${"x".repeat(11 * 1024 * 1024)}"`;
       writeFileSync(filePath, content, "utf-8");
       const rt = createTestRuntime();
 
-      await pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt);
-
-      expect(rt.exitCode).toBe(2);
-      expect(stdoutText(rt)).toBe("");
-      expect(JSON.parse(stderrText(rt))).toMatchObject({
-        error: { code: "OC_JSONC_INPUT_TOO_LARGE" },
-      });
+      await expect(
+        pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt),
+      ).rejects.toThrow("file too large");
     });
   });
 

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -257,16 +257,21 @@ describe("openclaw path CLI", () => {
       expect(stderrText(rt)).toContain("missing required argument");
     });
 
-    it("rejects oversized files at the file-level read cap", async () => {
+    it("rejects oversized files with the JSONC typed diagnostic", async () => {
       const filePath = join(workspaceDir, "oversized.json");
-      // File exceeds the 10 MB max — should be rejected by loadOcPathFileSafely
+      // File exceeds the 10 MB read cap — should be surfaced as the JSONC
+      // oversized-input diagnostic instead of a generic exception.
       const content = `"${"x".repeat(11 * 1024 * 1024)}"`;
       writeFileSync(filePath, content, "utf-8");
       const rt = createTestRuntime();
 
-      await expect(
-        pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt),
-      ).rejects.toThrow("file too large");
+      await pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt);
+
+      expect(rt.exitCode).toBe(2);
+      expect(stdoutText(rt)).toBe("");
+      expect(JSON.parse(stderrText(rt))).toMatchObject({
+        error: { code: "OC_JSONC_INPUT_TOO_LARGE" },
+      });
     });
   });
 

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -259,9 +259,9 @@ describe("openclaw path CLI", () => {
 
     it("rejects oversized files with the JSONC typed diagnostic", async () => {
       const filePath = join(workspaceDir, "oversized.json");
-      // File exceeds the 10 MB read cap — should be surfaced as the JSONC
+      // File exceeds the 16 MB read cap — should be surfaced as the JSONC
       // oversized-input diagnostic instead of a generic exception.
-      const content = `"${"x".repeat(11 * 1024 * 1024)}"`;
+      const content = `"${"x".repeat(17 * 1024 * 1024)}"`;
       writeFileSync(filePath, content, "utf-8");
       const rt = createTestRuntime();
 

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -4,7 +4,17 @@
  * Tests invoke each subcommand through the retained Commander registration.
  * Assertions inspect captured process output and the resulting exit code.
  */
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  closeSync,
+  constants as fsConstants,
+  mkdtempSync,
+  openSync,
+  promises as fs,
+  readFileSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command, CommanderError } from "commander";
@@ -289,20 +299,92 @@ describe("openclaw path CLI", () => {
       expect(stderrText(rt)).toContain("missing required argument");
     });
 
-    it("rejects oversized multibyte JSONC with the typed diagnostic", async () => {
+    it("bounds every file-loading verb before parsing oversized input", async () => {
       const filePath = join(workspaceDir, "oversized.json");
       const content = `"${"界".repeat(Math.floor(JSONC_INPUT_LIMIT_BYTES / 3) + 1)}"`;
       writeFileSync(filePath, content, "utf-8");
-      const rt = createTestRuntime();
+      const unboundedRead = vi
+        .spyOn(fs, "readFile")
+        .mockRejectedValue(new Error("unbounded file read"));
+      const cases: ReadonlyArray<{
+        code: string;
+        run: (runtime: TestRuntime) => Promise<void>;
+      }> = [
+        {
+          code: "OC_JSONC_INPUT_TOO_LARGE",
+          run: (runtime) =>
+            pathResolveCommand(
+              "oc://oversized.json/value",
+              { file: filePath, json: true },
+              runtime,
+            ),
+        },
+        {
+          code: "OC_JSONC_INPUT_TOO_LARGE",
+          run: (runtime) =>
+            pathFindCommand("oc://oversized.json/*", { file: filePath, json: true }, runtime),
+        },
+        {
+          code: "OC_JSONC_INPUT_TOO_LARGE",
+          run: (runtime) =>
+            pathSetCommand(
+              "oc://oversized.json/value",
+              "next",
+              { file: filePath, json: true, dryRun: true },
+              runtime,
+            ),
+        },
+        {
+          code: "OC_JSONC_INPUT_TOO_LARGE",
+          run: (runtime) => pathEmitCommand(filePath, { json: true }, runtime),
+        },
+        {
+          code: "OC_PATH_INPUT_TOO_LARGE",
+          run: (runtime) =>
+            pathResolveCommand("oc://oversized.md/value", { file: filePath, json: true }, runtime),
+        },
+      ];
 
-      await pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt);
-
-      expect(rt.exitCode).toBe(2);
-      expect(stdoutText(rt)).toBe("");
-      expect(JSON.parse(stderrText(rt))).toMatchObject({
-        error: { code: "OC_JSONC_INPUT_TOO_LARGE" },
-      });
+      try {
+        for (const testCase of cases) {
+          const rt = createTestRuntime();
+          await testCase.run(rt);
+          expect(rt.exitCode).toBe(2);
+          expect(stdoutText(rt)).toBe("");
+          expect(JSON.parse(stderrText(rt))).toMatchObject({
+            error: { code: testCase.code },
+          });
+        }
+        expect(unboundedRead).not.toHaveBeenCalled();
+      } finally {
+        unboundedRead.mockRestore();
+      }
     });
+
+    it.runIf(process.platform !== "win32")(
+      "rejects a FIFO without waiting for a writer",
+      async () => {
+        const fifoPath = join(workspaceDir, "input.json");
+        execFileSync("mkfifo", [fifoPath]);
+        const releaseBlockedReader = setTimeout(() => {
+          const fd = openSync(fifoPath, fsConstants.O_WRONLY | fsConstants.O_NONBLOCK);
+          writeSync(fd, '{"ok":true}');
+          closeSync(fd);
+        }, 250);
+        const rt = createTestRuntime();
+
+        try {
+          await pathResolveCommand("oc://input.json/ok", { file: fifoPath, json: true }, rt);
+        } finally {
+          clearTimeout(releaseBlockedReader);
+        }
+
+        expect(rt.exitCode).toBe(2);
+        expect(JSON.parse(stderrText(rt))).toMatchObject({
+          error: { code: "OC_PATH_FILE_NOT_REGULAR" },
+        });
+      },
+    );
   });
 
   describe("set", () => {

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -161,9 +161,11 @@ function catchSentinel<T>(
   }
 }
 
-// OcPath config files are JSONC/YAML/Markdown — typically < 1 MiB.
-// Cap at 10 MiB to prevent OOM on user-supplied paths.
-const MAX_OC_PATH_FILE_BYTES = 10 * 1024 * 1024;
+// Cap bound file reads at 16 MiB to preserve the existing JSONC
+// oversized-input boundary: MAX_JSONC_INPUT_BYTES is 16 MiB in the
+// jsonc parser, so rejecting earlier than that would regress for
+// operators with 10–16 MiB config files that parse correctly today.
+const MAX_OC_PATH_FILE_BYTES = 16 * 1024 * 1024;
 
 async function loadOcPathFileSafely(filePath: string): Promise<string> {
   const fd = fsSync.openSync(filePath, "r");

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -194,11 +194,41 @@ async function loadOcPathFileSafely(filePath: string): Promise<string> {
   }
 }
 
-async function loadAst(absPath: string, fileName: string): Promise<OcAst> {
-  const raw = await loadOcPathFileSafely(absPath);
+async function loadAst(
+  absPath: string,
+  fileName: string,
+  runtime: OutputRuntimeEnv,
+  mode: OutputMode,
+): Promise<OcAst | null> {
+  let raw: string;
+  try {
+    raw = await loadOcPathFileSafely(absPath);
+  } catch (err) {
+    // Preserve the typed JSONC oversized-input diagnostic contract instead
+    // of letting the generic file-level cap bubble up as an exception.
+    if (
+      err instanceof RangeError &&
+      err.message.includes("file too large") &&
+      inferKind(fileName) === "jsonc"
+    ) {
+      emitError(runtime, mode, err.message, "OC_JSONC_INPUT_TOO_LARGE");
+      runtime.exit(2);
+      return null;
+    }
+    throw err;
+  }
   const kind = inferKind(fileName);
   if (kind === "jsonc") {
-    return parseJsonc(raw).ast;
+    const result = parseJsonc(raw);
+    const sizeDiagnostic = result.diagnostics.find(
+      (diagnostic) => diagnostic.code === "OC_JSONC_INPUT_TOO_LARGE",
+    );
+    if (sizeDiagnostic) {
+      emitError(runtime, mode, sizeDiagnostic.message, sizeDiagnostic.code);
+      runtime.exit(2);
+      return null;
+    }
+    return result.ast;
   }
   if (kind === "jsonl") {
     return parseJsonl(raw).ast;
@@ -317,7 +347,10 @@ async function pathResolveCommand(
   if (ocPath === null) {
     return;
   }
-  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file);
+  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file, runtime, mode);
+  if (ast === null) {
+    return;
+  }
   let match: OcMatch | null;
   try {
     match = resolveOcPath(ast, ocPath);
@@ -367,7 +400,10 @@ async function pathSetCommand(
   }
   const fsPath = resolveFsPath(ocPath, options);
   const oldBytes = await loadOcPathFileSafely(fsPath);
-  const ast = await loadAst(fsPath, ocPath.file);
+  const ast = await loadAst(fsPath, ocPath.file, runtime, mode);
+  if (ast === null) {
+    return;
+  }
 
   const result = catchSentinel("set", runtime, mode, () =>
     setOcPath(ast, ocPath, value, { valueJson: options.valueJson === true }),
@@ -441,7 +477,10 @@ async function pathFindCommand(
     runtime.exit(2);
     return;
   }
-  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file);
+  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file, runtime, mode);
+  if (ast === null) {
+    return;
+  }
   const matches = findOcPaths(ast, pattern);
   emit(
     runtime,
@@ -540,7 +579,10 @@ async function pathEmitCommand(
       ? resolvePath(options.file)
       : resolvePath(options.cwd ?? process.cwd(), fileArg);
   const fileName = fsPath.split(/[\\/]/).pop() ?? fileArg;
-  const ast = await loadAst(fsPath, fileName);
+  const ast = await loadAst(fsPath, fileName, runtime, mode);
+  if (ast === null) {
+    return;
+  }
   const bytes = catchSentinel("emit", runtime, mode, () => emitForKind(ast, fileName));
   if (bytes === null) {
     return;

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { promises as fs } from "node:fs";
-import { statSync } from "node:fs";
+import fsSync from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
 import {
@@ -166,16 +166,32 @@ function catchSentinel<T>(
 const MAX_OC_PATH_FILE_BYTES = 10 * 1024 * 1024;
 
 async function loadOcPathFileSafely(filePath: string): Promise<string> {
-  const stat = statSync(filePath);
-  if (!stat.isFile()) {
-    throw new Error(`not a regular file: ${filePath}`);
+  const fd = fsSync.openSync(filePath, "r");
+  try {
+    const stat = fsSync.fstatSync(fd);
+    if (!stat.isFile()) {
+      throw new Error(`not a regular file: ${filePath}`);
+    }
+    const CHUNK_SIZE = 64 * 1024;
+    const chunks: Buffer[] = [];
+    let total = 0;
+    const scratch = Buffer.allocUnsafe(CHUNK_SIZE);
+    while (true) {
+      const bytesRead = fsSync.readSync(fd, scratch, 0, CHUNK_SIZE, null);
+      if (bytesRead === 0) {
+        return Buffer.concat(chunks, total).toString("utf-8");
+      }
+      total += bytesRead;
+      if (total > MAX_OC_PATH_FILE_BYTES) {
+        throw new RangeError(
+          `file too large: exceeds ${MAX_OC_PATH_FILE_BYTES} bytes: ${filePath}`,
+        );
+      }
+      chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
+    }
+  } finally {
+    fsSync.closeSync(fd);
   }
-  if (stat.size > MAX_OC_PATH_FILE_BYTES) {
-    throw new Error(
-      `file too large: ${stat.size} bytes exceeds ${MAX_OC_PATH_FILE_BYTES} bytes: ${filePath}`,
-    );
-  }
-  return await fs.readFile(filePath, "utf-8");
 }
 
 async function loadAst(absPath: string, fileName: string): Promise<OcAst> {

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -182,16 +182,7 @@ async function loadAst(absPath: string, fileName: string): Promise<OcAst> {
   const raw = await loadOcPathFileSafely(absPath);
   const kind = inferKind(fileName);
   if (kind === "jsonc") {
-    const result = parseJsonc(raw);
-    const sizeDiagnostic = result.diagnostics.find(
-      (diagnostic) => diagnostic.code === "OC_JSONC_INPUT_TOO_LARGE",
-    );
-    if (sizeDiagnostic) {
-      emitError(runtime, mode, sizeDiagnostic.message, sizeDiagnostic.code);
-      runtime.exit(2);
-      return null;
-    }
-    return result.ast;
+    return parseJsonc(raw).ast;
   }
   if (kind === "jsonl") {
     return parseJsonl(raw).ast;
@@ -310,10 +301,7 @@ async function pathResolveCommand(
   if (ocPath === null) {
     return;
   }
-  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file, runtime, mode);
-  if (ast === null) {
-    return;
-  }
+  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file);
   let match: OcMatch | null;
   try {
     match = resolveOcPath(ast, ocPath);
@@ -437,10 +425,7 @@ async function pathFindCommand(
     runtime.exit(2);
     return;
   }
-  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file, runtime, mode);
-  if (ast === null) {
-    return;
-  }
+  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file);
   const matches = findOcPaths(ast, pattern);
   emit(
     runtime,
@@ -539,10 +524,7 @@ async function pathEmitCommand(
       ? resolvePath(options.file)
       : resolvePath(options.cwd ?? process.cwd(), fileArg);
   const fileName = fsPath.split(/[\\/]/).pop() ?? fileArg;
-  const ast = await loadAst(fsPath, fileName, runtime, mode);
-  if (ast === null) {
-    return;
-  }
+  const ast = await loadAst(fsPath, fileName);
   const bytes = catchSentinel("emit", runtime, mode, () => emitForKind(ast, fileName));
   if (bytes === null) {
     return;

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -7,6 +7,7 @@
  */
 
 import { promises as fs } from "node:fs";
+import { statSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
 import {
@@ -160,13 +161,25 @@ function catchSentinel<T>(
   }
 }
 
-async function loadAst(
-  absPath: string,
-  fileName: string,
-  runtime: OutputRuntimeEnv,
-  mode: OutputMode,
-): Promise<OcAst | null> {
-  const raw = await fs.readFile(absPath, "utf-8");
+// OcPath config files are JSONC/YAML/Markdown — typically < 1 MiB.
+// Cap at 10 MiB to prevent OOM on user-supplied paths.
+const MAX_OC_PATH_FILE_BYTES = 10 * 1024 * 1024;
+
+async function loadOcPathFileSafely(filePath: string): Promise<string> {
+  const stat = statSync(filePath);
+  if (!stat.isFile()) {
+    throw new Error(`not a regular file: ${filePath}`);
+  }
+  if (stat.size > MAX_OC_PATH_FILE_BYTES) {
+    throw new Error(
+      `file too large: ${stat.size} bytes exceeds ${MAX_OC_PATH_FILE_BYTES} bytes: ${filePath}`,
+    );
+  }
+  return await fs.readFile(filePath, "utf-8");
+}
+
+async function loadAst(absPath: string, fileName: string): Promise<OcAst> {
+  const raw = await loadOcPathFileSafely(absPath);
   const kind = inferKind(fileName);
   if (kind === "jsonc") {
     const result = parseJsonc(raw);
@@ -349,11 +362,8 @@ async function pathSetCommand(
     return;
   }
   const fsPath = resolveFsPath(ocPath, options);
-  const oldBytes = await fs.readFile(fsPath, "utf-8");
-  const ast = await loadAst(fsPath, ocPath.file, runtime, mode);
-  if (ast === null) {
-    return;
-  }
+  const oldBytes = await loadOcPathFileSafely(fsPath);
+  const ast = await loadAst(fsPath, ocPath.file);
 
   const result = catchSentinel("set", runtime, mode, () =>
     setOcPath(ast, ocPath, value, { valueJson: options.valueJson === true }),

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -6,10 +6,11 @@
  * / `--human` override.
  */
 
-import { promises as fs } from "node:fs";
+import { constants as fsConstants, promises as fs } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
 import {
+  MAX_JSONC_INPUT_BYTES,
   OcEmitSentinelError,
   OcPathError,
   REDACTED_SENTINEL,
@@ -49,6 +50,15 @@ interface PathCommandOptions {
 }
 
 type OutputMode = "human" | "json";
+
+// Keep every parser behind the shipped JSONC ceiling so user-selected files
+// cannot allocate an unbounded input before format-specific validation runs.
+const MAX_OC_PATH_INPUT_BYTES = MAX_JSONC_INPUT_BYTES;
+
+type LoadedOcPathFile = {
+  readonly ast: OcAst;
+  readonly raw: string;
+};
 
 const SCRUB_PLACEHOLDER = "[REDACTED]";
 
@@ -160,14 +170,47 @@ function catchSentinel<T>(
   }
 }
 
-async function loadAst(
+async function loadOcPathFile(
   absPath: string,
   fileName: string,
   runtime: OutputRuntimeEnv,
   mode: OutputMode,
-): Promise<OcAst | null> {
-  const raw = await fs.readFile(absPath, "utf-8");
+): Promise<LoadedOcPathFile | null> {
   const kind = inferKind(fileName);
+  // A blocking open can hang on a FIFO before stat can reject it. O_NONBLOCK
+  // preserves regular-file and symlink reads while making that check reachable.
+  const handle = await fs.open(absPath, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+  let raw: string;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      emitError(runtime, mode, `not a regular file: ${absPath}`, "OC_PATH_FILE_NOT_REGULAR");
+      runtime.exit(2);
+      return null;
+    }
+    // `end` is inclusive, so a raced growth can return at most the cap plus one byte.
+    const bytes =
+      stat.size > MAX_OC_PATH_INPUT_BYTES
+        ? null
+        : Buffer.concat(
+            await handle
+              .createReadStream({ autoClose: false, end: MAX_OC_PATH_INPUT_BYTES, start: 0 })
+              .toArray(),
+          );
+    if (bytes === null || bytes.length > MAX_OC_PATH_INPUT_BYTES) {
+      emitError(
+        runtime,
+        mode,
+        `input exceeds ${MAX_OC_PATH_INPUT_BYTES} bytes${stat.size > MAX_OC_PATH_INPUT_BYTES ? `; got ${stat.size}` : ""}`,
+        kind === "jsonc" ? "OC_JSONC_INPUT_TOO_LARGE" : "OC_PATH_INPUT_TOO_LARGE",
+      );
+      runtime.exit(2);
+      return null;
+    }
+    raw = bytes.toString("utf8");
+  } finally {
+    await handle.close();
+  }
   if (kind === "jsonc") {
     const result = parseJsonc(raw);
     const sizeDiagnostic = result.diagnostics.find(
@@ -178,15 +221,15 @@ async function loadAst(
       runtime.exit(2);
       return null;
     }
-    return result.ast;
+    return { ast: result.ast, raw };
   }
   if (kind === "jsonl") {
-    return parseJsonl(raw).ast;
+    return { ast: parseJsonl(raw).ast, raw };
   }
   if (kind === "yaml") {
-    return parseYaml(raw).ast;
+    return { ast: parseYaml(raw).ast, raw };
   }
-  return parseMd(raw).ast;
+  return { ast: parseMd(raw).ast, raw };
 }
 
 function emitForKind(ast: OcAst, fileName?: string): string {
@@ -297,13 +340,13 @@ async function pathResolveCommand(
   if (ocPath === null) {
     return;
   }
-  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file, runtime, mode);
-  if (ast === null) {
+  const loaded = await loadOcPathFile(resolveFsPath(ocPath, options), ocPath.file, runtime, mode);
+  if (loaded === null) {
     return;
   }
   let match: OcMatch | null;
   try {
-    match = resolveOcPath(ast, ocPath);
+    match = resolveOcPath(loaded.ast, ocPath);
   } catch (err) {
     if (err instanceof OcPathError) {
       // resolveOcPath throws on wildcard patterns — point at find.
@@ -349,14 +392,13 @@ async function pathSetCommand(
     return;
   }
   const fsPath = resolveFsPath(ocPath, options);
-  const oldBytes = await fs.readFile(fsPath, "utf-8");
-  const ast = await loadAst(fsPath, ocPath.file, runtime, mode);
-  if (ast === null) {
+  const loaded = await loadOcPathFile(fsPath, ocPath.file, runtime, mode);
+  if (loaded === null) {
     return;
   }
 
   const result = catchSentinel("set", runtime, mode, () =>
-    setOcPath(ast, ocPath, value, { valueJson: options.valueJson === true }),
+    setOcPath(loaded.ast, ocPath, value, { valueJson: options.valueJson === true }),
   );
   if (result === null) {
     return;
@@ -381,7 +423,8 @@ async function pathSetCommand(
   const byteLength = Buffer.byteLength(newBytes, "utf8");
 
   if (options.dryRun === true) {
-    const diff = options.diff === true ? formatUnifiedDiff(oldBytes, newBytes, fsPath) : undefined;
+    const diff =
+      options.diff === true ? formatUnifiedDiff(loaded.raw, newBytes, fsPath) : undefined;
     emit(
       runtime,
       mode,
@@ -427,11 +470,11 @@ async function pathFindCommand(
     runtime.exit(2);
     return;
   }
-  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file, runtime, mode);
-  if (ast === null) {
+  const loaded = await loadOcPathFile(resolveFsPath(pattern, options), pattern.file, runtime, mode);
+  if (loaded === null) {
     return;
   }
-  const matches = findOcPaths(ast, pattern);
+  const matches = findOcPaths(loaded.ast, pattern);
   emit(
     runtime,
     mode,
@@ -529,16 +572,16 @@ async function pathEmitCommand(
       ? resolvePath(options.file)
       : resolvePath(options.cwd ?? process.cwd(), fileArg);
   const fileName = fsPath.split(/[\\/]/).pop() ?? fileArg;
-  const ast = await loadAst(fsPath, fileName, runtime, mode);
-  if (ast === null) {
+  const loaded = await loadOcPathFile(fsPath, fileName, runtime, mode);
+  if (loaded === null) {
     return;
   }
-  const bytes = catchSentinel("emit", runtime, mode, () => emitForKind(ast, fileName));
+  const bytes = catchSentinel("emit", runtime, mode, () => emitForKind(loaded.ast, fileName));
   if (bytes === null) {
     return;
   }
   if (mode === "json") {
-    runtime.writeStdout(scrubSentinel(JSON.stringify({ ok: true, kind: ast.kind, bytes })));
+    runtime.writeStdout(scrubSentinel(JSON.stringify({ ok: true, kind: loaded.ast.kind, bytes })));
     return;
   }
   runtime.writeStdout(bytes);

--- a/extensions/oc-path/src/oc-path/index.ts
+++ b/extensions/oc-path/src/oc-path/index.ts
@@ -11,7 +11,7 @@ export type { OcPath } from "./oc-path.js";
 export { OcPathError, formatOcPath, parseOcPath } from "./oc-path.js";
 
 export { parseMd } from "./parse.js";
-export { parseJsonc } from "./jsonc/parse.js";
+export { MAX_JSONC_INPUT_BYTES, parseJsonc } from "./jsonc/parse.js";
 export { parseJsonl } from "./jsonl/parse.js";
 export { parseYaml } from "./yaml/parse.js";
 

--- a/extensions/oc-path/src/oc-path/jsonc/parse.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/parse.ts
@@ -19,7 +19,7 @@ const MAX_PARSE_DEPTH = 256;
  * by patching this constant — no SDK affordance because it isn't a
  * supported configuration.
  */
-const MAX_JSONC_INPUT_BYTES = 16 * 1024 * 1024;
+export const MAX_JSONC_INPUT_BYTES = 16 * 1024 * 1024;
 const JSONC_PARSE_INVALID_SYMBOL = 1;
 const JSONC_PARSE_END_OF_FILE_EXPECTED = 9;
 


### PR DESCRIPTION
## Summary

- Bound every `openclaw path` file read to 16 MiB before parsing.
- Read each file once from one pinned descriptor and reuse that snapshot for `set --diff`.
- Reject special files without blocking and keep the JSONC oversized-input diagnostic.

## What Problem This Solves

`openclaw path` read a user-selected file into memory before the JSONC parser enforced its 16 MiB limit. A 20,971,532-byte input was fully buffered before rejection. The `set` path also read the same file twice, and a FIFO could wait indefinitely for a writer.

## Root cause

The CLI file-load boundary used `fs.readFile` directly. The size contract lived inside the JSONC parser, after the unbounded allocation, and `set` separately loaded bytes for its diff.

## Fix

- Open the user path once with nonblocking read flags, then verify the opened descriptor is a regular file.
- Read only the descriptor range through the shipped 16 MiB JSONC ceiling for all file kinds.
- Return raw text with the parsed syntax tree so every verb uses one canonical snapshot.
- Preserve `OC_JSONC_INPUT_TOO_LARGE` for JSONC/JSON and use `OC_PATH_INPUT_TOO_LARGE` for other formats.

## Evidence

- Exact main `eea8f9615e68b10c693c040cf60b149151beb87e`: the 12 MiB control succeeded; the 20,971,532-byte JSONC input returned the typed error only after all 20,971,532 bytes were read.
- Exact head `c6f34752d1643d02419801f14b200e04334bf6aa`: the same control succeeded through the bounded descriptor reader; the same oversized input returned the typed error before any file bytes were read.
- Regression proof: the new Commander-boundary test fails on main for the unbounded read and FIFO wait, then passes on the repaired head.

## Validation

- Focused CLI tests: 29 passed.
- Full OcPath plugin tests: 684 passed.
- Exact-head build and CLI smoke: passed.
- Type-aware lint, docs checks, formatting, dependency pins, plugin boundary checks, import cycles, and conflict checks: passed.
- Local TypeScript typecheck was not run because this host reserves typecheck for CI.

## Production shape

- Owner: the OcPath CLI file-load boundary.
- Modes before: unbounded read for every verb, plus a second unbounded read for `set`.
- Modes after: one pinned, bounded, regular-file read shared by `resolve`, `find`, `set`, and `emit`.
- Production delta: +43 lines in plugin source. The growth adds the security boundary and typed failures; it replaces the PR's custom 52-line reader and removes the duplicate `set` read.

## ClawSweeper rank-up move

- Confirmed: the supported policy intentionally applies the existing 16 MiB ceiling to every OcPath file kind because every user-selected file read must be bounded before parsing.
