### PR TITLE
fix(session-memory): bound session transcript file read with size cap

### DIFF
--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -86,4 +86,36 @@ describe("session-memory transcript extraction", () => {
       "assistant: Answer [REMOVED_SPECIAL_TOKEN]",
     );
   });
+
+  it("returns a single-line transcript without a trailing newline", async () => {
+    const transcriptPath = await writeTranscript(message("user", "hello"));
+
+    await expect(getRecentSessionContentWithResetFallback(transcriptPath)).resolves.toBe(
+      "user: hello",
+    );
+  });
+
+  it("reads only a bounded tail from oversized transcripts and keeps recent events", async () => {
+    const transcriptPath = await writeTranscript(
+      [
+        message("user", `early-marker ${"x".repeat(51 * 1024 * 1024)}`),
+        message("user", "recent tail marker"),
+        message("assistant", "recent tail answer"),
+      ].join("\n"),
+    );
+
+    const memoryContent = await getRecentSessionContentWithResetFallback(transcriptPath);
+
+    expect(memoryContent).toContain("user: recent tail marker");
+    expect(memoryContent).toContain("assistant: recent tail answer");
+    expect(memoryContent).not.toContain("early-marker");
+    expect(memoryContent?.length).toBeLessThan(1024);
+  });
+
+  it("returns null for non-regular transcript paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-memory-transcript-"));
+    tempRoots.push(root);
+
+    await expect(getRecentSessionContentWithResetFallback(root)).resolves.toBeNull();
+  });
 });

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,4 +1,3 @@
-import { statSync } from "node:fs";
 // Session memory transcript helpers persist compact session transcript excerpts.
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -135,22 +134,46 @@ export function getRecentSessionContentFromEvents(
 }
 
 // Session transcript files contain agent-user conversation content.
-// Most transcripts are under 1 MiB; cap at 50 MiB to prevent OOM on
+// Most transcripts are under 1 MiB; cap reads at 50 MiB to prevent OOM on
 // extremely long sessions or corrupted files.
 const MAX_SESSION_TRANSCRIPT_BYTES = 50 * 1024 * 1024;
 
-/** Read a session transcript file with size pre-check. */
+/**
+ * Read a session transcript through one file descriptor, bounding the read to
+ * the trailing MAX_SESSION_TRANSCRIPT_BYTES. Only recent events are consumed,
+ * so an oversized transcript still yields its latest messages instead of
+ * failing, and concurrent growth or replacement after open cannot bypass the
+ * bound.
+ */
 async function readSessionTranscriptSafely(filePath: string): Promise<string> {
-  const stat = statSync(filePath);
-  if (!stat.isFile()) {
-    throw new Error(`not a regular file: ${filePath}`);
+  const handle = await fs.open(filePath, "r");
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error(`not a regular file: ${filePath}`);
+    }
+    const start = Math.max(0, stat.size - MAX_SESSION_TRANSCRIPT_BYTES);
+    const length = Math.min(stat.size, MAX_SESSION_TRANSCRIPT_BYTES);
+    const buffer = Buffer.alloc(length);
+    let offset = 0;
+    while (offset < length) {
+      const { bytesRead } = await handle.read(buffer, offset, length - offset, start + offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+    const tail = buffer.subarray(0, offset).toString("utf-8");
+    if (start === 0) {
+      return tail;
+    }
+    // A truncated tail can start mid-line; drop the partial first line so
+    // JSONL parsing resumes at an event boundary.
+    const firstNewline = tail.indexOf("\n");
+    return firstNewline === -1 ? "" : tail.slice(firstNewline + 1);
+  } finally {
+    await handle.close();
   }
-  if (stat.size > MAX_SESSION_TRANSCRIPT_BYTES) {
-    throw new Error(
-      `session transcript too large: ${filePath} is ${stat.size} bytes (max ${MAX_SESSION_TRANSCRIPT_BYTES})`,
-    );
-  }
-  return await fs.readFile(filePath, "utf-8");
 }
 
 async function getRecentSessionContent(

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,3 +1,4 @@
+import { statSync } from "node:fs";
 // Session memory transcript helpers persist compact session transcript excerpts.
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -133,12 +134,31 @@ export function getRecentSessionContentFromEvents(
   return allMessages.slice(-messageCount).join("\n");
 }
 
+// Session transcript files contain agent-user conversation content.
+// Most transcripts are under 1 MiB; cap at 50 MiB to prevent OOM on
+// extremely long sessions or corrupted files.
+const MAX_SESSION_TRANSCRIPT_BYTES = 50 * 1024 * 1024;
+
+/** Read a session transcript file with size pre-check. */
+async function readSessionTranscriptSafely(filePath: string): Promise<string> {
+  const stat = statSync(filePath);
+  if (!stat.isFile()) {
+    throw new Error(`not a regular file: ${filePath}`);
+  }
+  if (stat.size > MAX_SESSION_TRANSCRIPT_BYTES) {
+    throw new Error(
+      `session transcript too large: ${filePath} is ${stat.size} bytes (max ${MAX_SESSION_TRANSCRIPT_BYTES})`,
+    );
+  }
+  return await fs.readFile(filePath, "utf-8");
+}
+
 async function getRecentSessionContent(
   sessionFilePath: string,
   messageCount = 15,
 ): Promise<string | null> {
   try {
-    const content = await fs.readFile(sessionFilePath, "utf-8");
+    const content = await readSessionTranscriptSafely(sessionFilePath);
     const lines = content.trim().split("\n");
 
     return getRecentSessionContentFromEvents(


### PR DESCRIPTION
## What Problem This Solves

`getRecentSessionContent` in `src/hooks/bundled/session-memory/transcript.ts` reads the entire session transcript file into memory with no size limit — despite only needing the last `messageCount` (default 15) events from the file.

Session transcripts contain agent-user conversation content — fully user-controlled data. An agent that generates a massive transcript (or a user feeding input that produces one) causes the entire file to be loaded into memory. The function only needs the last N events but reads the whole file anyway.

## Why This Change Was Made

Unbounded `readFile` on user-controlled session files is a valid OOM vector. The intent of the function is to return only recent messages, so the full-file read is wasteful even without the security concern.

Revision after ClawSweeper review: the first revision used a pathname `statSync` + full `readFile`, which (a) left a TOCTOU gap — a file growing or replaced between stat and read bypassed the cap, and (b) hard-rejected transcripts above 50 MiB, dropping recent-session memory for valid long sessions. This revision addresses both findings.

## What Changed

`readSessionTranscriptSafely` now binds validation and reading to one file descriptor:

1. `fs.open` the transcript once; `fstat` the descriptor and reject non-regular files.
2. Read only the trailing 50 MiB window through that descriptor (`handle.read` with an explicit position and a fixed-size buffer) — concurrent growth or replacement after open cannot bypass the bound.
3. Oversized transcripts are no longer rejected: the truncated tail drops its partial first line so JSONL parsing resumes at an event boundary, and the recent events the caller needs are still returned.
4. Files at or under the cap are read in full, exactly as before.

## User Impact

| Before | After |
|--------|-------|
| Session with 2 GB transcript -> OOM during memory hook | -> bounded 50 MiB tail read; recent messages still returned |
| Normal sessions (transcripts < 1 MiB) -> works | -> works (unchanged) |

## Evidence

**Real behavior proof** — 59.0 MiB transcript (above the 50 MiB cap) whose oldest event is a ~59 MiB single line, with two recent events appended. Actual run output:

```
transcript size: 59.0 MiB (cap: 50 MiB)
rss delta during read: -77.1 MiB
returned memory (54 chars):
user: proof tail question
assistant: proof tail answer
--- assertions ---
contains recent events: true
old content excluded: true
bounded read (rss delta < file size): true
```

The recent events are returned from an above-cap transcript while the read stays bounded (no full-file allocation; RSS delta is far below the file size — GC even reclaimed during the call).

**Regression coverage** — all 6 session-memory transcript tests pass, including the new oversized-tail, single-line-without-trailing-newline, and non-regular-path cases:

```
✓ src/hooks/bundled/session-memory/transcript.test.ts (6 tests) 855ms
  ✓ reads only a bounded tail from oversized transcripts and keeps recent events 527ms
Test Files  1 passed (1)
     Tests  6 passed (6)
```

50 MiB cap is well above any legitimate session transcript (a year of daily active sessions with full content is typically under 50 MiB); above it, session memory now degrades to the most recent events instead of failing.
