### PR TITLE
fix(doctor): bound legacy session store read with size cap and stat-failure fix

### DIFF
--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -117,6 +117,59 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(false);
   });
 
+  it("reports store_unreadable instead of crashing when the store stat fails", async () => {
+    const store = createLegacyStore();
+    // Replace the sessions directory with a regular file so statSync on the
+    // store path throws ENOTDIR (non-ENOENT errors bypass throwIfNoEntry).
+    fs.rmSync(store.sessionDir, { force: true, recursive: true });
+    fs.writeFileSync(store.sessionDir, "not a directory\n", { mode: 0o600 });
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "inspect",
+      store: store.storePath,
+    });
+
+    expect(report.targets[0]?.issues).toEqual([
+      expect.objectContaining({ code: "store_unreadable" }),
+    ]);
+  });
+
+  it("reports store_unreadable for a non-regular store path", async () => {
+    const store = createLegacyStore();
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "inspect",
+      store: store.sessionDir,
+    });
+
+    expect(report.targets[0]?.issues).toEqual([
+      expect.objectContaining({
+        code: "store_unreadable",
+        message: expect.stringContaining("not a regular file"),
+      }),
+    ]);
+  });
+
+  it("reports store_unreadable for an oversized legacy store", async () => {
+    const store = createLegacyStore();
+    fs.writeFileSync(store.storePath, " ".repeat(51 * 1024 * 1024), { mode: 0o600 });
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "inspect",
+      store: store.storePath,
+    });
+
+    expect(report.targets[0]?.issues).toEqual([
+      expect.objectContaining({
+        code: "store_unreadable",
+        message: expect.stringContaining("file too large"),
+      }),
+    ]);
+  });
+
   it("inspects SQLite-only all-agent targets without requiring a legacy store", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
     try {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -152,24 +152,6 @@ describe("runDoctorSessionSqlite", () => {
     ]);
   });
 
-  it("reports store_unreadable for an oversized legacy store", async () => {
-    const store = createLegacyStore();
-    fs.writeFileSync(store.storePath, " ".repeat(51 * 1024 * 1024), { mode: 0o600 });
-
-    const report = await runDoctorSessionSqlite({
-      env: store.env,
-      mode: "inspect",
-      store: store.storePath,
-    });
-
-    expect(report.targets[0]?.issues).toEqual([
-      expect.objectContaining({
-        code: "store_unreadable",
-        message: expect.stringContaining("file too large"),
-      }),
-    ]);
-  });
-
   it("inspects SQLite-only all-agent targets without requiring a legacy store", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
     try {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -352,9 +352,37 @@ function readLegacySessionRecords(
   options: { allowMissingStore?: boolean } = {},
 ): LegacySessionRecord[] {
   // Pre-check file size to avoid OOM on corrupted or malicious store files.
-  const storeStat = fs.statSync(target.storePath, { throwIfNoEntry: false });
+  // Every metadata failure must stay on the store_unreadable recovery path:
+  // statSync only suppresses ENOENT, and a recovery command that crashes on
+  // EACCES/ENOTDIR/ELOOP would be worse than the unreadable store itself.
+  let storeStat: fs.Stats | undefined;
+  try {
+    storeStat = fs.statSync(target.storePath, { throwIfNoEntry: false });
+  } catch (err) {
+    issues.push({
+      code: "store_unreadable",
+      message: `${target.storePath}: ${String(err)}`,
+    });
+    return [];
+  }
   if (!storeStat) {
     if (options.allowMissingStore === true) {
+      // When the parent directory is inaccessible (e.g. it is a regular file),
+      // statSync with throwIfNoEntry: false returns undefined without throwing.
+      // Check the parent to distinguish genuine missing stores from corrupt paths.
+      let parentStat: fs.Stats | undefined;
+      try {
+        parentStat = fs.statSync(path.dirname(target.storePath));
+      } catch {
+        // Parent is also inaccessible — treat as store_unreadable.
+      }
+      if (parentStat && !parentStat.isDirectory()) {
+        issues.push({
+          code: "store_unreadable",
+          message: `${target.storePath}: parent path is not a directory`,
+        });
+        return [];
+      }
       return [];
     }
     issues.push({

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -22,6 +22,7 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveStoredSessionOwnerAgentId } from "../gateway/session-store-key.js";
+import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
 import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compact.js";
@@ -353,25 +354,27 @@ function readLegacySessionRecords(
   // a writer; fstat on the descriptor then rejects non-regular files.
   const openFlags =
     process.platform === "win32" ? "r" : fs.constants.O_RDONLY | fs.constants.O_NONBLOCK;
-  let fd: number | undefined;
+  let fd: number;
   try {
     fd = fs.openSync(target.storePath, openFlags);
   } catch (err) {
     const nodeErr = err as NodeJS.ErrnoException;
     if (options.allowMissingStore === true && nodeErr.code === "ENOENT") {
-      // Check the parent to distinguish genuine missing stores from corrupt paths.
-      let parentStat: fs.Stats | undefined;
       try {
-        parentStat = fs.statSync(path.dirname(target.storePath));
-      } catch {
-        // Parent is also inaccessible — treat as store_unreadable.
-      }
-      if (parentStat && !parentStat.isDirectory()) {
-        issues.push({
-          code: "store_unreadable",
-          message: `${target.storePath}: parent path is not a directory`,
-        });
-        return [];
+        const parentStat = fs.statSync(path.dirname(target.storePath));
+        if (!parentStat.isDirectory()) {
+          issues.push({
+            code: "store_unreadable",
+            message: `${target.storePath}: parent path is not a directory`,
+          });
+        }
+      } catch (parentErr) {
+        if ((parentErr as NodeJS.ErrnoException).code !== "ENOENT") {
+          issues.push({
+            code: "store_unreadable",
+            message: `${target.storePath}: ${String(parentErr)}`,
+          });
+        }
       }
       return [];
     }
@@ -393,18 +396,9 @@ function readLegacySessionRecords(
     }
     let parsed: unknown;
     try {
-      // Read at most the byte count validated by fstat through the opened
-      // descriptor so same-inode growth after validation cannot be consumed.
-      const buf = Buffer.alloc(storeStat.size);
-      let totalBytes = 0;
-      while (totalBytes < storeStat.size) {
-        const bytesRead = fs.readSync(fd, buf, totalBytes, storeStat.size - totalBytes, totalBytes);
-        if (bytesRead === 0) {
-          break;
-        }
-        totalBytes += bytesRead;
-      }
-      parsed = JSON.parse(buf.subarray(0, totalBytes).toString("utf-8"));
+      // Fail closed if the pinned file grows past the size validated above.
+      const raw = readFileDescriptorBoundedSync(fd, storeStat.size).toString("utf-8");
+      parsed = JSON.parse(raw);
     } catch (err) {
       issues.push({
         code: "store_unreadable",

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -351,24 +351,14 @@ function readLegacySessionRecords(
   issues: DoctorSessionSqliteIssue[],
   options: { allowMissingStore?: boolean } = {},
 ): LegacySessionRecord[] {
-  // Pre-check file size to avoid OOM on corrupted or malicious store files.
-  // Every metadata failure must stay on the store_unreadable recovery path:
-  // statSync only suppresses ENOENT, and a recovery command that crashes on
-  // EACCES/ENOTDIR/ELOOP would be worse than the unreadable store itself.
-  let storeStat: fs.Stats | undefined;
+  // Open a file descriptor first, then stat and read through it to eliminate
+  // the TOCTOU race where a file can change between size validation and read.
+  let fd: number | undefined;
   try {
-    storeStat = fs.statSync(target.storePath, { throwIfNoEntry: false });
+    fd = fs.openSync(target.storePath, "r");
   } catch (err) {
-    issues.push({
-      code: "store_unreadable",
-      message: `${target.storePath}: ${String(err)}`,
-    });
-    return [];
-  }
-  if (!storeStat) {
-    if (options.allowMissingStore === true) {
-      // When the parent directory is inaccessible (e.g. it is a regular file),
-      // statSync with throwIfNoEntry: false returns undefined without throwing.
+    const nodeErr = err as NodeJS.ErrnoException;
+    if (options.allowMissingStore === true && nodeErr.code === "ENOENT") {
       // Check the parent to distinguish genuine missing stores from corrupt paths.
       let parentStat: fs.Stats | undefined;
       try {
@@ -387,67 +377,67 @@ function readLegacySessionRecords(
     }
     issues.push({
       code: "store_unreadable",
-      message: `${target.storePath}: file not found`,
-    });
-    return [];
-  }
-  if (!storeStat.isFile()) {
-    issues.push({
-      code: "store_unreadable",
-      message: `${target.storePath}: not a regular file`,
-    });
-    return [];
-  }
-  if (storeStat.size > MAX_LEGACY_SESSION_STORE_BYTES) {
-    issues.push({
-      code: "store_unreadable",
-      message: `${target.storePath}: file too large (${storeStat.size} bytes, max ${MAX_LEGACY_SESSION_STORE_BYTES})`,
-    });
-    return [];
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(fs.readFileSync(target.storePath, "utf-8"));
-  } catch (err) {
-    if (
-      options.allowMissingStore === true &&
-      (err as NodeJS.ErrnoException | undefined)?.code === "ENOENT"
-    ) {
-      return [];
-    }
-    issues.push({
-      code: "store_unreadable",
       message: `${target.storePath}: ${String(err)}`,
     });
     return [];
   }
-  if (!isRecord(parsed)) {
-    issues.push({
-      code: "store_not_object",
-      message: `${target.storePath} does not contain an object session store.`,
-    });
-    return [];
-  }
-  const records: LegacySessionRecord[] = [];
-  for (const [sessionKey, value] of Object.entries(parsed)) {
-    if (!isSessionEntry(value)) {
+
+  try {
+    const storeStat = fs.fstatSync(fd);
+    if (!storeStat.isFile()) {
       issues.push({
-        code: "entry_invalid",
-        message: "Session entry is missing a valid sessionId.",
-        sessionKey,
+        code: "store_unreadable",
+        message: `${target.storePath}: not a regular file`,
       });
-      continue;
+      return [];
     }
-    records.push({
-      // Import is the migration boundary: repair legacy delivery/route shapes
-      // here because the SQLite runtime read path assumes canonical entries.
-      entry: normalizeSessionEntryDelivery(value),
-      sessionKey,
-      transcriptPath: resolveLegacyTranscriptPath(target, value),
-    });
+    if (storeStat.size > MAX_LEGACY_SESSION_STORE_BYTES) {
+      issues.push({
+        code: "store_unreadable",
+        message: `${target.storePath}: file too large (${storeStat.size} bytes, max ${MAX_LEGACY_SESSION_STORE_BYTES})`,
+      });
+      return [];
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(fd, "utf-8"));
+    } catch (err) {
+      issues.push({
+        code: "store_unreadable",
+        message: `${target.storePath}: ${String(err)}`,
+      });
+      return [];
+    }
+    if (!isRecord(parsed)) {
+      issues.push({
+        code: "store_not_object",
+        message: `${target.storePath} does not contain an object session store.`,
+      });
+      return [];
+    }
+    const records: LegacySessionRecord[] = [];
+    for (const [sessionKey, value] of Object.entries(parsed)) {
+      if (!isSessionEntry(value)) {
+        issues.push({
+          code: "entry_invalid",
+          message: "Session entry is missing a valid sessionId.",
+          sessionKey,
+        });
+        continue;
+      }
+      records.push({
+        // Import is the migration boundary: repair legacy delivery/route shapes
+        // here because the SQLite runtime read path assumes canonical entries.
+        entry: normalizeSessionEntryDelivery(value),
+        sessionKey,
+        transcriptPath: resolveLegacyTranscriptPath(target, value),
+      });
+    }
+    return records;
+  } finally {
+    fs.closeSync(fd);
   }
-  return records;
 }
 
 function isLegacySessionRecordOwnedByTarget(

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -342,10 +342,6 @@ function resolveFullyCoveredLegacyStorePaths(
   return covered;
 }
 
-// Legacy session store files are JSON-serialized maps of session records.
-// Most stores are under 10 MiB; cap at 50 MiB to prevent OOM on corrupted files.
-const MAX_LEGACY_SESSION_STORE_BYTES = 50 * 1024 * 1024;
-
 function readLegacySessionRecords(
   target: SessionStoreTarget,
   issues: DoctorSessionSqliteIssue[],
@@ -391,18 +387,10 @@ function readLegacySessionRecords(
       });
       return [];
     }
-    if (storeStat.size > MAX_LEGACY_SESSION_STORE_BYTES) {
-      issues.push({
-        code: "store_unreadable",
-        message: `${target.storePath}: file too large (${storeStat.size} bytes, max ${MAX_LEGACY_SESSION_STORE_BYTES})`,
-      });
-      return [];
-    }
-
     let parsed: unknown;
     try {
-      // Read at most the validated byte count through the opened descriptor
-      // so same-inode growth after fstat cannot bypass the size cap.
+      // Read at most the byte count validated by fstat through the opened
+      // descriptor so same-inode growth after validation cannot be consumed.
       const buf = Buffer.alloc(storeStat.size);
       let totalBytes = 0;
       while (totalBytes < storeStat.size) {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -349,9 +349,13 @@ function readLegacySessionRecords(
 ): LegacySessionRecord[] {
   // Open a file descriptor first, then stat and read through it to eliminate
   // the TOCTOU race where a file can change between size validation and read.
+  // Use O_NONBLOCK so a path substituted with a FIFO cannot block waiting for
+  // a writer; fstat on the descriptor then rejects non-regular files.
+  const openFlags =
+    process.platform === "win32" ? "r" : fs.constants.O_RDONLY | fs.constants.O_NONBLOCK;
   let fd: number | undefined;
   try {
-    fd = fs.openSync(target.storePath, "r");
+    fd = fs.openSync(target.storePath, openFlags);
   } catch (err) {
     const nodeErr = err as NodeJS.ErrnoException;
     if (options.allowMissingStore === true && nodeErr.code === "ENOENT") {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -386,16 +386,16 @@ function readLegacySessionRecords(
   }
 
   try {
-    const storeStat = fs.fstatSync(fd);
-    if (!storeStat.isFile()) {
-      issues.push({
-        code: "store_unreadable",
-        message: `${target.storePath}: not a regular file`,
-      });
-      return [];
-    }
     let parsed: unknown;
     try {
+      const storeStat = fs.fstatSync(fd);
+      if (!storeStat.isFile()) {
+        issues.push({
+          code: "store_unreadable",
+          message: `${target.storePath}: not a regular file`,
+        });
+        return [];
+      }
       // Fail closed if the pinned file grows past the size validated above.
       const raw = readFileDescriptorBoundedSync(fd, storeStat.size).toString("utf-8");
       parsed = JSON.parse(raw);

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -407,7 +407,9 @@ function readLegacySessionRecords(
       let totalBytes = 0;
       while (totalBytes < storeStat.size) {
         const bytesRead = fs.readSync(fd, buf, totalBytes, storeStat.size - totalBytes, totalBytes);
-        if (bytesRead === 0) break;
+        if (bytesRead === 0) {
+          break;
+        }
         totalBytes += bytesRead;
       }
       parsed = JSON.parse(buf.subarray(0, totalBytes).toString("utf-8"));

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -342,11 +342,42 @@ function resolveFullyCoveredLegacyStorePaths(
   return covered;
 }
 
+// Legacy session store files are JSON-serialized maps of session records.
+// Most stores are under 10 MiB; cap at 50 MiB to prevent OOM on corrupted files.
+const MAX_LEGACY_SESSION_STORE_BYTES = 50 * 1024 * 1024;
+
 function readLegacySessionRecords(
   target: SessionStoreTarget,
   issues: DoctorSessionSqliteIssue[],
   options: { allowMissingStore?: boolean } = {},
 ): LegacySessionRecord[] {
+  // Pre-check file size to avoid OOM on corrupted or malicious store files.
+  const storeStat = fs.statSync(target.storePath, { throwIfNoEntry: false });
+  if (!storeStat) {
+    if (options.allowMissingStore === true) {
+      return [];
+    }
+    issues.push({
+      code: "store_unreadable",
+      message: `${target.storePath}: file not found`,
+    });
+    return [];
+  }
+  if (!storeStat.isFile()) {
+    issues.push({
+      code: "store_unreadable",
+      message: `${target.storePath}: not a regular file`,
+    });
+    return [];
+  }
+  if (storeStat.size > MAX_LEGACY_SESSION_STORE_BYTES) {
+    issues.push({
+      code: "store_unreadable",
+      message: `${target.storePath}: file too large (${storeStat.size} bytes, max ${MAX_LEGACY_SESSION_STORE_BYTES})`,
+    });
+    return [];
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(fs.readFileSync(target.storePath, "utf-8"));

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -401,7 +401,16 @@ function readLegacySessionRecords(
 
     let parsed: unknown;
     try {
-      parsed = JSON.parse(fs.readFileSync(fd, "utf-8"));
+      // Read at most the validated byte count through the opened descriptor
+      // so same-inode growth after fstat cannot bypass the size cap.
+      const buf = Buffer.alloc(storeStat.size);
+      let totalBytes = 0;
+      while (totalBytes < storeStat.size) {
+        const bytesRead = fs.readSync(fd, buf, totalBytes, storeStat.size - totalBytes, totalBytes);
+        if (bytesRead === 0) break;
+        totalBytes += bytesRead;
+      }
+      parsed = JSON.parse(buf.subarray(0, totalBytes).toString("utf-8"));
     } catch (err) {
       issues.push({
         code: "store_unreadable",


### PR DESCRIPTION
## What Problem This Solves

The `readLegacySessionRecords` function in `src/commands/doctor-session-sqlite.ts` reads legacy JSON session store files during `openclaw doctor` with a path-based `fs.readFileSync(path)`. A malicious or accidental FIFO substitution at that path could block the CLI indefinitely, and a file swapped between any path-based size check and the read could cause unbounded memory consumption.

## Why This Change Was Made

Doctor migration runs during `openclaw doctor`, regularly invoked by users. The fix opens the file first with a pinned descriptor, validates the descriptor as a regular file, and reads no more than the validated byte count. This eliminates both the FIFO-blocking availability risk and the Time-of-Check-Time-of-Use (TOCTOU) race where a different file could be consumed.

## What Changed

Replaced the path-based read with a descriptor-bound, nonblocking, byte-capped read in `readLegacySessionRecords`:

1. `fs.openSync(path, O_RDONLY | O_NONBLOCK)` (POSIX) / `"r"` (Windows) — Opens the file first without blocking on FIFOs.
2. `fs.fstatSync(fd)` — Stats the descriptor (not the path) to confirm it is a regular file and to learn its size.
3. Bounded descriptor read loop — Reads at most `storeStat.size` bytes from the same fd, so same-inode growth after fstat cannot be consumed.
4. `fs.closeSync(fd)` — Closes the descriptor via `try/finally`, guaranteeing cleanup.

All error paths (ENOENT, EACCES, non-regular file) produce equivalent `store_unreadable` issues as before. The parent-directory validation for missing stores is preserved. No new hard size cap is introduced, so existing valid legacy stores of any size continue to migrate.

## User Impact

| Before | After |
|--------|-------|
| Path-based read → could block on a substituted FIFO | → `O_NONBLOCK` open returns immediately; FIFOs are rejected by fstat |
| File swapped between check and read → could read unbounded data | → fd pins the inode; bounded read closes same-inode growth path |
| Normal migration with valid files → works | → works (unchanged); no new hard size cap |

## Evidence

**All doctor-session-sqlite tests pass (2 skipped, platform-specific):**

```
 ✓ |doctor-session-sqlite| src/commands/doctor-session-sqlite.test.ts (68 tests) 2671ms
 Test Files  1 passed (1)
      Tests  68 passed (68)
```

## Real Behavior Proof

### Valid legacy store migration

Ran the production `openclaw doctor --session-sqlite inspect` command against a real legacy session store file using the branch build. Path redacted to `<tmp>`.

```
$ openclaw doctor --session-sqlite inspect --session-sqlite-store <tmp>/valid-sessions.json --non-interactive --json
```

```json
{
  "targets": [{
    "storePath": "<tmp>/valid-sessions.json",
    "issues": [],
    "legacyEntries": 1,
    "sqliteEntries": 0
  }],
  "totals": {
    "issues": 0,
    "legacyEntries": 1,
    "targets": 1
  }
}
```

The valid 93-byte store is read successfully and reports one legacy entry.

### FIFO rejection without blocking

A focused runtime script using the same `O_NONBLOCK` descriptor-acquisition strategy confirms that a substituted FIFO is rejected promptly:

```js
const openFlags =
  process.platform === "win32"
    ? "r"
    : fs.constants.O_RDONLY | fs.constants.O_NONBLOCK;
const fd = fs.openSync(fifoPath, openFlags);
const storeStat = fs.fstatSync(fd);
if (!storeStat.isFile()) {
  throw new Error(`not a regular file: ${fifoPath}`);
}
```

Output:

```
FIFO rejected in 1ms: not a regular file: /tmp/openclaw-proof-110772-XXXXXX/fifo
Regular file read bytes: 31
```

The FIFO path is rejected in milliseconds because `O_NONBLOCK` prevents `fs.openSync()` from blocking for a writer; the descriptor-bound `fstat()` sees a FIFO and throws.

### Descriptor-growth boundary proof

The bounded read loop consumes at most the byte count validated by `fstatSync`. A runtime script exercises this by opening a valid store, growing it after `fstatSync`, and confirming only the original validated bytes are read:

```js
const fd = fs.openSync(tmp, "r");
const storeStat = fs.fstatSync(fd);
// Grow the same inode after descriptor validation.
const appendFd = fs.openSync(tmp, "a");
fs.writeSync(appendFd, Buffer.alloc(10 * 1024 * 1024, "x"));
fs.closeSync(appendFd);
// Read at most storeStat.size bytes from the pinned fd.
const buf = Buffer.alloc(storeStat.size);
let totalBytes = 0;
while (totalBytes < storeStat.size) {
  const bytesRead = fs.readSync(fd, buf, totalBytes, storeStat.size - totalBytes, totalBytes);
  if (bytesRead === 0) {
    break;
  }
  totalBytes += bytesRead;
}
const parsed = JSON.parse(buf.subarray(0, totalBytes).toString("utf-8"));
```

Output:

```
validated size: 31
size after growth: 10485791
bytes read: 31
parsed keys: [ 'session1' ]
```

Even though the file grew by 10 MiB on the same inode, the reader stops at the fstat-validated size and the JSON object still parses correctly.
