### PR TITLE
fix(stt-live-audio): cancel ElevenLabs error response body

### DIFF
--- a/extensions/elevenlabs/tts.test.ts
+++ b/extensions/elevenlabs/tts.test.ts
@@ -1,5 +1,6 @@
 // Elevenlabs tests cover tts plugin behavior.
 import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { synthesizeElevenLabsLiveSpeech } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingErrorResponse } from "../test-support/streaming-error-response.js";
 import { elevenLabsTTS, elevenLabsTTSStream } from "./tts.js";
@@ -324,5 +325,39 @@ describe("elevenlabs tts diagnostics", () => {
     await expect(elevenLabsTTSStream(createDefaultTtsRequest())).rejects.toThrow(
       "ElevenLabs API error: malformed audio response",
     );
+  });
+});
+
+describe("elevenlabs live audio helper error-path body release", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("cancels an unread streaming error body when ElevenLabs returns non-2xx", async () => {
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+        cancel,
+      }),
+      { status: 401 },
+    );
+    globalThis.fetch = vi.fn(async () => response) as typeof fetch;
+
+    await expect(
+      synthesizeElevenLabsLiveSpeech({
+        text: "OpenClaw leak check.",
+        apiKey: "x",
+        outputFormat: "mp3_44100_128",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow("ElevenLabs live TTS failed (401)");
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(response.bodyUsed).toBe(true);
   });
 });

--- a/src/plugin-sdk/test-helpers/stt-live-audio.ts
+++ b/src/plugin-sdk/test-helpers/stt-live-audio.ts
@@ -71,6 +71,9 @@ export async function synthesizeElevenLabsLiveSpeech(params: {
       signal: controller.signal,
     });
     if (!response.ok) {
+      // Error payloads are not used by the live fixture. Cancel instead of buffering an
+      // untrusted or unbounded body so Undici can release the connection promptly.
+      await response.body?.cancel().catch(() => undefined);
       throw new Error(`ElevenLabs live TTS failed (${response.status})`);
     }
     return Buffer.from(await response.arrayBuffer());


### PR DESCRIPTION
## Problem

`synthesizeElevenLabsLiveSpeech` threw immediately on a non-2xx ElevenLabs response without consuming or cancelling the response body. Undici requires response bodies to be consumed or cancelled so the underlying connection can be reused or released; relying on garbage collection can exhaust connection slots during repeated live-test failures.

## Fix

Cancel the unused response body before preserving the existing status-based error. Cancellation is preferable to `arrayBuffer()` here because the provider error payload is unused, remote-controlled, and potentially unbounded or streaming. A cancellation failure is intentionally ignored so it cannot mask the original ElevenLabs status.

The regression test uses a real Web `Response` backed by a `ReadableStream`. It verifies the stream cancellation hook runs exactly once and that the body becomes disturbed, without socket timing, sleeps, or Undici-private behavior.

## Proof

- Exact head: `b5dba65c9afd5092a7b5098a8beb4d8ee696568a`
- Focused Testbox: `pnpm test extensions/elevenlabs/tts.test.ts` — 16/16 passed (`tbx_01kxvf6rw0c2t5fbw6mh2bbhmt`)
- Exact-head CI run `29660041095` — success, including `openclaw/ci-gate`
- Maintainer autoreview — clean, no accepted/actionable findings

## Risk

Low. This changes only the ElevenLabs live-audio test helper's non-2xx cleanup path. Successful audio responses and the surfaced error message are unchanged.
