### PR TITLE
fix(agents): cap sessions_list tool limit before gateway dispatch

### DIFF
--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -351,6 +351,20 @@ describe("sessions-list-tool", () => {
     expect(getSessionsListDetails(result).sessions?.[0]).not.toHaveProperty("archivedAt");
   });
 
+  it("clamps pathological limit values before the gateway call", async () => {
+    mocks.gatewayCall.mockResolvedValue({ path: "/tmp/sessions.json", sessions: [] });
+    const tool = createSessionsListTool({ config: {} as never });
+
+    await tool.execute("call-clamp", { limit: 1_000_000_000_000 });
+
+    expect(mocks.gatewayCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.list",
+        params: expect.objectContaining({ limit: 1000 }),
+      }),
+    );
+  });
+
   it.each([
     [{ limit: 1.5 }, "limit must be a positive integer"],
     [{ activeMinutes: 0 }, "activeMinutes must be a positive integer"],

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -172,7 +172,11 @@ export function createSessionsListTool(opts?: {
       );
       const allowedKinds = allowedKindsList.length ? new Set(allowedKindsList) : undefined;
 
-      const limit = readPositiveIntegerParam(params, "limit");
+      // Model-supplied limits are clamped before they reach the gateway session
+      // store, same shape as the messageLimit cap below; direct RPC callers keep
+      // the unbounded sessions.list contract.
+      const limitRaw = readPositiveIntegerParam(params, "limit");
+      const limit = limitRaw === undefined ? undefined : Math.min(limitRaw, 1000);
       const activeMinutes = readPositiveIntegerParam(params, "activeMinutes");
       const messageLimitRaw = readNonNegativeIntegerParam(params, "messageLimit") ?? 0;
       const messageLimit = Math.min(messageLimitRaw, 20);


### PR DESCRIPTION
## What Problem This Solves

The shipped `sessions_list` agent tool accepts a model-supplied `limit` with only a lower bound (`readPositiveIntegerParam`) and passes it straight into the gateway `sessions.list` RPC (`src/agents/tools/sessions-list-tool.ts:175,190`). A pathological value (e.g. `limit: 1_000_000_000_000`) forces the gateway session store to scan and materialize an unbounded result window for a single tool call.

## Why This Change Was Made

The tool's untrusted input boundary is the right place for the bound: the gateway RPC contract for direct operator clients stays unbounded (no compatibility change), while model-generated tool calls get clamped before dispatch. The tool already uses this exact pattern two lines below for `messageLimit` (`Math.min(messageLimitRaw, 20)`). The clamp is 1000, matching the gateway's established session-domain list caps (`sessions-history-http.ts` `MAX_SESSION_HISTORY_LIMIT = 1000`, `server-plugins.ts` `PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT = 1_000`) should the RPC ever adopt one — but this PR intentionally does not touch RPC behavior.

## User Impact

Before: a model-issued `sessions_list` call with an extreme `limit` can force a full session-store scan in one request. After: the tool clamps `limit` to 1000 before gateway dispatch; paginating models still get `hasMore`/`nextOffset` from the gateway response to continue. Direct `sessions.list` RPC clients see zero behavior change.

## Evidence

### Current-head tool-path proof (head `6b07b34d6d`, 2026-07-21)

**Source change — tool only, 2 files, +19/-1, zero RPC surface touched:**

```
 src/agents/tools/sessions-list-tool.test.ts | 14 ++++++++++++++
 src/agents/tools/sessions-list-tool.ts      |  6 +++++-
 2 files changed, 19 insertions(+), 1 deletion(-)
```

**The clamp (sessions-list-tool.ts:175-178):**

```ts
// Model-supplied limits are clamped before they reach the gateway session
// store, same shape as the messageLimit cap below; direct RPC callers keep
// the unbounded sessions.list contract.
const limitRaw = readPositiveIntegerParam(params, "limit");
const limit = limitRaw === undefined ? undefined : Math.min(limitRaw, 1000);
```

**Regression test (sessions-list-tool.test.ts:354-366):**

```ts
it("clamps pathological limit values before the gateway call", async () => {
    mocks.gatewayCall.mockResolvedValue({ path: "/tmp/sessions.json", sessions: [] });
    const tool = createSessionsListTool({ config: {} as never });

    await tool.execute("call-clamp", { limit: 1_000_000_000_000 });

    expect(mocks.gatewayCall).toHaveBeenCalledWith(
      expect.objectContaining({
        method: "sessions.list",
        params: expect.objectContaining({ limit: 1000 }),
      }),
    );
  });
```

**Full suite on head `6b07b34d6d`: 12/12 pass**

```
node scripts/run-vitest.mjs src/agents/tools/sessions-list-tool.test.ts
→ Tests  12 passed (12)
```

Specifically:
- `limit: 1_000_000_000_000` reaches the gateway as `limit: 1000` (tool-level clamp on current head)
- Pre-existing validations still reject before dispatch: `limit: 1.5` → "limit must be a positive integer", `messageLimit: -1` → "messageLimit must be a non-negative integer"
- Gateway RPC path (`src/gateway/session-utils.ts`) is **untouched** — direct `sessions.list` callers keep the existing unbounded contract

**Why this is tool-path (not RPC-path) evidence:** the supplied proof exercises `createSessionsListTool().execute()` on head `6b07b34d6d`, which is the shipped agent-tool code path. It does not exercise the gateway RPC handler directly (which this PR leaves unchanged). This addresses the prior review note that the earlier live gateway transcript proved the now-discarded RPC-level clamp.
