### PR TITLE
fix(daemon): force killSignal SIGKILL on Windows tasklist PID probe

### DIFF
--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -544,4 +544,69 @@ describe("Scheduled Task stop/restart cleanup", () => {
       expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });
+
+  it("uses killSignal SIGKILL for tasklist.exe probe so stalled Windows PID probes do not hang", async () => {
+    // Regression: spawnSync defaults killSignal to SIGTERM, which an unresponsive
+    // tasklist.exe can ignore. Matching #109243 and #109731, the probe must use
+    // SIGKILL so the 1.5s deadline actually reaps the child.
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    try {
+      await withPreparedGatewayTask(async ({ env, stdout }) => {
+        pushSuccessfulSchtasksResponses(3);
+        findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+        inspectPortUsage
+          .mockResolvedValueOnce(busyPortUsage(4242))
+          .mockResolvedValueOnce(freePortUsage());
+
+        // taskkill.exe succeeds; tasklist.exe returns no matching PID ("missing");
+        // PowerShell snapshot fails so probeProcessState falls through to tasklist.
+        spawnSync.mockImplementation((cmd: string) => {
+          if (typeof cmd === "string" && cmd.endsWith("tasklist.exe")) {
+            return {
+              pid: 0,
+              output: [null, "", ""],
+              stdout: "",
+              stderr: "",
+              status: 0,
+              signal: null,
+            };
+          }
+          if (typeof cmd === "string" && cmd.endsWith("taskkill.exe")) {
+            return {
+              pid: 0,
+              output: [null, "", ""],
+              stdout: "",
+              stderr: "",
+              status: 0,
+              signal: null,
+            };
+          }
+          return {
+            pid: 0,
+            output: [null, "", ""],
+            stdout: "",
+            stderr: "",
+            status: 1,
+            signal: null,
+          };
+        });
+
+        await stopScheduledTask({ env, stdout });
+
+        const tasklistCall = spawnSync.mock.calls.find(
+          ([cmd]) => typeof cmd === "string" && cmd.endsWith("tasklist.exe"),
+        );
+        expect(tasklistCall).toBeDefined();
+        expect(tasklistCall?.[2]).toMatchObject({
+          encoding: "utf8",
+          timeout: 1_500,
+          killSignal: "SIGKILL",
+          windowsHide: true,
+        });
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
 });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -789,7 +789,7 @@ function probeProcessState(pid: number): "alive" | "missing" | "unknown" {
     const tasklist = spawnSync(
       getWindowsSystem32ExePath("tasklist.exe"),
       ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"],
-      { encoding: "utf8", timeout: 1_500, windowsHide: true },
+      { encoding: "utf8", timeout: 1_500, killSignal: "SIGKILL", windowsHide: true },
     );
     if (tasklist.error || tasklist.status !== 0) {
       return "unknown";


### PR DESCRIPTION
## Problem

`probeProcessState` in `src/daemon/schtasks.ts` calls `spawnSync` on `tasklist.exe` with `timeout: 1_500` but relies on the default `killSignal` (SIGTERM). An unresponsive or hung `tasklist.exe` can ignore SIGTERM, keeping the `spawnSync` blocked past the 1.5s deadline. Since `probeProcessState` is called in a tight loop by `waitForProcessExit` during gateway stop/restart, each stalled probe inflates the polling cycle and can hang doctor/daemon cleanup on Windows.

This is the same class of bug fixed by:
- #109243 (doctor TUI `ps` probe)
- #109731 (gateway pid `ps` probe)

…but the `tasklist.exe` probe in `schtasks.ts` was missed.

## Fix

Force `killSignal: "SIGKILL"` so a stalled `tasklist.exe` is reaped at the deadline instead of hanging the termination path.

- Files changed: 2
- LOC delta: +66 / -1

## Regression proof

New test in `src/daemon/schtasks.stop.test.ts` mocks `process.platform` to `"win32"` and asserts the full `spawnSync` options for `tasklist.exe` include `killSignal: "SIGKILL"`:

\`\`\`
 ✓ |daemon| ../../src/daemon/schtasks.stop.test.ts (21 tests) 977ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
\`\`\`

## Risk

Minimal. Only adds `killSignal: "SIGKILL"` to an existing `spawnSync` call that already has a `timeout: 1_500`. On normal Windows hosts where `tasklist.exe` responds within 1.5s, the kill signal is never delivered. The change only affects the abnormal case where the child ignores SIGTERM.