### PR TITLE
fix(telegram): preserve per-item captions in media groups (albums)

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -281,6 +281,12 @@ export function createTelegramInboundMediaGroupRuntime(
             ),
         }).catch(() => {});
       }
+      // Albums can carry a caption on any item, not only the primary message.
+      // Route multi-caption groups through the shared multi-message body path
+      // so every caption survives in album order instead of only the first.
+      const captionedCount = entry.messages.filter((item) =>
+        getTelegramTextParts(item.msg).text.trim(),
+      ).length;
       const result = await processMessageWithReplyChain({
         ctx: primary.ctx,
         msg: primary.msg,
@@ -288,6 +294,9 @@ export function createTelegramInboundMediaGroupRuntime(
         promptContextMessageSelection: selection,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
+          ...(captionedCount > 1
+            ? { inboundDebounceMessages: entry.messages.map((item) => item.msg) }
+            : {}),
           ...promptContextBoundaryOptions(
             entry.promptContextMinTimestampMs,
             entry.promptContextAmbientWatermark,

--- a/extensions/telegram/src/bot.create-telegram-bot.media-group-captions.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.media-group-captions.test.ts
@@ -1,0 +1,211 @@
+// Telegram tests cover media-group per-item caption aggregation (#110690).
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+const resolveMediaMock = vi.fn();
+
+vi.mock("./bot/delivery.resolve-media.js", () => ({
+  resolveMedia: (...args: unknown[]) => resolveMediaMock(...args),
+}));
+
+const { createTelegramInboundMediaGroupRuntime } =
+  await import("./bot-handlers.inbound-media-group.runtime.js");
+
+type AlbumMessage = ReturnType<typeof albumMessage>;
+
+function albumMessage(params: { messageId: number; caption?: string }) {
+  return {
+    message_id: params.messageId,
+    date: 1736380800 + params.messageId,
+    chat: { id: 4242, type: "private" as const, first_name: "Alice" },
+    from: { id: 42, is_bot: false as const, first_name: "Alice" },
+    media_group_id: "album-1",
+    photo: [{ file_id: `p${params.messageId}` }],
+    ...(params.caption ? { caption: params.caption } : {}),
+  };
+}
+
+function createRuntimeHarness() {
+  resolveMediaMock.mockReset();
+  resolveMediaMock.mockImplementation(async (params: { ctx: { fileId?: string } }) => ({
+    path: `/tmp/${params.ctx.fileId ?? "media"}.jpg`,
+    contentType: "image/jpeg",
+  }));
+  const processMessageWithReplyChain = vi.fn(async () => ({ kind: "completed" as const }));
+  const messageRuntime = {
+    mediaRuntimeWithAbort: {},
+    promptContextBoundaryOptions: () => ({}),
+    latestPromptContextMinTimestampMs: () => undefined,
+    latestPromptContextAmbientWatermark: () => undefined,
+    mergeDispatchDedupeClaims: (...claims: unknown[][]) => claims.flat(),
+    releaseDispatchDedupeClaims: () => {},
+    buildFailedProcessingResult: (error: unknown) => ({ kind: "failed" as const, error }),
+    settleSpooledReplayParticipants: () => {},
+    createSpooledReplayParticipantForBufferedWork: () => undefined,
+    spooledReplayOptions: () => ({}),
+    resolveTelegramSessionState: () => ({ sessionKey: "session", agentId: "agent" }),
+    processMessageWithReplyChain,
+  };
+  const runtime = createTelegramInboundMediaGroupRuntime(
+    {
+      accountId: "default",
+      bot: { api: { sendMessage: vi.fn(async () => ({})) } },
+      opts: { testTimings: { mediaGroupFlushMs: 20 } },
+      runtime: { log: () => {}, error: () => {} },
+      mediaMaxBytes: 5 * 1024 * 1024,
+      telegramCfg: {},
+      logger: { info: () => {} },
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+    } as never,
+    messageRuntime as never,
+  );
+  return { runtime, processMessageWithReplyChain };
+}
+
+function enqueueAlbum(
+  runtime: ReturnType<typeof createRuntimeHarness>["runtime"],
+  captions: readonly (string | undefined)[],
+) {
+  const messages: AlbumMessage[] = [];
+  captions.forEach((caption, index) => {
+    const msg = albumMessage({ messageId: 100 + index, caption });
+    messages.push(msg);
+    const handled = runtime.handleMediaGroup({
+      ctx: { me: { username: "openclaw_bot" }, fileId: `p${msg.message_id}` },
+      msg,
+      chatId: 4242,
+      isGroup: false,
+      isForum: false,
+      senderId: "42",
+      authorizationCfg: {},
+      effectiveGroupAllow: undefined,
+      effectiveDmAllow: undefined,
+      storeAllowFrom: [],
+      dispatchDedupeClaims: [],
+    } as never);
+    expect(handled).toBe(true);
+  });
+  return messages;
+}
+
+async function waitForFlush() {
+  await delay(120);
+}
+
+describe("processMediaGroup per-item captions (#110690)", () => {
+  it("forwards every album message through the multi-message body path when captions span items", async () => {
+    const { runtime, processMessageWithReplyChain } = createRuntimeHarness();
+    enqueueAlbum(runtime, ["before shot", "during shot", "after shot"]);
+    await waitForFlush();
+
+    expect(processMessageWithReplyChain).toHaveBeenCalledTimes(1);
+    const call = processMessageWithReplyChain.mock.calls[0]?.[0] as {
+      msg: AlbumMessage;
+      allMedia: unknown[];
+      options?: { inboundDebounceMessages?: AlbumMessage[] };
+    };
+    expect(call.msg.message_id).toBe(100);
+    expect(call.allMedia).toHaveLength(3);
+    const forwarded = call.options?.inboundDebounceMessages;
+    expect(forwarded).toBeDefined();
+    expect(forwarded?.map((msg) => msg.message_id)).toEqual([100, 101, 102]);
+    expect(forwarded?.map((msg) => msg.caption)).toEqual([
+      "before shot",
+      "during shot",
+      "after shot",
+    ]);
+  });
+
+  it("keeps caption order for albums with uncaptioned items between captions", async () => {
+    const { runtime, processMessageWithReplyChain } = createRuntimeHarness();
+    enqueueAlbum(runtime, ["first labeled", undefined, "third labeled"]);
+    await waitForFlush();
+
+    expect(processMessageWithReplyChain).toHaveBeenCalledTimes(1);
+    const call = processMessageWithReplyChain.mock.calls[0]?.[0] as {
+      options?: { inboundDebounceMessages?: AlbumMessage[] };
+    };
+    expect(call.options?.inboundDebounceMessages?.map((msg) => msg.caption ?? null)).toEqual([
+      "first labeled",
+      null,
+      "third labeled",
+    ]);
+  });
+
+  it("keeps the single-caption album on the existing primary-message path", async () => {
+    const { runtime, processMessageWithReplyChain } = createRuntimeHarness();
+    enqueueAlbum(runtime, ["solo caption", undefined, undefined]);
+    await waitForFlush();
+
+    expect(processMessageWithReplyChain).toHaveBeenCalledTimes(1);
+    const call = processMessageWithReplyChain.mock.calls[0]?.[0] as {
+      msg: AlbumMessage;
+      allMedia: unknown[];
+      options?: { inboundDebounceMessages?: AlbumMessage[] };
+    };
+    expect(call.msg.caption).toBe("solo caption");
+    expect(call.allMedia).toHaveLength(3);
+    expect(call.options?.inboundDebounceMessages).toBeUndefined();
+  });
+
+  it("keeps a tail-only caption on the existing primary-message path", async () => {
+    const { runtime, processMessageWithReplyChain } = createRuntimeHarness();
+    enqueueAlbum(runtime, [undefined, undefined, "tail caption"]);
+    await waitForFlush();
+
+    expect(processMessageWithReplyChain).toHaveBeenCalledTimes(1);
+    const call = processMessageWithReplyChain.mock.calls[0]?.[0] as {
+      msg: AlbumMessage;
+      options?: { inboundDebounceMessages?: AlbumMessage[] };
+    };
+    expect(call.msg.caption).toBe("tail caption");
+    expect(call.options?.inboundDebounceMessages).toBeUndefined();
+  });
+});
+
+describe("message context renders forwarded album captions (#110690)", () => {
+  it("keeps every caption and positional placeholders in the aggregated body", async () => {
+    const chat = { id: 4242, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const first = {
+      message_id: 100,
+      date: 1_700_000_000,
+      chat,
+      from: sender,
+      photo: [{ file_id: "p100" }],
+      caption: "before shot",
+    };
+    const context = await buildTelegramMessageContextForTest({
+      message: first,
+      options: {
+        inboundDebounceMessages: [
+          first,
+          {
+            message_id: 101,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            photo: [{ file_id: "p101" }],
+          },
+          {
+            message_id: 102,
+            date: 1_700_000_002,
+            chat,
+            from: sender,
+            photo: [{ file_id: "p102" }],
+            caption: "after shot",
+          },
+        ],
+      },
+    });
+
+    const body = String(context?.ctxPayload?.Body ?? "");
+    expect(body).toContain("before shot");
+    expect(body).toContain("after shot");
+    expect(body.indexOf("before shot")).toBeLessThan(body.indexOf("after shot"));
+    const middle = body.slice(body.indexOf("before shot"), body.indexOf("after shot"));
+    expect(middle).toContain("<media:image>");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

When a user sends a Telegram media group (album) where multiple items carry their own captions, only one caption reaches the agent. `processMediaGroup` selects a single primary message (the first captioned one) and hands only that message to the reply chain, so every other per-item caption is silently dropped.

## Why This Change Was Made

The Telegram channel already has a shared multi-message body path: `TelegramMessageContextOptions.inboundDebounceMessages`, consumed in `bot-message-context.session.ts`. It renders each message's caption/text in order and switches `bodyForAgent` to the aggregated text.

`processMediaGroup` now routes albums through that same path when more than one item carries a caption:
- Captions stay in album order (messages sorted by `message_id`)
- Uncaptioned items render as media placeholders between captioned ones
- Albums with zero or one caption keep the existing single-primary behavior

## Changes

- **`extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts`** — count captioned album items; when >1, pass album messages as `inboundDebounceMessages`
- **`extensions/telegram/src/bot.create-telegram-bot.media-group-captions.test.ts`** — 5 new tests: multi-caption, gapped captions, single-caption fallback, tail-caption fallback, positional placeholders

## Evidence

### New test suite

```
 ✓ processMediaGroup per-item captions (#110690) > forwards every album message through the multi-message body path when captions span items
 ✓ processMediaGroup per-item captions (#110690) > keeps caption order for albums with uncaptioned items between captions
 ✓ processMediaGroup per-item captions (#110690) > keeps the single-caption album on the existing primary-message path
 ✓ processMediaGroup per-item captions (#110690) > keeps a tail-only caption on the existing primary-message path
 ✓ message context renders forwarded album captions (#110690) > keeps every caption and positional placeholders in the aggregated body

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### Full regression (3 files, 11 tests)

```
Test Files  3 passed (3)
     Tests  11 passed (11)
```

### Mantis proof request

I cannot run a live Telegram gateway from this environment. A maintainer can dispatch the Mantis capture for real behavior proof:

```
@openclaw-mantis telegram desktop proof: verify that a three-image album with distinct captions reaches the agent in order, including an uncaptioned item between captions.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)