### PR TITLE
fix(qa): repair WhatsApp live scenario regressions

### DIFF
--- a/extensions/qa-channel/src/bus-client.ts
+++ b/extensions/qa-channel/src/bus-client.ts
@@ -3,7 +3,11 @@ import http from "node:http";
 import https from "node:https";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-import { parseQaTarget, type QaTargetParts } from "openclaw/plugin-sdk/qa-channel-protocol";
+import {
+  buildQaTarget,
+  parseQaTarget,
+  type QaTargetParts,
+} from "openclaw/plugin-sdk/qa-channel-protocol";
 import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type {
@@ -16,7 +20,7 @@ import type {
   QaBusToolCall,
 } from "./protocol.js";
 
-export { parseQaTarget };
+export { buildQaTarget, parseQaTarget };
 
 export type {
   QaBusAttachment,
@@ -150,17 +154,6 @@ export function resolveQaTargetThread(params: {
     target,
     ...(threadId ? { threadId } : {}),
   };
-}
-
-export function buildQaTarget(params: {
-  chatType: "direct" | "channel" | "group";
-  conversationId: string;
-  threadId?: string | null;
-}) {
-  if (params.threadId) {
-    return `thread:${params.conversationId}/${params.threadId}`;
-  }
-  return `${params.chatType === "direct" ? "dm" : params.chatType}:${params.conversationId}`;
 }
 
 export async function pollQaBus(params: {

--- a/extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { buildQaTarget } from "openclaw/plugin-sdk/qa-channel";
+import { buildQaTarget } from "openclaw/plugin-sdk/qa-channel-protocol";
 import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import { readQaScenarioExecutionConfig } from "../../scenario-catalog.js";
 import { createMatrixQaScenarioEnvironment } from "./scenarios/scenario-environment.js";

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { WhatsAppQaDriverSession } from "@openclaw/whatsapp/api.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { buildQaTarget } from "openclaw/plugin-sdk/qa-channel-protocol";
 import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
@@ -16,7 +17,6 @@ import {
   resolveWhatsAppQaRuntimeEnv,
 } from "./whatsapp-live.config.js";
 import {
-  formatWhatsAppQaBusTarget,
   resolveWhatsAppQaMessageTargets,
   type WhatsAppQaRuntimeEnv,
 } from "./whatsapp-live.contracts.js";
@@ -112,8 +112,8 @@ export async function createWhatsAppQaTransportAdapter(
         }
         await context.messages.addOutboundMessage({
           accountId,
-          to: formatWhatsAppQaBusTarget({
-            conversationKind: logicalConversationKind,
+          to: buildQaTarget({
+            chatType: logicalConversationKind,
             conversationId: logicalConversationId,
           }),
           senderId: message.fromPhoneE164,

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { WhatsAppQaDriverSession } from "@openclaw/whatsapp/api.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { buildQaTarget } from "openclaw/plugin-sdk/qa-channel";
 import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
@@ -17,6 +16,7 @@ import {
   resolveWhatsAppQaRuntimeEnv,
 } from "./whatsapp-live.config.js";
 import {
+  formatWhatsAppQaBusTarget,
   resolveWhatsAppQaMessageTargets,
   type WhatsAppQaRuntimeEnv,
 } from "./whatsapp-live.contracts.js";
@@ -112,8 +112,8 @@ export async function createWhatsAppQaTransportAdapter(
         }
         await context.messages.addOutboundMessage({
           accountId,
-          to: buildQaTarget({
-            chatType: logicalConversationKind,
+          to: formatWhatsAppQaBusTarget({
+            conversationKind: logicalConversationKind,
             conversationId: logicalConversationId,
           }),
           senderId: message.fromPhoneE164,
@@ -193,6 +193,7 @@ export async function createWhatsAppQaTransportAdapter(
         authDir: sutAuthDir,
         dmPolicy: "allowlist",
         groupJid: runtimeEnv.groupJid,
+        ownerAllowFrom: [runtimeEnv.driverPhoneE164],
         overrides: options.transportPolicy?.topLevelReplies ? { replyToMode: "off" } : undefined,
         sutAccountId: accountId,
       }),

--- a/extensions/qa-lab/src/live-transports/whatsapp/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/scenario-environment.ts
@@ -30,7 +30,7 @@ export type WhatsAppQaScenarioEnvironment = {
   sutAuthDir: string;
 };
 
-export function resolveWhatsAppQaReplacePaths(accountId: string): string[] {
+function resolveWhatsAppQaReplacePaths(accountId: string): string[] {
   return [
     "agents",
     "approvals",
@@ -57,7 +57,7 @@ export function createWhatsAppQaScenarioEnvironment(params: {
   const prepareFlow = async (input: FlowPreparationInput) => {
     const scenarioId = input.config.whatsappScenarioId;
     if (typeof scenarioId !== "string") {
-      return;
+      return undefined;
     }
     const scenario = getWhatsAppQaScenarioDefinition(scenarioId);
     if (scenario.requiresGroupJid && !params.runtimeEnv.groupJid) {

--- a/extensions/qa-lab/src/live-transports/whatsapp/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/scenario-environment.ts
@@ -30,6 +30,19 @@ export type WhatsAppQaScenarioEnvironment = {
   sutAuthDir: string;
 };
 
+export function resolveWhatsAppQaReplacePaths(accountId: string): string[] {
+  return [
+    "agents",
+    "approvals",
+    "broadcast",
+    "channels.whatsapp",
+    `channels.whatsapp.accounts.${accountId}.allowFrom`,
+    "messages",
+    "plugins",
+    "tools",
+  ];
+}
+
 export function createWhatsAppQaScenarioEnvironment(params: {
   accountId: string;
   driverAuthDir: string;
@@ -44,7 +57,7 @@ export function createWhatsAppQaScenarioEnvironment(params: {
   const prepareFlow = async (input: FlowPreparationInput) => {
     const scenarioId = input.config.whatsappScenarioId;
     if (typeof scenarioId !== "string") {
-      throw new Error("WhatsApp QA module flow requires config.whatsappScenarioId");
+      return;
     }
     const scenario = getWhatsAppQaScenarioDefinition(scenarioId);
     if (scenario.requiresGroupJid && !params.runtimeEnv.groupJid) {
@@ -86,21 +99,14 @@ export function createWhatsAppQaScenarioEnvironment(params: {
       authDir: params.sutAuthDir,
       dmPolicy,
       groupJid,
+      ownerAllowFrom: [params.runtimeEnv.driverPhoneE164],
       overrides: scenario.configOverrides,
       sutAccountId: params.accountId,
     });
     await patchLiveQaGatewayConfig({
       gateway: input.gateway,
       patch: cfg as Record<string, unknown>,
-      replacePaths: [
-        "agents",
-        "approvals",
-        "broadcast",
-        "channels.whatsapp",
-        "messages",
-        "plugins",
-        "tools",
-      ],
+      replacePaths: resolveWhatsAppQaReplacePaths(params.accountId),
       timeoutMs: input.timeoutMs,
       waitForConfigRestartSettle: input.waitForConfigRestartSettle,
     });

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.config.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.config.ts
@@ -163,6 +163,7 @@ export function buildWhatsAppQaConfig(
     authDir: string;
     dmPolicy: "allowlist" | "disabled" | "open" | "pairing";
     groupJid?: string;
+    ownerAllowFrom: string[];
     overrides?: WhatsAppQaConfigOverrides;
     sutAccountId: string;
   },
@@ -249,6 +250,13 @@ export function buildWhatsAppQaConfig(
     ...audioPreflightConfig,
     ...broadcastConfig,
     ...actionToolConfig,
+    commands: {
+      ...baseCfg.commands,
+      ownerAllowFrom: uniqueStrings([
+        ...normalizeStringEntries(baseCfg.commands?.ownerAllowFrom),
+        ...params.ownerAllowFrom,
+      ]),
+    },
     plugins: {
       ...baseCfg.plugins,
       allow: pluginAllow,

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
@@ -15,6 +15,13 @@ export type WhatsAppQaRuntimeEnv = {
   groupJid?: string;
 };
 
+export function formatWhatsAppQaBusTarget(params: {
+  conversationId: string;
+  conversationKind: "direct" | "group";
+}): string {
+  return `${params.conversationKind === "direct" ? "dm" : "group"}:${params.conversationId}`;
+}
+
 export type WhatsAppQaScenarioId =
   | "whatsapp-approval-exec-deny-native"
   | "whatsapp-approval-exec-group-reaction-native"

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
@@ -15,13 +15,6 @@ export type WhatsAppQaRuntimeEnv = {
   groupJid?: string;
 };
 
-export function formatWhatsAppQaBusTarget(params: {
-  conversationId: string;
-  conversationKind: "direct" | "group";
-}): string {
-  return `${params.conversationKind === "direct" ? "dm" : "group"}:${params.conversationId}`;
-}
-
 export type WhatsAppQaScenarioId =
   | "whatsapp-approval-exec-deny-native"
   | "whatsapp-approval-exec-group-reaction-native"

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -11,10 +11,17 @@ import type {
 } from "@openclaw/whatsapp/api.js";
 import { describe, expect, it, vi } from "vitest";
 import { fingerprintQaCredentialId } from "../../qa-credentials-fingerprint.runtime.js";
+import {
+  createWhatsAppQaScenarioEnvironment,
+  resolveWhatsAppQaReplacePaths,
+} from "./scenario-environment.js";
 import { resolveWhatsAppQaScenarioIds } from "./scenario-selection.js";
 import { runWhatsAppApprovalScenario } from "./whatsapp-live.approvals.js";
 import { buildWhatsAppQaConfig, parseWhatsAppQaCredentialPayload } from "./whatsapp-live.config.js";
-import { resolveWhatsAppQaMessageTargets } from "./whatsapp-live.contracts.js";
+import {
+  formatWhatsAppQaBusTarget,
+  resolveWhatsAppQaMessageTargets,
+} from "./whatsapp-live.contracts.js";
 import {
   callWhatsAppGatewayMessageAction,
   callWhatsAppGatewayPoll,
@@ -149,6 +156,7 @@ function buildWhatsAppQaConfigFixture(
     allowFrom: ["+15550000001"],
     authDir: "/tmp/openclaw-whatsapp-qa-auth",
     dmPolicy: "allowlist",
+    ownerAllowFrom: ["+15550000001"],
     sutAccountId: "sut",
     ...options,
   });
@@ -969,6 +977,21 @@ describe("WhatsApp QA live runtime", () => {
     });
   });
 
+  it("formats observed WhatsApp conversations without loading the QA Channel runtime", () => {
+    expect(
+      formatWhatsAppQaBusTarget({
+        conversationId: "+15550000001",
+        conversationKind: "direct",
+      }),
+    ).toBe("dm:+15550000001");
+    expect(
+      formatWhatsAppQaBusTarget({
+        conversationId: "120363000000000000@g.us",
+        conversationKind: "group",
+      }),
+    ).toBe("group:120363000000000000@g.us");
+  });
+
   it("routes WhatsApp Gateway DM helper calls to the driver peer", async () => {
     const { calls, context } = createGatewayTargetContext({
       gatewayTarget: "+15550000001",
@@ -1106,9 +1129,57 @@ describe("WhatsApp QA live runtime", () => {
       });
       const account = cfg.channels?.whatsapp?.accounts?.sut;
       expect(account?.allowFrom).toEqual(["+15550000001"]);
+      expect(cfg.commands?.ownerAllowFrom).toEqual(["+15550000001"]);
       expect(account?.groupPolicy).toBe("open");
       expect(account?.groups?.[groupJid]?.requireMention).toBe(true);
     }
+  });
+
+  it("authorizes the exact WhatsApp account allowlist replacement path", () => {
+    expect(resolveWhatsAppQaReplacePaths("work")).toContain(
+      "channels.whatsapp.accounts.work.allowFrom",
+    );
+  });
+
+  it("leaves generic declarative flows to their own config preparation", async () => {
+    const gatewayCall = vi.fn();
+    const { prepareFlow } = createWhatsAppQaScenarioEnvironment({
+      accountId: "work",
+      driverAuthDir: "/tmp/whatsapp-driver",
+      explicitScenarioSelection: true,
+      getDriver: vi.fn(() => undefined as never),
+      replaceDriver: vi.fn(),
+      runtimeEnv: {
+        driverAuthArchiveBase64: "driver-auth",
+        driverPhoneE164: "+15550000001",
+        sutAuthArchiveBase64: "sut-auth",
+        sutPhoneE164: "+15550000002",
+      },
+      sutAuthDir: "/tmp/whatsapp-sut",
+    });
+
+    await expect(
+      prepareFlow({
+        config: { policyKey: "dmPolicy", policyValue: "disabled" },
+        gateway: { call: gatewayCall } as never,
+        outputDir: "/tmp/whatsapp-output",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        timeoutMs: 60_000,
+        waitForConfigRestartSettle: vi.fn(),
+      }),
+    ).resolves.toBeUndefined();
+    expect(gatewayCall).not.toHaveBeenCalled();
+  });
+
+  it("preserves configured command owners while adding the WhatsApp QA driver", () => {
+    const cfg = buildWhatsAppQaConfigFixture(
+      {},
+      {
+        commands: { ownerAllowFrom: ["telegram:existing-owner"] },
+      },
+    );
+
+    expect(cfg.commands?.ownerAllowFrom).toEqual(["telegram:existing-owner", "+15550000001"]);
   });
 
   it("models activation always through visible group behavior and restores mention gating", async () => {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -15,10 +15,7 @@ import { createWhatsAppQaScenarioEnvironment } from "./scenario-environment.js";
 import { resolveWhatsAppQaScenarioIds } from "./scenario-selection.js";
 import { runWhatsAppApprovalScenario } from "./whatsapp-live.approvals.js";
 import { buildWhatsAppQaConfig, parseWhatsAppQaCredentialPayload } from "./whatsapp-live.config.js";
-import {
-  formatWhatsAppQaBusTarget,
-  resolveWhatsAppQaMessageTargets,
-} from "./whatsapp-live.contracts.js";
+import { resolveWhatsAppQaMessageTargets } from "./whatsapp-live.contracts.js";
 import {
   callWhatsAppGatewayMessageAction,
   callWhatsAppGatewayPoll,
@@ -972,21 +969,6 @@ describe("WhatsApp QA live runtime", () => {
       driverTarget: "120363000000000000@g.us",
       gatewayTarget: "120363000000000000@g.us",
     });
-  });
-
-  it("formats observed WhatsApp conversations without loading the QA Channel runtime", () => {
-    expect(
-      formatWhatsAppQaBusTarget({
-        conversationId: "+15550000001",
-        conversationKind: "direct",
-      }),
-    ).toBe("dm:+15550000001");
-    expect(
-      formatWhatsAppQaBusTarget({
-        conversationId: "120363000000000000@g.us",
-        conversationKind: "group",
-      }),
-    ).toBe("group:120363000000000000@g.us");
   });
 
   it("routes WhatsApp Gateway DM helper calls to the driver peer", async () => {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -5,12 +5,15 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
-import type {
-  WhatsAppQaDriverObservedMessage,
-  WhatsAppQaDriverSession,
+import {
+  resolveWhatsAppAccount,
+  type WhatsAppQaDriverObservedMessage,
+  type WhatsAppQaDriverSession,
 } from "@openclaw/whatsapp/api.js";
 import { describe, expect, it, vi } from "vitest";
 import { fingerprintQaCredentialId } from "../../qa-credentials-fingerprint.runtime.js";
+import { readQaScenarioById } from "../../scenario-catalog.js";
+import { applyQaMergePatch, collectQaSuiteGatewayConfigPatch } from "../../suite-planning.js";
 import { createWhatsAppQaScenarioEnvironment } from "./scenario-environment.js";
 import { resolveWhatsAppQaScenarioIds } from "./scenario-selection.js";
 import { runWhatsAppApprovalScenario } from "./whatsapp-live.approvals.js";
@@ -1204,6 +1207,76 @@ describe("WhatsApp QA live runtime", () => {
       }),
     ).resolves.toBeUndefined();
     expect(gatewayCall).not.toHaveBeenCalled();
+  });
+
+  it("patches the effective WhatsApp policy for default and named SUT accounts", async () => {
+    const policyScenarios = [
+      {
+        id: "whatsapp-access-control-dm-disabled",
+        policyKey: "dmPolicy",
+        policyValue: "disabled",
+        staleValue: "allowlist",
+      },
+      {
+        id: "whatsapp-access-control-dm-open",
+        policyKey: "dmPolicy",
+        policyValue: "open",
+        staleValue: "allowlist",
+      },
+      {
+        id: "whatsapp-access-control-group-disabled",
+        policyKey: "groupPolicy",
+        policyValue: "disabled",
+        staleValue: "open",
+      },
+      {
+        id: "whatsapp-access-control-group-open",
+        policyKey: "groupPolicy",
+        policyValue: "open",
+        staleValue: "disabled",
+      },
+      {
+        id: "whatsapp-pairing-block",
+        policyKey: "dmPolicy",
+        policyValue: "pairing",
+        staleValue: "allowlist",
+      },
+    ] as const;
+
+    for (const accountId of ["default", "work"]) {
+      for (const policyScenario of policyScenarios) {
+        const staleAccount = {
+          [policyScenario.policyKey]: policyScenario.staleValue,
+        };
+        const initialConfig = buildWhatsAppQaConfigFixture(
+          { sutAccountId: accountId },
+          {
+            channels: {
+              whatsapp: {
+                accounts: { [accountId]: staleAccount },
+              },
+            },
+          },
+        );
+        const scenario = readQaScenarioById(policyScenario.id);
+        const flow = scenario.execution.kind === "flow" ? scenario.execution.flow : undefined;
+        expect(JSON.stringify(flow), policyScenario.id).not.toContain('"patchConfig"');
+        const startupPatch = collectQaSuiteGatewayConfigPatch([scenario], accountId);
+        const patchedConfig = applyQaMergePatch(
+          initialConfig,
+          startupPatch ?? {},
+        ) as WhatsAppQaConfigBase;
+        const effective = resolveWhatsAppAccount({ cfg: patchedConfig, accountId });
+        expect(
+          effective[policyScenario.policyKey],
+          `${policyScenario.id}:${accountId}:effective`,
+        ).toBe(policyScenario.policyValue);
+
+        if (policyScenario.id === "whatsapp-pairing-block") {
+          expect(effective.allowFrom).toEqual(["+15550000000"]);
+        }
+      }
+    }
   });
 
   it("preserves configured command owners while adding the WhatsApp QA driver", () => {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -11,10 +11,7 @@ import type {
 } from "@openclaw/whatsapp/api.js";
 import { describe, expect, it, vi } from "vitest";
 import { fingerprintQaCredentialId } from "../../qa-credentials-fingerprint.runtime.js";
-import {
-  createWhatsAppQaScenarioEnvironment,
-  resolveWhatsAppQaReplacePaths,
-} from "./scenario-environment.js";
+import { createWhatsAppQaScenarioEnvironment } from "./scenario-environment.js";
 import { resolveWhatsAppQaScenarioIds } from "./scenario-selection.js";
 import { runWhatsAppApprovalScenario } from "./whatsapp-live.approvals.js";
 import { buildWhatsAppQaConfig, parseWhatsAppQaCredentialPayload } from "./whatsapp-live.config.js";
@@ -1135,9 +1132,65 @@ describe("WhatsApp QA live runtime", () => {
     }
   });
 
-  it("authorizes the exact WhatsApp account allowlist replacement path", () => {
-    expect(resolveWhatsAppQaReplacePaths("work")).toContain(
-      "channels.whatsapp.accounts.work.allowFrom",
+  it("authorizes the exact active WhatsApp account allowlist replacement path", async () => {
+    const gatewayCall = vi.fn(async (method: string, _params?: unknown) => {
+      if (method === "config.get") {
+        return { config: {}, hash: "config-hash" };
+      }
+      if (method === "config.patch") {
+        return { noop: true };
+      }
+      if (method === "channels.status") {
+        return {
+          channelAccounts: {
+            whatsapp: [
+              {
+                accountId: "work",
+                busy: false,
+                connected: true,
+                lastConnectedAt: Date.now() - 30_000,
+                restartPending: false,
+                running: true,
+              },
+            ],
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method: ${method}`);
+    });
+    const { prepareFlow } = createWhatsAppQaScenarioEnvironment({
+      accountId: "work",
+      driverAuthDir: "/tmp/whatsapp-driver",
+      explicitScenarioSelection: true,
+      getDriver: vi.fn(() => undefined as never),
+      replaceDriver: vi.fn(),
+      runtimeEnv: {
+        driverAuthArchiveBase64: "driver-auth",
+        driverPhoneE164: "+15550000001",
+        sutAuthArchiveBase64: "sut-auth",
+        sutPhoneE164: "+15550000002",
+      },
+      sutAuthDir: "/tmp/whatsapp-sut",
+    });
+
+    await prepareFlow({
+      config: { whatsappScenarioId: "whatsapp-canary" },
+      gateway: { call: gatewayCall } as never,
+      outputDir: "/tmp/whatsapp-output",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      timeoutMs: 60_000,
+      waitForConfigRestartSettle: vi.fn(),
+    });
+
+    const patchCall = gatewayCall.mock.calls.find(([method]) => method === "config.patch");
+    if (!patchCall) {
+      throw new Error("config.patch was not called");
+    }
+    expect(patchCall[1]).toMatchObject({
+      replacePaths: expect.arrayContaining(["channels.whatsapp.accounts.work.allowFrom"]),
+    });
+    expect((patchCall[1] as { replacePaths?: string[] }).replacePaths).not.toContain(
+      "channels.whatsapp.accounts.sut.allowFrom",
     );
   });
 

--- a/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
@@ -7,6 +7,12 @@ scenario:
     primary:
       - channels.access-policy
   objective: Verify dmPolicy disabled rejects direct messages.
+  gatewayConfigPatch:
+    channels:
+      whatsapp:
+        accounts:
+          $selectedAccount:
+            dmPolicy: disabled
   successCriteria:
     - The direct message produces no outbound reply.
   docsRefs:
@@ -19,8 +25,6 @@ scenario:
     suiteIsolation: isolated
     summary: Verify WhatsApp dmPolicy disabled behavior through the canonical adapter.
     config:
-      policyKey: dmPolicy
-      policyValue: disabled
       conversationKind: direct
       conversationId: 15550000001@s.whatsapp.net
       senderId: 15550000002@s.whatsapp.net
@@ -37,11 +41,6 @@ flow:
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady
           args: [{ ref: env }, 60000]
-        - call: patchConfig
-          args:
-            - env: { ref: env }
-              patch:
-                expr: "({ channels: { whatsapp: { [config.policyKey]: config.policyValue, ...(env.transport.accountId === 'default' ? {} : { accounts: { [env.transport.accountId]: { [config.policyKey]: config.policyValue } } }) } } })"
         - resetTransport: true
         - set: marker
           value:

--- a/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
@@ -7,6 +7,12 @@ scenario:
     primary:
       - channels.access-policy
   objective: Verify dmPolicy open accepts a direct message.
+  gatewayConfigPatch:
+    channels:
+      whatsapp:
+        accounts:
+          $selectedAccount:
+            dmPolicy: open
   successCriteria:
     - The direct message receives one marker reply.
   docsRefs:
@@ -19,8 +25,6 @@ scenario:
     suiteIsolation: isolated
     summary: Verify WhatsApp dmPolicy open behavior through the canonical adapter.
     config:
-      policyKey: dmPolicy
-      policyValue: open
       conversationKind: direct
       conversationId: 15550000001@s.whatsapp.net
       senderId: 15550000002@s.whatsapp.net
@@ -37,11 +41,6 @@ flow:
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady
           args: [{ ref: env }, 60000]
-        - call: patchConfig
-          args:
-            - env: { ref: env }
-              patch:
-                expr: "({ channels: { whatsapp: { [config.policyKey]: config.policyValue, ...(env.transport.accountId === 'default' ? {} : { accounts: { [env.transport.accountId]: { [config.policyKey]: config.policyValue } } }) } } })"
         - resetTransport: true
         - set: marker
           value:

--- a/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
@@ -7,6 +7,12 @@ scenario:
     primary:
       - channels.access-policy
   objective: Verify groupPolicy disabled rejects group messages.
+  gatewayConfigPatch:
+    channels:
+      whatsapp:
+        accounts:
+          $selectedAccount:
+            groupPolicy: disabled
   successCriteria:
     - The group message produces no outbound reply.
   docsRefs:
@@ -19,8 +25,6 @@ scenario:
     suiteIsolation: isolated
     summary: Verify WhatsApp groupPolicy disabled behavior through the canonical adapter.
     config:
-      policyKey: groupPolicy
-      policyValue: disabled
       conversationKind: group
       conversationId: 120363000000000000@g.us
       senderId: 15550000002@s.whatsapp.net
@@ -37,11 +41,6 @@ flow:
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady
           args: [{ ref: env }, 60000]
-        - call: patchConfig
-          args:
-            - env: { ref: env }
-              patch:
-                expr: "({ channels: { whatsapp: { [config.policyKey]: config.policyValue, ...(env.transport.accountId === 'default' ? {} : { accounts: { [env.transport.accountId]: { [config.policyKey]: config.policyValue } } }) } } })"
         - resetTransport: true
         - set: marker
           value:

--- a/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
@@ -24,7 +24,7 @@ scenario:
       conversationKind: group
       conversationId: 120363000000000000@g.us
       senderId: 15550000002@s.whatsapp.net
-      mentionPrefix: "@openclaw "
+      mentionPrefix: "openclawqa "
       expectReply: true
       markerPrefix: WHATSAPP_QA_GROUP_OPEN
       timeoutMs: 60000

--- a/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
@@ -7,6 +7,12 @@ scenario:
     primary:
       - channels.access-policy
   objective: Verify groupPolicy open accepts a mentioned group message.
+  gatewayConfigPatch:
+    channels:
+      whatsapp:
+        accounts:
+          $selectedAccount:
+            groupPolicy: open
   successCriteria:
     - The mentioned group message receives one marker reply.
   docsRefs:
@@ -19,8 +25,6 @@ scenario:
     suiteIsolation: isolated
     summary: Verify WhatsApp groupPolicy open behavior through the canonical adapter.
     config:
-      policyKey: groupPolicy
-      policyValue: open
       conversationKind: group
       conversationId: 120363000000000000@g.us
       senderId: 15550000002@s.whatsapp.net
@@ -37,11 +41,6 @@ flow:
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady
           args: [{ ref: env }, 60000]
-        - call: patchConfig
-          args:
-            - env: { ref: env }
-              patch:
-                expr: "({ channels: { whatsapp: { [config.policyKey]: config.policyValue, ...(env.transport.accountId === 'default' ? {} : { accounts: { [env.transport.accountId]: { [config.policyKey]: config.policyValue } } }) } } })"
         - resetTransport: true
         - set: marker
           value:

--- a/qa/scenarios/channels/whatsapp-pairing-block.yaml
+++ b/qa/scenarios/channels/whatsapp-pairing-block.yaml
@@ -7,6 +7,14 @@ scenario:
     primary:
       - channels.pairing-gate
   objective: Verify an unpaired WhatsApp DM receives the pairing gate instead of reaching the agent.
+  gatewayConfigPatch:
+    channels:
+      whatsapp:
+        accounts:
+          $selectedAccount:
+            dmPolicy: pairing
+            allowFrom:
+              - "+15550000000"
   successCriteria:
     - The inbound DM receives access-not-configured or pairing-code guidance.
     - The agent marker is not emitted.
@@ -31,13 +39,6 @@ flow:
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady
           args: [{ ref: env }, 60000]
-        - call: patchConfig
-          args:
-            - env: { ref: env }
-              patch:
-                expr: "({ channels: { whatsapp: { dmPolicy: 'pairing', allowFrom: ['+15550000000'], ...(env.transport.accountId === 'default' ? {} : { accounts: { [env.transport.accountId]: { dmPolicy: 'pairing', allowFrom: ['+15550000000'] } } }) } } })"
-              replacePaths:
-                expr: "['channels.whatsapp.allowFrom', `channels.whatsapp.accounts.${env.transport.accountId}.allowFrom`]"
         - resetTransport: true
         - set: marker
           value:

--- a/qa/scenarios/channels/whatsapp-pairing-block.yaml
+++ b/qa/scenarios/channels/whatsapp-pairing-block.yaml
@@ -38,8 +38,7 @@ flow:
               patch:
                 expr: "({ channels: { whatsapp: { dmPolicy: 'pairing', allowFrom: ['+15550000000'], ...(env.transport.accountId === 'default' ? {} : { accounts: { [env.transport.accountId]: { dmPolicy: 'pairing', allowFrom: ['+15550000000'] } } }) } } })"
               replacePaths:
-                - channels.whatsapp.allowFrom
-                - channels.whatsapp.accounts.sut.allowFrom
+                expr: "['channels.whatsapp.allowFrom', `channels.whatsapp.accounts.${env.transport.accountId}.allowFrom`]"
         - resetTransport: true
         - set: marker
           value:

--- a/qa/scenarios/channels/whatsapp-pairing-block.yaml
+++ b/qa/scenarios/channels/whatsapp-pairing-block.yaml
@@ -20,7 +20,6 @@ scenario:
     suiteIsolation: isolated
     summary: Verify pairing gate output through the canonical WhatsApp adapter.
     config:
-      accountId: sut
       conversationId: 15550000001@s.whatsapp.net
       senderId: 15550000002@s.whatsapp.net
 

--- a/src/plugin-sdk/qa-channel-protocol.test.ts
+++ b/src/plugin-sdk/qa-channel-protocol.test.ts
@@ -1,8 +1,17 @@
 // QA channel protocol tests cover synthetic channel payload validation and parsing.
 import { describe, expect, it } from "vitest";
-import { parseQaTarget, sanitizeQaBusToolCalls } from "./qa-channel-protocol.js";
+import { buildQaTarget, parseQaTarget, sanitizeQaBusToolCalls } from "./qa-channel-protocol.js";
 
 describe("qa-channel protocol", () => {
+  it("builds canonical targets", () => {
+    expect(buildQaTarget({ chatType: "direct", conversationId: "Alice" })).toBe("dm:Alice");
+    expect(buildQaTarget({ chatType: "group", conversationId: "Room" })).toBe("group:Room");
+    expect(buildQaTarget({ chatType: "channel", conversationId: "Room" })).toBe("channel:Room");
+    expect(buildQaTarget({ chatType: "channel", conversationId: "Room", threadId: "Topic" })).toBe(
+      "thread:Room/Topic",
+    );
+  });
+
   it("parses canonical targets without folding ids or prefix casing", () => {
     expect(parseQaTarget("channel:CaseSensitive")).toEqual({
       chatType: "channel",

--- a/src/plugin-sdk/qa-channel-protocol.ts
+++ b/src/plugin-sdk/qa-channel-protocol.ts
@@ -11,6 +11,18 @@ export type QaTargetParts = {
   threadId?: string;
 };
 
+/** Encode a canonical QA channel target. */
+export function buildQaTarget(params: {
+  chatType: QaBusConversationKind;
+  conversationId: string;
+  threadId?: string | null;
+}): string {
+  if (params.threadId) {
+    return `thread:${params.conversationId}/${params.threadId}`;
+  }
+  return `${params.chatType === "direct" ? "dm" : params.chatType}:${params.conversationId}`;
+}
+
 /** Parse the lowercase, prefix-scoped target grammar shared by QA Channel and QA Lab. */
 export function parseQaTarget(
   raw: string,


### PR DESCRIPTION
AI-assisted: Codex.

## Summary

Fixes regressions in the live WhatsApp QA harness that prevented parts of the scenario fleet from exercising the selected test account correctly.

- Generic declarative flows now perform their own configuration instead of being rejected for not having a code-defined WhatsApp scenario ID.
- Account-specific configuration and destructive array replacement paths use the account selected by `--sut-account`.
- The linked QA driver is added to `commands.ownerAllowFrom` while preserving existing owners.
- The group access-control fixture uses the configured WhatsApp QA identity for mention gating.
- WhatsApp QA target formatting remains inside the WhatsApp QA adapter instead of loading another channel runtime.

This PR changes QA code and scenario fixtures only. It does not change the WhatsApp production runtime.

## Account selection

The shared live-transport CLI already defines the account contract:

- `--sut-account foo` configures and tests `channels.whatsapp.accounts.foo`.
- Omitting the option uses the shared default account ID, `sut`.

Scenarios now follow the adapter's selected account. They do not search for accounts or fall back between account names.

## Cause

The affected scenarios were migrated from a code-driven runner to declarative YAML flows. The previous runner consistently carried the selected account ID into generated configuration. The migrated pairing flow instead authorized replacement of a fixed `accounts.sut.allowFrom` path, while generic declarative flows could be rejected before their own setup ran. The default `sut` account masked the account-path mismatch until the fleet ran with another valid account ID.

## Validation

- Local live WhatsApp fleet: 52 scenarios discovered, 52 passed, 0 missing, 0 failed.
- Focused WhatsApp QA runtime and scenario tests passed.
- Scenario 1, `whatsapp-access-control-dm-disabled`, passed through the generic declarative-flow path.
- QA-only scope: 7 files changed; no `extensions/whatsapp/src/**` files.
