### PR TITLE
fix(ui): send on first tap with mobile keyboard open

### DIFF
--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -180,6 +180,28 @@ describe("renderChatComposer controls", () => {
     ).toBeNull();
   });
 
+  it("keeps textarea focus through a touch send so the mobile click is not consumed", () => {
+    const onSend = vi.fn();
+    const { container } = renderComposer({ draft: "Send from mobile", onSend });
+    document.body.append(container);
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    const send = button(container, t("chat.runControls.sendMessage"));
+    if (!textarea) {
+      throw new Error("expected composer textarea");
+    }
+    textarea.focus();
+    const pointerDown = new Event("pointerdown", { bubbles: true, cancelable: true });
+    Object.defineProperty(pointerDown, "pointerType", { value: "touch" });
+
+    expect(send.dispatchEvent(pointerDown)).toBe(false);
+    expect(pointerDown.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(textarea);
+
+    send.click();
+    expect(onSend).toHaveBeenCalledOnce();
+    container.remove();
+  });
+
   it("keeps voice and generation stop controls distinct when both are active", () => {
     const onAbort = vi.fn();
     const onToggleRealtimeTalk = vi.fn();

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1766,6 +1766,15 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
     }
     props.onSend();
   };
+  const preserveComposerFocusOnTouch = (event: PointerEvent) => {
+    // Mobile browsers can consume the first tap while moving focus away from
+    // the textarea and resizing the visual viewport for the software keyboard.
+    // Keeping textarea focus through pointerdown lets the subsequent click
+    // reach the primary action normally.
+    if (event.pointerType === "touch") {
+      event.preventDefault();
+    }
+  };
   const abortAction = props.canAbort
     ? html`
         <openclaw-tooltip .content=${t("chat.runControls.stop")}>
@@ -1854,6 +1863,7 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
                   <openclaw-tooltip .content=${activeRunActionLabel}>
                     <button
                       class="chat-send-btn"
+                      @pointerdown=${preserveComposerFocusOnTouch}
                       @click=${storeDraftAndSend}
                       ?disabled=${!props.canSend || props.sending}
                       aria-label=${activeRunActionDescription}
@@ -1882,6 +1892,7 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
               >
                 <button
                   class="chat-send-btn"
+                  @pointerdown=${preserveComposerFocusOnTouch}
                   @click=${storeDraftAndSend}
                   ?disabled=${!props.canSend || props.sending}
                   aria-label=${props.isBusy


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users tapping the Control UI send button with the software keyboard open could have the first tap ignored. The message would send only after dismissing the keyboard or tapping again.

## Why This Change Was Made

The primary send actions now preserve textarea focus during touch `pointerdown`, before the mobile browser can blur the composer and resize the visual viewport. Mouse and keyboard interaction are unchanged, and the existing click handler remains the only path that submits the message.

A regression test verifies that touch pointerdown is cancelled, textarea focus is retained, and the following click sends exactly once.

## User Impact

Mobile users can send a composed message on the first tap while the software keyboard remains open.

## Evidence

Real-device observation on an iPhone 17 with OpenClaw `2026.7.2-beta.2`:

- Before: tapping Send while the software keyboard was open did not submit; dismissing the keyboard first made the same button work.
- After applying this change to the installed Control UI: repeated test messages submitted with the keyboard still open.

Validation on current `main`:

- `corepack pnpm --dir ui test --run src/pages/chat/chat-composer.test.ts`
- Full Control UI suite: 309 files, 4,407 tests passed
- `corepack pnpm ui:build`
- `corepack pnpm exec oxfmt --check ui/src/pages/chat/components/chat-composer.ts ui/src/pages/chat/chat-composer.test.ts`
- `git diff --check`
