### PR TITLE
fix(feishu): migrate delivery-trace goldens off the retired capture seam

### DIFF
--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -1,7 +1,8 @@
 // Feishu delivery trace goldens: replayable wire-level lifecycle recordings.
 //
-// IN events are fed straight into the reply-dispatcher wiring (the options
-// createReplyDispatcherWithTyping receives plus replyOptions callbacks); OUT
+// IN events are fed straight into the reply-dispatcher wiring (the core-owned
+// dispatcher options and delivery returned by createFeishuReplyDispatcher plus
+// replyOptions callbacks); OUT
 // events are recorded at the mocked Lark SDK client and the mocked CardKit
 // HTTP fetch, so streaming-card entity calls are captured at the wire seam.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
@@ -37,7 +38,6 @@ type FeishuTraceState = {
   account: ResolvedFeishuAccount | null;
   larkClient: unknown;
   cardKitFetch: typeof fetch | null;
-  dispatcherOptions: FeishuDispatcherOptions | null;
   messageCount: number;
   reactionCount: number;
   cardCount: number;
@@ -51,7 +51,6 @@ const traceState = vi.hoisted(
     account: null,
     larkClient: null,
     cardKitFetch: null,
-    dispatcherOptions: null,
     messageCount: 0,
     reactionCount: 0,
     cardCount: 0,
@@ -84,17 +83,6 @@ vi.mock("./client.js", async (importOriginal) => {
         throw new Error("trace Lark client not initialized");
       }
       return traceState.larkClient;
-    },
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createReplyDispatcherWithTyping: (options: FeishuDispatcherOptions) => {
-      traceState.dispatcherOptions = options;
-      return { dispatcher: {}, replyOptions: {}, markDispatchIdle: () => {} };
     },
   };
 });
@@ -378,10 +366,10 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
     sendTarget: "oc-trace-chat",
     replyToMessageId: "om-inbound",
   });
-  const options = traceState.dispatcherOptions;
-  if (!options) {
-    throw new Error("dispatcher options were not captured");
-  }
+  const options = {
+    ...created.dispatcherOptions,
+    deliver: created.delivery.deliver,
+  } as FeishuDispatcherOptions;
 
   return async (step: DeliveryTraceInStep) => {
     switch (step.kind) {


### PR DESCRIPTION
## What Problem This Solves

`extensions/feishu/src/delivery-trace.test.ts` fails deterministically on unmodified `main` — all five goldens throw `dispatcher options were not captured`. Because the `checks-node-changed-*` dependency graph pulls this shard in, the required `openclaw/ci-gate` check goes red for any PR that touches the Feishu reply-dispatcher surface (e.g. #110730 hit this on an unrelated diff).

## Why This Change Was Made

PR #110095 (refactor(channels): move inbound turn execution into core) changed `createFeishuReplyDispatcher` to return `dispatcherOptions` / `delivery` / `replyOptions` for core to wire up — it no longer calls `createReplyDispatcherWithTyping` itself. The same PR migrated the sibling msteams and slack delivery-trace suites off the old capture-seam mock, but missed the feishu suite, whose `vi.mock("openclaw/plugin-sdk/reply-runtime")` capture never fires anymore.

This completes that migration for feishu, mirroring the exact pattern #110095 applied to `extensions/msteams/src/delivery-trace.test.ts`: drop the retired capture-seam mock and build the step-driver options directly from the dispatcher's own return value (`created.dispatcherOptions` + `created.delivery.deliver`). The feishu plan options already expose `onReplyStart` / `onIdle` / `onCleanup`, so the scenario step wiring is unchanged, and the committed golden traces stay byte-identical — no golden refresh needed.

## Changes

- **`extensions/feishu/src/delivery-trace.test.ts`** — remove the retired `createReplyDispatcherWithTyping` capture-seam mock and the `traceState.dispatcherOptions` slot; build `options` from `created.dispatcherOptions` spread plus `created.delivery.deliver`, matching the msteams/slack pattern from #110095

## Evidence

### Test command

```
npx vitest run extensions/feishu/src/delivery-trace.test.ts extensions/msteams/src/delivery-trace.test.ts extensions/slack/src/delivery-trace.test.ts --reporter=verbose
```

### Test output

Before (unmodified main, matching the issue report):

```
× records streaming-happy 21ms
× records final-only 3ms
× records cancel-mid-stream 2ms
× records rate-limit-during-preview 1ms
× records overflow-pagination 1ms
Error: dispatcher options were not captured
Test Files  1 failed (1)  |  Tests  5 failed (5)
```

After (this change), including the msteams/slack sibling suites as regressions:

```
✓ feishu delivery trace goldens > records streaming-happy 62ms
✓ feishu delivery trace goldens > records final-only 7ms
✓ feishu delivery trace goldens > records cancel-mid-stream 6ms
✓ feishu delivery trace goldens > records rate-limit-during-preview 7ms
✓ feishu delivery trace goldens > records overflow-pagination 117ms
✓ msteams delivery trace goldens (4 tests) all passed
✓ slack delivery trace goldens (5 tests) all passed
Test Files  3 passed (3)  |  Tests  14 passed (14)
```

### Behavior

- Before: the five feishu goldens fail on unmodified main and block ci-gate for any Feishu dispatcher PR
- After: all five goldens pass against the unchanged committed traces (byte-identical wire recordings — the dispatcher behavior itself was never wrong, only the test seam was stale)

## Related

Closes #110744
Follow-up to #110095 (which migrated msteams/slack but missed feishu); unblocks PRs like #110730

## AI Assistance Disclosure

Implemented with AI assistance (Claude Code). I reviewed and understand every changed line; the evidence above is real local terminal output (Node 24.15.0, Windows).
