### PR TITLE
fix(plugins): agent runs hang when tool-result middleware never settles

### DIFF
--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -1,7 +1,7 @@
 // Imported by loader.test.ts to keep its mocked suite in one Vitest module graph.
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 import { createHookRunner } from "./hooks.js";
 import { loadOpenClawPlugins } from "./loader.js";
@@ -19,6 +19,7 @@ import {
   createSetupEntryChannelPluginFixture,
   globalAfterEach0,
   globalAfterAll1,
+  updatePluginManifest,
 } from "./loader.test-harness.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
@@ -1691,6 +1692,76 @@ describe("loadOpenClawPlugins", () => {
       before_model_resolve: 750,
       before_agent_start: 250,
     });
+  });
+
+  it("bounds agent tool-result middleware with configured typed hook timeout", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "tool-result-middleware-timeout",
+      filename: "tool-result-middleware-timeout.cjs",
+      body: `module.exports = { id: "tool-result-middleware-timeout", register(api) {
+    api.registerAgentToolResultMiddleware(() => new Promise(() => {}), {
+      runtimes: ["openclaw"],
+    });
+  } };`,
+    });
+    updatePluginManifest(plugin, {
+      contracts: { agentToolResultMiddleware: ["openclaw"] },
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["tool-result-middleware-timeout"],
+        entries: {
+          "tool-result-middleware-timeout": {
+            hooks: {
+              timeoutMs: 250,
+              timeouts: { after_tool_call: 25 },
+            },
+          },
+        },
+      },
+    });
+    const middleware = registry.agentToolResultMiddlewares[0];
+    if (!middleware) {
+      throw new Error("expected tool-result middleware registration");
+    }
+
+    vi.useFakeTimers();
+    try {
+      const middlewareRun = middleware.handler(
+        {
+          toolCallId: "call-1",
+          toolName: "exec",
+          args: {},
+          result: { content: [{ type: "text", text: "raw" }], details: {} },
+        },
+        { runtime: "openclaw" },
+      );
+      const outcome = Promise.race([
+        Promise.resolve(middlewareRun).then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({
+            status: "rejected" as const,
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        ),
+        new Promise<{ status: "blocked" }>((resolve) => {
+          setTimeout(() => resolve({ status: "blocked" }), 1_000);
+        }),
+      ]);
+
+      await vi.runAllTimersAsync();
+
+      await expect(outcome).resolves.toEqual({
+        status: "rejected",
+        message:
+          "agent tool result middleware for tool-result-middleware-timeout timed out after 25ms",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("blocks conversation typed hooks for non-bundled plugins unless explicitly allowed", () => {

--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -1832,7 +1832,7 @@ describe("loadOpenClawPlugins", () => {
 
     vi.useFakeTimers();
     try {
-      const run = runner.runAfterToolCall({ toolName: "exec", params: {} }, {});
+      const run = runner.runAfterToolCall({ toolName: "exec", params: {} }, { toolName: "exec" });
       await vi.advanceTimersByTimeAsync(30);
 
       await expect(run).resolves.toBeUndefined();

--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -1694,12 +1694,24 @@ describe("loadOpenClawPlugins", () => {
     });
   });
 
-  it("bounds agent tool-result middleware with configured typed hook timeout", async () => {
+  it.each([
+    {
+      label: "per-hook timeout over the global timeout",
+      hooks: { timeoutMs: 250, timeouts: { after_tool_call: 25 } },
+      expectedTimeoutMs: 25,
+    },
+    {
+      label: "global timeout when no per-hook timeout is configured",
+      hooks: { timeoutMs: 40 },
+      expectedTimeoutMs: 40,
+    },
+  ])("bounds agent tool-result middleware with $label", async ({ hooks, expectedTimeoutMs }) => {
     useNoBundledPlugins();
+    const pluginId = `tool-result-middleware-timeout-${expectedTimeoutMs}`;
     const plugin = writePlugin({
-      id: "tool-result-middleware-timeout",
-      filename: "tool-result-middleware-timeout.cjs",
-      body: `module.exports = { id: "tool-result-middleware-timeout", register(api) {
+      id: pluginId,
+      filename: `${pluginId}.cjs`,
+      body: `module.exports = { id: ${JSON.stringify(pluginId)}, register(api) {
     api.registerAgentToolResultMiddleware(() => new Promise(() => {}), {
       runtimes: ["openclaw"],
     });
@@ -1712,13 +1724,10 @@ describe("loadOpenClawPlugins", () => {
     const registry = loadRegistryFromSinglePlugin({
       plugin,
       pluginConfig: {
-        allow: ["tool-result-middleware-timeout"],
+        allow: [pluginId],
         entries: {
-          "tool-result-middleware-timeout": {
-            hooks: {
-              timeoutMs: 250,
-              timeouts: { after_tool_call: 25 },
-            },
+          [pluginId]: {
+            hooks,
           },
         },
       },
@@ -1739,26 +1748,97 @@ describe("loadOpenClawPlugins", () => {
         },
         { runtime: "openclaw" },
       );
-      const outcome = Promise.race([
-        Promise.resolve(middlewareRun).then(
-          () => ({ status: "resolved" as const }),
-          (error: unknown) => ({
-            status: "rejected" as const,
-            message: error instanceof Error ? error.message : String(error),
-          }),
-        ),
-        new Promise<{ status: "blocked" }>((resolve) => {
-          setTimeout(() => resolve({ status: "blocked" }), 1_000);
+      const outcome = Promise.resolve(middlewareRun).then(
+        () => ({ status: "resolved" as const }),
+        (error: unknown) => ({
+          status: "rejected" as const,
+          message: error instanceof Error ? error.message : String(error),
         }),
-      ]);
-
-      await vi.runAllTimersAsync();
+      );
+      await vi.advanceTimersByTimeAsync(expectedTimeoutMs);
 
       await expect(outcome).resolves.toEqual({
         status: "rejected",
-        message:
-          "agent tool result middleware for tool-result-middleware-timeout timed out after 25ms",
+        message: `agent tool result middleware for ${pluginId} timed out after ${expectedTimeoutMs}ms`,
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves agent tool-result middleware unbounded when no timeout is configured", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "tool-result-middleware-no-timeout",
+      filename: "tool-result-middleware-no-timeout.cjs",
+      body: `module.exports = { id: "tool-result-middleware-no-timeout", register(api) {
+    api.registerAgentToolResultMiddleware(() => new Promise(() => {}), {
+      runtimes: ["openclaw"],
+    });
+  } };`,
+    });
+    updatePluginManifest(plugin, {
+      contracts: { agentToolResultMiddleware: ["openclaw"] },
+    });
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["tool-result-middleware-no-timeout"] },
+    });
+    const middleware = registry.agentToolResultMiddlewares[0];
+    if (!middleware) {
+      throw new Error("expected tool-result middleware registration");
+    }
+
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      void Promise.resolve(
+        middleware.handler(
+          {
+            toolCallId: "call-1",
+            toolName: "exec",
+            args: {},
+            result: { content: [{ type: "text", text: "raw" }], details: {} },
+          },
+          { runtime: "openclaw" },
+        ),
+      ).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(settled).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the registration option when typed hook policy has no timeout", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "after-tool-call-option-timeout",
+      filename: "after-tool-call-option-timeout.cjs",
+      body: `module.exports = { id: "after-tool-call-option-timeout", register(api) {
+    api.on("after_tool_call", () => new Promise(() => {}), { timeoutMs: 30 });
+  } };`,
+    });
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["after-tool-call-option-timeout"] },
+    });
+    const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const runner = createHookRunner(registry, { logger });
+
+    vi.useFakeTimers();
+    try {
+      const run = runner.runAfterToolCall({ toolName: "exec", params: {} }, {});
+      await vi.advanceTimersByTimeAsync(30);
+
+      await expect(run).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        "[hooks] after_tool_call handler from after-tool-call-option-timeout failed: timed out after 30ms",
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -239,7 +239,7 @@ export function createPluginApiFactory(
                 registerCodexAppServerExtensionFactory(record, factory);
               },
               registerAgentToolResultMiddleware: (handler, options) => {
-                registerAgentToolResultMiddleware(record, handler, options);
+                registerAgentToolResultMiddleware(record, handler, options, params.hookPolicy);
               },
               registerSessionExtension: (extension) => registerSessionExtension(record, extension),
               enqueueNextTurnInjection: (injection) => {

--- a/src/plugins/registry-registrars-tools-hooks.ts
+++ b/src/plugins/registry-registrars-tools-hooks.ts
@@ -5,6 +5,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import { registerInternalHook, unregisterInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { withTimeout } from "../utils/with-timeout.js";
 import type { AgentToolResultMiddleware } from "./agent-tool-result-middleware-types.js";
 import {
   normalizeAgentToolResultMiddlewareRuntimeIds,
@@ -170,6 +171,7 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     handler: Parameters<OpenClawPluginApi["registerAgentToolResultMiddleware"]>[0],
     options: Parameters<OpenClawPluginApi["registerAgentToolResultMiddleware"]>[1],
+    policy?: PluginTypedHookPolicy,
   ) => {
     if (typeof (handler as unknown) !== "function") {
       pushDiagnostic({
@@ -219,9 +221,14 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
       existing.runtimes = uniqueValues([...existing.runtimes, ...runtimes]);
       return;
     }
+    const timeoutMs = resolveTypedHookTimeoutMs({ hookName: "after_tool_call", policy });
     const safeHandler: AgentToolResultMiddleware = async (event, ctx) => {
       try {
-        return await handler(event, ctx);
+        return await withTimeout(
+          Promise.resolve(handler(event, ctx)),
+          timeoutMs ?? 0,
+          `agent tool result middleware for ${record.id}`,
+        );
       } catch (error) {
         registryParams.logger.warn(
           `[plugins] agent tool result middleware failed for ${record.id}`,

--- a/src/plugins/registry-registrars-tools-hooks.ts
+++ b/src/plugins/registry-registrars-tools-hooks.ts
@@ -224,6 +224,7 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     const timeoutMs = resolveTypedHookTimeoutMs({ hookName: "after_tool_call", policy });
     const safeHandler: AgentToolResultMiddleware = async (event, ctx) => {
       try {
+        // fs-safe bounds only this await; it cannot cancel plugin work, so late side effects remain possible.
         return await withTimeout(
           Promise.resolve(handler(event, ctx)),
           timeoutMs ?? 0,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where an agent run could hang indefinitely when a local plugin's tool-result middleware returned a Promise that never settled. The configured typed-hook timeout was not applied on this middleware path, so the tool result and the rest of the run could remain frozen.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The plugin registry now forwards the existing hook policy to the tool-result middleware owner and applies the `after_tool_call` typed-hook timeout around each plugin handler. This reuses the shared timeout helper and existing fail-closed middleware behavior; it does not add a new setting or change timeout defaults.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Agent runs can recover when a local plugin's tool-result middleware becomes unresponsive. After the configured timeout, the middleware failure is logged and the tool-result path continues instead of blocking the entire run.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Regression on the pinned base: a middleware returning a never-settling Promise was still pending when the 1,000 ms control timer fired, despite `hooks.timeouts.after_tool_call` being configured to 25 ms.
- Patched loader suite: 170/170 tests passed, including the new timeout regression.
- Tool-result fail-closed suite: 25/25 tests passed.
- Targeted Oxlint and Oxfmt checks passed for all three changed files.
- Live runtime proof: an isolated OpenClaw gateway loaded a proof plugin whose tool-result middleware never settled. A real DeepSeek-backed agent called `session_status`; the gateway logged the plugin middleware timeout and harness fail-closed path, then returned `TOOL_RESULT_PATH_COMPLETED` with status `ok` in 47.353 seconds.
- Local limitations: the guarded core typecheck could not start because its resource guard was unavailable. `check:changed` passed its preliminary and formatting lanes, then stopped on a pre-existing Plugin SDK baseline mismatch that reproduced byte-for-byte on the clean base; no generated baseline was changed.
