### PR TITLE
fix(acp): /acp sessions exposes every gateway session to non-owner senders

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -796,9 +796,10 @@ lists only the current bound or requester session; owner identity and
 
 `/acp status` shows the effective runtime options plus runtime-level and
 backend-level session identifiers. Unsupported-control errors surface
-clearly when a backend lacks a capability. `/acp sessions` target tokens
-(`session-key`, `session-id`, or `session-label`) resolve through gateway
-session discovery, including custom per-agent `session.store` roots.
+clearly when a backend lacks a capability. Commands that accept target tokens
+(`session-key`, `session-id`, or `session-label`) resolve them through gateway
+session discovery, including custom per-agent `session.store` roots. `/acp sessions`
+does not accept a target token.
 
 ### Runtime options mapping
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -790,7 +790,9 @@ Runtime controls (`spawn`, `cancel`, `steer`, `close`, `status`, `set-mode`,
 `set`, `cwd`, `permissions`, `timeout`, `model`, and `reset-options`) require
 owner identity from external channels and `operator.admin` from internal
 Gateway clients. Authorized non-owner senders can still use `sessions`,
-`doctor`, `install`, and `help`.
+`doctor`, `install`, and `help`. For non-owner senders, `/acp sessions`
+lists only the current bound or requester session; owner identity and
+`operator.admin` clients see all recent sessions.
 
 `/acp status` shows the effective runtime options plus runtime-level and
 backend-level session identifiers. Unsupported-control errors surface

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -796,11 +796,9 @@ lists only the current bound or requester session; owner identity and
 
 `/acp status` shows the effective runtime options plus runtime-level and
 backend-level session identifiers. Unsupported-control errors surface
-clearly when a backend lacks a capability. For non-owner senders, `/acp sessions`
-reads only the current bound or requester session; owner identity and
-`operator.admin` clients scan all recent ACP sessions. Target tokens
-(`session-key`, `session-id`, or `session-label`) resolve through gateway session
-discovery, including custom per-agent `session.store` roots.
+clearly when a backend lacks a capability. `/acp sessions` target tokens
+(`session-key`, `session-id`, or `session-label`) resolve through gateway
+session discovery, including custom per-agent `session.store` roots.
 
 ### Runtime options mapping
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -796,10 +796,11 @@ lists only the current bound or requester session; owner identity and
 
 `/acp status` shows the effective runtime options plus runtime-level and
 backend-level session identifiers. Unsupported-control errors surface
-clearly when a backend lacks a capability. `/acp sessions` reads the store
-for the current bound or requester session; target tokens (`session-key`,
-`session-id`, or `session-label`) resolve through gateway session discovery,
-including custom per-agent `session.store` roots.
+clearly when a backend lacks a capability. For non-owner senders, `/acp sessions`
+reads only the current bound or requester session; owner identity and
+`operator.admin` clients scan all recent ACP sessions. Target tokens
+(`session-key`, `session-id`, or `session-label`) resolve through gateway session
+discovery, including custom per-agent `session.store` roots.
 
 ### Runtime options mapping
 

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1998,6 +1998,17 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain("Missing session key");
   });
 
+  it("rejects explicit target tokens for /acp sessions", async () => {
+    const params = createDiscordParams("/acp sessions agent:claude:acp:foreign");
+    params.command.senderIsOwner = false;
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result?.reply?.text).toBe("Usage: /acp sessions");
+    expect(hoisted.readAcpSessionEntryMock).not.toHaveBeenCalled();
+    expect(hoisted.listAcpSessionEntriesMock).not.toHaveBeenCalled();
+  });
+
   it("shows ACP status for the thread-bound ACP session", async () => {
     mockBoundThreadSession({
       identity: {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1910,6 +1910,38 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain(`thread:${defaultThreadId}`);
   });
 
+  it("lists all stored ACP sessions for the owner", async () => {
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createBoundThreadSession("agent:codex:acp:own"),
+    );
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      createAcpSessionEntry({ sessionKey: "agent:codex:acp:own" }),
+      createAcpSessionEntry({ sessionKey: "agent:claude:acp:foreign" }),
+    ]);
+
+    const result = await runDiscordAcpCommand("/acp sessions", baseCfg);
+
+    expect(result?.reply?.text).toContain("agent:codex:acp:own");
+    expect(result?.reply?.text).toContain("agent:claude:acp:foreign");
+  });
+
+  it("hides foreign ACP sessions from authorized non-owner senders", async () => {
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createBoundThreadSession("agent:codex:acp:own"),
+    );
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      createAcpSessionEntry({ sessionKey: "agent:codex:acp:own" }),
+      createAcpSessionEntry({ sessionKey: "agent:claude:acp:foreign" }),
+    ]);
+    const params = createDiscordParams("/acp sessions");
+    params.command.senderIsOwner = false;
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result?.reply?.text).toContain("agent:codex:acp:own");
+    expect(result?.reply?.text).not.toContain("agent:claude:acp:foreign");
+  });
+
   it("shows ACP status for the thread-bound ACP session", async () => {
     mockBoundThreadSession({
       identity: {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1942,6 +1942,30 @@ describe("/acp command", () => {
     expect(result?.reply?.text).not.toContain("agent:claude:acp:foreign");
   });
 
+  it("returns an empty listing to non-owner senders with no matching session", async () => {
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      createAcpSessionEntry({ sessionKey: "agent:claude:acp:foreign" }),
+    ]);
+    const params = createDiscordParams("/acp sessions");
+    params.command.senderIsOwner = false;
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result?.reply?.text).toContain("(none)");
+    expect(result?.reply?.text).not.toContain("agent:claude:acp:foreign");
+  });
+
+  it("warns when no session key resolves for /acp sessions", async () => {
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([createAcpSessionEntry()]);
+    const params = createDiscordParams("/acp sessions");
+    params.command.senderIsOwner = false;
+    params.sessionKey = "";
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result?.reply?.text).toContain("Missing session key");
+  });
+
   it("shows ACP status for the thread-bound ACP session", async () => {
     mockBoundThreadSession({
       identity: {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -2172,17 +2172,7 @@ describe("/acp command", () => {
   });
 
   it("keeps read-only /acp actions available to internal operator.write clients", async () => {
-    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
-      createAcpSessionEntry({
-        identity: {
-          state: "resolved",
-          source: "status",
-          acpxSessionId: "runtime-1",
-          agentSessionId: "session-1",
-          lastUpdatedAt: Date.now(),
-        },
-      }),
-    ]);
+    hoisted.readAcpSessionEntryMock.mockReturnValue(createAcpSessionEntry());
 
     const result = await runInternalAcpCommand({
       commandBody: "/acp sessions",
@@ -2190,7 +2180,24 @@ describe("/acp command", () => {
     });
 
     expect(result?.shouldContinue).toBe(false);
-    expect(result?.reply?.text).toContain("ACP sessions");
+    expect(result?.reply?.text).toContain(defaultAcpSessionKey);
+    expect(hoisted.listAcpSessionEntriesMock).not.toHaveBeenCalled();
+  });
+
+  it("lists all ACP sessions for internal operator.admin clients", async () => {
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      createAcpSessionEntry({ sessionKey: "agent:codex:acp:own" }),
+      createAcpSessionEntry({ sessionKey: "agent:claude:acp:foreign" }),
+    ]);
+
+    const result = await runInternalAcpCommand({
+      commandBody: "/acp sessions",
+      scopes: ["operator.admin"],
+    });
+
+    expect(result?.reply?.text).toContain("agent:codex:acp:own");
+    expect(result?.reply?.text).toContain("agent:claude:acp:foreign");
+    expect(hoisted.readAcpSessionEntryMock).not.toHaveBeenCalled();
   });
 
   it("allows mutating /acp actions for internal operator.admin clients", async () => {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1923,36 +1923,64 @@ describe("/acp command", () => {
 
     expect(result?.reply?.text).toContain("agent:codex:acp:own");
     expect(result?.reply?.text).toContain("agent:claude:acp:foreign");
+    expect(hoisted.readAcpSessionEntryMock).not.toHaveBeenCalled();
   });
 
-  it("hides foreign ACP sessions from authorized non-owner senders", async () => {
-    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
-      createBoundThreadSession("agent:codex:acp:own"),
+  it("lists only the current raw ACP session for an authorized non-owner sender", async () => {
+    const currentSessionKey = "agent:codex:acp:current";
+    hoisted.readAcpSessionEntryMock.mockReturnValue(
+      createAcpSessionEntry({ sessionKey: currentSessionKey }),
     );
-    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
-      createAcpSessionEntry({ sessionKey: "agent:codex:acp:own" }),
-      createAcpSessionEntry({ sessionKey: "agent:claude:acp:foreign" }),
-    ]);
     const params = createDiscordParams("/acp sessions");
     params.command.senderIsOwner = false;
+    params.sessionKey = currentSessionKey;
 
     const result = await handleAcpCommand(params, true);
 
-    expect(result?.reply?.text).toContain("agent:codex:acp:own");
-    expect(result?.reply?.text).not.toContain("agent:claude:acp:foreign");
+    expect(result?.reply?.text).toContain(currentSessionKey);
+    expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith({
+      cfg: baseCfg,
+      sessionKey: currentSessionKey,
+    });
+    expect(hoisted.listAcpSessionEntriesMock).not.toHaveBeenCalled();
   });
 
-  it("returns an empty listing to non-owner senders with no matching session", async () => {
-    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
-      createAcpSessionEntry({ sessionKey: "agent:claude:acp:foreign" }),
-    ]);
+  it("prefers the bound-thread ACP session over a non-owner sender's raw session key", async () => {
+    const boundSessionKey = "agent:codex:acp:bound";
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createBoundThreadSession(boundSessionKey),
+    );
+    hoisted.readAcpSessionEntryMock.mockReturnValue(
+      createAcpSessionEntry({ sessionKey: boundSessionKey }),
+    );
     const params = createDiscordParams("/acp sessions");
     params.command.senderIsOwner = false;
+    params.sessionKey = "agent:main:raw-requester";
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result?.reply?.text).toContain(boundSessionKey);
+    expect(result?.reply?.text).not.toContain("agent:main:raw-requester");
+    expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith({
+      cfg: baseCfg,
+      sessionKey: boundSessionKey,
+    });
+    expect(hoisted.listAcpSessionEntriesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty listing when a non-owner's raw session key is not an ACP session", async () => {
+    const params = createDiscordParams("/acp sessions");
+    params.command.senderIsOwner = false;
+    params.sessionKey = "agent:main:raw-requester";
 
     const result = await handleAcpCommand(params, true);
 
     expect(result?.reply?.text).toContain("(none)");
-    expect(result?.reply?.text).not.toContain("agent:claude:acp:foreign");
+    expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith({
+      cfg: baseCfg,
+      sessionKey: "agent:main:raw-requester",
+    });
+    expect(hoisted.listAcpSessionEntriesMock).not.toHaveBeenCalled();
   });
 
   it("warns when no session key resolves for /acp sessions", async () => {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1969,6 +1969,10 @@ describe("/acp command", () => {
   });
 
   it("returns an empty listing when a non-owner's raw session key is not an ACP session", async () => {
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      ...createAcpSessionEntry({ sessionKey: "agent:main:raw-requester" }),
+      acp: undefined,
+    });
     const params = createDiscordParams("/acp sessions");
     params.command.senderIsOwner = false;
     params.sessionKey = "agent:main:raw-requester";

--- a/src/auto-reply/reply/commands-acp/diagnostics.ts
+++ b/src/auto-reply/reply/commands-acp/diagnostics.ts
@@ -7,7 +7,7 @@ import {
 import { getAcpSessionManager } from "../../../acp/control-plane/manager.js";
 import { toAcpRuntimeError } from "../../../acp/runtime/errors.js";
 import { getAcpRuntimeBackend, requireAcpRuntimeBackend } from "../../../acp/runtime/registry.js";
-import { listAcpSessionEntries } from "../../../acp/runtime/session-meta.js";
+import { listAcpSessionEntries, readAcpSessionEntry } from "../../../acp/runtime/session-meta.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { SessionAcpMeta } from "../../../config/sessions/types.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
@@ -190,10 +190,14 @@ export async function handleAcpSessionsAction(
   const normalizedChannel = bindingContext.channel;
   const normalizedAccountId = bindingContext.accountId || undefined;
   const bindingService = getSessionBindingService();
-  const entries = await listAcpSessionEntries({ cfg: params.cfg });
+  const currentEntry = params.command.senderIsOwner
+    ? null
+    : readAcpSessionEntry({ cfg: params.cfg, sessionKey: currentSessionKey });
   const visibleEntries = params.command.senderIsOwner
-    ? entries
-    : entries.filter((candidate) => candidate.storeSessionKey === currentSessionKey);
+    ? await listAcpSessionEntries({ cfg: params.cfg })
+    : currentEntry
+      ? [currentEntry]
+      : [];
 
   const rows = visibleEntries
     .toSorted((a, b) => (b.entry?.updatedAt ?? 0) - (a.entry?.updatedAt ?? 0))

--- a/src/auto-reply/reply/commands-acp/diagnostics.ts
+++ b/src/auto-reply/reply/commands-acp/diagnostics.ts
@@ -191,8 +191,11 @@ export async function handleAcpSessionsAction(
   const normalizedAccountId = bindingContext.accountId || undefined;
   const bindingService = getSessionBindingService();
   const entries = await listAcpSessionEntries({ cfg: params.cfg });
+  const visibleEntries = params.command.senderIsOwner
+    ? entries
+    : entries.filter((candidate) => candidate.storeSessionKey === currentSessionKey);
 
-  const rows = entries
+  const rows = visibleEntries
     .toSorted((a, b) => (b.entry?.updatedAt ?? 0) - (a.entry?.updatedAt ?? 0))
     .slice(0, 20)
     .map(({ storeSessionKey, entry, acp }) => {

--- a/src/auto-reply/reply/commands-acp/diagnostics.ts
+++ b/src/auto-reply/reply/commands-acp/diagnostics.ts
@@ -195,7 +195,7 @@ export async function handleAcpSessionsAction(
     : readAcpSessionEntry({ cfg: params.cfg, sessionKey: currentSessionKey });
   const visibleEntries = params.command.senderIsOwner
     ? await listAcpSessionEntries({ cfg: params.cfg })
-    : currentEntry
+    : currentEntry?.entry && currentEntry.acp
       ? [currentEntry]
       : [];
 


### PR DESCRIPTION
Closes #103055

## What Problem This Solves

Fixes an issue where an authorized non-owner sender could run `/acp sessions` and enumerate every ACP session on the Gateway, including session keys, labels, agents, runtime state, backend, and thread bindings belonging to other senders or the owner.

## Why This Change Was Made

`/acp sessions` now enforces visibility at the command boundary, where sender authorization and the current conversation binding are available. Owners and internal `operator.admin` clients retain the full diagnostic listing. Other authorized senders perform a targeted read of only their current bound or requester session, and that result is included only when both the stored session entry and ACP metadata exist.

The shared session registry remains gateway-wide because startup identity reconciliation and task maintenance legitimately need to scan every ACP session. Explicit target tokens are rejected by `/acp sessions`, preventing callers from redirecting this read to another session. Bound-thread resolution continues to take precedence over the raw requester session key.

Sibling read-only actions were checked: `doctor` and `install` expose backend health or setup instructions but do not enumerate session identifiers. The `/acp sessions` path does not log session identifiers.

Release-note context: authorized non-owner senders and internal `operator.write` clients no longer see Gateway-wide ACP sessions; they see only their current ACP session. Owners and `operator.admin` clients retain the full listing.

## User Impact

Authorized non-owner senders can still use `/acp sessions` for their current ACP session without learning about other users' sessions. Owners and administrative Gateway clients keep the aggregate diagnostic view.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-acp.test.ts`: 73 passed. The matrix covers owner-wide visibility, internal `operator.admin` visibility, scoped `operator.write`, non-owner current raw ACP sessions, bound-thread precedence, ordinary non-ACP requester sessions, missing requester keys, and explicit foreign target rejection.
- `./node_modules/.bin/oxfmt --check docs/tools/acp-agents.md src/auto-reply/reply/commands-acp.test.ts src/auto-reply/reply/commands-acp/diagnostics.ts`: passed.
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/commands-acp.test.ts src/auto-reply/reply/commands-acp/diagnostics.ts`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Structured autoreview: clean after validating the `operator.admin` authorization mapping, the real `readAcpSessionEntry` missing-metadata contract, and target-token rejection.
- Contributor production-path proof seeded two ACP sessions through the real SQLite store and demonstrated the original cross-sender leak, then the intended owner/non-owner output split. The maintainer refinement replaces the gateway-wide non-owner scan with an exact-key read; hosted exact-head CI provides the final integration gate.
- Testbox changed-surface runs [29665861197](https://github.com/openclaw/openclaw/actions/runs/29665861197) and [29666066477](https://github.com/openclaw/openclaw/actions/runs/29666066477) were infrastructure-blocked during checkout sync before any repository check executed. Focused local proof was used per trusted-source fallback policy.

Not tested: a live Telegram or Discord transport roundtrip. The command dispatcher and authorization/session-resolution paths are covered directly.
