### PR TITLE
fix: guard NaN in ordered-list start and colon-form SGR params

### DIFF
--- a/packages/markdown-core/src/ir.nested-lists.test.ts
+++ b/packages/markdown-core/src/ir.nested-lists.test.ts
@@ -40,6 +40,34 @@
 import { describe, it, expect } from "vitest";
 import { markdownToIR } from "./ir.js";
 
+describe("Ordered List start attribute NaN guard", () => {
+  it("renders a standard ordered list with numeric prefixes and no NaN", () => {
+    const markdown = `1. alpha\n2. beta\n3. gamma`;
+    const result = markdownToIR(markdown);
+    expect(result.text).toContain("1. alpha");
+    expect(result.text).toContain("2. beta");
+    expect(result.text).toContain("3. gamma");
+    expect(result.text).not.toContain("NaN");
+  });
+
+  it("renders ordered lists nested inside bullet lists without NaN", () => {
+    const markdown = `- Top\n  1. Nested one\n  2. Nested two`;
+    const result = markdownToIR(markdown);
+    expect(result.text).toContain("• Top");
+    expect(result.text).toContain("1. Nested one");
+    expect(result.text).toContain("2. Nested two");
+    expect(result.text).not.toContain("NaN");
+  });
+
+  it("renders ordered lists inside ordered lists with correct prefixes and no NaN", () => {
+    const markdown = `1. Ordered 1\n   - Bullet sub 1\n   - Bullet sub 2\n2. Ordered 2`;
+    const result = markdownToIR(markdown);
+    expect(result.text).toContain("1. Ordered 1");
+    expect(result.text).toContain("2. Ordered 2");
+    expect(result.text).not.toContain("NaN");
+  });
+});
+
 describe("Nested Lists - 2 Level Nesting", () => {
   it("renders bullet items nested inside bullet items with proper indentation", () => {
     const input = `- Item 1

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -886,7 +886,8 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         if (state.env.listStack.length > 0) {
           appendNestedListSeparator(state);
         }
-        const start = Number(getAttr(token, "start") ?? "1");
+        const parsedStart = Number(getAttr(token, "start") ?? "1");
+        const start = Number.isFinite(parsedStart) ? parsedStart : 1;
         state.env.listStack.push({
           type: "ordered",
           index: start - 1,

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -108,6 +108,36 @@ describe("renderTable", () => {
     }
   });
 
+  it("ignores malformed colon-form SGR parameters without NaN propagation", () => {
+    const malformed = "\x1b[38:abc:5:196mTEXT\x1b[0m";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: malformed }],
+    });
+
+    expect(out).toContain("TEXT");
+    expect(out).not.toContain("NaN");
+  });
+
+  it("renders valid colon-form SGR parameters normally", () => {
+    const valid = "\x1b[38;5;196mRED TEXT\x1b[0m";
+    const out = renderTable({
+      width: 30,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: valid }],
+    });
+
+    expect(out).toContain("RED TEXT");
+    expect(out).not.toContain("NaN");
+  });
+
   it("trims leading spaces on wrapped ANSI-colored continuation lines", () => {
     const out = renderTable({
       width: 113,

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -251,6 +251,9 @@ function applySgrSequence(active: Map<SgrCategory, string>, value: string): void
     const field = fields[index] ?? "";
     if (field.includes(":")) {
       const param = Number(field.slice(0, field.indexOf(":")));
+      if (!Number.isInteger(param)) {
+        continue;
+      }
       const category = extendedSgrCategory(param) ?? simpleSgrCategory(param);
       if (category) {
         active.set(category, sgrSequence(sequence.introducer, field));


### PR DESCRIPTION
Two defensive NaN guards. ir.ts #110726 + table.ts #110729. 77 tests pass.