### PR TITLE
fix(scripts): retry auth alerts after ntfy rejects delivery

### DIFF
--- a/scripts/auth-monitor.sh
+++ b/scripts/auth-monitor.sh
@@ -32,6 +32,7 @@ MIN_INTERVAL=3600
 send_notification() {
     local message="$1"
     local priority="${2:-default}"
+    local notification_sent=0
 
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $message"
 
@@ -46,23 +47,30 @@ send_notification() {
         # Check if we can still use openclaw
         if "$SCRIPT_DIR/claude-auth-status.sh" simple 2>/dev/null | grep -q "OK\|EXPIRING"; then
             echo "Sending via OpenClaw to $NOTIFY_PHONE..."
-            openclaw send --to "$NOTIFY_PHONE" --message "$message" 2>/dev/null || true
+            if openclaw send --to "$NOTIFY_PHONE" --message "$message" 2>/dev/null; then
+                notification_sent=1
+            fi
         fi
     fi
 
     # Send via ntfy.sh if configured
     if [ -n "$NOTIFY_NTFY" ]; then
         echo "Sending via ntfy.sh to $NOTIFY_NTFY..."
-        curl -s --connect-timeout 5 --max-time 15 -o /dev/null \
+        if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null \
             -H "Title: OpenClaw Auth Alert" \
             -H "Priority: $priority" \
             -H "Tags: warning,key" \
             -d "$message" \
-            "https://ntfy.sh/$NOTIFY_NTFY" || true
+            "https://ntfy.sh/$NOTIFY_NTFY"; then
+            notification_sent=1
+        fi
     fi
 
-    # Update state
-    echo "$NOW" > "$STATE_FILE"
+    if [ "$notification_sent" -eq 1 ]; then
+        echo "$NOW" > "$STATE_FILE"
+    else
+        echo "No notification delivered; cooldown not updated" >&2
+    fi
 }
 
 # Check auth status

--- a/test/scripts/auth-monitor.test.ts
+++ b/test/scripts/auth-monitor.test.ts
@@ -24,6 +24,7 @@ function createAuthMonitorHarness() {
   const home = mkdtempSync(join(tmpdir(), "openclaw-auth-monitor-"));
   const binDir = join(home, "bin");
   const curlLog = join(home, "curl.log");
+  const openclawLog = join(home, "openclaw.log");
   const stateFile = join(home, ".openclaw", "auth-monitor-state");
   mkdirSync(binDir);
   writeFileSync(
@@ -31,13 +32,52 @@ function createAuthMonitorHarness() {
     '#!/bin/sh\nprintf "called\\n" >> "$FAKE_CURL_LOG"\nexit "$FAKE_CURL_EXIT_CODE"\n',
     { mode: 0o755 },
   );
+  writeFileSync(
+    join(binDir, "openclaw"),
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "models" ]; then',
+      "  exit 1",
+      "fi",
+      'printf "called\\n" >> "$FAKE_OPENCLAW_LOG"',
+      'exit "$FAKE_OPENCLAW_EXIT_CODE"',
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
 
   return {
     curlLog,
     home,
+    openclawLog,
     stateFile,
     cleanup: () => rmSync(home, { recursive: true, force: true }),
-    run: (curlExitCode: number) =>
+    enablePhoneAuth: () => {
+      const expiresAt = Date.now() + 90 * 60 * 1000;
+      mkdirSync(join(home, ".claude"), { recursive: true });
+      mkdirSync(join(home, ".openclaw", "agents", "main", "agent"), { recursive: true });
+      writeFileSync(
+        join(home, ".claude", ".credentials.json"),
+        JSON.stringify({ claudeAiOauth: { expiresAt } }),
+      );
+      writeFileSync(
+        join(home, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+        JSON.stringify({
+          profiles: { "anthropic:default": { expires: expiresAt, provider: "anthropic" } },
+        }),
+      );
+    },
+    run: ({
+      curlExitCode = 0,
+      notifyNtfy = "test-topic",
+      notifyPhone = "",
+      openclawExitCode = 0,
+    }: {
+      curlExitCode?: number;
+      notifyNtfy?: string;
+      notifyPhone?: string;
+      openclawExitCode?: number;
+    } = {}) =>
       spawnSync("bash", [AUTH_MONITOR_PATH], {
         cwd: process.cwd(),
         encoding: "utf8",
@@ -45,10 +85,13 @@ function createAuthMonitorHarness() {
           ...process.env,
           FAKE_CURL_EXIT_CODE: String(curlExitCode),
           FAKE_CURL_LOG: curlLog,
+          FAKE_OPENCLAW_EXIT_CODE: String(openclawExitCode),
+          FAKE_OPENCLAW_LOG: openclawLog,
           HOME: home,
-          NOTIFY_NTFY: "test-topic",
-          NOTIFY_PHONE: "",
+          NOTIFY_NTFY: notifyNtfy,
+          NOTIFY_PHONE: notifyPhone,
           PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          WARN_HOURS: "2",
         },
       }),
   };
@@ -97,12 +140,12 @@ describe("auth monitoring scripts", () => {
     const harness = createAuthMonitorHarness();
 
     try {
-      const rejected = harness.run(22);
+      const rejected = harness.run({ curlExitCode: 22 });
       expect(rejected.status).toBe(1);
       expect(existsSync(harness.stateFile)).toBe(false);
       expect(rejected.stderr).toContain("No notification delivered; cooldown not updated");
 
-      const retry = harness.run(0);
+      const retry = harness.run();
       expect(retry.stdout).toContain("Sending via ntfy.sh to test-topic...");
       expect(retry.stdout).not.toContain("Skipping notification (sent recently)");
       expect(readFileSync(harness.curlLog, "utf8").trim().split("\n")).toHaveLength(2);
@@ -115,13 +158,64 @@ describe("auth monitoring scripts", () => {
     const harness = createAuthMonitorHarness();
 
     try {
-      const accepted = harness.run(0);
+      const accepted = harness.run();
       expect(accepted.status).toBe(1);
       expect(existsSync(harness.stateFile)).toBe(true);
 
-      const throttled = harness.run(0);
+      const throttled = harness.run();
       expect(throttled.stdout).toContain("Skipping notification (sent recently)");
       expect(readFileSync(harness.curlLog, "utf8").trim().split("\n")).toHaveLength(1);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it("rate-limits after any configured notification channel succeeds", () => {
+    const harness = createAuthMonitorHarness();
+    harness.enablePhoneAuth();
+
+    try {
+      const delivered = harness.run({
+        curlExitCode: 22,
+        notifyPhone: "+15550000000",
+      });
+      expect(delivered.status).toBe(0);
+      expect(existsSync(harness.stateFile)).toBe(true);
+
+      const throttled = harness.run({
+        curlExitCode: 22,
+        notifyPhone: "+15550000000",
+      });
+      expect(throttled.stdout).toContain("Skipping notification (sent recently)");
+      expect(readFileSync(harness.openclawLog, "utf8").trim().split("\n")).toHaveLength(1);
+      expect(readFileSync(harness.curlLog, "utf8").trim().split("\n")).toHaveLength(1);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it("retries when all configured notification channels fail", () => {
+    const harness = createAuthMonitorHarness();
+    harness.enablePhoneAuth();
+
+    try {
+      const failed = harness.run({
+        curlExitCode: 22,
+        notifyPhone: "+15550000000",
+        openclawExitCode: 1,
+      });
+      expect(failed.status).toBe(0);
+      expect(existsSync(harness.stateFile)).toBe(false);
+      expect(failed.stderr).toContain("No notification delivered; cooldown not updated");
+
+      const retry = harness.run({
+        curlExitCode: 22,
+        notifyPhone: "+15550000000",
+        openclawExitCode: 1,
+      });
+      expect(retry.stdout).not.toContain("Skipping notification (sent recently)");
+      expect(readFileSync(harness.openclawLog, "utf8").trim().split("\n")).toHaveLength(2);
+      expect(readFileSync(harness.curlLog, "utf8").trim().split("\n")).toHaveLength(2);
     } finally {
       harness.cleanup();
     }

--- a/test/scripts/auth-monitor.test.ts
+++ b/test/scripts/auth-monitor.test.ts
@@ -1,5 +1,8 @@
 // Auth monitor tests cover optional systemd and Termux helper script contracts.
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const AUTH_MONITOR_PATH = "scripts/auth-monitor.sh";
@@ -15,6 +18,40 @@ const TERMUX_WIDGET_PATHS = [
 
 function readScript(path: string): string {
   return readFileSync(path, "utf8");
+}
+
+function createAuthMonitorHarness() {
+  const home = mkdtempSync(join(tmpdir(), "openclaw-auth-monitor-"));
+  const binDir = join(home, "bin");
+  const curlLog = join(home, "curl.log");
+  const stateFile = join(home, ".openclaw", "auth-monitor-state");
+  mkdirSync(binDir);
+  writeFileSync(
+    join(binDir, "curl"),
+    '#!/bin/sh\nprintf "called\\n" >> "$FAKE_CURL_LOG"\nexit "$FAKE_CURL_EXIT_CODE"\n',
+    { mode: 0o755 },
+  );
+
+  return {
+    curlLog,
+    home,
+    stateFile,
+    cleanup: () => rmSync(home, { recursive: true, force: true }),
+    run: (curlExitCode: number) =>
+      spawnSync("bash", [AUTH_MONITOR_PATH], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_CURL_EXIT_CODE: String(curlExitCode),
+          FAKE_CURL_LOG: curlLog,
+          HOME: home,
+          NOTIFY_NTFY: "test-topic",
+          NOTIFY_PHONE: "",
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      }),
+  };
 }
 
 describe("auth monitoring scripts", () => {
@@ -53,7 +90,41 @@ describe("auth monitoring scripts", () => {
   it("bounds ntfy notification requests", () => {
     const script = readScript(AUTH_MONITOR_PATH);
 
-    expect(script).toContain("curl -s --connect-timeout 5 --max-time 15 -o /dev/null");
+    expect(script).toContain("curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null");
+  });
+
+  it("retries after ntfy rejects a notification", () => {
+    const harness = createAuthMonitorHarness();
+
+    try {
+      const rejected = harness.run(22);
+      expect(rejected.status).toBe(1);
+      expect(existsSync(harness.stateFile)).toBe(false);
+      expect(rejected.stderr).toContain("No notification delivered; cooldown not updated");
+
+      const retry = harness.run(0);
+      expect(retry.stdout).toContain("Sending via ntfy.sh to test-topic...");
+      expect(retry.stdout).not.toContain("Skipping notification (sent recently)");
+      expect(readFileSync(harness.curlLog, "utf8").trim().split("\n")).toHaveLength(2);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it("rate-limits after ntfy accepts a notification", () => {
+    const harness = createAuthMonitorHarness();
+
+    try {
+      const accepted = harness.run(0);
+      expect(accepted.status).toBe(1);
+      expect(existsSync(harness.stateFile)).toBe(true);
+
+      const throttled = harness.run(0);
+      expect(throttled.stdout).toContain("Skipping notification (sent recently)");
+      expect(readFileSync(harness.curlLog, "utf8").trim().split("\n")).toHaveLength(1);
+    } finally {
+      harness.cleanup();
+    }
   });
 
   it("keeps mobile reauth wired to local auth status and Claude token setup", () => {


### PR DESCRIPTION
Related: #108650

## What Problem This Solves

Fixes an issue where operators using the auth monitor with ntfy notifications could lose a later authentication alert for up to one hour when ntfy rejected the earlier request. The rejected request was still recorded as a successful notification, so the next scheduled run printed `Skipping notification (sent recently)` instead of retrying.

## Why This Change Was Made

The ntfy request now treats HTTP 4xx/5xx responses as delivery failures, and the monitor records its cooldown only after at least one configured notification channel succeeds. Existing connection and transfer timeouts remain unchanged. This does not change credential discovery, refresh-token handling, configuration, or systemd setup.

## User Impact

Authentication alerts remain eligible for retry when ntfy rejects or cannot deliver a notification. Successful deliveries are still rate-limited to one notification per hour.

## Evidence

- Regression test first failed on current main because an ntfy failure still created `~/.openclaw/auth-monitor-state`.
- `pnpm test test/scripts/auth-monitor.test.ts` — 6 tests passed on the final rebased commit.
- Live ntfy control: a randomly generated test-only topic received the credentials-missing alert and the cooldown state was written.
- Live ntfy rejection: HTTP 400 produced no cooldown state; an immediate second run attempted delivery again and did not print the recent-notification skip message.
- `bash -n scripts/auth-monitor.sh` and focused formatting/oxlint checks passed.
- Changed-file validation passed conflict, attribution, dependency, format, patch, temp-file, script-declaration, and test-root type checks. The broader `lint:scripts` lane did not complete because its unrelated plugin-sdk boundary artifact generator failed on this host; the modified TypeScript test passed targeted oxlint.

Full repository build and test suites were not run for this two-file script fix.
