### PR TITLE
fix(scripts): bound duplicate PR closure GitHub lookups

### DIFF
--- a/scripts/close-duplicate-prs-after-merge.d.mts
+++ b/scripts/close-duplicate-prs-after-merge.d.mts
@@ -26,6 +26,26 @@ export function parseArgs(
       repo: string;
     };
 /**
+ * Runs a GitHub CLI command with the workflow timeout policy.
+ */
+export function defaultRunGh(
+  args: string[],
+  options?: { input?: string },
+  params?: {
+    execFileSyncImpl?: (
+      command: string,
+      args: string[],
+      options: {
+        encoding: "utf8";
+        input?: string;
+        killSignal: "SIGKILL";
+        stdio: ["ignore", "pipe", "inherit"] | ["pipe", "pipe", "inherit"];
+        timeout: number;
+      },
+    ) => string;
+  },
+): string;
+/**
  * Parses changed hunk ranges from unified diff text.
  */
 export function parseUnifiedDiffRanges(diffText: unknown): Map<unknown, unknown>;

--- a/scripts/close-duplicate-prs-after-merge.mjs
+++ b/scripts/close-duplicate-prs-after-merge.mjs
@@ -3,6 +3,10 @@ import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 const DEFAULT_LABELS = ["duplicate", "close:duplicate", "dedupe:child"];
+// Duplicate PR closure performs multiple sequential gh API reads and writes.
+// Keep enough headroom for GitHub latency while preventing one stalled request
+// from blocking the surrounding workflow job.
+const GH_COMMAND_TIMEOUT_MS = 60_000;
 
 function usage() {
   return `Usage: node scripts/close-duplicate-prs-after-merge.mjs --landed-pr <number> --duplicates <numbers> [--repo owner/repo] [--apply]
@@ -89,10 +93,12 @@ function ghJson(args, runGh) {
   return JSON.parse(runGh(args));
 }
 
-function defaultRunGh(args, options = {}) {
+export function defaultRunGh(args, options = {}) {
   return execFileSync("gh", args, {
     encoding: "utf8",
+    killSignal: "SIGKILL",
     stdio: options.input ? ["pipe", "pipe", "inherit"] : ["ignore", "pipe", "inherit"],
+    timeout: GH_COMMAND_TIMEOUT_MS,
     ...(options.input ? { input: options.input } : {}),
   });
 }

--- a/scripts/close-duplicate-prs-after-merge.mjs
+++ b/scripts/close-duplicate-prs-after-merge.mjs
@@ -93,8 +93,9 @@ function ghJson(args, runGh) {
   return JSON.parse(runGh(args));
 }
 
-export function defaultRunGh(args, options = {}) {
-  return execFileSync("gh", args, {
+export function defaultRunGh(args, options = {}, params = {}) {
+  const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
+  return execFileSyncImpl("gh", args, {
     encoding: "utf8",
     killSignal: "SIGKILL",
     stdio: options.input ? ["pipe", "pipe", "inherit"] : ["ignore", "pipe", "inherit"],

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -120,6 +120,17 @@ export function validateCandidateCheckout({
   toolingSha: unknown;
   workflowRef: unknown;
 };
+export function validateTrustedToolingPin({
+  toolingSha,
+  pinnedToolingSha,
+  latestTrustedToolingSha,
+  isAncestor,
+}: {
+  toolingSha: string;
+  pinnedToolingSha: string;
+  latestTrustedToolingSha: string;
+  isAncestor?: (ancestor: string, target: string) => boolean;
+}): string;
 export function candidateCumulativeShippedPullRequests(
   changelog: string,
   label: string,

--- a/test/scripts/close-duplicate-prs-after-merge.test.ts
+++ b/test/scripts/close-duplicate-prs-after-merge.test.ts
@@ -1,8 +1,14 @@
 // Close Duplicate Prs After Merge tests cover close duplicate prs after merge script behavior.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
 
 import {
   applyClosePlan,
@@ -292,5 +298,31 @@ describe("defaultRunGh", () => {
       input: "body",
       stdio: ["pipe", "pipe", "inherit"],
     });
+  });
+});
+
+describe("defaultRunGh real subprocess behavior", () => {
+  // These tests use the real spawnSync (not mocked by vi.mock) to prove the
+  // timeout + SIGKILL surface works against actual child processes.
+  // spawnSync is not in the vi.mock("node:child_process") factory so it
+  // remains the real implementation.
+  it("kills a real subprocess that exceeds a short timeout", () => {
+    const proc = spawnSync("node", ["-e", "setTimeout(() => {}, 60000)"], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: 1,
+    });
+    expect(proc.error).toBeDefined();
+    expect(proc.signal).toBe("SIGKILL");
+  });
+
+  it("completes a real short-lived subprocess within the 60-second bound", () => {
+    const proc = spawnSync("node", ["-e", "process.exit(0)"], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: 60_000,
+    });
+    expect(proc.status).toBe(0);
+    expect(proc.signal).toBeNull();
   });
 });

--- a/test/scripts/close-duplicate-prs-after-merge.test.ts
+++ b/test/scripts/close-duplicate-prs-after-merge.test.ts
@@ -1,8 +1,13 @@
 // Close Duplicate Prs After Merge tests cover close duplicate prs after merge script behavior.
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
 import {
   applyClosePlan,
   buildDuplicateClosePlan,
+  defaultRunGh,
   parseArgs,
   parsePrNumberList,
   parseUnifiedDiffRanges,
@@ -251,5 +256,41 @@ Closing #70592 as a duplicate.`,
       ["pr", "comment", "70592", "--repo", "openclaw/openclaw", "--body", "closing"],
       ["pr", "close", "70592", "--repo", "openclaw/openclaw"],
     ]);
+  });
+});
+
+describe("defaultRunGh", () => {
+  it("bounds each GitHub lookup with a timeout and SIGKILL", () => {
+    const mockExecFileSync = vi.mocked(execFileSync);
+    mockExecFileSync.mockReturnValue("result");
+
+    const result = defaultRunGh(["pr", "view", "123"]);
+
+    expect(result).toBe("result");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    const [command, args, options] = mockExecFileSync.mock.calls[0]!;
+    expect(command).toBe("gh");
+    expect(args).toEqual(["pr", "view", "123"]);
+    expect(options).toMatchObject({
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: 60_000,
+    });
+  });
+
+  it("forwards stdin input while keeping the timeout bound", () => {
+    const mockExecFileSync = vi.mocked(execFileSync);
+    mockExecFileSync.mockReturnValue("ok");
+
+    defaultRunGh(["pr", "edit", "123", "--add-label", "duplicate"], { input: "body" });
+
+    const lastCall = mockExecFileSync.mock.calls.at(-1)!;
+    const options = lastCall[2];
+    expect(options).toMatchObject({
+      killSignal: "SIGKILL",
+      timeout: 60_000,
+      input: "body",
+      stdio: ["pipe", "pipe", "inherit"],
+    });
   });
 });

--- a/test/scripts/close-duplicate-prs-after-merge.test.ts
+++ b/test/scripts/close-duplicate-prs-after-merge.test.ts
@@ -1,15 +1,5 @@
 // Close Duplicate Prs After Merge tests cover close duplicate prs after merge script behavior.
-import { execFileSync, spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
-
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  return {
-    ...actual,
-    execFileSync: vi.fn(),
-  };
-});
-
 import {
   applyClosePlan,
   buildDuplicateClosePlan,
@@ -267,62 +257,50 @@ Closing #70592 as a duplicate.`,
 
 describe("defaultRunGh", () => {
   it("bounds each GitHub lookup with a timeout and SIGKILL", () => {
-    const mockExecFileSync = vi.mocked(execFileSync);
-    mockExecFileSync.mockReturnValue("result");
+    const execFileSyncImpl = vi.fn(() => "result");
 
-    const result = defaultRunGh(["pr", "view", "123"]);
+    const result = defaultRunGh(["pr", "view", "123"], {}, { execFileSyncImpl });
 
     expect(result).toBe("result");
-    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
-    const [command, args, options] = mockExecFileSync.mock.calls[0]!;
-    expect(command).toBe("gh");
-    expect(args).toEqual(["pr", "view", "123"]);
-    expect(options).toMatchObject({
-      encoding: "utf8",
-      killSignal: "SIGKILL",
-      timeout: 60_000,
-    });
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "view", "123"],
+      expect.objectContaining({
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        stdio: ["ignore", "pipe", "inherit"],
+        timeout: 60_000,
+      }),
+    );
   });
 
   it("forwards stdin input while keeping the timeout bound", () => {
-    const mockExecFileSync = vi.mocked(execFileSync);
-    mockExecFileSync.mockReturnValue("ok");
+    const execFileSyncImpl = vi.fn(() => "ok");
 
-    defaultRunGh(["pr", "edit", "123", "--add-label", "duplicate"], { input: "body" });
+    defaultRunGh(
+      ["pr", "edit", "123", "--add-label", "duplicate"],
+      { input: "body" },
+      { execFileSyncImpl },
+    );
 
-    const lastCall = mockExecFileSync.mock.calls.at(-1)!;
-    const options = lastCall[2];
-    expect(options).toMatchObject({
-      killSignal: "SIGKILL",
-      timeout: 60_000,
-      input: "body",
-      stdio: ["pipe", "pipe", "inherit"],
-    });
-  });
-});
-
-describe("defaultRunGh real subprocess behavior", () => {
-  // These tests use the real spawnSync (not mocked by vi.mock) to prove the
-  // timeout + SIGKILL surface works against actual child processes.
-  // spawnSync is not in the vi.mock("node:child_process") factory so it
-  // remains the real implementation.
-  it("kills a real subprocess that exceeds a short timeout", () => {
-    const proc = spawnSync("node", ["-e", "setTimeout(() => {}, 60000)"], {
-      encoding: "utf8",
-      killSignal: "SIGKILL",
-      timeout: 1,
-    });
-    expect(proc.error).toBeDefined();
-    expect(proc.signal).toBe("SIGKILL");
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "edit", "123", "--add-label", "duplicate"],
+      expect.objectContaining({
+        input: "body",
+        killSignal: "SIGKILL",
+        stdio: ["pipe", "pipe", "inherit"],
+        timeout: 60_000,
+      }),
+    );
   });
 
-  it("completes a real short-lived subprocess within the 60-second bound", () => {
-    const proc = spawnSync("node", ["-e", "process.exit(0)"], {
-      encoding: "utf8",
-      killSignal: "SIGKILL",
-      timeout: 60_000,
+  it("propagates timeout failures from the GitHub CLI process", () => {
+    const timeout = Object.assign(new Error("spawnSync gh ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const execFileSyncImpl = vi.fn(() => {
+      throw timeout;
     });
-    expect(proc.status).toBe(0);
-    expect(proc.signal).toBeNull();
+
+    expect(() => defaultRunGh(["pr", "view", "123"], {}, { execFileSyncImpl })).toThrow(timeout);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The duplicate PR closure helper performs multiple sequential `gh` reads and writes after a merge. Each call used `execFileSync` without a timeout, so one stalled GitHub request could consume the surrounding workflow budget indefinitely.

## Why This Change Was Made

The shared `defaultRunGh` owner now applies a 60-second timeout and `SIGKILL` to every GitHub CLI invocation. This covers the landed-PR lookup, candidate lookups and diffs, plus label/comment/close mutations while preserving the existing stdin and stdio behavior.

The runner accepts an injected subprocess implementation for deterministic contract tests. That keeps unit proof attached to the production boundary instead of globally mocking `node:child_process` or separately testing an unrelated `spawnSync` call.

## User Impact

Duplicate PR closure no longer waits indefinitely on a stalled GitHub subprocess. Healthy behavior is unchanged; a request that exceeds one minute fails so the workflow can be inspected or retried.

## Evidence

Exact head: `230d9f0e090c29c728b95bad4ef7340c376f6d7c`, based on `556a2ee276f08192bd1644a4f4f40b8812ef37dd`.

- Focused tests: `node scripts/run-vitest.mjs test/scripts/close-duplicate-prs-after-merge.test.ts test/scripts/release-candidate-checklist.test.ts` — 65/65 passed.
- Declaration gate: `node scripts/check-script-declarations.mjs` — all 235 contracts match. This repairs the current-main `validateTrustedToolingPin` declaration drift that caused the first exact-head CI run to fail independently of the timeout change.
- Live subprocess proof on Testbox `tbx_01kxvncvt48b40mc8d5dd1kvg6`: the production helper completed a real `gh --version`; an injected real stalled Node child received the production 60-second policy and, under a shortened proof timeout, failed with `ETIMEDOUT` and `SIGKILL`.
- Full changed gate: `pnpm check:changed` passed the scripts, testRoot, and tooling lanes in run 29664031028.
- Final autoreview: clean, confidence 0.96.
- Exact-head hosted CI: run 29664173453 passed.
