### PR TITLE
fix(gateway): cap sessions.compact maxLines

### DIFF
--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -42,6 +42,11 @@ import {
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
+// 100k transcript lines: an unbounded maxLines makes the manual trim load and
+// rewrite the entire transcript as an expensive no-op. Callers that want to
+// keep full history should omit maxLines and use model-backed compaction.
+const MAX_COMPACT_MAX_LINES = 100_000;
+
 export const sessionCompactHandlers: GatewayRequestHandlers = {
   "sessions.compact": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsCompactParams, "sessions.compact", respond)) {
@@ -58,7 +63,7 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
 
     const maxLines =
       typeof p.maxLines === "number" && Number.isFinite(p.maxLines)
-        ? Math.max(1, Math.floor(p.maxLines))
+        ? Math.min(Math.max(1, Math.floor(p.maxLines)), MAX_COMPACT_MAX_LINES)
         : undefined;
 
     const cfg = context.getRuntimeConfig();

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -13,6 +13,7 @@ import {
   loadTranscriptEvents,
   patchSessionEntry as patchAccessorSessionEntry,
   replaceSessionEntry,
+  replaceTranscriptEvents,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import {
@@ -1586,6 +1587,56 @@ test("sessions.compact maxLines trims SQLite transcript rows and returns an arch
 
   ws.close();
 });
+
+test(
+  "sessions.compact maxLines clamps absurd values to the manual trim cap",
+  // Seeding and trimming 100k+ transcript rows runs multi-second synchronous
+  // SQLite transactions that also stall the test process event loop.
+  { timeout: 180_000 },
+  async () => {
+    const { storePath } = await createSessionStoreDir();
+    await seedSessionEntry({
+      entry: sessionStoreEntry("sess-main"),
+      sessionKey: "agent:main:main",
+      storePath,
+    });
+    // Seed one row past the 100k cap so the clamped value is observable: an
+    // uncapped maxLines of 1e12 would keep all 100_001 rows as an expensive
+    // no-op, while the clamped cap trims to exactly 100_000.
+    await replaceTranscriptEvents(
+      {
+        sessionId: "sess-main",
+        sessionKey: "agent:main:main",
+        storePath,
+      },
+      buildSessionTranscriptLines("sess-main", 100_001).map((line): unknown => JSON.parse(line)),
+    );
+
+    const { ws } = await openClient();
+    const compacted = await rpcReq<{
+      ok: true;
+      key: string;
+      compacted: boolean;
+      kept?: number;
+      archived?: string;
+    }>(ws, "sessions.compact", { key: "main", maxLines: 1e12 }, 150_000);
+
+    expect(compacted.ok).toBe(true);
+    expect(compacted.payload?.compacted).toBe(true);
+    expect(compacted.payload?.kept).toBe(100_000);
+    expect(compacted.payload?.archived).toContain(`sqlite:main:sess-main:${storePath}.bak.`);
+
+    const retained = await loadTranscriptRows({
+      sessionId: "sess-main",
+      sessionKey: "agent:main:main",
+      storePath,
+    });
+    expect(retained).toHaveLength(100_000);
+    expect(retained[0]).toMatchObject({ type: "session", id: "sess-main" });
+
+    ws.close();
+  },
+);
 
 test("sessions.compact maxLines refuses an active run without trimming rows", async () => {
   const { dir, storePath } = await createSessionStoreDir();


### PR DESCRIPTION
## What Problem This Solves

`openclaw sessions compact <key> --max-lines N` accepts an unbounded `N`. The CLI parses it with `parseStrictPositiveIntOrUndefined` (no maximum; `src/cli/program/register.status-health-sessions.ts:432`) and forwards it to the `sessions.compact` gateway RPC. The gateway handler (`src/gateway/server-methods/sessions-compact.ts`) only lower-bounds the value:

```ts
Math.max(1, Math.floor(p.maxLines))
```

With `maxLines` set to `Number.MAX_SAFE_INTEGER` (or any value larger than the transcript), `trimSessionTranscriptForManualCompact` in `src/config/sessions/session-accessor.transcript.ts` loads every transcript event, serializes them all, and — because `events.length <= maxLines` — writes nothing useful: an intentional compaction becomes an expensive no-op / memory spike that still pays the full transcript read. There is no ceiling anywhere on the path (CLI parse, TypeBox schema `Type.Integer({ minimum: 1 })`, gateway handler, accessor).

## Why This Change Was Made

Add a named constant and clamp at the gateway boundary, the last common point every client (CLI, webchat, SDK) passes through:

```ts
const MAX_COMPACT_MAX_LINES = 100_000;

const maxLines =
  typeof p.maxLines === "number" && Number.isFinite(p.maxLines)
    ? Math.min(Math.max(1, Math.floor(p.maxLines)), MAX_COMPACT_MAX_LINES)
    : undefined;
```

This mirrors the merged `parseDays` day-count cap from #110552 (`MAX_USAGE_DAYS`, clamp-only at the handler, no schema change). The TypeBox schema in `packages/gateway-protocol` is deliberately untouched: clamping keeps the wire contract permissive instead of turning oversized values into validation errors, so older/newer clients keep working. Callers that genuinely want full-history retention are unaffected in intent — they should omit `maxLines` and use model-backed compaction, which is what the no-`maxLines` path already does.

## User Impact

- `openclaw sessions compact <key> --max-lines 9007199254740991` no longer triggers a full-transcript load/rewrite no-op; the effective keep-count is capped at 100,000 lines.
- All previously valid requests (any `maxLines` up to 100k, or omitted) behave exactly as before — the clamp only engages for absurd values that were already no-ops or memory hazards.
- No config, schema, or CLI flag changes; no migration needed.

## Evidence

New regression test in `src/gateway/server.sessions.compaction.test.ts`:

- `sessions.compact maxLines clamps absurd values to the manual trim cap` — seeds 100,001 SQLite transcript rows through the real accessor (`replaceTranscriptEvents`), then calls the real gateway RPC `sessions.compact` with `maxLines: 1e12`. Asserts `compacted: true`, `kept: 100_000`, an archive marker, and exactly 100,000 retained rows reloaded from the store. Uncapped, the same request would return `compacted: false, kept: 100_001` (the expensive no-op).

Reverse verification (control-red): with the handler change stashed, the new test FAILS (`compacted` is `false`, all 100,001 rows retained — the no-op); with the fix restored it passes. So the test pins the clamp, not incidental behavior.

Test suite:

```
$ node scripts/run-vitest.mjs src/gateway/server.sessions.compaction.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

(21 pre-existing tests plus the new one; all green. The new test is intentionally slower — it seeds and trims 100k real SQLite rows to make the cap observable through the production RPC path.)

tsgo (scoped lanes covering both touched files):

```
$ pnpm tsgo:core        # exit 0
$ pnpm tsgo:core:test   # exit 0
```

Lint / formatting:

```
$ node scripts/run-oxlint.mjs src/gateway/server-methods/sessions-compact.ts src/gateway/server.sessions.compaction.test.ts   # exit 0
$ ./node_modules/.bin/oxfmt --check <both files>   # all matched files use the correct format
$ git diff --check   # clean
```

Diff stat:

```
 src/gateway/server-methods/sessions-compact.ts |  7 +++-
 src/gateway/server.sessions.compaction.test.ts | 51 ++++++++++++++++++++
 2 files changed, 57 insertions(+), 1 deletion(-)
```

Production change is 4 lines: the `MAX_COMPACT_MAX_LINES` constant plus the `Math.min(...)` clamp. No schema, CLI, or accessor changes.

Pattern precedent: #110552 (merged) — named handler-level cap, clamp-only, no stricter validation.
