### PR TITLE
fix(cli): scope dns-cli timeout to probe operations only

### DIFF
--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -1,0 +1,77 @@
+// Regression: dns-cli subprocess probes (DNS lookup + sudo tee) must be bounded
+// by a timeout so a hung binary cannot block `openclaw dns setup`.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeChildProcessSpawnSync(spawnSyncMock, () =>
+    vi.importActual<typeof import("node:child_process")>("node:child_process"),
+  );
+});
+
+vi.mock("../infra/widearea-dns.js", async () => {
+  return {
+    getWideAreaZonePath: () => "/tmp/openclaw-dns-test.zone",
+    normalizeWideAreaDomain: (d: string) => d,
+    resolveWideAreaDiscoveryDomain: () => "openclaw.internal.",
+  };
+});
+
+vi.mock("../infra/tailnet.js", async () => {
+  return {
+    pickPrimaryTailnetIPv4: () => "100.64.0.1",
+    pickPrimaryTailnetIPv6: () => undefined,
+  };
+});
+
+vi.mock("../config/config.js", async () => {
+  return { getRuntimeConfig: () => ({}) };
+});
+
+import { Command } from "commander";
+import os from "node:os";
+import { registerDnsCli } from "./dns-cli.js";
+
+describe("dns-cli probe bounds", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes a timeout to spawned dns setup subprocesses", async () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "brew" && args?.[0] === "--prefix") {
+        return {
+          stdout: "/opt/homebrew",
+          stderr: "",
+          pid: 1,
+          output: [],
+          status: 0,
+          signal: null,
+        };
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        pid: 1,
+        output: [],
+        status: 0,
+        signal: null,
+      };
+    });
+
+    const program = new Command();
+    program.exitOverride();
+    registerDnsCli(program);
+
+    await program.parseAsync(["node", "openclaw", "dns", "setup", "--domain", "openclaw.internal", "--apply"]);
+
+    const spawned = spawnSyncMock.mock.calls;
+    expect(spawned.length).toBeGreaterThan(0);
+    for (const [, , opts] of spawned) {
+      expect(opts?.timeout).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -1,6 +1,6 @@
-// Regression: dns-cli subprocess probes (DNS lookup + sudo tee) must be bounded
+// Regression: dns-cli subprocess probes (brew --prefix) must be bounded
 // by a timeout so a hung binary cannot block `openclaw dns setup`.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 
@@ -11,36 +11,10 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-vi.mock("../infra/widearea-dns.js", async () => {
-  return {
-    getWideAreaZonePath: () => "/tmp/openclaw-dns-test.zone",
-    normalizeWideAreaDomain: (d: string) => d,
-    resolveWideAreaDiscoveryDomain: () => "openclaw.internal.",
-  };
-});
-
-vi.mock("../infra/tailnet.js", async () => {
-  return {
-    pickPrimaryTailnetIPv4: () => "100.64.0.1",
-    pickPrimaryTailnetIPv6: () => undefined,
-  };
-});
-
-vi.mock("../config/config.js", async () => {
-  return { getRuntimeConfig: () => ({}) };
-});
-
-import { Command } from "commander";
-import os from "node:os";
-import { registerDnsCli } from "./dns-cli.js";
+import { detectBrewPrefix, PROBE_TIMEOUT_MS } from "./dns-cli.js";
 
 describe("dns-cli probe bounds", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("passes a timeout to spawned dns setup subprocesses", async () => {
-    vi.spyOn(os, "platform").mockReturnValue("darwin");
+  it("passes a timeout to brew --prefix probe", () => {
     spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "brew" && args?.[0] === "--prefix") {
         return {
@@ -62,16 +36,16 @@ describe("dns-cli probe bounds", () => {
       };
     });
 
-    const program = new Command();
-    program.exitOverride();
-    registerDnsCli(program);
+    const prefix = detectBrewPrefix();
+    expect(prefix).toBe("/opt/homebrew");
 
-    await program.parseAsync(["node", "openclaw", "dns", "setup", "--domain", "openclaw.internal", "--apply"]);
+    const calls = spawnSyncMock.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
 
-    const spawned = spawnSyncMock.mock.calls;
-    expect(spawned.length).toBeGreaterThan(0);
-    for (const [, , opts] of spawned) {
-      expect(opts?.timeout).toBeGreaterThan(0);
-    }
+    const brewCall = calls.find(([cmd, args]) => cmd === "brew" && args?.[0] === "--prefix");
+    expect(brewCall).toBeDefined();
+    const opts = brewCall?.[2];
+    expect(opts?.timeout).toBe(PROBE_TIMEOUT_MS);
+    expect(opts?.killSignal).toBe("SIGKILL");
   });
 });

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -21,6 +21,7 @@ function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    timeout: 15_000,
   });
   if (res.error) {
     throw res.error;
@@ -51,6 +52,7 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
+    timeout: 15_000,
   });
   if (res.error) {
     throw res.error;

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -15,13 +15,16 @@ import {
 } from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
 
-type RunOpts = { allowFailure?: boolean; inherit?: boolean };
+type RunOpts = { allowFailure?: boolean; inherit?: boolean; timeoutMs?: number };
+
+export const PROBE_TIMEOUT_MS = 15_000;
 
 function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
-    timeout: 15_000,
+    timeout: opts?.timeoutMs,
+    killSignal: opts?.timeoutMs ? "SIGKILL" : undefined,
   });
   if (res.error) {
     throw res.error;
@@ -52,7 +55,6 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
-    timeout: 15_000,
   });
   if (res.error) {
     throw res.error;
@@ -88,8 +90,8 @@ function zoneFileNeedsBootstrap(zonePath: string): boolean {
   }
 }
 
-function detectBrewPrefix(): string {
-  const out = run("brew", ["--prefix"]);
+export function detectBrewPrefix(): string {
+  const out = run("brew", ["--prefix"], { timeoutMs: PROBE_TIMEOUT_MS });
   const prefix = out.trim();
   if (!prefix) {
     throw new Error("failed to resolve Homebrew prefix");


### PR DESCRIPTION
## What Problem This Solves

The original PR (#110671) added a 15-second timeout to all `spawnSync` calls in dns-cli, which could break legitimate slow DNS setup operations like `brew install coredns` or `sudo brew services restart coredns`.

## Why This Change Was Made

This PR fixes the scope issue by:
1. Making timeout an optional parameter instead of a global default
2. Applying timeout only to the probe operation (`brew --prefix`)
3. Using `SIGKILL` to guarantee termination of signal-resistant processes
4. Removing timeout from non-probe operations that may legitimately take longer

## User Impact

No functional change for normal operations. Hung subprocess probes will be terminated after 15s with guaranteed termination.

## Evidence

**Real environment:** macOS (Darwin 24.6.0 arm64), Node v24.18.0, pnpm 11.2.2.

**Test verification:**
```
$ node scripts/run-vitest.mjs run src/cli/dns-cli.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  720ms
```

**Lint check:**
```
$ node scripts/run-oxlint.mjs --threads=1 src/cli/dns-cli.test.ts
(no output - passed)
```

**What was tested:** The probe operation timeout behavior with SIGKILL guarantee.

**What was not tested:** Full DNS setup end-to-end (requires Homebrew + sudo + a real Tailscale interface on the host).