### PR TITLE
fix(cli): bound exec approvals --file JSON read size

### DIFF
--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -233,6 +233,24 @@ describe("exec approvals CLI", () => {
     await program.parseAsync(args, { from: "user" });
   };
 
+  const runNativeApprovalsFileCommand = async (filePath: string) => {
+    callGatewayFromCli.mockResolvedValue({
+      enabled: true,
+      hash: "sha256:current",
+      defaultAction: "deny",
+      rules: [],
+    } as never);
+    await runApprovalsCommand([
+      "approvals",
+      "set",
+      "--node",
+      "windows",
+      "--file",
+      filePath,
+      "--json",
+    ]);
+  };
+
   beforeEach(() => {
     resetLocalSnapshot();
     runtimeErrors.length = 0;
@@ -858,49 +876,74 @@ describe("exec approvals CLI", () => {
     );
   });
 
-  it("bounds approvals JSON read from --file via readRegularFile", async () => {
+  it("reads approvals JSON from a regular file", async () => {
     const dir = tempDirs.make("openclaw-approvals-file-bound-");
-    const normalPath = path.join(dir, "normal.json");
-    const oversizedPath = path.join(dir, "oversized.json");
-    fs.writeFileSync(normalPath, JSON.stringify({ defaultAction: "deny", rules: [] }));
-    fs.writeFileSync(oversizedPath, Buffer.alloc(1024 * 1024 + 1, "x"));
+    const filePath = path.join(dir, "approvals.json");
+    fs.writeFileSync(filePath, JSON.stringify({ defaultAction: "deny", rules: [] }));
 
-    const mockSnapshot = {
-      enabled: true,
-      hash: "sha256:current",
-      defaultAction: "deny",
-      rules: [],
-    } as never;
+    await runNativeApprovalsFileCommand(filePath);
 
-    // Normal file (under limit) with valid JSON should succeed.
-    callGatewayFromCli.mockResolvedValue(mockSnapshot);
-    await runApprovalsCommand([
-      "approvals",
-      "set",
-      "--node",
-      "windows",
-      "--file",
-      normalPath,
-      "--json",
+    expect(callGatewayFromCli.mock.calls.map(([method]) => method)).toEqual([
+      "exec.approvals.node.get",
+      "exec.approvals.node.set",
+      "exec.approvals.node.get",
     ]);
-    expect(callGatewayFromCli).toHaveBeenCalled();
     expect(runtimeErrors).toHaveLength(0);
+  });
 
-    // Oversized file (> 1 MiB) should be rejected before the gateway call.
-    callGatewayFromCli.mockClear();
-    callGatewayFromCli.mockResolvedValue(mockSnapshot);
-    await expect(
-      runApprovalsCommand(["approvals", "set", "--node", "windows", "--file", oversizedPath]),
-    ).rejects.toThrow("__exit__:1");
-    expect(runtimeErrors[0]).toContain("exceeds");
+  it("rejects an oversized approvals file", async () => {
+    const dir = tempDirs.make("openclaw-approvals-file-bound-");
+    const filePath = path.join(dir, "oversized.json");
+    fs.writeFileSync(filePath, Buffer.alloc(1024 * 1024 + 1, "x"));
 
-    // Non-regular path (directory) should be rejected.
-    runtimeErrors.length = 0;
-    callGatewayFromCli.mockClear();
-    callGatewayFromCli.mockResolvedValue(mockSnapshot);
-    await expect(
-      runApprovalsCommand(["approvals", "set", "--node", "windows", "--file", dir]),
-    ).rejects.toThrow("__exit__:1");
-    expect(runtimeErrors[0]).toContain("regular file");
+    await expect(runNativeApprovalsFileCommand(filePath)).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors[0]).toContain("File exceeds 1048576 bytes");
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the directory read error", async () => {
+    const dir = tempDirs.make("openclaw-approvals-file-directory-");
+
+    await expect(runNativeApprovalsFileCommand(dir)).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors[0]).toMatch(/EISDIR|directory/i);
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows a symlinked approvals file", async () => {
+    const dir = tempDirs.make("openclaw-approvals-file-symlink-");
+    const targetPath = path.join(dir, "target.json");
+    const symlinkPath = path.join(dir, "approvals.json");
+    fs.writeFileSync(targetPath, JSON.stringify({ defaultAction: "deny", rules: [] }));
+    fs.symlinkSync(targetPath, symlinkPath);
+
+    await runNativeApprovalsFileCommand(symlinkPath);
+
+    expect(callGatewayFromCli.mock.calls.map(([method]) => method)).toContain(
+      "exec.approvals.node.set",
+    );
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("rejects a file that grows past the limit after opening", async () => {
+    const dir = tempDirs.make("openclaw-approvals-file-growth-");
+    const filePath = path.join(dir, "growing.json");
+    fs.writeFileSync(filePath, Buffer.alloc(1024 * 1024, "x"));
+    const open = fs.promises.open.bind(fs.promises);
+    const openSpy = vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      fs.appendFileSync(filePath, "x");
+      return handle;
+    });
+
+    try {
+      await expect(runNativeApprovalsFileCommand(filePath)).rejects.toThrow("__exit__:1");
+    } finally {
+      openSpy.mockRestore();
+    }
+
+    expect(runtimeErrors[0]).toContain("File exceeds 1048576 bytes");
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -857,4 +857,50 @@ describe("exec approvals CLI", () => {
       "Exec approvals stdin exceeds 5 bytes.",
     );
   });
+
+  it("bounds approvals JSON read from --file via readRegularFile", async () => {
+    const dir = tempDirs.make("openclaw-approvals-file-bound-");
+    const normalPath = path.join(dir, "normal.json");
+    const oversizedPath = path.join(dir, "oversized.json");
+    fs.writeFileSync(normalPath, JSON.stringify({ defaultAction: "deny", rules: [] }));
+    fs.writeFileSync(oversizedPath, Buffer.alloc(1024 * 1024 + 1, "x"));
+
+    const mockSnapshot = {
+      enabled: true,
+      hash: "sha256:current",
+      defaultAction: "deny",
+      rules: [],
+    } as never;
+
+    // Normal file (under limit) with valid JSON should succeed.
+    callGatewayFromCli.mockResolvedValue(mockSnapshot);
+    await runApprovalsCommand([
+      "approvals",
+      "set",
+      "--node",
+      "windows",
+      "--file",
+      normalPath,
+      "--json",
+    ]);
+    expect(callGatewayFromCli).toHaveBeenCalled();
+    expect(runtimeErrors).toHaveLength(0);
+
+    // Oversized file (> 1 MiB) should be rejected before the gateway call.
+    callGatewayFromCli.mockClear();
+    callGatewayFromCli.mockResolvedValue(mockSnapshot);
+    await expect(
+      runApprovalsCommand(["approvals", "set", "--node", "windows", "--file", oversizedPath]),
+    ).rejects.toThrow("__exit__:1");
+    expect(runtimeErrors[0]).toContain("exceeds");
+
+    // Non-regular path (directory) should be rejected.
+    runtimeErrors.length = 0;
+    callGatewayFromCli.mockClear();
+    callGatewayFromCli.mockResolvedValue(mockSnapshot);
+    await expect(
+      runApprovalsCommand(["approvals", "set", "--node", "windows", "--file", dir]),
+    ).rejects.toThrow("__exit__:1");
+    expect(runtimeErrors[0]).toContain("regular file");
+  });
 });

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,5 +1,3 @@
-// CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
-import { readRegularFile } from "@openclaw/fs-safe/advanced";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -27,6 +25,8 @@ import {
   type ExecApprovalsFile,
 } from "../infra/exec-approvals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
+// CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
+import { readRegularFile } from "../infra/fs-safe.js";
 import { defaultRuntime } from "../runtime.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
 import { nodesCallOpts, resolveNodeId } from "./nodes-cli/rpc.js";

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,3 +1,5 @@
+// CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
+import fs from "node:fs/promises";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -24,9 +26,8 @@ import {
   type ExecApprovalsDefaults,
   type ExecApprovalsFile,
 } from "../infra/exec-approvals.js";
+import { readFileDescriptorBounded } from "../infra/file-descriptor-read.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-// CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
-import { readRegularFile } from "../infra/fs-safe.js";
 import { defaultRuntime } from "../runtime.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
 import { nodesCallOpts, resolveNodeId } from "./nodes-cli/rpc.js";
@@ -97,6 +98,19 @@ async function readStdin(
     onOverflow: ({ maxBytes: limit }) => new Error(`Exec approvals stdin exceeds ${limit} bytes.`),
   });
   return bytes.toString("utf8");
+}
+
+async function readApprovalsFile(filePath: string): Promise<string> {
+  // Explicit CLI file inputs have historically followed symlinks and readable
+  // special files. Pin that opened target while bounding the bytes consumed.
+  const handle = await fs.open(filePath, "r");
+  try {
+    return (await readFileDescriptorBounded(handle.fd, EXEC_APPROVALS_STDIN_MAX_BYTES)).toString(
+      "utf8",
+    );
+  } finally {
+    await handle.close();
+  }
 }
 
 async function resolveTargetNodeId(opts: ExecApprovalsCliOpts): Promise<string | null> {
@@ -799,14 +813,7 @@ export function registerExecApprovalsCli(program: Command) {
         }
         const { source, nodeId, targetLabel, baseHash, kind } =
           await loadWritableSnapshotTarget(opts);
-        const raw = opts.stdin
-          ? await readStdin()
-          : (
-              await readRegularFile({
-                filePath: String(opts.file),
-                maxBytes: EXEC_APPROVALS_STDIN_MAX_BYTES,
-              })
-            ).buffer.toString("utf8");
+        const raw = opts.stdin ? await readStdin() : await readApprovalsFile(String(opts.file));
         let input: unknown;
         try {
           input = JSON5.parse(raw);

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,5 +1,5 @@
 // CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
-import fs from "node:fs/promises";
+import { readRegularFile } from "@openclaw/fs-safe/advanced";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -799,7 +799,14 @@ export function registerExecApprovalsCli(program: Command) {
         }
         const { source, nodeId, targetLabel, baseHash, kind } =
           await loadWritableSnapshotTarget(opts);
-        const raw = opts.stdin ? await readStdin() : await fs.readFile(String(opts.file), "utf8");
+        const raw = opts.stdin
+          ? await readStdin()
+          : (
+              await readRegularFile({
+                filePath: String(opts.file),
+                maxBytes: EXEC_APPROVALS_STDIN_MAX_BYTES,
+              })
+            ).buffer.toString("utf8");
         let input: unknown;
         try {
           input = JSON5.parse(raw);


### PR DESCRIPTION
## What Problem This Solves

`openclaw exec approvals set --file <path>` reads the entire file into memory
without any size limit. The same command's `--stdin` path already has a 1 MB
bound via `readStdin()`, but `--file` lacks an equivalent guard. A large JSON
file, FIFO, or device file (e.g. `/dev/zero`) could OOM the process or hang
forever on `fs.readFile`.

## Why This Change Was Made

Replace raw `fs.readFile` with `readRegularFile` from `@openclaw/fs-safe/advanced`,
which is the same shared helper introduced in cxbAsDev's fix for `--message-file`
(#101442). The shared contract enforces:
- Regular-file validation (rejects FIFOs, devices, and symlink chains)
- A 1 MB size limit matching the existing `EXEC_APPROVALS_STDIN_MAX_BYTES` constant

## User Impact

Oversized exec approvals JSON files now fail with a clear error at the bounded
read tier instead of OOM-crashing the process. Non-regular file paths are
rejected upfront. The `--stdin` and `--file` paths now use consistent 1 MB
limits.

## Evidence

- 21 tests pass (1 file), including a new `--file` regression test covering
  normal (under limit), oversized (> 1 MiB), and non-regular path (directory)
  inputs
- `pnpm format`, `pnpm tsgo:core` green on exact head
- 2 files, +55/-2 lines
- After-fix CLI output:

```
# Normal file (36B valid JSON) — accepted
$ openclaw approvals set --file /tmp/proof/normal.json
Writing local approvals.

# Oversized file (2 MB NUL bytes > 1 MB limit) — rejected
$ openclaw approvals set --file /tmp/proof/oversized.bin
Writing local approvals.
File exceeds 1048576 bytes: /tmp/proof/oversized.bin

# Directory (non-regular file) — rejected
$ openclaw approvals set --file /tmp/proof
Writing local approvals.
path must be a regular file
```