### PR TITLE
refactor(ui): unify transcript inline UI on one widget card

### DIFF
--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -1,15 +1,8 @@
 // Control UI chat module implements tool cards behavior.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
-import { keyed } from "lit/directives/keyed.js";
-import { ensureCustomElementDefined } from "../../../app/lazy-custom-element.ts";
 import { icons, type IconName } from "../../../components/icons.ts";
 import { isMarkdownBlockArtText } from "../../../components/markdown.ts";
-import {
-  dispatchWidgetPrompt,
-  WIDGET_PROMPT_EVENT,
-  type WidgetPromptEventDetail,
-} from "../../../components/mcp-app-security.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ToolCard, ToolCardOutcome } from "../../../lib/chat/chat-types.ts";
@@ -25,15 +18,19 @@ import {
 } from "../../../lib/chat/tool-cards.ts";
 import {
   formatToolDetail,
-  isInternalCanvasEntryUrl,
-  resolveCanvasIframeUrl,
-  resolveEmbedSandbox,
   resolveToolDisplay,
   type EmbedSandboxMode,
 } from "../../../lib/chat/tool-display.ts";
 import { getToolCallTitle } from "../tool-titles.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
+import { renderToolPreview } from "./widget-card.ts";
+
+export {
+  renderToolPreview,
+  WIDGET_PROMPT_EVENT,
+  type WidgetPromptEventDetail,
+} from "./widget-card.ts";
 
 type FullMessageRequest = NonNullable<SidebarContent["fullMessageRequest"]>;
 
@@ -137,283 +134,6 @@ function handleRawDetailsToggle(event: Event) {
   const expanded = button.getAttribute("aria-expanded") === "true";
   button.setAttribute("aria-expanded", String(!expanded));
   body.hidden = expanded;
-}
-
-// Sandboxed widget documents report their content height via postMessage so the
-// preview iframe can fit short/tall widgets. The event source must be one of our
-// preview frames and the height is clamped, so widget code can only resize its
-// own frame within the same bounds the preview contract allows.
-const WIDGET_SIZE_MESSAGE_TYPE = "openclaw:widget-size";
-const WIDGET_PROMPT_OFFER_MESSAGE_TYPE = "openclaw:widget-prompt-offer";
-const WIDGET_PROMPT_MESSAGE_TYPE = "openclaw:widget-prompt";
-export { WIDGET_PROMPT_EVENT };
-export type { WidgetPromptEventDetail };
-const WIDGET_FRAME_MIN_HEIGHT = 160;
-const WIDGET_FRAME_MAX_HEIGHT = 1200;
-// Preview frames render inside lit shadow roots, so a document query cannot
-// find them; frames register themselves on load and are dropped once detached.
-const widgetFrameRegistry = new Set<HTMLIFrameElement>();
-// Reported heights keyed by frame src: lit re-renders re-apply the style
-// binding, so the template must read the reported height back or it resets.
-const widgetFrameHeightsBySrc = new Map<string, number>();
-const WIDGET_FRAME_HEIGHTS_MAX_ENTRIES = 100;
-// Keyed by window, not a module boolean: non-isolated test workers swap the
-// global window between files while module state persists.
-const widgetSizeListenerWindows = new WeakSet<Window>();
-
-function rememberWidgetFrameHeight(src: string, height: number) {
-  if (
-    !widgetFrameHeightsBySrc.has(src) &&
-    widgetFrameHeightsBySrc.size >= WIDGET_FRAME_HEIGHTS_MAX_ENTRIES
-  ) {
-    const oldest = widgetFrameHeightsBySrc.keys().next().value;
-    if (oldest !== undefined) {
-      widgetFrameHeightsBySrc.delete(oldest);
-    }
-  }
-  widgetFrameHeightsBySrc.set(src, height);
-}
-
-function registerWidgetFrame(event: Event) {
-  const frame = event.currentTarget;
-  if (frame instanceof HTMLIFrameElement) {
-    widgetFrameRegistry.add(frame);
-  }
-}
-
-function handleWidgetPromptMessage(frame: HTMLIFrameElement, data: unknown) {
-  const payload = data as { type?: unknown; prompt?: unknown } | null;
-  if (!payload || payload.type !== WIDGET_PROMPT_MESSAGE_TYPE) {
-    return;
-  }
-  dispatchWidgetPrompt(frame, payload.prompt, frame.getAttribute("src") ?? "");
-}
-
-// Prompt authority is a MessagePort OFFERED by the trusted bridge script that
-// wraps every hosted widget document. The bridge posts its offer at document
-// parse time — before any widget code can run, steal the endpoint, or navigate
-// the frame — so buffering only the FIRST offer per content window and adopting
-// it once, at the frame's first load, binds the capability to the genuine
-// widget document. A document that navigates away closes its ports with it,
-// externally allowed embed URLs are never adopted, and later offers or loads
-// cannot re-arm a consumed frame.
-const pendingWidgetPromptPorts = new WeakMap<object, MessagePort>();
-const offeredWidgetPromptSources = new WeakSet<object>();
-const promptEligibleFrames = new WeakSet<HTMLIFrameElement>();
-const adoptedWidgetPromptFrames = new WeakSet<HTMLIFrameElement>();
-// Keyed by window, not a module boolean: non-isolated test workers swap the
-// global window between files while module state persists.
-const widgetPromptOfferListenerWindows = new WeakSet<Window>();
-
-function tryAdoptWidgetPromptPort(frame: HTMLIFrameElement) {
-  const source = frame.contentWindow as unknown as object | null;
-  if (adoptedWidgetPromptFrames.has(frame) || !promptEligibleFrames.has(frame) || !source) {
-    return;
-  }
-  const port = pendingWidgetPromptPorts.get(source);
-  if (!port) {
-    return;
-  }
-  adoptedWidgetPromptFrames.add(frame);
-  pendingWidgetPromptPorts.delete(source);
-  port.addEventListener("message", (message: MessageEvent) => {
-    handleWidgetPromptMessage(frame, message.data);
-  });
-  port.start();
-}
-
-function installWidgetPromptOfferListener() {
-  if (typeof window === "undefined" || widgetPromptOfferListenerWindows.has(window)) {
-    return;
-  }
-  widgetPromptOfferListenerWindows.add(window);
-  window.addEventListener("message", (event: MessageEvent) => {
-    const data = event.data as { type?: unknown } | null;
-    if (!data || data.type !== WIDGET_PROMPT_OFFER_MESSAGE_TYPE) {
-      return;
-    }
-    const source = event.source;
-    const port = event.ports[0];
-    // Hosted widget documents run in an opaque origin; anything else is not a
-    // Canvas widget bridge.
-    if (!source || !port || event.origin !== "null") {
-      return;
-    }
-    if (offeredWidgetPromptSources.has(source as unknown as object)) {
-      // Only the first offer per content window can win; a replacement
-      // document's offer must never displace the genuine bridge's.
-      port.close();
-      return;
-    }
-    offeredWidgetPromptSources.add(source as unknown as object);
-    pendingWidgetPromptPorts.set(source as unknown as object, port);
-    // Posted-message and iframe-load tasks have no guaranteed cross-source
-    // ordering, so the offer may arrive after the eligible frame's load;
-    // adopt for it now instead of stranding the widget without a channel.
-    for (const frame of widgetFrameRegistry) {
-      if (frame.contentWindow === source) {
-        tryAdoptWidgetPromptPort(frame);
-        return;
-      }
-    }
-  });
-}
-
-function adoptWidgetPromptPort(frame: HTMLIFrameElement) {
-  // Eligibility is granted at the frame's first prompt-capable load and the
-  // adoption itself is one-shot; first-offer-wins buffering ensures the port
-  // adopted here always belongs to the frame's original bridge document.
-  promptEligibleFrames.add(frame);
-  tryAdoptWidgetPromptPort(frame);
-}
-
-function installWidgetSizeListener() {
-  if (typeof window === "undefined" || widgetSizeListenerWindows.has(window)) {
-    return;
-  }
-  widgetSizeListenerWindows.add(window);
-  window.addEventListener("message", (event: MessageEvent) => {
-    const data = event.data as { type?: unknown; height?: unknown } | null;
-    if (!data || data.type !== WIDGET_SIZE_MESSAGE_TYPE || typeof data.height !== "number") {
-      return;
-    }
-    for (const frame of widgetFrameRegistry) {
-      if (!frame.isConnected) {
-        widgetFrameRegistry.delete(frame);
-        continue;
-      }
-      if (frame.contentWindow === event.source) {
-        const height = Math.min(
-          Math.max(Math.trunc(data.height), WIDGET_FRAME_MIN_HEIGHT),
-          WIDGET_FRAME_MAX_HEIGHT,
-        );
-        // The stylesheet floors the frame at min-height 420px; reported sizes
-        // must override both properties to fit short widgets.
-        frame.style.height = `${height}px`;
-        frame.style.minHeight = `${height}px`;
-        const src = frame.getAttribute("src");
-        if (src) {
-          rememberWidgetFrameHeight(src, height);
-        }
-        return;
-      }
-    }
-  });
-}
-
-function renderPreviewFrame(params: {
-  title: string;
-  src?: string;
-  height?: number;
-  sandbox?: string;
-  promptCapable?: boolean;
-}) {
-  installWidgetSizeListener();
-  const sandbox = params.sandbox ?? "";
-  const src = params.src ?? "";
-  const reportedHeight = src ? widgetFrameHeightsBySrc.get(src) : undefined;
-  const height = reportedHeight ?? params.height;
-  if (params.promptCapable) {
-    installWidgetPromptOfferListener();
-  }
-  const handleLoad = (event: Event) => {
-    registerWidgetFrame(event);
-    if (params.promptCapable && event.currentTarget instanceof HTMLIFrameElement) {
-      adoptWidgetPromptPort(event.currentTarget);
-    }
-  };
-  return keyed(
-    `${sandbox}\u0000${src}\u0000${params.height ?? ""}`,
-    html`
-      <iframe
-        class="chat-tool-card__preview-frame"
-        title=${params.title}
-        sandbox=${sandbox}
-        src=${src || nothing}
-        style=${height ? `height:${height}px;min-height:${height}px` : ""}
-        @load=${handleLoad}
-      ></iframe>
-    `,
-  );
-}
-
-const loadMcpAppView = () => import("../../../components/mcp-app-view-registration.ts");
-
-function renderMcpAppView(params: {
-  sessionKey: string;
-  viewId: string;
-  height: number;
-  title: string;
-}) {
-  // Insert the tag before its chunk arrives. Native custom-element upgrade
-  // preserves these bound fields, so the first preview initializes after registration.
-  void ensureCustomElementDefined("mcp-app-view", loadMcpAppView).catch((error: unknown) => {
-    console.error("[openclaw] failed to load MCP App view", error);
-  });
-  return html`<mcp-app-view
-    .sessionKey=${params.sessionKey}
-    .viewId=${params.viewId}
-    .height=${params.height}
-    .title=${params.title}
-  ></mcp-app-view>`;
-}
-
-export function renderToolPreview(
-  preview: ToolPreview | undefined,
-  surface: "chat_tool" | "chat_message" | "sidebar",
-  options?: {
-    onOpenSidebar?: (content: SidebarContent) => void;
-    rawText?: string | null;
-    canvasPluginSurfaceUrl?: string | null;
-    embedSandboxMode?: EmbedSandboxMode;
-    allowExternalEmbedUrls?: boolean;
-    sessionKey?: string;
-  },
-) {
-  if (!preview) {
-    return nothing;
-  }
-  if (
-    preview.kind !== "canvas" ||
-    surface === "chat_tool" ||
-    (preview.mcpApp && surface !== "chat_message")
-  ) {
-    return nothing;
-  }
-  if (preview.surface !== "assistant_message") {
-    return nothing;
-  }
-  return html`
-    <div class="chat-tool-card__preview" data-kind="canvas" data-surface=${surface}>
-      <div class="chat-tool-card__preview-header">
-        <span class="chat-tool-card__preview-label"
-          >${preview.title?.trim() || t("chat.toolCards.canvas")}</span
-        >
-      </div>
-      <div class="chat-tool-card__preview-panel" data-side="canvas">
-        ${preview.mcpApp
-          ? renderMcpAppView({
-              sessionKey: options?.sessionKey ?? "",
-              viewId: preview.mcpApp.viewId,
-              height: preview.preferredHeight ?? 600,
-              title: preview.title?.trim() || t("mcpApp.title"),
-            })
-          : renderPreviewFrame({
-              title: preview.title?.trim() || t("chat.toolCards.canvas"),
-              src: resolveCanvasIframeUrl(
-                preview.url,
-                options?.canvasPluginSurfaceUrl,
-                options?.allowExternalEmbedUrls ?? false,
-              ),
-              height: preview.preferredHeight,
-              sandbox: resolveEmbedSandbox(options?.embedSandboxMode ?? "scripts", preview.sandbox),
-              // Only hosted Canvas documents may drive the chat; externally
-              // allowed embed URLs render but never get prompt authority.
-              promptCapable: isInternalCanvasEntryUrl(preview.url),
-            })}
-      </div>
-    </div>
-  `;
 }
 
 function buildSidebarContent(

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -2,13 +2,13 @@
 
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { renderWidgetCard } from "./widget-card.ts";
+import { renderToolPreview } from "./widget-card.ts";
 
 describe("widget-card", () => {
   it("dispatches canvas HTML and MCP App content and ignores unknown kinds", () => {
     const canvas = document.createElement("div");
     render(
-      renderWidgetCard(
+      renderToolPreview(
         {
           kind: "canvas",
           surface: "assistant_message",
@@ -25,7 +25,7 @@ describe("widget-card", () => {
 
     const app = document.createElement("div");
     render(
-      renderWidgetCard(
+      renderToolPreview(
         {
           kind: "canvas",
           surface: "assistant_message",
@@ -43,7 +43,7 @@ describe("widget-card", () => {
     expect(app.querySelector("iframe")).toBeNull();
 
     const unknown = document.createElement("div");
-    render(renderWidgetCard({ kind: "unknown" } as never, "chat_message"), unknown);
+    render(renderToolPreview({ kind: "unknown" } as never, "chat_message"), unknown);
     expect(unknown.childElementCount).toBe(0);
   });
 });

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -1,0 +1,49 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderWidgetCard } from "./widget-card.ts";
+
+describe("widget-card", () => {
+  it("dispatches canvas HTML and MCP App content and ignores unknown kinds", () => {
+    const canvas = document.createElement("div");
+    render(
+      renderWidgetCard(
+        {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          url: "/__openclaw__/canvas/documents/cv_dispatch/index.html",
+          preferredHeight: 320,
+        },
+        "chat_message",
+      ),
+      canvas,
+    );
+    expect(canvas.querySelector("iframe.chat-tool-card__preview-frame")).not.toBeNull();
+    expect(canvas.querySelector("mcp-app-view")).toBeNull();
+
+    const app = document.createElement("div");
+    render(
+      renderWidgetCard(
+        {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          title: "App",
+          preferredHeight: 480,
+          mcpApp: { viewId: "view-dispatch" },
+        },
+        "chat_message",
+        { sessionKey: "agent:main:main" },
+      ),
+      app,
+    );
+    expect(app.querySelector("mcp-app-view")).not.toBeNull();
+    expect(app.querySelector("iframe")).toBeNull();
+
+    const unknown = document.createElement("div");
+    render(renderWidgetCard({ kind: "unknown" } as never, "chat_message"), unknown);
+    expect(unknown.childElementCount).toBe(0);
+  });
+});

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -1,0 +1,316 @@
+import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
+import { ensureCustomElementDefined } from "../../../app/lazy-custom-element.ts";
+import {
+  dispatchWidgetPrompt,
+  WIDGET_PROMPT_EVENT,
+  type WidgetPromptEventDetail,
+} from "../../../components/mcp-app-security.ts";
+import { t } from "../../../i18n/index.ts";
+import type { ToolPreview } from "../../../lib/chat/tool-cards.ts";
+import {
+  isInternalCanvasEntryUrl,
+  resolveCanvasIframeUrl,
+  resolveEmbedSandbox,
+  type EmbedSandboxMode,
+} from "../../../lib/chat/tool-display.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
+
+export { WIDGET_PROMPT_EVENT };
+export type { WidgetPromptEventDetail };
+
+export type WidgetCardOptions = {
+  onOpenSidebar?: (content: SidebarContent) => void;
+  rawText?: string | null;
+  canvasPluginSurfaceUrl?: string | null;
+  embedSandboxMode?: EmbedSandboxMode;
+  allowExternalEmbedUrls?: boolean;
+  sessionKey?: string;
+};
+
+// Sandboxed widget documents report their content height via postMessage so the
+// preview iframe can fit short/tall widgets. The event source must be one of our
+// preview frames and the height is clamped, so widget code can only resize its
+// own frame within the same bounds the preview contract allows.
+const WIDGET_SIZE_MESSAGE_TYPE = "openclaw:widget-size";
+const WIDGET_PROMPT_OFFER_MESSAGE_TYPE = "openclaw:widget-prompt-offer";
+const WIDGET_PROMPT_MESSAGE_TYPE = "openclaw:widget-prompt";
+const WIDGET_FRAME_MIN_HEIGHT = 160;
+const WIDGET_FRAME_MAX_HEIGHT = 1200;
+// Preview frames render inside lit shadow roots, so a document query cannot
+// find them; frames register themselves on load and are dropped once detached.
+const widgetFrameRegistry = new Set<HTMLIFrameElement>();
+// Reported heights keyed by frame src: lit re-renders re-apply the style
+// binding, so the template must read the reported height back or it resets.
+const widgetFrameHeightsBySrc = new Map<string, number>();
+const WIDGET_FRAME_HEIGHTS_MAX_ENTRIES = 100;
+// Keyed by window, not a module boolean: non-isolated test workers swap the
+// global window between files while module state persists.
+const widgetSizeListenerWindows = new WeakSet<Window>();
+
+function rememberWidgetFrameHeight(src: string, height: number) {
+  if (
+    !widgetFrameHeightsBySrc.has(src) &&
+    widgetFrameHeightsBySrc.size >= WIDGET_FRAME_HEIGHTS_MAX_ENTRIES
+  ) {
+    const oldest = widgetFrameHeightsBySrc.keys().next().value;
+    if (oldest !== undefined) {
+      widgetFrameHeightsBySrc.delete(oldest);
+    }
+  }
+  widgetFrameHeightsBySrc.set(src, height);
+}
+
+function registerWidgetFrame(event: Event) {
+  const frame = event.currentTarget;
+  if (frame instanceof HTMLIFrameElement) {
+    widgetFrameRegistry.add(frame);
+  }
+}
+
+function handleWidgetPromptMessage(frame: HTMLIFrameElement, data: unknown) {
+  const payload = data as { type?: unknown; prompt?: unknown } | null;
+  if (!payload || payload.type !== WIDGET_PROMPT_MESSAGE_TYPE) {
+    return;
+  }
+  dispatchWidgetPrompt(frame, payload.prompt, frame.getAttribute("src") ?? "");
+}
+
+// Prompt authority is a MessagePort OFFERED by the trusted bridge script that
+// wraps every hosted widget document. The bridge posts its offer at document
+// parse time — before any widget code can run, steal the endpoint, or navigate
+// the frame — so buffering only the FIRST offer per content window and adopting
+// it once, at the frame's first load, binds the capability to the genuine
+// widget document. A document that navigates away closes its ports with it,
+// externally allowed embed URLs are never adopted, and later offers or loads
+// cannot re-arm a consumed frame.
+const pendingWidgetPromptPorts = new WeakMap<object, MessagePort>();
+const offeredWidgetPromptSources = new WeakSet<object>();
+const promptEligibleFrames = new WeakSet<HTMLIFrameElement>();
+const adoptedWidgetPromptFrames = new WeakSet<HTMLIFrameElement>();
+// Keyed by window, not a module boolean: non-isolated test workers swap the
+// global window between files while module state persists.
+const widgetPromptOfferListenerWindows = new WeakSet<Window>();
+
+function tryAdoptWidgetPromptPort(frame: HTMLIFrameElement) {
+  const source = frame.contentWindow as unknown as object | null;
+  if (adoptedWidgetPromptFrames.has(frame) || !promptEligibleFrames.has(frame) || !source) {
+    return;
+  }
+  const port = pendingWidgetPromptPorts.get(source);
+  if (!port) {
+    return;
+  }
+  adoptedWidgetPromptFrames.add(frame);
+  pendingWidgetPromptPorts.delete(source);
+  port.addEventListener("message", (message: MessageEvent) => {
+    handleWidgetPromptMessage(frame, message.data);
+  });
+  port.start();
+}
+
+function installWidgetPromptOfferListener() {
+  if (typeof window === "undefined" || widgetPromptOfferListenerWindows.has(window)) {
+    return;
+  }
+  widgetPromptOfferListenerWindows.add(window);
+  window.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data as { type?: unknown } | null;
+    if (!data || data.type !== WIDGET_PROMPT_OFFER_MESSAGE_TYPE) {
+      return;
+    }
+    const source = event.source;
+    const port = event.ports[0];
+    // Hosted widget documents run in an opaque origin; anything else is not a
+    // Canvas widget bridge.
+    if (!source || !port || event.origin !== "null") {
+      return;
+    }
+    if (offeredWidgetPromptSources.has(source as unknown as object)) {
+      // Only the first offer per content window can win; a replacement
+      // document's offer must never displace the genuine bridge's.
+      port.close();
+      return;
+    }
+    offeredWidgetPromptSources.add(source as unknown as object);
+    pendingWidgetPromptPorts.set(source as unknown as object, port);
+    // Posted-message and iframe-load tasks have no guaranteed cross-source
+    // ordering, so the offer may arrive after the eligible frame's load;
+    // adopt for it now instead of stranding the widget without a channel.
+    for (const frame of widgetFrameRegistry) {
+      if (frame.contentWindow === source) {
+        tryAdoptWidgetPromptPort(frame);
+        return;
+      }
+    }
+  });
+}
+
+function adoptWidgetPromptPort(frame: HTMLIFrameElement) {
+  // Eligibility is granted at the frame's first prompt-capable load and the
+  // adoption itself is one-shot; first-offer-wins buffering ensures the port
+  // adopted here always belongs to the frame's original bridge document.
+  promptEligibleFrames.add(frame);
+  tryAdoptWidgetPromptPort(frame);
+}
+
+function installWidgetSizeListener() {
+  if (typeof window === "undefined" || widgetSizeListenerWindows.has(window)) {
+    return;
+  }
+  widgetSizeListenerWindows.add(window);
+  window.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data as { type?: unknown; height?: unknown } | null;
+    if (!data || data.type !== WIDGET_SIZE_MESSAGE_TYPE || typeof data.height !== "number") {
+      return;
+    }
+    for (const frame of widgetFrameRegistry) {
+      if (!frame.isConnected) {
+        widgetFrameRegistry.delete(frame);
+        continue;
+      }
+      if (frame.contentWindow === event.source) {
+        const height = Math.min(
+          Math.max(Math.trunc(data.height), WIDGET_FRAME_MIN_HEIGHT),
+          WIDGET_FRAME_MAX_HEIGHT,
+        );
+        // The stylesheet floors the frame at min-height 420px; reported sizes
+        // must override both properties to fit short widgets.
+        frame.style.height = `${height}px`;
+        frame.style.minHeight = `${height}px`;
+        const src = frame.getAttribute("src");
+        if (src) {
+          rememberWidgetFrameHeight(src, height);
+        }
+        return;
+      }
+    }
+  });
+}
+
+function renderPreviewFrame(params: {
+  title: string;
+  src?: string;
+  height?: number;
+  sandbox?: string;
+  promptCapable?: boolean;
+}) {
+  installWidgetSizeListener();
+  const sandbox = params.sandbox ?? "";
+  const src = params.src ?? "";
+  const reportedHeight = src ? widgetFrameHeightsBySrc.get(src) : undefined;
+  const height = reportedHeight ?? params.height;
+  if (params.promptCapable) {
+    installWidgetPromptOfferListener();
+  }
+  const handleLoad = (event: Event) => {
+    registerWidgetFrame(event);
+    if (params.promptCapable && event.currentTarget instanceof HTMLIFrameElement) {
+      adoptWidgetPromptPort(event.currentTarget);
+    }
+  };
+  return keyed(
+    `${sandbox}\u0000${src}\u0000${params.height ?? ""}`,
+    html`
+      <iframe
+        class="chat-tool-card__preview-frame"
+        title=${params.title}
+        sandbox=${sandbox}
+        src=${src || nothing}
+        style=${height ? `height:${height}px;min-height:${height}px` : ""}
+        @load=${handleLoad}
+      ></iframe>
+    `,
+  );
+}
+
+const loadMcpAppView = () => import("../../../components/mcp-app-view-registration.ts");
+
+function renderMcpAppView(params: {
+  sessionKey: string;
+  viewId: string;
+  height: number;
+  title: string;
+}) {
+  // Insert the tag before its chunk arrives. Native custom-element upgrade
+  // preserves these bound fields, so the first preview initializes after registration.
+  void ensureCustomElementDefined("mcp-app-view", loadMcpAppView).catch((error: unknown) => {
+    console.error("[openclaw] failed to load MCP App view", error);
+  });
+  return html`<mcp-app-view
+    .sessionKey=${params.sessionKey}
+    .viewId=${params.viewId}
+    .height=${params.height}
+    .title=${params.title}
+  ></mcp-app-view>`;
+}
+
+function renderWidgetContent(
+  kind: "canvas-html" | "mcp-app",
+  preview: ToolPreview,
+  options?: WidgetCardOptions,
+) {
+  switch (kind) {
+    case "canvas-html":
+      return renderPreviewFrame({
+        title: preview.title?.trim() || t("chat.toolCards.canvas"),
+        src: resolveCanvasIframeUrl(
+          preview.url,
+          options?.canvasPluginSurfaceUrl,
+          options?.allowExternalEmbedUrls ?? false,
+        ),
+        height: preview.preferredHeight,
+        sandbox: resolveEmbedSandbox(options?.embedSandboxMode ?? "scripts", preview.sandbox),
+        // Only hosted Canvas documents may drive the chat; externally
+        // allowed embed URLs render but never get prompt authority.
+        promptCapable: isInternalCanvasEntryUrl(preview.url),
+      });
+    case "mcp-app":
+      return preview.mcpApp
+        ? renderMcpAppView({
+            sessionKey: options?.sessionKey ?? "",
+            viewId: preview.mcpApp.viewId,
+            height: preview.preferredHeight ?? 600,
+            title: preview.title?.trim() || t("mcpApp.title"),
+          })
+        : nothing;
+  }
+  return nothing;
+}
+
+export function renderWidgetCard(
+  preview: ToolPreview | undefined,
+  surface: "chat_tool" | "chat_message" | "sidebar",
+  options?: WidgetCardOptions,
+) {
+  if (!preview) {
+    return nothing;
+  }
+  if (
+    preview.kind !== "canvas" ||
+    surface === "chat_tool" ||
+    (preview.mcpApp && surface !== "chat_message")
+  ) {
+    return nothing;
+  }
+  if (preview.surface !== "assistant_message") {
+    return nothing;
+  }
+  const label = preview.title?.trim() || t("chat.toolCards.canvas");
+  const contentKind = preview.mcpApp ? "mcp-app" : "canvas-html";
+  // Keep the reserved action hook hidden until populated so it adds no layout
+  // or accessibility chrome to today's widget card.
+  return html`
+    <div class="chat-tool-card__preview" data-kind="canvas" data-surface=${surface}>
+      <div class="chat-tool-card__preview-header">
+        <span class="chat-tool-card__preview-label">${label}</span>
+        <div data-widget-actions hidden></div>
+      </div>
+      <div class="chat-tool-card__preview-panel" data-side="canvas">
+        ${renderWidgetContent(contentKind, preview, options)}
+      </div>
+    </div>
+  `;
+}
+
+export const renderToolPreview = renderWidgetCard;

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -19,7 +19,7 @@ import type { SidebarContent } from "./chat-sidebar.ts";
 export { WIDGET_PROMPT_EVENT };
 export type { WidgetPromptEventDetail };
 
-export type WidgetCardOptions = {
+type WidgetCardOptions = {
   onOpenSidebar?: (content: SidebarContent) => void;
   rawText?: string | null;
   canvasPluginSurfaceUrl?: string | null;
@@ -278,7 +278,7 @@ function renderWidgetContent(
   return nothing;
 }
 
-export function renderWidgetCard(
+function renderWidgetCard(
   preview: ToolPreview | undefined,
   surface: "chat_tool" | "chat_message" | "sidebar",
   options?: WidgetCardOptions,


### PR DESCRIPTION
## What Problem This Solves

The transcript renders inline UI through two parallel paths: canvas widget previews (core `show_widget`) and MCP app previews (`<mcp-app-view>` special-cases in `chat-tool-cards.ts`). The session-dashboard program (design: `docs/web/dashboard-architecture.md`, "Transcript display: one widget card") unifies inline UI on one widget primitive; this PR is the display-side refactor.

## Why This Change Was Made

One `widget-card` renderer now owns card chrome + content-kind dispatch (`canvas-html` | `mcp-app`) plus a hidden future-action slot the pin-to-dashboard affordance lands in later. Behavior-neutral: sandbox flags, auto-sizing, prompt-bridge adoption/validation/rate limits, mcp-app URL checks, surface gating, dedup, and reconstruction all moved byte-identically.

## User Impact

None (pixel/semantic parity; only DOM addition is a `hidden` action-slot node).

## Evidence

- 186 tests across the 8 contract suites green (canvas iframe, mcp chat_message gate, prompt adoption/limits, extraction, reconstruction/dedup, mcp-app lifecycle/security) + new dispatch test.
- LOC: `chat-tool-cards.ts` −280; new file +316; net +36 non-test.
- Targeted formatting, UI typecheck, core-test typecheck, oxlint, `git diff --check`, autoreview clean.
- Broad chat run 1,484 tests passing; two known environment-only failures (Node localStorage in jsdom lane, missing built uirouter artifacts in worktree) unrelated to this diff.
