### PR TITLE
fix(tts): contract speech requests hang on stalled endpoints

### DIFF
--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -1,5 +1,6 @@
 // TTS contract suites provide reusable text-to-speech plugin contract assertions.
-import http from "node:http";
+import http, { type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createEmptyPluginRegistry,
@@ -7,6 +8,10 @@ import {
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { ResolvedTtsConfig, SpeechProviderPlugin } from "openclaw/plugin-sdk/speech-core";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AssistantMessage, Model } from "../../llm/types.js";
@@ -168,6 +173,42 @@ function createAudioBuffer(length = 2): Buffer {
   return Buffer.from(new Uint8Array(length).fill(1));
 }
 
+async function listenLocal(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return (server.address() as AddressInfo).port;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function withHangingSpeechServer(
+  run: (baseUrl: string, getRequestCount: () => number) => Promise<void>,
+): Promise<void> {
+  let requestCount = 0;
+  const server = http.createServer((_req, _res) => {
+    requestCount += 1;
+  });
+  const port = await listenLocal(server);
+  try {
+    await run(`http://127.0.0.1:${port}/v1`, () => requestCount);
+  } finally {
+    await closeServer(server);
+  }
+}
+
 async function withMockedSpeechFetch(
   run: (fetchMock: ReturnType<typeof vi.fn>) => Promise<void>,
   audioLength: number,
@@ -187,6 +228,25 @@ async function withMockedSpeechFetch(
 
 function resolveBaseUrl(rawValue: unknown, fallback: string): string {
   return typeof rawValue === "string" && rawValue.trim() ? rawValue.replace(/\/+$/u, "") : fallback;
+}
+
+async function requestTestOpenAISpeech(params: {
+  baseUrl: string;
+  body: Record<string, unknown>;
+  timeoutMs: number;
+}): Promise<void> {
+  const requestUrl = `${params.baseUrl}/audio/speech`;
+  const { release } = await fetchWithSsrFGuard({
+    url: requestUrl,
+    init: {
+      method: "POST",
+      body: JSON.stringify(params.body),
+    },
+    timeoutMs: params.timeoutMs,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(params.baseUrl),
+    auditContext: "tts-contract-openai",
+  });
+  await release();
 }
 
 function resolveTestProviderConfig(
@@ -267,22 +327,17 @@ function buildTestOpenAISpeechProvider(): SpeechProviderPlugin {
     isConfigured: ({ providerConfig }) =>
       typeof (providerConfig as Record<string, unknown> | undefined)?.apiKey === "string" ||
       typeof process.env.OPENAI_API_KEY === "string",
-    synthesize: async ({ text, providerConfig, providerOverrides }) => {
+    synthesize: async ({ text, providerConfig, providerOverrides, timeoutMs }) => {
       const config = providerConfig as Record<string, unknown> | undefined;
-      const res = await fetch(
-        `${resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1")}/audio/speech`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            input: text,
-            model: providerOverrides?.model ?? config?.model ?? "gpt-4o-mini-tts",
-            voice: providerOverrides?.voice ?? config?.voice ?? "alloy",
-          }),
+      await requestTestOpenAISpeech({
+        baseUrl: resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1"),
+        body: {
+          input: text,
+          model: providerOverrides?.model ?? config?.model ?? "gpt-4o-mini-tts",
+          voice: providerOverrides?.voice ?? config?.voice ?? "alloy",
         },
-      );
-      // The contract only asserts the request, but an unread audio body pins the
-      // connection-pool socket — release it instead of leaking fds across calls.
-      await res.body?.cancel().catch(() => {});
+        timeoutMs,
+      });
       return {
         audioBuffer: createAudioBuffer(1),
         outputFormat: "mp3",
@@ -290,7 +345,7 @@ function buildTestOpenAISpeechProvider(): SpeechProviderPlugin {
         voiceCompatible: true,
       };
     },
-    synthesizeTelephony: async ({ text, providerConfig }) => {
+    synthesizeTelephony: async ({ text, providerConfig, timeoutMs }) => {
       const config = providerConfig as Record<string, unknown> | undefined;
       const configuredModel = typeof config?.model === "string" ? config.model : undefined;
       const model = configuredModel ?? "tts-1";
@@ -298,19 +353,16 @@ function buildTestOpenAISpeechProvider(): SpeechProviderPlugin {
         typeof config?.instructions === "string" ? config.instructions : undefined;
       const instructions =
         model === "gpt-4o-mini-tts" ? configuredInstructions || undefined : undefined;
-      const res = await fetch(
-        `${resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1")}/audio/speech`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            input: text,
-            model,
-            voice: config?.voice ?? "alloy",
-            instructions,
-          }),
+      await requestTestOpenAISpeech({
+        baseUrl: resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1"),
+        body: {
+          input: text,
+          model,
+          voice: config?.voice ?? "alloy",
+          instructions,
         },
-      );
-      await res.body?.cancel().catch(() => {});
+        timeoutMs,
+      });
       return {
         audioBuffer: createAudioBuffer(2),
         outputFormat: "mp3",
@@ -1260,6 +1312,79 @@ export function describeTtsProviderRuntimeContract() {
         },
       );
     });
+
+    it.each([
+      {
+        name: "ordinary synthesis",
+        run: async (cfg: OpenClawConfig, timeoutMs: number) =>
+          await ttsRuntime.textToSpeech({
+            text: "Hello from the timeout contract.",
+            cfg,
+            disableFallback: true,
+            timeoutMs,
+          }),
+      },
+      {
+        name: "telephony synthesis",
+        run: async (cfg: OpenClawConfig, timeoutMs: number) =>
+          await ttsRuntime.textToSpeechTelephony({
+            text: "Hello from the telephony timeout contract.",
+            cfg,
+            timeoutMs,
+          }),
+      },
+    ] as const)(
+      "aborts stalled OpenAI $name within the caller timeout",
+      { timeout: 2_000 },
+      async (testCase) => {
+        await withHangingSpeechServer(async (baseUrl, getRequestCount) => {
+          const registry = createEmptyPluginRegistry();
+          registry.speechProviders = [
+            { pluginId: "openai", provider: buildTestOpenAISpeechProvider(), source: "test" },
+          ];
+          setActivePluginRegistry(registry);
+          const cfg = asLegacyTtsConfig({
+            messages: {
+              tts: {
+                provider: "openai",
+                providers: {
+                  openai: {
+                    apiKey: "test-key",
+                    baseUrl,
+                    model: "gpt-4o-mini-tts",
+                    voice: "alloy",
+                  },
+                },
+              },
+            },
+          });
+          const timeoutMs = 100;
+          const startedAt = Date.now();
+          let watchdog: ReturnType<typeof setTimeout> | undefined;
+
+          try {
+            const result = await Promise.race([
+              testCase.run(cfg, timeoutMs),
+              new Promise<never>((_, reject) => {
+                watchdog = setTimeout(
+                  () => reject(new Error(`${testCase.name} did not time out`)),
+                  1_000,
+                );
+              }),
+            ]);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toMatch(/aborted|timeout|timed out/i);
+            expect(Date.now() - startedAt).toBeLessThan(1_000);
+            expect(getRequestCount()).toBe(1);
+          } finally {
+            if (watchdog) {
+              clearTimeout(watchdog);
+            }
+          }
+        });
+      },
+    );
   });
 }
 

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -236,7 +236,7 @@ async function requestTestOpenAISpeech(params: {
   timeoutMs: number;
 }): Promise<void> {
   const requestUrl = `${params.baseUrl}/audio/speech`;
-  const { release } = await fetchWithSsrFGuard({
+  const { response, release } = await fetchWithSsrFGuard({
     url: requestUrl,
     init: {
       method: "POST",
@@ -246,7 +246,11 @@ async function requestTestOpenAISpeech(params: {
     policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(params.baseUrl),
     auditContext: "tts-contract-openai",
   });
-  await release();
+  try {
+    await response.body?.cancel().catch(() => {});
+  } finally {
+    await release();
+  }
 }
 
 function resolveTestProviderConfig(

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -1,6 +1,4 @@
 // TTS contract suites provide reusable text-to-speech plugin contract assertions.
-import http, { type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createEmptyPluginRegistry,
@@ -12,7 +10,7 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
-import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { withEnv, withEnvAsync, withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AssistantMessage, Model } from "../../llm/types.js";
 import { resolveWorkspacePackagePublicModuleUrl } from "../../plugin-sdk/test-helpers/public-surface-loader.js";
@@ -173,40 +171,18 @@ function createAudioBuffer(length = 2): Buffer {
   return Buffer.from(new Uint8Array(length).fill(1));
 }
 
-async function listenLocal(server: Server): Promise<number> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  return (server.address() as AddressInfo).port;
-}
-
-async function closeServer(server: Server): Promise<void> {
-  server.closeAllConnections();
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
 async function withHangingSpeechServer(
   run: (baseUrl: string, getRequestCount: () => number) => Promise<void>,
 ): Promise<void> {
   let requestCount = 0;
-  const server = http.createServer((_req, _res) => {
-    requestCount += 1;
-  });
-  const port = await listenLocal(server);
-  try {
-    await run(`http://127.0.0.1:${port}/v1`, () => requestCount);
-  } finally {
-    await closeServer(server);
-  }
+  await withServer(
+    (_req, _res) => {
+      requestCount += 1;
+    },
+    async (baseUrl) => {
+      await run(`${baseUrl}/v1`, () => requestCount);
+    },
+  );
 }
 
 async function withMockedSpeechFetch(
@@ -1198,44 +1174,36 @@ export function describeTtsProviderRuntimeContract() {
       it("cancels the discarded speech response body after synthesize", async () => {
         await withIsolatedSpeechProviderEnvAsync({}, async () => {
           let sawConnectionClose = false;
-          const server = http.createServer((_req, res) => {
-            res.writeHead(200, { "content-type": "audio/mpeg" });
-            res.write(Buffer.alloc(16));
-            res.on("close", () => {
-              sawConnectionClose = true;
-            });
-            // Intentionally never res.end(): an unread body must still be
-            // released by the caller, not left pinning the connection.
-          });
-          await new Promise<void>((resolve) => {
-            server.listen(0, "127.0.0.1", resolve);
-          });
-          const address = server.address();
-          const port = typeof address === "object" && address ? address.port : 0;
-          try {
-            const result = await ttsRuntime.synthesizeSpeech({
-              text: "hello cancel",
-              cfg: asLegacyOpenClawConfig({
-                agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
-                messages: {
-                  tts: {
-                    provider: "openai",
-                    openai: {
-                      baseUrl: `http://127.0.0.1:${port}/v1`,
-                      apiKey: "fixture-api-key",
+          await withServer(
+            (_req, res) => {
+              res.writeHead(200, { "content-type": "audio/mpeg" });
+              res.write(Buffer.alloc(16));
+              res.on("close", () => {
+                sawConnectionClose = true;
+              });
+              // Intentionally never res.end(): an unread body must still be
+              // released by the caller, not left pinning the connection.
+            },
+            async (baseUrl) => {
+              const result = await ttsRuntime.synthesizeSpeech({
+                text: "hello cancel",
+                cfg: asLegacyOpenClawConfig({
+                  agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+                  messages: {
+                    tts: {
+                      provider: "openai",
+                      openai: {
+                        baseUrl: `${baseUrl}/v1`,
+                        apiKey: "fixture-api-key",
+                      },
                     },
                   },
-                },
-              }),
-            });
-            expect(result.success).toBe(true);
-            await vi.waitFor(() => expect(sawConnectionClose).toBe(true), { timeout: 5_000 });
-          } finally {
-            server.closeAllConnections();
-            await new Promise((resolve) => {
-              server.close(resolve);
-            });
-          }
+                }),
+              });
+              expect(result.success).toBe(true);
+              await vi.waitFor(() => expect(sawConnectionClose).toBe(true), { timeout: 5_000 });
+            },
+          );
         });
       });
 

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -1321,7 +1321,7 @@ export function describeTtsProviderRuntimeContract() {
                 provider: "openai",
                 providers: {
                   openai: {
-                    apiKey: "test-key",
+                    apiKey: "test-api-key",
                     baseUrl,
                     model: "gpt-4o-mini-tts",
                     voice: "alloy",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running the reusable OpenAI TTS contracts against a custom or local endpoint could wait indefinitely when the endpoint accepted the HTTP request but never returned response headers. Ordinary synthesis and telephony synthesis each had an independent unbounded request path.

## Why This Change Was Made

Both contract fixture entry points now share one request helper built on the existing guarded fetch path. The helper applies the caller-provided speech timeout, limits configured-origin trust to the selected base URL hostname, cancels the discarded speech response body, and releases the guarded transport.

The production OpenAI TTS provider already follows this invariant, so this change stays inside the reusable contract fixture and does not change public APIs, configuration, schemas, or provider defaults.

## User Impact

TTS contract runs now fail within a bounded interval when an OpenAI-compatible endpoint stalls before headers, instead of hanging the test process indefinitely. This covers both normal audio synthesis and telephony synthesis.

## Evidence

### Exact-head CI proof

- PR HEAD: `25e8fdff716413ce7ced84fc1efe2356612d5474`
- Canonical exact-head CI job: https://github.com/openclaw/openclaw/actions/runs/29719474273/job/88279336342
- Canonical aggregate gate: https://github.com/openclaw/openclaw/actions/runs/29719474273/job/88279527039
- Job `checks-fast-contracts-plugins-b`: passed.
- `src/plugins/contracts/tts.contract.test.ts`: 44/44 tests passed.
- Complete plugin contract shard: 20/20 test files and 269/269 tests passed.

```text
✓ src/plugins/contracts/tts.contract.test.ts (44 tests)
Test Files  20 passed (20)
Tests       269 passed (269)
```

### Exact-head real loopback and release proof

- Public secretless proof run: https://github.com/zhangguiping-xydt/openclaw/actions/runs/29725259799/job/88296769288
- The job checks out the immutable PR commit directly and fails unless `git rev-parse HEAD` equals `25e8fdff716413ce7ced84fc1efe2356612d5474`.
- The selected tests use real Node loopback HTTP servers; no provider credentials or private endpoints are involved.

```text
tested_head=25e8fdff716413ce7ced84fc1efe2356612d5474

$ node scripts/run-vitest.mjs run \
    src/plugins/contracts/tts.contract.test.ts \
    --reporter verbose \
    --testNamePattern 'aborts stalled OpenAI|cancels the discarded speech response body after synthesize'

✓ tts provider runtime contract > fallback readiness errors > cancels the discarded speech response body after synthesize 1580ms
✓ tts provider runtime contract > aborts stalled OpenAI 'ordinary synthesis' within the caller timeout 117ms
✓ tts provider runtime contract > aborts stalled OpenAI 'telephony synthesis' within the caller timeout 106ms

Test Files  1 passed (1)
Tests       3 passed | 41 skipped (44)
```

What the three cases prove:

- Ordinary synthesis: a real server accepts exactly one POST and never writes response headers; the caller's 100 ms timeout terminates the request before the 1 s watchdog.
- Telephony synthesis: the independent telephony entry point exercises the same stalled-header condition and terminates within the caller timeout.
- Discarded-response cleanup: a real server sends headers plus 16 audio bytes but intentionally never calls `res.end()`. The test only passes after the server observes `close`, demonstrating the final-head helper cancels the unread response body and releases the guarded dispatcher instead of pinning the connection.

The relevant fixture paths are the shared guarded request helper and its two callers in [`src/plugins/contracts/tts-contract-suites.ts`](https://github.com/openclaw/openclaw/blob/25e8fdff716413ce7ced84fc1efe2356612d5474/src/plugins/contracts/tts-contract-suites.ts#L233-L373), the connection-close regression at [lines 1198-1232](https://github.com/openclaw/openclaw/blob/25e8fdff716413ce7ced84fc1efe2356612d5474/src/plugins/contracts/tts-contract-suites.ts#L1198-L1232), and the stalled-header regressions at [lines 1320-1394](https://github.com/openclaw/openclaw/blob/25e8fdff716413ce7ced84fc1efe2356612d5474/src/plugins/contracts/tts-contract-suites.ts#L1320-L1394).

Gateway startup is not applicable because the affected path is the reusable contract fixture transport rather than a gateway request path. The proof directly executes both fixture entry points and the cleanup invariant over real TCP/HTTP connections.
