### PR TITLE
fix(grep): bound file reads with size cap in default grep operations

### DIFF
--- a/src/agents/sessions/tools/grep-bound-read.test.ts
+++ b/src/agents/sessions/tools/grep-bound-read.test.ts
@@ -1,53 +1,49 @@
-// Grep tool bounded read tests verify the size-check contract in readFile.
+// Grep tool bounded read tests verify the size-check contract in the real defaultGrepOperations.
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import type { GrepOperations } from "./grep.js";
-import { createGrepToolDefinition } from "./grep.js";
+import { defaultGrepOperations } from "./grep.js";
 
-describe("createGrepTool bounded reads", () => {
-  it("exposes the default readFile size cap as an exported contract", () => {
-    // 50 MiB is the internal constant in grep.ts.
-    // This test verifies that the constant is reachable by re-checking the value
-    // that the default implementation enforces.
-    const toolDef = createGrepToolDefinition("/tmp");
-    expect(toolDef.name).toBe("grep");
+describe("defaultGrepOperations.readFile", () => {
+  it("rejects non-regular files (e.g. directories)", () => {
+    const tmpDir = fs.mkdtempSync("grep-bound-test-dir-");
+    expect(() => defaultGrepOperations.readFile(tmpDir)).toThrow("not a regular file");
+    fs.rmSync(tmpDir, { force: true, recursive: true });
   });
 
-  it("disallows files above 50 MiB via custom readFile pre-check", () => {
-    const ops: GrepOperations = {
-      isDirectory: () => false,
-      readFile: (p) => {
-        const stats = fs.statSync(p);
-        if (stats.size > 50 * 1024 * 1024) {
-          throw new Error(`file too large`);
-        }
-        return fs.readFileSync(p, "utf-8");
-      },
-    };
+  it("rejects files exceeding the 50 MiB cap", () => {
+    const tmpDir = fs.mkdtempSync("grep-bound-test-large-");
+    const largeFile = path.join(tmpDir, "large.bin");
+    const fd = fs.openSync(largeFile, "w");
+    fs.ftruncateSync(fd, 51 * 1024 * 1024);
+    fs.closeSync(fd);
 
-    const tmpDir = fs.mkdtempSync("grep-bound-test-");
-    const largeFile = path.join(tmpDir, "large.txt");
-    fs.writeFileSync(largeFile, Buffer.alloc(51 * 1024 * 1024));
-
-    expect(() => ops.readFile(largeFile)).toThrow("file too large");
+    expect(() => defaultGrepOperations.readFile(largeFile)).toThrow("file too large");
 
     fs.rmSync(tmpDir, { force: true, recursive: true });
   });
 
-  it("accepts files under the size cap", () => {
-    const ops: GrepOperations = {
-      isDirectory: () => false,
-      readFile: (p) => fs.readFileSync(p, "utf-8"),
-    };
-
-    const tmpDir = fs.mkdtempSync("grep-bound-test-");
+  it("accepts files below the 50 MiB cap and returns their content", () => {
+    const tmpDir = fs.mkdtempSync("grep-bound-test-small-");
     const smallFile = path.join(tmpDir, "small.txt");
-    const content = "hello";
+    const content = "hello world";
     fs.writeFileSync(smallFile, content, "utf8");
 
-    const result = ops.readFile(smallFile);
+    const result = defaultGrepOperations.readFile(smallFile);
     expect(result).toBe(content);
+
+    fs.rmSync(tmpDir, { force: true, recursive: true });
+  });
+
+  it("accepts files exactly at the 50 MiB cap boundary", () => {
+    const tmpDir = fs.mkdtempSync("grep-bound-test-boundary-");
+    const boundaryFile = path.join(tmpDir, "boundary.bin");
+    const fd = fs.openSync(boundaryFile, "w");
+    fs.ftruncateSync(fd, 50 * 1024 * 1024);
+    fs.closeSync(fd);
+
+    // Should succeed because the check is strict greater-than, not greater-or-equal.
+    expect(() => defaultGrepOperations.readFile(boundaryFile)).not.toThrow();
 
     fs.rmSync(tmpDir, { force: true, recursive: true });
   });

--- a/src/agents/sessions/tools/grep-bound-read.test.ts
+++ b/src/agents/sessions/tools/grep-bound-read.test.ts
@@ -1,0 +1,54 @@
+// Grep tool bounded read tests verify the size-check contract in readFile.
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { GrepOperations } from "./grep.js";
+import { createGrepToolDefinition } from "./grep.js";
+
+describe("createGrepTool bounded reads", () => {
+  it("exposes the default readFile size cap as an exported contract", () => {
+    // 50 MiB is the internal constant in grep.ts.
+    // This test verifies that the constant is reachable by re-checking the value
+    // that the default implementation enforces.
+    const toolDef = createGrepToolDefinition("/tmp");
+    expect(toolDef.name).toBe("grep");
+  });
+
+  it("disallows files above 50 MiB via custom readFile pre-check", () => {
+    const ops: GrepOperations = {
+      isDirectory: () => false,
+      readFile: (p) => {
+        const stats = fs.statSync(p);
+        if (stats.size > 50 * 1024 * 1024) {
+          throw new Error(`file too large`);
+        }
+        return fs.readFileSync(p, "utf-8");
+      },
+    };
+
+    const tmpDir = fs.mkdtempSync("grep-bound-test-");
+    const largeFile = path.join(tmpDir, "large.txt");
+    fs.writeFileSync(largeFile, Buffer.alloc(51 * 1024 * 1024));
+
+    expect(() => ops.readFile(largeFile)).toThrow("file too large");
+
+    fs.rmSync(tmpDir, { force: true, recursive: true });
+  });
+
+  it("accepts files under the size cap", () => {
+    const ops: GrepOperations = {
+      isDirectory: () => false,
+      readFile: (p) => fs.readFileSync(p, "utf-8"),
+    };
+
+    const tmpDir = fs.mkdtempSync("grep-bound-test-");
+    const smallFile = path.join(tmpDir, "small.txt");
+    const content = "hello";
+    fs.writeFileSync(smallFile, content, "utf8");
+
+    const result = ops.readFile(smallFile);
+    expect(result).toBe(content);
+
+    fs.rmSync(tmpDir, { force: true, recursive: true });
+  });
+});

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -67,7 +67,7 @@ export interface GrepOperations {
   readFile: (absolutePath: string) => Promise<string> | string;
 }
 
-const defaultGrepOperations: GrepOperations = {
+export const defaultGrepOperations: GrepOperations = {
   isDirectory: (p) => statSync(p).isDirectory(),
   readFile: (p) => {
     const stats = statSync(p);

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -52,6 +52,10 @@ const grepSchema = Type.Object({
 });
 const DEFAULT_LIMIT = 100;
 
+// Cap file reads during grep context rendering at 50 MiB to prevent OOM from
+// large binary files or oversized text files that grep would match against.
+const MAX_GREP_FILE_BYTES = 50 * 1024 * 1024;
+
 /**
  * Pluggable operations for the grep tool.
  * Override these to delegate search to remote systems (for example SSH).
@@ -65,7 +69,18 @@ export interface GrepOperations {
 
 const defaultGrepOperations: GrepOperations = {
   isDirectory: (p) => statSync(p).isDirectory(),
-  readFile: (p) => readFileSync(p, "utf-8"),
+  readFile: (p) => {
+    const stats = statSync(p);
+    if (!stats.isFile()) {
+      throw new Error(`not a regular file: ${p}`);
+    }
+    if (stats.size > MAX_GREP_FILE_BYTES) {
+      throw new Error(
+        `file too large (${stats.size} bytes > ${MAX_GREP_FILE_BYTES} byte limit): ${p}`,
+      );
+    }
+    return readFileSync(p, "utf-8");
+  },
 };
 
 export interface GrepToolOptions {

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -67,6 +67,7 @@ export interface GrepOperations {
   readFile: (absolutePath: string) => Promise<string> | string;
 }
 
+/** @internal Exported for testing */
 export const defaultGrepOperations: GrepOperations = {
   isDirectory: (p) => statSync(p).isDirectory(),
   readFile: (p) => {


### PR DESCRIPTION
## What Problem This Solves

The default `readFile` operation in the grep tool reads files with no size bound. When grep matches lines in a large file (e.g., a multi-GB log file), `getFileLines` loads the entire file into memory to render context, risking OOM.

## Why This Change Was Made

The `defaultGrepOperations.readFile` function used raw `readFileSync(p, "utf-8")` with no size pre-check. The fix adds a `statSync` pre-check that:

1. Verifies the path is a regular file (not a directory or device)
2. Rejects files exceeding 50 MiB with a clear error
3. Only then reads content with `readFileSync`

The error is caught by `getFileLines`, which returns empty lines on error — the same graceful degradation as other read failures (e.g. permission errors).

## User Impact

- Prevents OOM crashes when grep matches lines in oversized files
- Context lines for oversized files render as `<path>:<line>: (unable to read file)` — the match itself is still reported, only the surrounding-context rendering is omitted
- No change for normal files under 50 MiB

## Evidence

**Focused tests** — `node scripts/run-vitest.mjs src/agents/sessions/tools/grep.stream-errors.test.ts src/agents/sessions/tools/grep-bound-read.test.ts` — 12/12 pass:

```text
 ✓ |agents| src/agents/sessions/tools/grep.stream-errors.test.ts (8 tests)
 ✓ |agents| src/agents/sessions/tools/grep-bound-read.test.ts (4 tests)
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

The new `grep-bound-read.test.ts` imports the real `defaultGrepOperations` and exercises its actual `readFile` for directory rejection, over-cap rejection, under-cap content return, and the exact 50 MiB boundary (strict `>` comparison).

**Knip (`deadcode:full`, both scans)** — production scan and all-exports scan both exit 0. `defaultGrepOperations` carries `/** @internal Exported for testing */`, the existing repo pattern for test-only exports (same as `parseModelPattern` in `src/agents/sessions/model-resolver.ts`): the production knip scan ignores `@internal` exports, and the all-exports scan counts the test file import as usage.

## Real Behavior Proof

Run on the pushed head `af2662120fdc5b07937f5b0b12ced49d06ba33dc` using the real default grep tool — `createGrepToolDefinition(cwd)` with **no custom operations** (the same construction the session tool registry uses in `src/agents/sessions/tools/index.ts`) — against an isolated scenario directory:

- `oversized.log` — 53,000,000 bytes (> 50 MiB = 52,428,800) with a `GREP_PROOF_NEEDLE` match on line 1
- `normal.log` — 127 bytes with the same needle surrounded by context lines

Redacted terminal transcript (`<home>` = local user home, scenario under `/tmp`):

```text
$ git rev-parse HEAD
af2662120fdc5b07937f5b0b12ced49d06ba33dc

$ git log -1 --oneline
af2662120fd fix(grep): tag test-only defaultGrepOperations export as @internal for knip

$ ls -l /tmp/openclaw-grep-proof-scenario
total 51764
-rw-rw-r-- 1 <user> <user>      127 Jul 19 08:29 normal.log
-rw-rw-r-- 1 <user> <user> 53000000 Jul 19 08:29 oversized.log

$ stat -c "%n %s bytes" /tmp/openclaw-grep-proof-scenario/*.log
/tmp/openclaw-grep-proof-scenario/normal.log 127 bytes
/tmp/openclaw-grep-proof-scenario/oversized.log 53000000 bytes

$ node --import tsx .tmp/grep-proof/driver.mts /tmp/openclaw-grep-proof-scenario /tmp/openclaw-grep-proof-scenario/oversized.log
direct readFile(oversized.log) threw: file too large (53000000 bytes > 52428800 byte limit): /tmp/openclaw-grep-proof-scenario/oversized.log
--- default grep tool output (context=2) ---
normal.log-1- before context line 1
normal.log-2- before context line 2
normal.log:3: GREP_PROOF_NEEDLE inside the normal file
normal.log-4- after context line 1
normal.log-5- after context line 2
oversized.log:1: (unable to read file)
--- tool run completed without crashing ---
exit code: 0
```

Observed on the current head:

1. The real default context reader rejects the oversized file before reading: `file too large (53000000 bytes > 52428800 byte limit)`.
2. In the full default grep run (real ripgrep spawn, `context=2`), the match in `oversized.log` degrades to bounded empty context — `oversized.log:1: (unable to read file)` — instead of loading 53 MB into memory.
3. The match in `normal.log` retains its full surrounding context (`normal.log-1-` through `normal.log-5-`).
4. The tool run completes successfully (exit code 0); grep keeps working normally for all other files.

## Degraded-Behavior Contract (maintainer confirmation requested)

Answering the review's maintainer-decision question explicitly: this PR intentionally establishes that matching regular files **over a fixed 50 MiB threshold** return **no context lines** through the existing read-error degradation path (`(unable to read file)`), rather than implementing a bounded/streaming context extraction for large files. Rationale: it is the smallest change that removes the unbounded-read OOM risk, it reuses the already-shipped degradation path used for every other read failure, and the match itself is still reported. Files exactly at 50 MiB are still read (strict `>`), and files under the cap are completely unaffected. If an owner prefers bounded context extraction for large files instead, this PR should be paused pending that decision.
