### PR TITLE
fix(cron): bound misconfigured timeoutSeconds/noOutputTimeoutSeconds to default

### DIFF
--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -2,7 +2,20 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Wrap runCommandWithTimeout in a spy that delegates to the real implementation
+// by default. This lets individual tests override it to assert the options
+// passed by runCronCommandJob without affecting tests that run real commands.
+vi.mock("../process/exec.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../process/exec.js")>();
+  return {
+    ...actual,
+    runCommandWithTimeout: vi.fn(actual.runCommandWithTimeout),
+  };
+});
+
+import { runCommandWithTimeout } from "../process/exec.js";
 import { runCronCommandJob } from "./command-runner.js";
 import type { CronJob } from "./types.js";
 
@@ -197,5 +210,141 @@ describe("runCronCommandJob", () => {
     expect(result.status).toBe("error");
     expect(result.error).toBe("command stopped");
     expect(result.summary).toBeUndefined();
+  });
+
+  it("negative timeoutSeconds falls back to default instead of unbounded", async () => {
+    // Regression: negative timeoutSeconds used to map to
+    // EFFECTIVELY_UNBOUNDED_TIMEOUT_MS (~24.8 days), hanging doctor/cron.
+    // It must now fall back to DEFAULT_COMMAND_TIMEOUT_MS (10 min).
+    const stub = vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "ok",
+      stderr: "",
+      code: 0,
+      signal: null,
+      timedOut: false,
+      termination: "exit" as const,
+    });
+
+    for (const badTimeout of [-1, -60]) {
+      stub.mockClear();
+      await runCronCommandJob({
+        job: makeCommandJob({
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('ok')"],
+          timeoutSeconds: badTimeout,
+        }),
+      });
+      expect(stub).toHaveBeenCalledTimes(1);
+      const options = stub.mock.calls[0]?.[1] as { timeoutMs?: number };
+      // Must be 600000 (10 min default), NOT 2147483647 (unbounded).
+      expect(options?.timeoutMs).toBe(600_000);
+      expect(options?.timeoutMs).not.toBe(2_147_483_647);
+    }
+    stub.mockRestore();
+  });
+
+  it("zero timeoutSeconds preserves no-timeout contract (unbounded)", async () => {
+    // 0 is an intentionally supported "no timeout" value per
+    // docs/automation/cron-jobs.md. It must remain unbounded, not fall back
+    // to the default.
+    const stub = vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "ok",
+      stderr: "",
+      code: 0,
+      signal: null,
+      timedOut: false,
+      termination: "exit" as const,
+    });
+
+    await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [process.execPath, "-e", "process.stdout.write('ok')"],
+        timeoutSeconds: 0,
+      }),
+    });
+    const options = stub.mock.calls[0]?.[1] as { timeoutMs?: number };
+    expect(options?.timeoutMs).toBe(2_147_483_647);
+    stub.mockRestore();
+  });
+
+  it("negative noOutputTimeoutSeconds is omitted instead of arming unbounded deadline", async () => {
+    // Regression: negative noOutputTimeoutSeconds used to map to
+    // EFFECTIVELY_UNBOUNDED_TIMEOUT_MS. It must now be omitted (undefined)
+    // so the runner does not arm a ~24.8-day no-output deadline.
+    const stub = vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "ok",
+      stderr: "",
+      code: 0,
+      signal: null,
+      timedOut: false,
+      termination: "exit" as const,
+    });
+
+    await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [process.execPath, "-e", "process.stdout.write('ok')"],
+        timeoutSeconds: 5,
+        noOutputTimeoutSeconds: -1,
+      }),
+    });
+    const options = stub.mock.calls[0]?.[1] as {
+      noOutputTimeoutMs?: number;
+    };
+    expect(options?.noOutputTimeoutMs).toBeUndefined();
+    stub.mockRestore();
+  });
+
+  it("real command run with negative timeout completes and arms default deadline", async () => {
+    // Real behavior proof: run a REAL command (no mockResolvedValue) with a
+    // negative timeoutSeconds. The spy observes the actual timeoutMs passed
+    // to runCommandWithTimeout while the real command executes and returns.
+    // Without the fix, timeoutMs would be 2_147_483_647 (~24.8 days);
+    // with the fix, it falls back to 600_000 (10 min default).
+    const spy = vi.mocked(runCommandWithTimeout);
+    spy.mockClear();
+
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [process.execPath, "-e", "process.stdout.write('real-ok')"],
+        timeoutSeconds: -1,
+      }),
+    });
+
+    // Real command executed successfully.
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe("real-ok");
+    // Spy observed the fallback timeout, not the unbounded value.
+    expect(spy).toHaveBeenCalledTimes(1);
+    const options = spy.mock.calls[0]?.[1] as { timeoutMs?: number };
+    expect(options?.timeoutMs).toBe(600_000);
+    expect(options?.timeoutMs).not.toBe(2_147_483_647);
+  });
+
+  it("real command run with zero timeout arms unbounded deadline", async () => {
+    // Real behavior proof: run a REAL command (no mockResolvedValue) with
+    // timeoutSeconds: 0. The spy observes the actual timeoutMs is
+    // 2_147_483_647 (unbounded), preserving the documented "no timeout"
+    // contract, while the real command executes and returns.
+    const spy = vi.mocked(runCommandWithTimeout);
+    spy.mockClear();
+
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [process.execPath, "-e", "process.stdout.write('real-zero')"],
+        timeoutSeconds: 0,
+      }),
+    });
+
+    // Real command executed successfully.
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe("real-zero");
+    // Spy observed the unbounded timeout (0 = no timeout per docs).
+    expect(spy).toHaveBeenCalledTimes(1);
+    const options = spy.mock.calls[0]?.[1] as { timeoutMs?: number };
+    expect(options?.timeoutMs).toBe(2_147_483_647);
   });
 });

--- a/src/cron/command-runner.ts
+++ b/src/cron/command-runner.ts
@@ -13,7 +13,16 @@ function secondsToMs(value: number | undefined): number | undefined {
   if (typeof value !== "number") {
     return undefined;
   }
-  if (value <= 0) {
+  if (value < 0) {
+    // Negative timeoutSeconds/noOutputTimeoutSeconds is misconfiguration.
+    // Fall back to undefined so the caller uses DEFAULT_COMMAND_TIMEOUT_MS
+    // instead of arming a ~24.8-day deadline (EFFECTIVELY_UNBOUNDED_TIMEOUT_MS)
+    // that hangs doctor/cron under abnormal config.
+    // Note: 0 is intentionally preserved as "no timeout" (unbounded) per the
+    // existing contract documented in docs/automation/cron-jobs.md.
+    return undefined;
+  }
+  if (value === 0) {
     return EFFECTIVELY_UNBOUNDED_TIMEOUT_MS;
   }
   return finiteSecondsToTimerSafeMilliseconds(value) ?? undefined;


### PR DESCRIPTION
## Problem

`secondsToMs` in `src/cron/command-runner.ts` mapped every `value <= 0` (including negative misconfigurations like `-1` or `-60`) to `EFFECTIVELY_UNBOUNDED_TIMEOUT_MS` (~24.8 days). This meant a misconfigured negative `timeoutSeconds`/`noOutputTimeoutSeconds` armed a ~24.8-day deadline that could hang doctor/cron indefinitely.

## Fix (revised per review feedback)

Only treat `value < 0` (negative) as misconfiguration, returning `undefined` so callers fall back to `DEFAULT_COMMAND_TIMEOUT_MS` (10 min). **Preserve `value === 0` as the intentional "no timeout" (unbounded) value** per the existing contract in `docs/automation/cron-jobs.md`.

This addresses the P1 concern from the initial review: existing command cron jobs that intentionally store `timeoutSeconds: 0` continue to work as "no timeout" — only negative values change behavior.

- Files changed: 2
- LOC delta: +160 / -2

## Real behavior proof

Two new tests run REAL commands (no `mockResolvedValue`) with a spy that observes the actual `timeoutMs` passed to `runCommandWithTimeout` while the real command executes:

### `real command run with negative timeout completes and arms default deadline`
- Runs `node -e "process.stdout.write('real-ok')"` with `timeoutSeconds: -1`
- Real command executes and returns `status: "ok"`, `summary: "real-ok"`
- Spy observes `timeoutMs: 600_000` (10 min default), NOT `2_147_483_647` (unbounded)

### `real command run with zero timeout arms unbounded deadline`
- Runs `node -e "process.stdout.write('real-zero')"` with `timeoutSeconds: 0`
- Real command executes and returns `status: "ok"`, `summary: "real-zero"`
- Spy observes `timeoutMs: 2_147_483_647` (unbounded, preserved per docs)

| Input | Real command result | Observed `timeoutMs` | Old behavior |
|-------|-------------------|---------------------|--------------|
| `timeoutSeconds: -1` | `ok` / `real-ok` | `600_000` (default) | `2_147_483_647` (unbounded) |
| `timeoutSeconds: 0` | `ok` / `real-zero` | `2_147_483_647` (unbounded, preserved) | `2_147_483_647` (unchanged) |
| `noOutputTimeoutSeconds: -1` | (mocked) | `undefined` (omitted) | `2_147_483_647` (unbounded) |

```
 ✓ |cron| ../../src/cron/command-runner.test.ts > runCronCommandJob > real command run with negative timeout completes and arms default deadline 90ms
 ✓ |cron| ../../src/cron/command-runner.test.ts > runCronCommandJob > real command run with zero timeout arms unbounded deadline 112ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

## Risk

Low. Only negative values change behavior — they now fall back to the 10-minute default instead of a 24.8-day deadline. Zero is preserved as "no timeout" per existing docs. No migration needed because negative values are not a documented or supported configuration.