### PR TITLE
fix(scripts): bound release CI summary GitHub lookups

### DIFF
--- a/scripts/release-ci-summary.d.mts
+++ b/scripts/release-ci-summary.d.mts
@@ -1,4 +1,23 @@
 #!/usr/bin/env node
+export function runReleaseCiGh(
+  args: string[],
+  params?: {
+    execFileSyncImpl?: (
+      command: string,
+      args: string[],
+      options: {
+        encoding: "utf8";
+        env: NodeJS.ProcessEnv;
+        killSignal: "SIGKILL";
+        maxBuffer: number;
+        stdio: unknown;
+        timeout: number;
+      },
+    ) => string;
+    stdio?: unknown;
+    timeoutMs?: number;
+  },
+): string;
 export function githubRestArgs(pathSuffix: string, repository?: string): string[];
 export function artifactDownloadArgs(artifactId: string | number, repository?: string): string[];
 export function validateParentRunBinding(

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -95,13 +95,14 @@ const RERUN_GROUP_CHILD_KEYS = new Map([
 
 export function runReleaseCiGh(args, params = {}) {
   const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
+  const timeoutMs = params.timeoutMs ?? GH_COMMAND_TIMEOUT_MS;
   return execFileSyncImpl(resolvePlainGhBin(), args, {
     encoding: "utf8",
     env: plainGhEnv(),
     killSignal: "SIGKILL",
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: GH_COMMAND_TIMEOUT_MS,
+    timeout: timeoutMs,
   });
 }
 

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -22,6 +22,10 @@ const MANIFEST_ARTIFACT_ENTRY = "full-release-validation-manifest.json";
 const MAX_MANIFEST_ARTIFACT_ZIP_BYTES = 256 * 1024;
 const MAX_MANIFEST_JSON_BYTES = 128 * 1024;
 const MAX_MANIFEST_ENTRY_LIST_BYTES = 8 * 1024;
+// Release evidence lookups run during full release validation, so keep enough
+// headroom for GitHub latency while preventing one stalled read from consuming
+// the workflow budget.
+const GH_COMMAND_TIMEOUT_MS = 60_000;
 
 const CHILD_DISPATCHES = [
   {
@@ -89,13 +93,20 @@ const RERUN_GROUP_CHILD_KEYS = new Map([
   ["performance", ["productPerformance"]],
 ]);
 
-function gh(args) {
-  return execFileSync(resolvePlainGhBin(), args, {
+export function runReleaseCiGh(args, params = {}) {
+  const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
+  return execFileSyncImpl(resolvePlainGhBin(), args, {
     encoding: "utf8",
     env: plainGhEnv(),
+    killSignal: "SIGKILL",
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: GH_COMMAND_TIMEOUT_MS,
   });
+}
+
+function gh(args) {
+  return runReleaseCiGh(args);
 }
 
 function jsonGh(args) {
@@ -119,7 +130,9 @@ function downloadArtifactZip(artifactId, destination, repository = DEFAULT_REPO)
   try {
     execFileSync(resolvePlainGhBin(), artifactDownloadArgs(artifactId, repository), {
       env: plainGhEnv(),
+      killSignal: "SIGKILL",
       stdio: ["ignore", output, "pipe"],
+      timeout: GH_COMMAND_TIMEOUT_MS,
     });
   } finally {
     closeSync(output);

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -96,12 +96,13 @@ const RERUN_GROUP_CHILD_KEYS = new Map([
 export function runReleaseCiGh(args, params = {}) {
   const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
   const timeoutMs = params.timeoutMs ?? GH_COMMAND_TIMEOUT_MS;
+  const stdio = params.stdio ?? ["ignore", "pipe", "pipe"];
   return execFileSyncImpl(resolvePlainGhBin(), args, {
     encoding: "utf8",
     env: plainGhEnv(),
     killSignal: "SIGKILL",
     maxBuffer: 64 * 1024 * 1024,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio,
     timeout: timeoutMs,
   });
 }
@@ -129,11 +130,8 @@ export function artifactDownloadArgs(artifactId, repository = DEFAULT_REPO) {
 function downloadArtifactZip(artifactId, destination, repository = DEFAULT_REPO) {
   const output = openSync(destination, "w");
   try {
-    execFileSync(resolvePlainGhBin(), artifactDownloadArgs(artifactId, repository), {
-      env: plainGhEnv(),
-      killSignal: "SIGKILL",
+    runReleaseCiGh(artifactDownloadArgs(artifactId, repository), {
       stdio: ["ignore", output, "pipe"],
-      timeout: GH_COMMAND_TIMEOUT_MS,
     });
   } finally {
     closeSync(output);

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   artifactDownloadArgs,
   expectedChildDispatches,
@@ -17,6 +17,7 @@ import {
   releaseCiWatchFingerprint,
   requiredChildKeysForRerunGroup,
   resolveManifestChildOriginAttempt,
+  runReleaseCiGh,
   selectExactChildRun,
   selectExactChildRunFromPages,
   selectManifestArtifact,
@@ -48,6 +49,39 @@ describe("GitHub API commands", () => {
       "api",
       "repos/owner/repo/actions/artifacts/456/zip",
     ]);
+  });
+});
+
+describe("runReleaseCiGh", () => {
+  it("bounds each GitHub lookup with a timeout and SIGKILL", () => {
+    const execFileSyncImpl = vi.fn(() => "result");
+
+    expect(
+      runReleaseCiGh(["api", "repos/openclaw/openclaw/actions/runs/1"], { execFileSyncImpl }),
+    ).toBe("result");
+    expect(execFileSyncImpl).toHaveBeenCalledTimes(1);
+    const [command, args, options] = execFileSyncImpl.mock.calls[0]!;
+    expect(command).toBeTypeOf("string");
+    expect(args).toEqual(["api", "repos/openclaw/openclaw/actions/runs/1"]);
+    expect(options).toMatchObject({
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: 60_000,
+    });
+  });
+
+  it("propagates GitHub lookup timeouts", () => {
+    const timeoutError = Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+
+    expect(() =>
+      runReleaseCiGh(["api", "rate_limit"], {
+        execFileSyncImpl: () => {
+          throw timeoutError;
+        },
+      }),
+    ).toThrow(timeoutError);
   });
 });
 

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -59,18 +59,16 @@ describe("runReleaseCiGh", () => {
     expect(
       runReleaseCiGh(["api", "repos/openclaw/openclaw/actions/runs/1"], { execFileSyncImpl }),
     ).toBe("result");
-    expect(execFileSyncImpl).toHaveBeenCalledTimes(1);
-    const [command, args, options] = expectDefined(
-      execFileSyncImpl.mock.calls[0],
-      "GitHub runner call",
+    expect(execFileSyncImpl).toHaveBeenCalledOnce();
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      expect.any(String),
+      ["api", "repos/openclaw/openclaw/actions/runs/1"],
+      expect.objectContaining({
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        timeout: 60_000,
+      }),
     );
-    expect(command).toBeTypeOf("string");
-    expect(args).toEqual(["api", "repos/openclaw/openclaw/actions/runs/1"]);
-    expect(options).toMatchObject({
-      encoding: "utf8",
-      killSignal: "SIGKILL",
-      timeout: 60_000,
-    });
   });
 
   it("propagates GitHub lookup timeouts", () => {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -60,7 +60,10 @@ describe("runReleaseCiGh", () => {
       runReleaseCiGh(["api", "repos/openclaw/openclaw/actions/runs/1"], { execFileSyncImpl }),
     ).toBe("result");
     expect(execFileSyncImpl).toHaveBeenCalledTimes(1);
-    const [command, args, options] = execFileSyncImpl.mock.calls[0]!;
+    const [command, args, options] = expectDefined(
+      execFileSyncImpl.mock.calls[0],
+      "GitHub runner call",
+    );
     expect(command).toBeTypeOf("string");
     expect(args).toEqual(["api", "repos/openclaw/openclaw/actions/runs/1"]);
     expect(options).toMatchObject({
@@ -74,7 +77,6 @@ describe("runReleaseCiGh", () => {
     const timeoutError = Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
       code: "ETIMEDOUT",
     });
-
     expect(() =>
       runReleaseCiGh(["api", "rate_limit"], {
         execFileSyncImpl: () => {
@@ -82,27 +84,6 @@ describe("runReleaseCiGh", () => {
         },
       }),
     ).toThrow(timeoutError);
-  });
-
-  it("kills a real gh subprocess that exceeds a short timeout", () => {
-    // Use a 1 ms timeout to force a real child-process timeout against a
-    // gh API call that would normally take longer.  This proves the
-    // SIGKILL + timeout surface works against actual child processes,
-    // not only against injected mocks.
-    expect(() => runReleaseCiGh(["api", "rate_limit"], { timeoutMs: 1 })).toThrow();
-  });
-
-  it("completes a real short-lived subprocess within the 60-second bound", () => {
-    // Prove the production timeout does not false-positive on fast
-    // completions.  Use `node -e 0` (exits immediately) via the real
-    // execFileSync, confirming the killSignal + timeout options do not
-    // interfere with successful child-process exits.
-    const result = execFileSync("node", ["-e", "process.exit(0)"], {
-      encoding: "utf8",
-      killSignal: "SIGKILL",
-      timeout: 60_000,
-    });
-    expect(result).toBe("");
   });
 });
 

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -83,6 +83,27 @@ describe("runReleaseCiGh", () => {
       }),
     ).toThrow(timeoutError);
   });
+
+  it("kills a real gh subprocess that exceeds a short timeout", () => {
+    // Use a 1 ms timeout to force a real child-process timeout against a
+    // gh API call that would normally take longer.  This proves the
+    // SIGKILL + timeout surface works against actual child processes,
+    // not only against injected mocks.
+    expect(() => runReleaseCiGh(["api", "rate_limit"], { timeoutMs: 1 })).toThrow();
+  });
+
+  it("completes a real short-lived subprocess within the 60-second bound", () => {
+    // Prove the production timeout does not false-positive on fast
+    // completions.  Use `node -e 0` (exits immediately) via the real
+    // execFileSync, confirming the killSignal + timeout options do not
+    // interfere with successful child-process exits.
+    const result = execFileSync("node", ["-e", "process.exit(0)"], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: 60_000,
+    });
+    expect(result).toBe("");
+  });
 });
 
 function crc32(input: Buffer): number {


### PR DESCRIPTION
## Problem

The full-release summary performs several synchronous GitHub CLI reads inside a five-minute verification job. Those reads and the manifest artifact download had no local deadline, so one stalled child could consume the job budget without identifying the failed operation.

## Solution

Route all release-summary GitHub operations through one release-owned runner with:

- a 60-second timeout;
- `SIGKILL` after the deadline;
- the existing plain-gh environment and 64 MiB read buffer;
- the artifact download's existing file-descriptor stdout destination.

The deadline matches the repository's npm release-recovery lookup budget. Required evidence reads still fail closed; the existing optional rate-limit telemetry keeps its local catch.

## Validation

- Focused Testbox run 29662977427: 43/43 release-summary tests passed.
- Full changed-surface Testbox gate passed: script declaration contracts, scripts/root-test TypeScript, formatting, and lint.
- Live helper proof on Testbox: a real `gh --version` process completed successfully; a deliberately stalled real child exited with `ETIMEDOUT` and `SIGKILL` through the production helper.
- Mandatory autoreview completed clean after the runner consolidation and again after the final type-safe assertion repair.
- Exact-head hosted CI run 29663188339 covers `e90f946459d8ed9f00e8502dbaf0fb80516d63e8`.

The original network-dependent 1 ms unit test was removed. Tests now inspect the production subprocess options deterministically, while live behavior proof remains outside the unit suite.

## Risk

A GitHub operation stalled for one minute now fails release verification and requires retry instead of occupying the surrounding job indefinitely. No authentication, endpoint, artifact-integrity, or release-evidence validation behavior changes.

Thanks to @tzy-17 for identifying the unbounded release lookup path and contributing the original fix.
