### PR TITLE
fix(qa): stop deadline-bounded health probes from re-probing on timer jitter

### DIFF
--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -568,12 +568,12 @@ export function createQaDockerRuntime(params: {
         break;
       }
       let response: QaDockerFetchResponse | undefined;
+      const probeDeadlineBounded = remainingMs <= DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS;
+      const probeSignal = AbortSignal.timeout(
+        Math.max(1, Math.min(DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS, remainingMs)),
+      );
       try {
-        response = await deps.fetchImpl(url, {
-          signal: AbortSignal.timeout(
-            Math.max(1, Math.min(DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS, remainingMs)),
-          ),
-        });
+        response = await deps.fetchImpl(url, { signal: probeSignal });
         if (response.ok) {
           return;
         }
@@ -582,6 +582,12 @@ export function createQaDockerRuntime(params: {
         lastError = error;
       } finally {
         await releaseQaDockerFetchResponse(response);
+      }
+      // A deadline-bounded probe whose abort timer fired has consumed the whole
+      // remaining budget; timer jitter can leave Date.now() a hair under the
+      // deadline, and looping again would start a probe past it.
+      if (probeDeadlineBounded && probeSignal.aborted) {
+        break;
       }
       const remainingSleepMs = deadline - Date.now();
       if (remainingSleepMs > 0) {


### PR DESCRIPTION
## What Problem This Solves

`src/plugin-sdk/qa-runtime.test.ts` "bounds a stalled waitForHealth probe by the remaining overall deadline" flaked on main (run 29648843242, `checks-node-compact-small-9`): expected 1 fetch call, observed 2.

Mechanism: `waitForHealth` bounds each probe with `AbortSignal.timeout(min(requestTimeout, remainingMs))`. When the probe is bounded by the *overall* deadline, the abort timer can fire while `Date.now()` still reads a hair under the deadline (timer clamping/rounding on loaded runners), so `while (Date.now() < deadline)` admits a second ~1ms probe. In production the poll sleep masks this; the test's no-op `sleepImpl` exposes it.

## Why This Change Was Made

When a deadline-bounded probe ends with its own signal aborted, the remaining budget is spent by definition — break instead of re-checking the wall clock. Mid-run request-timeout aborts (remaining > request timeout) keep retrying exactly as before; success still returns early. This is a production-correctness tightening, not a test patch: without it, real runs can fire a doomed extra probe past the intended deadline.

## User Impact

QA Docker health checks respect their overall deadline deterministically; the flaky shard stops failing green main runs.

## Evidence

- Run 29648843242 failure: "expected 'vi.fn()' to be called 1 times, but got 2 times" at qa-runtime.test.ts:396; the test and its subject last changed two days ago (ee70f20fed455) and were green across dozens of runs since — load-dependent flake, not a regression.
- With the fix: `node scripts/run-vitest.mjs src/plugin-sdk/qa-runtime.test.ts` passed 8/8 in a bounded repeat loop.
- Codex autoreview (commit mode): clean, "patch is correct (0.97)", explicitly noting retries for ordinary request timeouts are preserved.
