### PR TITLE
fix(session-cost-usage): reject fractional limits in loadSessionLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Docs: https://docs.openclaw.ai
 
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Session usage log limits:** reject fractional `limit` values in `loadSessionLogs` so `slice(-0.5)` cannot bypass the cap and return every log line for the session.
 - **Bounded input and provider responses:** cap pasted auth/config input and enforce wall-clock deadlines across generated-media downloads, polling JSON, and failed response details so oversized or slow-drip streams cannot exceed resource budgets (thanks @Pick-cat).
 - **Cloud worker derived workspace caches:** exclude Python caches, dependency trees, and macOS metadata symmetrically from outbound sync and inbound reconciliation so local cache rewrites cannot fence later cloud results or worker reclaim.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2877,6 +2877,11 @@ example
     await expect(
       loadSessionLogs({ sessionFile, limit: Number.POSITIVE_INFINITY }),
     ).resolves.toEqual([]);
+    // Fractional positive limits must not fall through to `slice(-limit)`:
+    // `slice(-0.5)` returns the entire array in JavaScript, which would
+    // bypass the cap and surface every log line for the session.
+    await expect(loadSessionLogs({ sessionFile, limit: 0.5 })).resolves.toEqual([]);
+    await expect(loadSessionLogs({ sessionFile, limit: 1.5 })).resolves.toEqual([]);
   });
 
   it("keeps the latest logs when transcript timestamps are out of order", async () => {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -2119,6 +2119,13 @@ export async function loadSessionLogs(params: {
     if (!Number.isFinite(params.limit) || params.limit <= 0) {
       return [];
     }
+    // Fractional positive limits must be rejected up front: the unbounded
+    // path below calls `slice(-limit)`, and `slice(-0.5)` returns the
+    // entire array in JavaScript, which would bypass the cap and surface
+    // every log line for the session. The schema contract is integer >= 1.
+    if (!Number.isInteger(params.limit)) {
+      return [];
+    }
   }
   const limit = params.limit ?? 50;
   const boundedLimit = Number.isInteger(limit);


### PR DESCRIPTION
## What Problem This Solves

`loadSessionLogs` already clamps zero, negative, and non-finite `limit` values to an empty array (see #82679). Fractional positive limits like `0.5` or `1.5` fall through the existing guard and reach the unbounded path, which ends with:

```ts
const sortedLogs = logs.toSorted((a, b) => a.timestamp - b.timestamp);
if (sortedLogs.length > limit) {
  return sortedLogs.slice(-limit);
}
return sortedLogs;
```

In JavaScript `slice(-0.5)` returns the **entire array**, so a caller passing a fractional limit ends up bypassing the cap and surfacing every log line for the session instead of none. The schema contract for `sessions.usage.logs` is `Type.Integer({ minimum: 1 })`, so fractional values are out of contract today; this PR makes the runtime path match the schema rather than silently returning the whole file.

## Root Cause

`src/infra/session-cost-usage.ts` (`loadSessionLogs`) only checks `Number.isFinite(params.limit)` and `params.limit <= 0`. The downstream `slice(-limit)` then receives a fractional number, and the `Array.prototype.slice` contract turns a fractional negative argument into "no truncation".

Reproduced locally before the fix:

```text
$ node -e "console.log([1,2,3,4,5].slice(-0.5))"
[ 1, 2, 3, 4, 5 ]
```

## Fix

Reject non-integer positive limits up front, mirroring the existing zero/negative/non-finite guard. The bounded in-memory retention path (`boundedLimit = Number.isInteger(limit)`) already expects an integer, so this keeps the two paths in lockstep.

## Real behavior proof

- **Behavior or issue addressed:** A fractional `limit` no longer returns the full transcript log buffer.
- **Real environment tested:** Linux (Ubuntu), Node v22.22.0, local checkout `tzy-17/openclaw@fix/loadSessionLogs-fractional-limit`.
- **Exact steps or command run after this patch:**
  1. `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts -t "returns empty logs for zero"`
- **Evidence after fix:**

```text
$ node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts -t "returns empty logs for zero"

 RUN  v4.1.10 /home/0668001293/Documents/trae_projects/openclaw

 Test Files  1 passed (1)
      Tests  1 passed | 55 skipped (56)
   Start at  22:14:37
   Duration  18.09s
```

Before the patch the same test failed with `expected [ …(2) ] to deeply equal []` because `limit: 0.5` returned both session log entries.

- **Observed result after fix:** `loadSessionLogs({ limit: 0.5 })` and `loadSessionLogs({ limit: 1.5 })` both resolve to `[]`, matching the existing behavior for `0`, `-1`, `NaN`, and `Infinity`.
- **What was not tested:** Live `sessions.usage.logs` Gateway round-trip (a schema-validated caller cannot reach this path today, but the runtime guard hardens the contract).

## Test plan

- [x] `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts -t "returns empty logs for zero"`
- [x] `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts -t "logs"` (4 log-related tests pass)
- [x] `node_modules/.bin/oxlint src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts`
- [x] `node_modules/.bin/tsc --noEmit -p tsconfig.json` (no `session-cost-usage` errors)

The remaining failures in `session-cost-usage.test.ts` are the pre-existing SQLite WAL guard (`Node 22.22.0 embeds SQLite 3.50.4 …`), unrelated to this change.

## Scope

- No public API change. `sessions.usage.logs` already documents `limit` as a positive integer in the schema.
- Single-line runtime guard plus two regression cases that mirror the existing zero/negative/non-finite assertions.