### PR TITLE
fix(usage): guard malformed Z.AI usage payloads

### DIFF
--- a/src/infra/provider-usage.fetch.zai.test.ts
+++ b/src/infra/provider-usage.fetch.zai.test.ts
@@ -20,6 +20,17 @@ describe("fetchZaiUsage", () => {
     expect(result.windows).toHaveLength(0);
   });
 
+  it.each([
+    ["null", null],
+    ["array", []],
+  ])("returns a stable API error for a successful %s payload", async (_name, payload) => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, payload));
+    const result = await fetchZaiUsage("key", 5000, mockFetch);
+
+    expect(result.error).toBe("API error");
+    expect(result.windows).toHaveLength(0);
+  });
+
   it("returns API message errors for unsuccessful payloads", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {

--- a/src/infra/provider-usage.fetch.zai.test.ts
+++ b/src/infra/provider-usage.fetch.zai.test.ts
@@ -32,16 +32,21 @@ describe("fetchZaiUsage", () => {
   });
 
   it.each([
+    ["missing data", { success: true, code: 200 }],
     ["null data", { success: true, code: 200, data: null }],
     ["array data", { success: true, code: 200, data: [] }],
     ["null limits", { success: true, code: 200, data: { limits: null } }],
     ["object limits", { success: true, code: 200, data: { limits: {} } }],
-  ])("returns a stable API error for successful payloads with %s", async (_name, payload) => {
+  ])("treats successful payloads with %s as empty usage", async (_name, payload) => {
     const mockFetch = createProviderUsageFetch(async () => makeResponse(200, payload));
     const result = await fetchZaiUsage("key", 5000, mockFetch);
 
-    expect(result.error).toBe("API error");
-    expect(result.windows).toHaveLength(0);
+    expect(result).toEqual({
+      provider: "zai",
+      displayName: "z.ai",
+      windows: [],
+      plan: undefined,
+    });
   });
 
   it("returns API message errors for unsuccessful payloads", async () => {
@@ -191,6 +196,11 @@ describe("fetchZaiUsage", () => {
               number: 6,
             },
             {
+              type: "TOKENS_LIMIT",
+              percentage: 10,
+              unit: 3,
+            },
+            {
               type: "TIME_LIMIT",
               percentage: "40",
             },
@@ -206,6 +216,11 @@ describe("fetchZaiUsage", () => {
       {
         label: "Tokens (6h)",
         usedPercent: 25,
+        resetAt: undefined,
+      },
+      {
+        label: "Tokens (Limit)",
+        usedPercent: 10,
         resetAt: undefined,
       },
       {

--- a/src/infra/provider-usage.fetch.zai.test.ts
+++ b/src/infra/provider-usage.fetch.zai.test.ts
@@ -31,6 +31,19 @@ describe("fetchZaiUsage", () => {
     expect(result.windows).toHaveLength(0);
   });
 
+  it.each([
+    ["null data", { success: true, code: 200, data: null }],
+    ["array data", { success: true, code: 200, data: [] }],
+    ["null limits", { success: true, code: 200, data: { limits: null } }],
+    ["object limits", { success: true, code: 200, data: { limits: {} } }],
+  ])("returns a stable API error for successful payloads with %s", async (_name, payload) => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, payload));
+    const result = await fetchZaiUsage("key", 5000, mockFetch);
+
+    expect(result.error).toBe("API error");
+    expect(result.windows).toHaveLength(0);
+  });
+
   it("returns API message errors for unsuccessful payloads", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {
@@ -156,6 +169,48 @@ describe("fetchZaiUsage", () => {
       {
         label: "Monthly",
         usedPercent: 100,
+        resetAt: undefined,
+      },
+    ]);
+  });
+
+  it("skips malformed limit entries while preserving valid siblings", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        success: true,
+        code: 200,
+        data: {
+          planName: " Team ",
+          limits: [
+            null,
+            "not-an-object",
+            {
+              type: "TOKENS_LIMIT",
+              percentage: 25,
+              unit: 3,
+              number: 6,
+            },
+            {
+              type: "TIME_LIMIT",
+              percentage: "40",
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await fetchZaiUsage("key", 5000, mockFetch);
+
+    expect(result.plan).toBe("Team");
+    expect(result.windows).toEqual([
+      {
+        label: "Tokens (6h)",
+        usedPercent: 25,
+        resetAt: undefined,
+      },
+      {
+        label: "Monthly",
+        usedPercent: 0,
         resetAt: undefined,
       },
     ]);

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -1,4 +1,5 @@
 // Fetches and normalizes Z.ai provider usage records.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   buildUsageHttpErrorSnapshot,
   discardUsageResponseBody,
@@ -56,9 +57,9 @@ export async function fetchZaiUsage(
   if (!parsed.ok) {
     return parsed.snapshot;
   }
-  const data = parsed.data as ZaiUsageResponse;
-  if (!data.success || data.code !== 200) {
-    const errorMessage = typeof data.msg === "string" ? data.msg.trim() : "";
+  const data = isRecord(parsed.data) ? (parsed.data as ZaiUsageResponse) : undefined;
+  if (!data || !data.success || data.code !== 200) {
+    const errorMessage = typeof data?.msg === "string" ? data.msg.trim() : "";
     return {
       provider: "zai",
       displayName: PROVIDER_LABELS.zai,

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -37,16 +37,11 @@ function normalizeZaiUsage(value: unknown): NormalizedZaiUsage | undefined {
     return { ok: false, message };
   }
 
-  if (!isRecord(value.data)) {
-    return undefined;
-  }
-  const rawLimits = value.data.limits;
-  if (rawLimits !== undefined && !Array.isArray(rawLimits)) {
-    return undefined;
-  }
+  const data = isRecord(value.data) ? value.data : {};
+  const rawLimits = Array.isArray(data.limits) ? data.limits : [];
 
   const limits: NormalizedZaiLimit[] = [];
-  for (const rawLimit of rawLimits ?? []) {
+  for (const rawLimit of rawLimits) {
     if (!isRecord(rawLimit)) {
       continue;
     }
@@ -61,7 +56,7 @@ function normalizeZaiUsage(value: unknown): NormalizedZaiUsage | undefined {
 
   return {
     ok: true,
-    plan: normalizeOptionalString(value.data.planName) ?? normalizeOptionalString(value.data.plan),
+    plan: normalizeOptionalString(data.planName) ?? normalizeOptionalString(data.plan),
     limits,
   };
 }

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -1,5 +1,7 @@
 // Fetches and normalizes Z.ai provider usage records.
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   buildUsageHttpErrorSnapshot,
   discardUsageResponseBody,
@@ -10,22 +12,59 @@ import {
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
-type ZaiUsageResponse = {
-  success?: boolean;
-  code?: number;
-  msg?: string;
-  data?: {
-    planName?: string;
-    plan?: string;
-    limits?: Array<{
-      type?: string;
-      percentage?: number;
-      unit?: number;
-      number?: number;
-      nextResetTime?: string;
-    }>;
-  };
+type NormalizedZaiLimit = {
+  type?: string;
+  percentage?: number;
+  unit?: number;
+  number?: number;
+  nextResetTime?: string;
 };
+
+type NormalizedZaiUsage =
+  | { ok: false; message?: string }
+  | {
+      ok: true;
+      plan?: string;
+      limits: NormalizedZaiLimit[];
+    };
+
+function normalizeZaiUsage(value: unknown): NormalizedZaiUsage | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const message = normalizeOptionalString(value.msg);
+  if (value.success !== true || asFiniteNumber(value.code) !== 200) {
+    return { ok: false, message };
+  }
+
+  if (!isRecord(value.data)) {
+    return undefined;
+  }
+  const rawLimits = value.data.limits;
+  if (rawLimits !== undefined && !Array.isArray(rawLimits)) {
+    return undefined;
+  }
+
+  const limits: NormalizedZaiLimit[] = [];
+  for (const rawLimit of rawLimits ?? []) {
+    if (!isRecord(rawLimit)) {
+      continue;
+    }
+    limits.push({
+      type: normalizeOptionalString(rawLimit.type),
+      percentage: asFiniteNumber(rawLimit.percentage),
+      unit: asFiniteNumber(rawLimit.unit),
+      number: asFiniteNumber(rawLimit.number),
+      nextResetTime: normalizeOptionalString(rawLimit.nextResetTime),
+    });
+  }
+
+  return {
+    ok: true,
+    plan: normalizeOptionalString(value.data.planName) ?? normalizeOptionalString(value.data.plan),
+    limits,
+  };
+}
 
 export async function fetchZaiUsage(
   apiKey: string,
@@ -57,29 +96,26 @@ export async function fetchZaiUsage(
   if (!parsed.ok) {
     return parsed.snapshot;
   }
-  const data = isRecord(parsed.data) ? (parsed.data as ZaiUsageResponse) : undefined;
-  if (!data || !data.success || data.code !== 200) {
-    const errorMessage = typeof data?.msg === "string" ? data.msg.trim() : "";
+  const usage = normalizeZaiUsage(parsed.data);
+  if (!usage || !usage.ok) {
     return {
       provider: "zai",
       displayName: PROVIDER_LABELS.zai,
       windows: [],
-      error: errorMessage || "API error",
+      error: usage?.message || "API error",
     };
   }
 
   const windows: UsageWindow[] = [];
-  const limits = data.data?.limits || [];
-
-  for (const limit of limits) {
-    const percent = clampPercent(limit.percentage || 0);
+  for (const limit of usage.limits) {
+    const percent = clampPercent(limit.percentage ?? 0);
     const nextReset = parseUsageResetAt(limit.nextResetTime);
     let windowLabel = "Limit";
-    if (limit.unit === 1) {
+    if (limit.unit === 1 && limit.number !== undefined) {
       windowLabel = `${limit.number}d`;
-    } else if (limit.unit === 3) {
+    } else if (limit.unit === 3 && limit.number !== undefined) {
       windowLabel = `${limit.number}h`;
-    } else if (limit.unit === 5) {
+    } else if (limit.unit === 5 && limit.number !== undefined) {
       windowLabel = `${limit.number}m`;
     }
 
@@ -98,11 +134,10 @@ export async function fetchZaiUsage(
     }
   }
 
-  const planName = data.data?.planName || data.data?.plan || undefined;
   return {
     provider: "zai",
     displayName: PROVIDER_LABELS.zai,
     windows,
-    plan: planName,
+    plan: usage.plan,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing Z.AI usage can hit an uncaught `TypeError` when the provider returns a successful HTTP response whose JSON payload is `null` or an array.

## Why This Change Was Made

The usage endpoint now treats non-record successful payloads like the existing unsuccessful-payload path and returns the stable `API error` snapshot. Valid Z.AI usage records keep the existing window and plan parsing behavior.

## User Impact

Z.AI usage checks degrade to a stable provider error instead of rejecting the usage refresh when the upstream sends a malformed top-level JSON shape.

## Evidence

- `node scripts/run-vitest.mjs src/infra/provider-usage.fetch.zai.test.ts` (9 tests passed)
- `oxfmt --check src/infra/provider-usage.fetch.zai.ts src/infra/provider-usage.fetch.zai.test.ts` (passed)
- `git diff --check` (passed)
- Submission base: `main` at `a115af277410a91fb039d2ed699eafad706f5c73`
- Core `tsgo` was attempted; the run is currently blocked by three unrelated existing errors in `packages/net-policy/src/ip.ts`.

## Exact-Head Runtime Proof

- Exact PR head: `c5073e3f81e4139e14ac801a4fbce49d1277373f`.
- [Secretless exact-head Actions proof](https://github.com/Leon-SK668/openclaw/actions/runs/29722160648) passed on Node 24.15.0. The workflow grants only `contents: read`, both checkouts use `persist-credentials: false`, and the runtime uses a synthetic token rather than repository or provider secrets.
- The proof imported the real `src/infra/provider-usage.fetch.zai.ts#fetchZaiUsage`, confirmed its fixed upstream target, and redirected that request through real `fetch` to a disposable loopback HTTP server. This is controlled-server runtime proof, not a credentialed call to the external Z.AI service.
- For both HTTP 200 malformed top-level payloads (`null` and `[]`), the refresh did not reject. Each result was `{ provider: "zai", error: "API error", windows: [] }`; the observed requests were `GET`, requested JSON, and carried only the redacted synthetic authorization header.
- The redacted [proof artifact](https://github.com/Leon-SK668/openclaw/actions/runs/29722160648/artifacts/8452830594) is `zai-usage-loopback-proof-c5073e3f81e4139e14ac801a4fbce49d1277373f` (GitHub artifact digest `sha256:1b4d0585fba98e7728fdb335552784b222bbcb9afefc7c1355321073804aabb9`; contained JSON SHA-256 `de08065516cbf7aa5bfead80a83879b6a3b8576b9e0028ac86ecef0df5ecb3e8`).

AI-assisted contribution; the change and its behavior are understood and covered by the focused regression tests and exact-head runtime proof.
