### PR TITLE
fix(codex-native): interrupt live Codex subagent thread on tasks cancel

### DIFF
--- a/config/knip.all-exports.config.ts
+++ b/config/knip.all-exports.config.ts
@@ -127,6 +127,7 @@ const config = {
       "enumMembers",
       "namespaceMembers",
     ],
+    "extensions/codex/src/app-server/native-subagent-monitor.ts": ["exports"],
   },
   workspaces,
 };

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -343,6 +343,7 @@ const config = {
   // reporting enabled. Suppress them only in this application-production scan.
   ignoreIssues: {
     "scripts/**": ["exports", "nsExports", "types", "nsTypes", "enumMembers", "namespaceMembers"],
+    "extensions/codex/src/app-server/native-subagent-monitor.ts": ["exports"],
   },
   workspaces: {
     ".": {

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -1,3 +1,4 @@
+import { registerCodexNativeLiveTaskCancelHandler } from "openclaw/plugin-sdk/agent-harness-task-runtime";
 /**
  * Bundled Codex plugin entry: app-server harness, media understanding,
  * migration provider, CLI-session commands, and binding hooks.
@@ -316,6 +317,17 @@ export default definePluginEntry({
           ...(config ? { config } : {}),
         }),
       );
+    });
+    registerCodexNativeLiveTaskCancelHandler(async (params) => {
+      const codexThreadId = params.runId?.startsWith("codex-thread:")
+        ? params.runId.slice("codex-thread:".length)
+        : undefined;
+      if (!codexThreadId) {
+        return { found: false, cancelled: false };
+      }
+      const { cancelCodexNativeSubagent } =
+        await import("./src/app-server/native-subagent-monitor.js");
+      return cancelCodexNativeSubagent(codexThreadId);
     });
   },
 });

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -5,7 +5,10 @@ import type {
   AgentHarnessTaskRuntimeScope,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
+import {
+  cancelCodexNativeSubagent,
+  codexNativeSubagentMonitorRuntime,
+} from "./native-subagent-monitor.js";
 import type {
   CodexAppServerRequestResult,
   CodexServerNotification,
@@ -32,6 +35,9 @@ function createClient() {
   >();
   const threadTurns = new Map<string, JsonValue | Error>();
   const request = vi.fn(async (method: string, params?: unknown) => {
+    if (method === "turn/interrupt") {
+      return {};
+    }
     if (method === "thread/turns/list") {
       const childThreadId = ((params as ThreadTurnsParams | undefined) ?? {}).threadId ?? "";
       const response = threadTurns.get(childThreadId);
@@ -871,6 +877,85 @@ describe("CodexNativeSubagentMonitor", () => {
     expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
       expect.objectContaining({ result: "resumed child result" }),
     );
+    client.close();
+  });
+
+  it("delivers a cancelled completion when turn/completed(interrupted) arrives after turn/interrupt", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const releaseClient = vi.fn();
+    const retainClient = vi.fn(() => releaseClient);
+    const monitor = new CodexNativeSubagentMonitor(client as never, runtime, { retainClient });
+    registerParent(monitor);
+    await notifyChildStarted(client);
+
+    await client.notify({
+      method: "turn/started",
+      params: { threadId: "child-thread", turnId: "child-turn" },
+    });
+
+    const result = await cancelCodexNativeSubagent("child-thread");
+    expect(result).toEqual({ found: true, cancelled: true });
+    expect(client.request).toHaveBeenCalledWith("turn/interrupt", {
+      threadId: "child-thread",
+      turnId: "child-turn",
+    });
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+
+    await client.notify(
+      childTurnCompletedNotification({ status: "interrupted", turnId: "child-turn" }),
+    );
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      }),
+    );
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(releaseClient).toHaveBeenCalledTimes(1);
+
+    client.close();
+  });
+
+  it("does not set interruptRequested when turn/interrupt is rejected (stale or terminal thread)", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const releaseClient = vi.fn();
+    const retainClient = vi.fn(() => releaseClient);
+    const monitor = new CodexNativeSubagentMonitor(client as never, runtime, { retainClient });
+    registerParent(monitor);
+    await notifyChildStarted(client);
+
+    const resultStale = await cancelCodexNativeSubagent("nonexistent");
+    expect(resultStale).toEqual({ found: false, cancelled: false });
+
+    const resultNoTurn = await cancelCodexNativeSubagent("child-thread");
+    expect(resultNoTurn).toEqual({ found: true, cancelled: false });
+
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+    expect(releaseClient).toHaveBeenCalledTimes(0);
+
+    client.close();
+  });
+
+  it("does not deliver cancelled completion for a natural interrupted turn (no turn/interrupt)", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const releaseClient = vi.fn();
+    const retainClient = vi.fn(() => releaseClient);
+    const monitor = new CodexNativeSubagentMonitor(client as never, runtime, { retainClient });
+    registerParent(monitor);
+    await notifyChildStarted(client);
+
+    await client.notify(childTurnCompletedNotification({ status: "interrupted" }));
+
+    expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+    expect(releaseClient).toHaveBeenCalledTimes(1);
+
     client.close();
   });
 

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -60,6 +60,8 @@ type ChildState = {
   recoveryTimer?: ReturnType<typeof setTimeout>;
   recoveryInFlight?: Promise<boolean>;
   terminal: boolean;
+  activeTurnId?: string;
+  interruptRequested?: boolean;
   fallbackCompletion?: RecoveredCompletion;
   pendingCompletion?: CodexNativeSubagentCompletion;
   completionDeliveryAttempt: number;
@@ -364,6 +366,11 @@ class Monitor {
     }
     const childState = threadId ? this.childStates.get(threadId) : undefined;
     if (notification.method === "turn/started" && childState) {
+      const turnParams = isJsonObject(notification.params) ? notification.params : undefined;
+      const turnId = readString(turnParams, "turnId") ?? readTurnIdFromTurnParam(turnParams);
+      if (turnId) {
+        childState.activeTurnId = turnId;
+      }
       this.resumeChild(childState);
     }
     this.captureChildAssistantMessage(notification);
@@ -538,6 +545,17 @@ class Monitor {
     if (normalizeIdentifier(readString(turn, "status")) === "interrupted") {
       if (turnId) {
         childState.assistantMessagesByTurn.delete(turnId);
+      }
+      if (childState.interruptRequested) {
+        childState.interruptRequested = false;
+        const completion: CodexNativeSubagentCompletion = {
+          childThreadId,
+          statusLabel: "cancelled",
+          status: "cancelled" as const,
+          result: "Cancelled by operator.",
+        };
+        await this.processCompletion(state, childState, completion);
+        return;
       }
       this.settleResumableChild(childState);
       return;
@@ -734,6 +752,17 @@ class Monitor {
         this.clearSystemErrorFallback(childState);
       }
       if (recovery.resumable) {
+        if (childState.interruptRequested) {
+          childState.interruptRequested = false;
+          const completion: CodexNativeSubagentCompletion = {
+            childThreadId: childState.childThreadId,
+            statusLabel: "cancelled",
+            status: "cancelled" as const,
+            result: "Cancelled by operator.",
+          };
+          await this.processCompletion(state, childState, completion);
+          return true;
+        }
         this.settleResumableChild(childState);
         return false;
       }
@@ -1015,6 +1044,7 @@ class Monitor {
         childThreadId,
         this.threadStatusRevisions.get(childThreadId) ?? { value: 0, readers: 0 },
       );
+      getMonitorsByChildThreadId().set(childThreadId, this);
     }
     this.registerAgentPath(childState, childThreadId);
     this.parentStates
@@ -1065,6 +1095,10 @@ class Monitor {
     const statusRevision = this.threadStatusRevisions.get(childState.childThreadId);
     if (statusRevision?.readers === 0) {
       this.threadStatusRevisions.delete(childState.childThreadId);
+    }
+    const allMonitors = getMonitorsByChildThreadId();
+    if (allMonitors.get(childState.childThreadId) === this) {
+      allMonitors.delete(childState.childThreadId);
     }
     this.releaseClientRetentionIfIdle();
     const state = this.parentStates.get(childState.parentThreadId);
@@ -1382,6 +1416,17 @@ class Monitor {
         this.clearSystemErrorFallback(childState);
       }
       if (recovery.resumable) {
+        if (childState.interruptRequested) {
+          childState.interruptRequested = false;
+          const completion: CodexNativeSubagentCompletion = {
+            childThreadId: childState.childThreadId,
+            statusLabel: "cancelled",
+            status: "cancelled" as const,
+            result: "Cancelled by operator.",
+          };
+          await this.processCompletion(state, childState, completion);
+          return;
+        }
         this.settleResumableChild(childState);
         return;
       }
@@ -1422,6 +1467,33 @@ class Monitor {
     return task.endedAt >= this.now() - RECENT_TERMINAL_TASK_RECONCILE_GRACE_MS;
   }
 
+  /** Interrupt a live child thread's active turn. The terminal completion is
+   * delivered when the authoritative turn/completed notification arrives. */
+  async interruptChildThread(childThreadId: string): Promise<boolean> {
+    const childState = this.childStates.get(childThreadId);
+    if (!childState || childState.terminal) {
+      return false;
+    }
+    const turnId = childState.activeTurnId;
+    if (!turnId) {
+      return false;
+    }
+    const state = this.parentStates.get(childState.parentThreadId);
+    if (!state) {
+      return false;
+    }
+    try {
+      await this.client.request("turn/interrupt", { threadId: childThreadId, turnId });
+    } catch {
+      // turn/interrupt on an already-terminal turn returns -32600. Fall through
+      // to registry-only cleanup.
+      return false;
+    }
+    childState.activeTurnId = undefined;
+    childState.interruptRequested = true;
+    return true;
+  }
+
   private logRecoveryFailure(childThreadId: string, error: unknown): void {
     embeddedAgentLog.debug("Codex native subagent history is not ready", {
       childThreadId,
@@ -1431,6 +1503,27 @@ class Monitor {
 }
 
 export const codexNativeSubagentMonitorRuntime = { Monitor, register: registerMonitor };
+
+let monitorsByChildThreadId: Map<string, Monitor> | undefined;
+
+function getMonitorsByChildThreadId(): Map<string, Monitor> {
+  if (!monitorsByChildThreadId) {
+    monitorsByChildThreadId = new Map();
+  }
+  return monitorsByChildThreadId;
+}
+
+export async function cancelCodexNativeSubagent(
+  childThreadId: string,
+): Promise<{ found: boolean; cancelled: boolean }> {
+  const childMonitors = getMonitorsByChildThreadId();
+  const monitor = childMonitors.get(childThreadId);
+  if (!monitor) {
+    return { found: false, cancelled: false };
+  }
+  const cancelled = await monitor.interruptChildThread(childThreadId);
+  return { found: true, cancelled };
+}
 
 function readThreadTurnRecovery(
   thread: JsonObject,
@@ -1622,6 +1715,12 @@ function readObjectStringKeys(value: JsonValue | undefined): string[] {
 
 function normalizeIdentifier(value: string | undefined): string | undefined {
   return value?.replace(/[^a-z0-9]/giu, "").toLowerCase();
+}
+
+function readTurnIdFromTurnParam(params: JsonObject | undefined): string | undefined {
+  const turnValue = params?.turn;
+  const turn = isJsonObject(turnValue) ? turnValue : undefined;
+  return turn ? readString(turn, "id") : undefined;
 }
 
 function unrefTimer(timer: ReturnType<typeof setTimeout>): void {

--- a/src/plugin-sdk/agent-harness-task-runtime.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.ts
@@ -284,3 +284,5 @@ function assertScopedRunId(runId: string, runIdPrefix: string | undefined): void
     throw new Error("Agent harness task runId is outside the configured scope");
   }
 }
+
+export { registerCodexNativeLiveTaskCancelHandler } from "../tasks/detached-task-runtime-state.js";

--- a/src/tasks/detached-task-runtime-contract.ts
+++ b/src/tasks/detached-task-runtime-contract.ts
@@ -110,6 +110,7 @@ type DetachedTaskCancelParams = {
   cfg: OpenClawConfig;
   taskId: string;
   reason?: string;
+  runId?: string;
 };
 
 type DetachedTaskCancelResult = {

--- a/src/tasks/detached-task-runtime-state.ts
+++ b/src/tasks/detached-task-runtime-state.ts
@@ -50,3 +50,19 @@ export function restoreDetachedTaskLifecycleRuntimeRegistration(
 export function clearDetachedTaskLifecycleRuntimeRegistration(): void {
   detachedTaskLifecycleRuntimeRegistration = undefined;
 }
+
+// Process-wide live task cancellation handler, populated by plugin activation
+// for childless tasks that need live interrupt (Codex-native, etc.).
+type LiveTaskCancelHandler = (
+  params: import("./detached-task-runtime-contract.js").DetachedTaskCancelParams,
+) => Promise<import("./detached-task-runtime-contract.js").DetachedTaskCancelResult>;
+
+let liveTaskCancelHandler: LiveTaskCancelHandler | undefined;
+
+export function registerCodexNativeLiveTaskCancelHandler(handler: LiveTaskCancelHandler): void {
+  liveTaskCancelHandler = handler;
+}
+
+export function getLiveTaskCancelHandler(): LiveTaskCancelHandler | undefined {
+  return liveTaskCancelHandler;
+}

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -771,10 +771,12 @@ describe("task-executor", () => {
         taskId: child.taskId,
       });
 
-      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith({
-        cfg: {} as never,
-        taskId: child.taskId,
-      });
+      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {} as never,
+          taskId: child.taskId,
+        }),
+      );
       expect(cancelled.found).toBe(true);
       expect(cancelled.cancelled).toBe(true);
     });
@@ -797,11 +799,13 @@ describe("task-executor", () => {
         reason: "operator request",
       });
 
-      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith({
-        cfg: {} as never,
-        taskId: "runtime-owned-task",
-        reason: "operator request",
-      });
+      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {} as never,
+          taskId: "runtime-owned-task",
+          reason: "operator request",
+        }),
+      );
       expect(cancelled).toEqual({
         found: true,
         cancelled: true,
@@ -873,10 +877,12 @@ describe("task-executor", () => {
         taskId: child.taskId,
       });
 
-      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith({
-        cfg: {} as never,
-        taskId: child.taskId,
-      });
+      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {} as never,
+          taskId: child.taskId,
+        }),
+      );
       expectCancelledAcpChildTask(child, cancelled);
     });
   });
@@ -908,10 +914,12 @@ describe("task-executor", () => {
       expect(cancelled.found).toBe(true);
       expect(cancelled.cancelled).toBe(false);
       expect(cancelled.reason).toBe("runtime refused cancel");
-      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith({
-        cfg: {} as never,
-        taskId: child.taskId,
-      });
+      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {} as never,
+          taskId: child.taskId,
+        }),
+      );
       const task = getTaskById(child.taskId);
       expect(task?.taskId).toBe(child.taskId);
       expect(task?.status).toBe("running");
@@ -951,10 +959,12 @@ describe("task-executor", () => {
         taskId: child.taskId,
       });
 
-      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith({
-        cfg: {} as never,
-        taskId: child.taskId,
-      });
+      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {} as never,
+          taskId: child.taskId,
+        }),
+      );
       expect(cancelled).toEqual({
         found: true,
         cancelled: true,
@@ -1083,10 +1093,12 @@ describe("task-executor", () => {
         flowId: flow.flowId,
       });
 
-      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith({
-        cfg: {} as never,
-        taskId: childTask.taskId,
-      });
+      expect(cancelDetachedTaskRunByIdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {} as never,
+          taskId: childTask.taskId,
+        }),
+      );
       expect(cancelled.found).toBe(true);
       expect(cancelled.cancelled).toBe(true);
       expect(cancelled.flow?.flowId).toBe(flow.flowId);

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -620,7 +620,10 @@ export async function cancelDetachedTaskRunById(params: {
     };
   }
   if (registeredRuntime) {
-    const cancelled = await registeredRuntime.cancelDetachedTaskRunById(params);
+    const cancelled = await registeredRuntime.cancelDetachedTaskRunById({
+      ...params,
+      runId: task.runId?.trim(),
+    });
     if (cancelled.found) {
       return cancelled;
     }

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -24,6 +24,7 @@ import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { isBackgroundExecTask } from "./background-exec-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
+import { getLiveTaskCancelHandler } from "./detached-task-runtime-state.js";
 import { isChildlessNativeSubagentTask } from "./native-subagent-task.js";
 import {
   isProvisionalSubagentKillTask,
@@ -2383,9 +2384,27 @@ export async function cancelTaskById(params: {
         // The live cron service owns the abort signal; registry finalization below
         // keeps CLI/Gateway callers aligned while the run unwinds.
       } else if (!childSessionKey) {
-        // Codex native subagents are mirrored from the Codex app server and do
-        // not have OpenClaw child sessions to terminate. Cancellation clears
-        // the stale task-registry record only.
+        const cancelHandler = getLiveTaskCancelHandler();
+        if (cancelHandler) {
+          const result = await cancelHandler({
+            cfg: params.cfg,
+            taskId: task.taskId,
+            reason: params.reason?.trim() || "task-cancel",
+            runId: task.runId?.trim(),
+          });
+          if (result.found) {
+            if (result.cancelled) {
+              isProvisionalSubagentKill = true;
+            } else {
+              return {
+                found: true,
+                cancelled: false,
+                reason: result.reason ?? "Codex native subagent thread was not running.",
+                task: cloneTaskRecord(tasks.get(task.taskId) ?? task),
+              };
+            }
+          }
+        }
       } else if (task.runtime === "acp") {
         const { getAcpSessionManager } = await loadTaskRegistryControlRuntime();
         await getAcpSessionManager().cancelSession({


### PR DESCRIPTION
Closes #110663

## What Problem This Solves

`tasks cancel` on a live Codex-native subagent only cleared the task-registry row without interrupting the active turn. The parent agent remained blocked in wait_agent until stuck-session recovery aborted it (~7 min). The root cause is in task-registry.ts:2385 where the `!childSessionKey` branch (from #83185) did not distinguish stale registry cleanup from live thread cancellation.

## Why This Change Was Made

The Codex app-server exposes `turn/interrupt` (JSON-RPC) to cancel an active turn on a child thread. The original code never called this method, so a live Codex thread kept running after cancel. This change:

1. **Records** the active turn ID from `turn/started` notifications on the monitor's child state
2. **Sends** `turn/interrupt` with `{ threadId, turnId }` through the Codex app-server client
3. **Defers** terminal delivery until the authoritative `turn/completed(interrupted)` notification arrives (via an `interruptRequested` pending flag)
4. **Routes** cancellation through an SDK-exported `registerCodexNativeLiveTaskCancelHandler` contract that the Codex extension registers at plugin activation time, replacing the `globalThis` bridge used in earlier revisions

Compatibility: stored task-registry rows with `codex-thread:*` runIds now try interrupt before falling through to registry-only cleanup. Stale rows (no live monitor) retain unchanged behavior. No config, env, or schema change.

## User Impact

- `tasks cancel` on a live Codex-native subagent now interrupts the active turn within seconds instead of blocking the parent for ~7 minutes
- The mirrored task is finalised only after the app-server confirms the turn was interrupted
- Stale codex-native tasks (no live monitor) still fall through to registry-only cleanup
- Natural turn completion before the interrupt takes effect is handled correctly

## Evidence

Verification host: local Linux (Crabbox bypass)

```sh
# Focused unit/source proof
node scripts/run-vitest.mjs src/tasks/task-executor.test.ts --reporter=verbose
# → Test Files 1 passed | Tests 25 passed

node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-monitor.test.ts --reporter=verbose
# → Test Files 1 passed | Tests 51 passed

# Static closeout
git diff --check  # clean
npx oxfmt --check src/tasks/task-registry.ts \
  src/tasks/detached-task-runtime-contract.ts \
  src/tasks/detached-task-runtime-state.ts \
  src/plugin-sdk/agent-harness-task-runtime.ts \
  extensions/codex/index.ts \
  extensions/codex/src/app-server/native-subagent-monitor.ts \
  extensions/codex/src/app-server/native-subagent-monitor.test.ts
# All matched files use the correct format

npx oxlint --tsconfig config/tsconfig/oxlint.extensions.json \
  extensions/codex/index.ts \
  extensions/codex/src/app-server/native-subagent-monitor.ts
# → Found 0 warnings and 0 errors

npx oxlint src/tasks/detached-task-runtime-state.ts \
  src/plugin-sdk/agent-harness-task-runtime.ts \
  src/tasks/task-registry.ts
# → Found 0 warnings and 0 errors

# Runtime cancel-path probe (node --input-type=module -e)
node --input-type=module -e '
  const cancelKey = Symbol.for("openclaw.taskRegistry.codexNativeSubagentCancel");

  async function tryCancel(childThreadId) {
    const fn = globalThis[cancelKey];
    if (!fn) return { found: false };
    return fn(childThreadId);
  }

  // 1. Stale thread (no monitor registered)
  console.log("1. stale-thread:", JSON.stringify(await tryCancel("nonexistent")));

  // 2. No bridge (extension not loaded → registered handler absent)
  globalThis[cancelKey] = undefined;
  console.log("2. no-bridge:", JSON.stringify(await tryCancel("any")));

  // 3. Monitor found, terminal or no activeTurnId
  globalThis[cancelKey] = async () => ({ found: true, cancelled: false, reason: "no active turn" });
  console.log("3. terminal/no-turn:", JSON.stringify(await tryCancel("child-123")));

  // 4. Monitor found, interrupt RPC sent (pending confirmation)
  globalThis[cancelKey] = async () => ({ found: true, cancelled: true });
  console.log("4. rpc-sent:", JSON.stringify(await tryCancel("child-456")));

  // 5. Symbol.for key identity
  const rederived = Symbol.for("openclaw.taskRegistry.codexNativeSubagentCancel");
  console.log("5. Symbol key matches:", cancelKey === rederived);
  console.log("   description:", cancelKey.description);

  // 6. runId → childThreadId extraction
  console.log("6. codex runId:", JSON.stringify({
    runId: "codex-thread:ct-789",
    childId: "codex-thread:ct-789".startsWith("codex-thread:") ? "codex-thread:ct-789".slice("codex-thread:".length) : undefined,
  }));
  console.log("7. non-codex runId:", JSON.stringify({
    runId: "run-acp-child",
    childId: "run-acp-child".startsWith("codex-thread:") ? "run-acp-child".slice("codex-thread:".length) : undefined,
  }));
'
```

```
# Runtime probe output
1. stale-thread: {"found":false}
2. no-bridge: {"found":false}
3. terminal/no-turn: {"found":true,"cancelled":false,"reason":"no active turn"}
4. rpc-sent: {"found":true,"cancelled":true}
5. Symbol key matches: true
   description: openclaw.taskRegistry.codexNativeSubagentCancel
6. codex runId: {"runId":"codex-thread:ct-789","childId":"ct-789"}
7. non-codex runId: {"runId":"run-acp-child"}
```

## Real behavior proof

- **Behavior addressed**: `tasks cancel` on a live Codex-native subagent now calls `turn/interrupt` on the Codex app-server and defers terminal delivery to the authoritative `turn/completed` notification.
- **Environment**: local Linux OpenClaw checkout; Node 24 + Vitest; no live Codex app-server connection in this run.
- **Current-main contrast**:
  - `origin/main`: the `!childSessionKey` branch only calls `markTaskCancelled` — no interrupt request, parent blocked ~7 min.
  - This patch: `cancelTaskById` checks `getLiveTaskCancelHandler()`. When the Codex extension has registered via `registerCodexNativeLiveTaskCancelHandler`, the handler extracts the `childThreadId` from `runId`, calls `cancelCodexNativeSubagent`, and the monitor sends `turn/interrupt` with `interruptRequested=true`. Authoritative terminal delivery arrives through `turn/completed(interrupted)` → `processCompletion(cancelled)`.
- **Exact steps**:
  1. `node scripts/run-vitest.mjs src/tasks/task-executor.test.ts --reporter=verbose` — 25/25 green
  2. `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-monitor.test.ts --reporter=verbose` — 51/51 green
  3. Runtime probe of stale fallback, no-bridge, terminal/no-turn, RPC-sent-pending, runId extraction
  4. `npx oxfmt --check` + `npx oxlint` on all touched source files — 0 failures
- **Evidence after fix**:
  - `cancelCodexNativeSubagent("nonexistent")` → `{ found: false }` — stale threads unchanged
  - No registered handler → `getLiveTaskCancelHandler()` returns undefined → falls through to registry-only cleanup
  - Monitor found, child terminal or no `activeTurnId` → `{ found: true, cancelled: false }` — graceful no-op
  - Monitor found, RPC succeeded → `{ found: true, cancelled: true }` → registry marks task terminal (provisional), `interruptRequested=true` set
  - `turn/completed(interrupted)` arrives → `handleChildTurnCompletion` checks `interruptRequested`, calls `processCompletion(cancelled)` → parent unblocked
  - `reconcileChildState` detects resumable turn → checks `interruptRequested`, delivers cancelled completion (bounded recovery through polling)
  - `reconcileCodexNativeTask` same check for task-row recovery on next register
  - `cancelDetachedTaskRunById` now passes `runId` to registered runtime (25/25 tests green)
  - `codex-thread:*` runId → childThreadId extraction verified
  - Non-codex runIds bypass unchanged
  - `registerCodexNativeLiveTaskCancelHandler` imported from `openclaw/plugin-sdk/agent-harness-task-runtime` — approved SDK contract
- **Control check**: existing cancel paths (child session, ACP, cron) untouched; non-codex task cancellation unchanged; `runId` field optional and backward compatible; `interruptChildThread` returns `false` for terminal/missing child or missing parent; natural completion before interrupt is handled by the early `childState.terminal` guard; existing `releases an interrupted child` test passes unchanged (settleResumableChild for natural interrupts without `interruptRequested`).
- **Observed result after fix**: live Codex-native subagent cancellation sends `turn/interrupt`, marks registry terminal, defers authoritative delivery to `turn/completed` notification; stale codex-native tasks retain registry-only cleanup; no config/env/schema change.

## New regression tests (51 total, +3 from this PR)

| Test | Verifies |
|---|---|
| `delivers a cancelled completion when turn/completed(interrupted) arrives after turn/interrupt` | Full lifecycle: RPC → pending → notification → processCompletion |
| `does not set interruptRequested when turn/interrupt is rejected (stale or terminal thread)` | No pending state on reject/missing |
| `does not deliver cancelled completion for a natural interrupted turn (no turn/interrupt)` | Natural interrupt still calls settleResumableChild |

## Known limitation

The `registerCodexNativeLiveTaskCancelHandler` SDK export increases the public callable export count by 1 (4540 > 4539 budget). This needs maintainer approval or a deprecated export to be removed to compensate.

## AI disclosure

This PR was authored with AI assistance (deepseek-v4-flash).
