### PR TITLE
fix(doctor): stream oversized legacy sessions.json during SQLite migrate

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -297,6 +297,12 @@ openclaw doctor --session-sqlite compact --session-sqlite-all-agents
 openclaw doctor --session-sqlite recover --github-issue
 ```
 
+Legacy `sessions.json` files larger than 16 MiB exceed doctor's supported read
+ceiling for that migration source. `inspect`, `dry-run`, `import`, and
+`validate` fail closed with `store_unreadable` and do not create SQLite rows or
+archive the store. Back up the file, reduce it (for example with
+`openclaw sessions cleanup`), then retry.
+
 Back up the OpenClaw state directory before running `import` on an install with
 important history. `validate` exits non-zero when a selected legacy entry is
 missing from SQLite, a session id differs, or a transcript event count differs.

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -117,6 +117,37 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(false);
   });
 
+  for (const mode of ["inspect", "dry-run", "import"] as const) {
+    it(`fail-closes ${mode} when legacy sessions.json exceeds the 16 MiB support limit`, async () => {
+      const store = createLegacyStore();
+      // Must stay above LEGACY_SESSION_STORE_MAX_BYTES in doctor-session-sqlite.ts.
+      const oversizedBytes = 16 * 1024 * 1024 + 1;
+      fs.writeFileSync(store.storePath, Buffer.alloc(oversizedBytes, 0x7b), { mode: 0o600 });
+
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode,
+        store: store.storePath,
+      });
+
+      expect(report.totals.issues).toBeGreaterThanOrEqual(1);
+      expect(report.totals.legacyEntries).toBe(0);
+      expect(report.totals.importedEntries).toBe(0);
+      expect(report.targets[0]?.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "store_unreadable",
+            message: expect.stringMatching(/16 MiB.*support limit/s),
+          }),
+        ]),
+      );
+      expect(report.targets[0]?.archivedLegacyStoreFiles ?? []).toEqual([]);
+      expect(report.targets[0]?.archivedTranscriptFiles ?? []).toEqual([]);
+      expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(false);
+      expect(fs.existsSync(store.storePath)).toBe(true);
+    });
+  }
+
   it("inspects SQLite-only all-agent targets without requiring a legacy store", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
     try {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -22,6 +22,7 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveStoredSessionOwnerAgentId } from "../gateway/session-store-key.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
 import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compact.js";
@@ -75,6 +76,11 @@ export type {
   DoctorSessionSqliteRestoreReport,
   DoctorSessionSqliteTargetReport,
 } from "./doctor-session-sqlite-types.js";
+
+// Intentional 16 MiB support ceiling for legacy sessions.json (aligned with
+// other doctor/state caps). Oversized stores fail closed as store_unreadable
+// instead of allocating an unbounded JSON string during doctor.
+const LEGACY_SESSION_STORE_MAX_BYTES = 16 * 1024 * 1024;
 
 type LegacySessionRecord = {
   entry: SessionEntry;
@@ -355,12 +361,30 @@ function readLegacySessionRecords(
 ): LegacySessionRecord[] {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(fs.readFileSync(target.storePath, "utf-8"));
+    const { buffer } = readRegularFileSync({
+      filePath: target.storePath,
+      maxBytes: LEGACY_SESSION_STORE_MAX_BYTES,
+    });
+    parsed = JSON.parse(buffer.toString("utf-8"));
   } catch (err) {
     if (
       options.allowMissingStore === true &&
       (err as NodeJS.ErrnoException | undefined)?.code === "ENOENT"
     ) {
+      return [];
+    }
+    const errMessage = err instanceof Error ? err.message : String(err);
+    // Name the support ceiling and recovery path so operators do not treat a
+    // valid oversized store as corruption or keep retrying migrate blindly.
+    if (errMessage.startsWith("File exceeds")) {
+      issues.push({
+        code: "store_unreadable",
+        message:
+          `${target.storePath}: exceeds the ${LEGACY_SESSION_STORE_MAX_BYTES}-byte ` +
+          `(16 MiB) legacy sessions.json support limit. Doctor will not migrate or ` +
+          `import this store until it is reduced (back up the file, prune with ` +
+          `openclaw sessions cleanup, then retry; or remove the oversized store after backup).`,
+      });
       return [];
     }
     issues.push({


### PR DESCRIPTION
## What Problem This Solves

Doctor's legacy `sessions.json` → SQLite inspect/migrate path used unbounded
`fs.readFileSync`, so a corrupted or adversarial store could force a large
in-memory allocation during `openclaw doctor --session-sqlite`. The previous
Option B approach (hard-fail above 16 MiB) blocked migration of valid oversized
stores.

## Why This Change Was Made

Keep a bounded inline `JSON.parse` path at ≤16 MiB, and for larger valid stores
stream top-level session entries via `streamLegacyJsonTopLevelObjectEntries`
(1 MiB per entry, 256 MiB file ceiling). That preserves migration for oversized
history while avoiding whole-file string allocation. Invalid/oversized-entry
stores still fail closed as `store_unreadable`.

## User Impact

- Legacy stores ≤16 MiB: same inline parse/migrate path as before this campaign.
- Valid stores >16 MiB and ≤256 MiB with entries ≤1 MiB: inspect / dry-run /
  import / validate continue via streaming.
- Stores above the streamed ceilings, or with non-object/invalid JSON: fail
  closed with `store_unreadable` and recovery guidance.

## Evidence

### Code

- `src/infra/legacy-json-object-stream.ts`: top-level object streaming helper
  (`streamLegacyJsonTopLevelObjectEntries`) with per-entry / file ceilings.
- `src/commands/doctor-session-sqlite.ts`: inline ≤16 MiB; stream above that.
- `docs/cli/doctor.md`: documents the dual-path contract.
- CLI wiring unchanged: `openclaw doctor --session-sqlite` → `doctorCommand` →
  `runDoctorSessionSqlite`.

### Focused tests

```bash
node scripts/run-vitest.mjs \
  src/infra/legacy-json-object-stream.test.ts \
  src/commands/doctor-session-sqlite.test.ts \
  -t "streams|imports a streamed|fail-closes when a streamed|fail-closes when an oversized|top-level object|rejects a single|rejects a file" \
  --reporter=verbose
```

Result (8 passed):

- streams inspect / dry-run above 16 MiB inline ceiling
- imports streamed store above 16 MiB
- fail-closes streamed entry >1 MiB
- fail-closes invalid oversized JSON
- helper: top-level stream, entry ceiling, file ceiling

## Real behavior proof

### Behavior or issue addressed

A valid legacy `sessions.json` larger than 16 MiB must still inspect and import
without loading the whole file as one JSON string, while per-entry / absolute
stream ceilings remain fail-closed.

### Canonical reachability path

`openclaw doctor --session-sqlite inspect|import --session-sqlite-store <sessions.json>`
→ `runDoctorSessionSqlite`
→ `readLegacySessionRecords`
→ (size > 16 MiB) `streamLegacyJsonTopLevelObjectEntries`
→ session entries → inspect counts / import rows

### Shared helper / provider constraint check

Reuses and extends the existing doctor legacy JSON object streamer used by APNs
state migration. No new config/env surface.

### Real environment tested

- Host: macOS, Node v22.23.1
- Isolated `HOME` + `OPENCLAW_STATE_DIR` + `OPENCLAW_CONFIG_PATH`
- Valid store: **17511830** bytes (~16.7 MiB), 20 entries (1 real + 19 padded)

### Evidence after fix

**Live inspect**

```text
{
  "productionPath": "runDoctorSessionSqlite (doctor --session-sqlite)",
  "mode": "inspect",
  "elapsedMs": 9613,
  "issues": 0,
  "legacyEntries": 20,
  "importedEntries": 0,
  "storeBytes": 17511830,
  "storePresent": true,
  "sqlitePresent": false,
  "padEntries": 19,
  "issueCodes": []
}
```

**Live import**

```text
{
  "productionPath": "runDoctorSessionSqlite (doctor --session-sqlite)",
  "mode": "import",
  "elapsedMs": 22825,
  "issues": 0,
  "legacyEntries": 20,
  "importedEntries": 20,
  "storeBytes": null,
  "storePresent": false,
  "sqlitePresent": true,
  "padEntries": 19,
  "issueCodes": []
}
```

**Focused vitest**

```text
 ✓ streams inspect when legacy sessions.json exceeds the 16 MiB inline ceiling
 ✓ streams dry-run when legacy sessions.json exceeds the 16 MiB inline ceiling
 ✓ imports a streamed legacy sessions.json above the 16 MiB inline ceiling
 ✓ fail-closes when a streamed legacy session entry exceeds 1 MiB
 ✓ fail-closes when an oversized legacy sessions.json is not valid JSON
 ✓ streams top-level object entries without requiring a wrapper property
 ✓ rejects a single entry above maxEntryBytes
 ✓ rejects a file above maxFileBytes before parsing
 Test Files  2 passed (2)
      Tests  8 passed | 69 skipped (77)
```

### Observed result after fix

1. Inspect of a ~16.7 MiB valid store reports 20 legacy entries, 0 issues, no SQLite create.
2. Import migrates all 20 entries, creates agent SQLite, archives the legacy store.
3. Per-entry >1 MiB and invalid oversized JSON still fail closed.

### What was not tested

- Built packaged `dist/entry.js` / global `openclaw` binary on this host
- Live operator gateway with a multi-year production oversized store

### Fix classification

bugfix / hardening — bounded inline read + Option A streamed migrate for oversized valid stores

## AI Assistance

AI-assisted. Author reviewed the dual-path ceilings, streaming helper, focused
tests, and live `runDoctorSessionSqlite` inspect/import proof.
