### PR TITLE
fix(process): preserve Windows output encoding through truncation

### DIFF
--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -168,6 +168,7 @@ export function decodeWindowsOutputBuffer(params: {
   buffer: Buffer;
   platform?: NodeJS.Platform;
   windowsEncoding?: string | null;
+  fullStreamUtf8Valid?: boolean;
 }): string {
   return decodeWindowsBufferWithFallback({
     ...params,
@@ -190,6 +191,7 @@ export function decodeWindowsTextFileBuffer(params: {
 function decodeWindowsBufferWithFallback(params: {
   buffer: Buffer;
   platform?: NodeJS.Platform;
+  fullStreamUtf8Valid?: boolean;
   resolveFallbackEncoding: () => string | null;
 }): string {
   const platform = params.platform ?? process.platform;
@@ -197,7 +199,9 @@ function decodeWindowsBufferWithFallback(params: {
     return params.buffer.toString("utf8");
   }
 
-  const utf8 = decodeStrictUtf8(params.buffer);
+  // A bounded capture can be valid UTF-8 even when discarded bytes proved the complete
+  // stream was not. Preserve the owner's full-stream decision when one is available.
+  const utf8 = params.fullStreamUtf8Valid === false ? null : decodeStrictUtf8(params.buffer);
   if (utf8 !== null) {
     return utf8;
   }

--- a/src/process/exec-output.ts
+++ b/src/process/exec-output.ts
@@ -17,6 +17,8 @@ export type CapturedOutputBuffers = {
   chunks: Buffer[];
   bytes: number;
   truncatedBytes: number;
+  utf8Validator: TextDecoder | null;
+  utf8Valid: boolean;
   preservedLines: string[];
   decoder: StringDecoder;
   pendingLine: string;
@@ -30,10 +32,30 @@ export function createCapturedOutputBuffers(): CapturedOutputBuffers {
     chunks: [],
     bytes: 0,
     truncatedBytes: 0,
+    utf8Validator: process.platform === "win32" ? new TextDecoder("utf-8", { fatal: true }) : null,
+    utf8Valid: true,
     preservedLines: [],
     decoder: new StringDecoder("utf8"),
     pendingLine: "",
   };
+}
+
+/** Tracks the complete stream so Windows can preserve its UTF-8-first decoding contract. */
+export function observeCapturedOutputEncoding(
+  capture: CapturedOutputBuffers,
+  chunk: Buffer | string,
+): void {
+  const validator = capture.utf8Validator;
+  if (!validator || !capture.utf8Valid) {
+    return;
+  }
+  try {
+    validator.decode(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk), {
+      stream: true,
+    });
+  } catch {
+    capture.utf8Valid = false;
+  }
 }
 
 function normalizeMaxOutputBytes(value: number | undefined): number {
@@ -114,7 +136,7 @@ function trimTruncatedUtf8Boundary(
   mode: CommandOutputCaptureMode,
   truncatedBytes: number,
 ): Buffer {
-  if (truncatedBytes === 0 || buffer.length === 0 || process.platform === "win32") {
+  if (truncatedBytes === 0 || buffer.length === 0) {
     return buffer;
   }
   if (mode === "tail") {
@@ -137,12 +159,31 @@ function trimTruncatedUtf8Boundary(
   return buffer;
 }
 
+function finalizeCapturedUtf8Validation(capture: CapturedOutputBuffers): boolean {
+  const validator = capture.utf8Validator;
+  if (!validator || !capture.utf8Valid) {
+    return false;
+  }
+  try {
+    validator.decode();
+    return true;
+  } catch {
+    capture.utf8Valid = false;
+    return false;
+  }
+}
+
 export function finalizeCapturedOutput(
   capture: CapturedOutputBuffers,
   mode: CommandOutputCaptureMode,
 ): Buffer {
   const buffered = Buffer.concat(capture.chunks, capture.bytes);
-  const trimmed = trimTruncatedUtf8Boundary(buffered, mode, capture.truncatedBytes);
+  // Mirror decodeWindowsOutputBuffer's UTF-8-first contract using the complete stream.
+  // Truncated bytes alone cannot distinguish UTF-8 from the active Windows code page.
+  const trimUtf8Boundary = process.platform !== "win32" || finalizeCapturedUtf8Validation(capture);
+  const trimmed = trimUtf8Boundary
+    ? trimTruncatedUtf8Boundary(buffered, mode, capture.truncatedBytes)
+    : buffered;
   capture.truncatedBytes += buffered.byteLength - trimmed.byteLength;
   return trimmed;
 }

--- a/src/process/exec-runner.ts
+++ b/src/process/exec-runner.ts
@@ -14,6 +14,7 @@ import {
   finalizeCapturedOutput,
   flushPreservedOutputLine,
   MAX_PRESERVED_PENDING_LINE_BYTES,
+  observeCapturedOutputEncoding,
   resolveMaxOutputBytes,
   resolveOutputCapture,
   shouldTerminateOnOutputLimit,
@@ -229,6 +230,7 @@ export async function runCommandWithTimeout(
     captureMode: CommandOutputCaptureMode,
   ) => {
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    observeCapturedOutputEncoding(capture, buffer);
     outputBytesByStream[stream] += buffer.byteLength;
     const streamLimitExceeded = outputBytesByStream[stream] > maxBytes;
     if (maxCombinedOutputBytes === undefined) {
@@ -447,15 +449,19 @@ export async function runCommandWithTimeout(
     }
   }
 
+  const stdoutBuffer = finalizeCapturedOutput(stdoutCapture, stdoutCaptureMode);
+  const stderrBuffer = finalizeCapturedOutput(stderrCapture, stderrCaptureMode);
   return {
     pid: child.pid,
     stdout: decodeWindowsOutputBuffer({
-      buffer: finalizeCapturedOutput(stdoutCapture, stdoutCaptureMode),
+      buffer: stdoutBuffer,
       windowsEncoding,
+      fullStreamUtf8Valid: stdoutCapture.utf8Valid,
     }),
     stderr: decodeWindowsOutputBuffer({
-      buffer: finalizeCapturedOutput(stderrCapture, stderrCaptureMode),
+      buffer: stderrBuffer,
       windowsEncoding,
+      fullStreamUtf8Valid: stderrCapture.utf8Valid,
     }),
     stdoutTruncatedBytes: stdoutCapture.truncatedBytes || undefined,
     stderrTruncatedBytes: stderrCapture.truncatedBytes || undefined,

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -2,9 +2,16 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import process from "node:process";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { setVerbose } from "../global-state.js";
+import { decodeWindowsOutputBuffer } from "../infra/windows-encoding.js";
 import { attachChildProcessBridge } from "./child-process-bridge.js";
+import {
+  appendCapturedOutput,
+  createCapturedOutputBuffers,
+  finalizeCapturedOutput,
+  observeCapturedOutputEncoding,
+} from "./exec-output.js";
 import {
   resolveCommandEnv,
   resolveProcessExitCode,
@@ -683,5 +690,80 @@ describe("attachChildProcessBridge", () => {
     child.emit("exit");
     expect(process.listeners("SIGTERM")).toHaveLength(beforeSigterm.size);
     detach();
+  });
+});
+
+describe("finalizeCapturedOutput UTF-8 boundary trimming on win32", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("trims leading continuation bytes in tail mode for a valid UTF-8 stream", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const capture = createCapturedOutputBuffers();
+    const fullOutput = Buffer.from("a😀z", "utf8");
+    observeCapturedOutputEncoding(capture, fullOutput);
+    appendCapturedOutput(capture, fullOutput, 3, "tail");
+
+    const result = finalizeCapturedOutput(capture, "tail");
+    expect(result.toString("utf8")).toBe("z");
+    expect(result.toString("utf8")).not.toContain("\uFFFD");
+  });
+
+  it("trims a trailing partial code point in head mode for a valid UTF-8 stream", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const capture = createCapturedOutputBuffers();
+    const fullOutput = Buffer.from("😀", "utf8");
+    observeCapturedOutputEncoding(capture, fullOutput);
+    appendCapturedOutput(capture, fullOutput, 3, "head");
+
+    const result = finalizeCapturedOutput(capture, "head");
+    expect(result.toString("utf8")).toBe("");
+    expect(result.toString("utf8")).not.toContain("\uFFFD");
+  });
+
+  it("preserves a valid GBK lead byte at a tail truncation boundary", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const gbk = Buffer.from([0xb2, 0xe2, 0xca, 0xd4, 0xa1, 0xab, 0xa3, 0xbb]);
+    const fullOutput = Buffer.concat([Buffer.from("x"), gbk]);
+    const capture = createCapturedOutputBuffers();
+    observeCapturedOutputEncoding(capture, fullOutput);
+    appendCapturedOutput(capture, fullOutput, gbk.byteLength, "tail");
+
+    expect(finalizeCapturedOutput(capture, "tail")).toEqual(gbk);
+  });
+
+  it("preserves a legacy full-stream verdict when the retained slice is valid UTF-8", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const fullOutput = Buffer.from([0xc3, 0xa9, 0xff]);
+    const capture = createCapturedOutputBuffers();
+    observeCapturedOutputEncoding(capture, fullOutput);
+    appendCapturedOutput(capture, fullOutput, 2, "head");
+
+    const retained = finalizeCapturedOutput(capture, "head");
+    expect(capture.utf8Valid).toBe(false);
+    expect(
+      decodeWindowsOutputBuffer({
+        buffer: retained,
+        platform: "win32",
+        windowsEncoding: "windows-1252",
+        fullStreamUtf8Valid: capture.utf8Valid,
+      }),
+    ).toBe("Ã©");
+  });
+
+  it("keeps real truncated UTF-8 command output on a code-point boundary", async () => {
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", "process.stdout.write('😀'.repeat(10))"],
+      {
+        maxOutputBytes: 18,
+        outputCapture: "head",
+        timeoutMs: 3_000,
+      },
+    );
+
+    expect(result.stdout).toBe("😀".repeat(4));
+    expect(result.stdout).not.toContain("\uFFFD");
+    expect(result.stdoutTruncatedBytes).toBe(24);
   });
 });


### PR DESCRIPTION
## Problem

Windows command output can be UTF-8 or a legacy code page. When capture limits truncate a stream, repairing a partial UTF-8 boundary from the retained bytes alone is unsafe: skipping repair leaves replacement characters in genuine UTF-8 output, while blindly repairing can corrupt legacy output. A retained suffix can also look like valid UTF-8 even when discarded bytes prove the complete stream was not UTF-8.

## Solution

Track a fatal UTF-8 decoder alongside each Windows stdout/stderr capture and feed it every complete raw chunk before capture limits discard bytes. Finalization now:

- trims partial UTF-8 boundaries only when the complete stream was valid UTF-8;
- carries that complete-stream verdict into Windows decoding, so an ambiguous retained slice cannot be reclassified;
- leaves non-Windows capture unchanged and does not allocate the validator there.

The encoding decision stays with the capture owner, where the complete bytes still exist, while the existing Windows decoder continues to own legacy-code-page fallback.

## Validation

- Focused Testbox run 29660997444: 56 assertions passed across the Windows decoder and process execution suites.
- Full changed-surface Testbox run 29661237399: formatting, type, lint, architecture, package, database, and cycle gates passed.
- Exact-head CI run 29661488314: the native `checks-windows-node-test` job passed, along with all touched-surface build, type, lint, boundary, and security gates.
- Mandatory autoreview completed clean at confidence 0.94 after its encoding-verdict finding was fixed.

The exact-head CI run has one unrelated failure in `src/agents/workspace.test.ts`. Both failing cases reproduce unchanged at merge base `0135c6bf89bfa9d15fd797af1ff7b46b58f930f8` in Testbox run 29661931278; the PR does not touch that workspace path.

## Test coverage

Regression cases cover valid UTF-8 head and tail truncation, a GBK lead byte, an ambiguous CP1252 retained slice whose discarded prefix determines the legacy verdict, and a real child process that emits emoji across the capture boundary.

## Risk

Bounded to truncated Windows process output. The implementation preserves the existing UTF-8-first decoding contract for complete valid streams and the existing legacy fallback for invalid streams.

Thanks to @tzy-17 for identifying the Windows truncation gap and contributing the original fix and regression coverage.
