### PR TITLE
fix(ci): bound plugin-clawhub-release git fetch with timeout

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -76,7 +76,7 @@ jobs:
           TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin \
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
             '+refs/heads/release/*:refs/remotes/origin/release/*'
           if [[ -n "${TARGET_REF}" ]]; then
@@ -125,7 +125,7 @@ jobs:
           done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
           if [[ "${TRUSTED_PUBLISH_BRANCH}" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             alpha_branch="${TRUSTED_PUBLISH_BRANCH}"
-            git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
+            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
             if git merge-base --is-ancestor HEAD "refs/remotes/origin/${alpha_branch}"; then
               exit 0
             fi

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4212,8 +4212,10 @@ NODE
     }
   });
 
-  it("bounds mantis discord smoke validation git fetches", () => {
-    const workflowPath = ".github/workflows/mantis-discord-smoke.yml";
+  it.each([
+    [".github/workflows/mantis-discord-smoke.yml"],
+    [".github/workflows/plugin-clawhub-release.yml"],
+  ])("bounds %s git fetches", (workflowPath) => {
     const source = readFileSync(workflowPath, "utf8");
     const gitFetchLines = source.split("\n").filter((line) => line.includes("git fetch"));
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the ClawHub plugin release workflow could spend the full
job timeout waiting on either of its two prepublish `git fetch` operations when
the remote transport stalls.

## Why This Change Was Made

Both explicit prepublish fetches now use the repository-standard
`timeout --signal=TERM --kill-after=10s 120s` prefix. Fetch arguments, checkout,
trusted-ref validation, OIDC, permissions, pins, environments, approval, and
publish behavior are unchanged.

The regression guard lives beside the existing workflow fetch guards in
`test/scripts/ci-workflow-guards.test.ts`. No duplicate
`package-acceptance-workflow` coverage is added.

## User Impact

Maintainers get a prompt failed release job instead of a runner that remains
stuck until the broader job timeout.

## Evidence

Final head: `f7bb7e75003a367b7b5d5602c6590df840caebfb`

- Production delta: `+2/-2` (net zero).
- Test delta: `+4/-2`.
- The workflow contains exactly two `git fetch` calls and both retain the exact
  `timeout --signal=TERM --kill-after=10s 120s` prefix.
- Blacksmith Testbox `tbx_01kzqyscjvzn5gsrzv4nz0xa9g`:
  workflow sanity passed, including actionlint, zizmor, composite-action input
  interpolation, and conflict-marker guards; the focused ClawHub workflow guard
  passed; a controlled stalled HTTP Git transport exited `124` after 5 seconds.
  Run: https://github.com/openclaw/openclaw/actions/runs/31473089000
- The final rebase was patch-identical to that tested commit. Blacksmith Testbox
  `tbx_01kzqzewpdmhwvgep4v4pvcttb` verified the final synced patch ID
  `8c2eacd028ce7ce895c57580017d31692593f250`, both changed-file SHA-256
  hashes, and `git diff --check`.
  Run: https://github.com/openclaw/openclaw/actions/runs/31473973490

Punchcard-Session: clear-orchard-harbor-ez



Punchcard-Session: coral-lantern-valley-55
