### PR TITLE
fix(prompt-assembly): clarify runtime-context header so models know the user message IS included (#110672)

### DIFF
--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -611,7 +611,7 @@ describe("runtime context prompt submission", () => {
       role: "custom",
       customType: "openclaw.runtime-context",
       content: [
-        "OpenClaw runtime context for the immediately preceding user message.",
+        "OpenClaw runtime context that accompanies the user message below. The user's own message text is delivered separately and IS included in this turn; this block only adds runtime context on top of it.",
         "This context is runtime-generated, not user-authored. Keep internal details private.",
         "",
         "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
@@ -621,6 +621,14 @@ describe("runtime context prompt submission", () => {
       display: false,
       details: { source: "openclaw-runtime-context" },
     });
+  });
+
+  it("runtime context header clarifies the user message IS included (#110672)", () => {
+    const message = buildRuntimeContextCustomMessage("secret runtime context");
+    const header = message?.content.split("\n")[0] ?? "";
+    expect(header).toContain("accompanies the user message");
+    expect(header).toContain("IS included in this turn");
+    expect(header).not.toContain("immediately preceding user message");
   });
 
   it("labels runtime-only events as system context", () => {

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -16,7 +16,7 @@ export const OPENCLAW_RUNTIME_CONTEXT_NOTICE =
   "This context is runtime-generated, not user-authored. Keep internal details private.";
 /** Header for context attached to the immediately preceding user message. */
 export const OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER =
-  "OpenClaw runtime context for the immediately preceding user message.";
+  "OpenClaw runtime context that accompanies the user message below. The user's own message text is delivered separately and IS included in this turn; this block only adds runtime context on top of it.";
 /** Header for runtime events passed as prompt context. */
 export const OPENCLAW_RUNTIME_EVENT_HEADER = "OpenClaw runtime event.";
 /** Custom message type used for structured runtime-context messages. */


### PR DESCRIPTION
## Summary
Fixes #110672 — the next-turn runtime-context header (`OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER`) read `OpenClaw runtime context for the immediately preceding user message.` Smaller reasoning-capable models infer the current message body `was not injected`, even though it is delivered in the same turn (their own reasoning trace quotes it verbatim).

Reword the header to state the user message text is delivered separately and **IS included** in this turn, and that this block only supplements it.

## Changes
- `src/agents/internal-runtime-context.ts`: reworded `OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER`.
- `src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts`: updated assertion + added regression test.

## Validation
- `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts` → **29 passed**.

Closes #110672.