### PR TITLE
fix(feishu): DMs send a spurious no-visible-reply fallback after an intentional silent NO_REPLY

### DIFF
--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -1,7 +1,8 @@
 // Feishu delivery trace goldens: replayable wire-level lifecycle recordings.
 //
-// IN events are fed straight into the reply-dispatcher wiring (the options
-// createReplyDispatcherWithTyping receives plus replyOptions callbacks); OUT
+// IN events are fed straight into the reply-dispatcher wiring (the core-owned
+// dispatcher options and delivery returned by createFeishuReplyDispatcher plus
+// replyOptions callbacks); OUT
 // events are recorded at the mocked Lark SDK client and the mocked CardKit
 // HTTP fetch, so streaming-card entity calls are captured at the wire seam.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
@@ -37,7 +38,6 @@ type FeishuTraceState = {
   account: ResolvedFeishuAccount | null;
   larkClient: unknown;
   cardKitFetch: typeof fetch | null;
-  dispatcherOptions: FeishuDispatcherOptions | null;
   messageCount: number;
   reactionCount: number;
   cardCount: number;
@@ -51,7 +51,6 @@ const traceState = vi.hoisted(
     account: null,
     larkClient: null,
     cardKitFetch: null,
-    dispatcherOptions: null,
     messageCount: 0,
     reactionCount: 0,
     cardCount: 0,
@@ -84,17 +83,6 @@ vi.mock("./client.js", async (importOriginal) => {
         throw new Error("trace Lark client not initialized");
       }
       return traceState.larkClient;
-    },
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createReplyDispatcherWithTyping: (options: FeishuDispatcherOptions) => {
-      traceState.dispatcherOptions = options;
-      return { dispatcher: {}, replyOptions: {}, markDispatchIdle: () => {} };
     },
   };
 });
@@ -161,7 +149,6 @@ afterAll(() => {
   vi.doUnmock("./client.js");
   vi.doUnmock("./runtime.js");
   vi.doUnmock("./streaming-card.js");
-  vi.doUnmock("openclaw/plugin-sdk/reply-runtime");
   vi.resetModules();
 });
 
@@ -169,7 +156,6 @@ afterEach(() => {
   traceState.account = null;
   traceState.larkClient = null;
   traceState.cardKitFetch = null;
-  traceState.dispatcherOptions = null;
   traceState.wireFaults = [];
   streamingStartBackoffUntilByAccount.clear();
 });
@@ -378,10 +364,10 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
     sendTarget: "oc-trace-chat",
     replyToMessageId: "om-inbound",
   });
-  const options = traceState.dispatcherOptions;
-  if (!options) {
-    throw new Error("dispatcher options were not captured");
-  }
+  const options = {
+    ...created.dispatcherOptions,
+    deliver: created.delivery.deliver,
+  } as FeishuDispatcherOptions;
 
   return async (step: DeliveryTraceInStep) => {
     switch (step.kind) {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1,6 +1,7 @@
 // Feishu tests cover reply dispatcher plugin behavior.
 import os from "node:os";
 import path from "node:path";
+import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type StreamingSessionStub = {
@@ -2087,6 +2088,75 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(result.getVisibleReplyState()).toEqual({
       visibleReplySent: false,
       skippedFinalReason: "silent",
+    });
+  });
+
+  it("does not send no-visible-reply fallback after an intentional silent block reply", async () => {
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
+  it("still sends no-visible-reply fallback after a non-silent block skip", async () => {
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "" }, { kind: "block", reason: "empty" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toContain(
+      "without visible content",
+    );
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: true,
+      skippedFinalReason: null,
+    });
+  });
+
+  it("suppresses the fallback for a real NO_REPLY block reply through the full dispatch pipeline", async () => {
+    // Unlike the tests above (which invoke the captured onSkip callback
+    // directly), this drives the exact production call path: the shared
+    // createReplyDispatcherWithTyping + normalizeReplyPayload pipeline decides
+    // "NO_REPLY" is silent on its own and calls Feishu's onSkip for us. Only
+    // the outbound Feishu HTTP calls are mocked, same as every other test here.
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+    const { dispatcher } = createReplyDispatcherWithTyping(options);
+
+    dispatcher.sendBlockReply({ text: "NO_REPLY" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
+  it("still delivers the fallback for a real genuinely-empty block reply through the full dispatch pipeline", async () => {
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+    const { dispatcher } = createReplyDispatcherWithTyping(options);
+
+    dispatcher.sendBlockReply({ text: "" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toContain(
+      "without visible content",
+    );
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: true,
+      skippedFinalReason: null,
     });
   });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -670,7 +670,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       conversationType: chatId.startsWith("oc_") ? "group" : "direct",
     },
     onSkip: (_payload, info) => {
-      if (info.kind === "final") {
+      if (info.kind === "final" || (info.kind === "block" && info.reason === "silent")) {
         skippedFinalReason = info.reason;
       }
     },


### PR DESCRIPTION
Related: #109912
Closes: #110744

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

1. Feishu DM users receive a spurious "⚠️ This reply completed without visible content..." fallback after an intentional silent `NO_REPLY` (block-kind skip was not recorded by `onSkip`).
2. `extensions/feishu/src/delivery-trace.test.ts` fails on unmodified `main` with `dispatcher options were not captured`, blocking `openclaw/ci-gate` for any PR that pulls in the Feishu reply-dispatcher shard.

## Why This Change Was Made

**NO_REPLY fallback:** Feishu's default `blockReplyBreak: "message_end"` routes the final assistant text through `sendBlockReply` (`kind: "block"`). The shared normalizer correctly reports `{ kind: "block", reason: "silent" }` for `NO_REPLY`, but Feishu's `onSkip` only recorded `kind === "final"`, so `ensureNoVisibleReplyFallback` still fired. The fix also captures silent block skips; non-silent empty block skips still get the fallback.

**delivery-trace:** PR #110095 moved inbound turn execution into core and migrated msteams/slack delivery-trace suites off the `createReplyDispatcherWithTyping` capture seam, but missed feishu. This applies the same pattern as #110775 / #110095 (msteams): build step-driver options from `created.dispatcherOptions` + `created.delivery.deliver`, and drop the retired mock (plus leftover `afterEach`/`afterAll` cleanup for that seam).

## User Impact

- Intentional `NO_REPLY` in Feishu DMs no longer produces a confusing fallback; genuinely empty completions still do.
- Feishu delivery-trace goldens pass again, unblocking the required CI gate for Feishu dispatcher PRs.

## Evidence

This PR is AI-assisted (built with Cursor/Claude); I reviewed and understand the change.

### NO_REPLY — full dispatch-pipeline before/after

```text
# Before (one-line onSkip reverted): positive case fails through real pipeline
× suppresses the fallback for a real NO_REPLY block reply through the full dispatch pipeline
AssertionError: expected true to be false
Tests  1 failed | 1 passed | 94 skipped

# After
Test Files  1 passed (1)
     Tests  96 passed (96)
```

### delivery-trace — before/after (mirrors #110775)

```text
# Before
× records streaming-happy / final-only / cancel-mid-stream / rate-limit / overflow
Error: dispatcher options were not captured
Tests  5 failed (5)

# After (this branch)
✓ feishu delivery-trace 5/5
✓ reply-dispatcher 96/96
Test Files  2 passed (2)  |  Tests  101 passed (101)
```

### Lint/format

Touched files pass `oxfmt --check` and oxlint for the extension tsconfig.

**Diff scope:** `reply-dispatcher.ts` (one-line `onSkip` widen), `reply-dispatcher.test.ts` (callback + full-pipeline regressions), `delivery-trace.test.ts` (capture-seam migration).
