### PR TITLE
fix(auth-profiles): bound auth-profile JSON reads with size cap

### DIFF
--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,13 +11,13 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
   });
 
   async function withAgentStore(profiles: Record<string, unknown>) {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
     const stateDir = path.join(root, "state");
     const agentDir = path.join(root, "agent");
-    await fs.mkdir(agentDir, { recursive: true });
-    await fs.mkdir(stateDir, { recursive: true });
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fs.writeFile(
+    await fsp.writeFile(
       path.join(agentDir, "auth-profiles.json"),
       JSON.stringify({ version: 1, profiles }),
     );
@@ -24,13 +25,13 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
   }
 
   async function withLegacyAuthStore(profiles: Record<string, unknown>) {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
     const stateDir = path.join(root, "state");
     const agentDir = path.join(root, "agent");
-    await fs.mkdir(agentDir, { recursive: true });
-    await fs.mkdir(stateDir, { recursive: true });
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles));
+    await fsp.writeFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles));
     return { agentDir };
   }
 
@@ -119,6 +120,44 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
         expires: Date.now() - 1000,
       },
     });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("treats oversized auth-profiles.json as having no credentials", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    // Write an auth-profiles.json exceeding the 10 MiB internal limit.
+    const largeContent = Buffer.alloc(11 * 1024 * 1024);
+    // Inject valid JSON at the start so the file is at least parseable if read.
+    const header = JSON.stringify({
+      version: 1,
+      profiles: { "openai:default": { type: "api_key", provider: "openai", key: "sk-test" } },
+    });
+    largeContent.set(Buffer.from(header, "utf8"), 0);
+    await fsp.writeFile(path.join(agentDir, "auth-profiles.json"), largeContent);
+
+    // The oversized file is silently skipped — no credentials detected.
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("treats oversized legacy auth.json as having no credentials", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const largeContent = Buffer.alloc(11 * 1024 * 1024);
+    const header = JSON.stringify({ openai: { mode: "apiKey", apiKey: "sk-test" } });
+    largeContent.set(Buffer.from(header, "utf8"), 0);
+    await fsp.writeFile(path.join(agentDir, "auth.json"), largeContent);
 
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
   });

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -27,8 +27,18 @@ function hasStoredAuthProfileFiles(agentDir?: string): boolean {
   );
 }
 
+// Cap auth-profile JSON reads at 10 MiB — credential stores are compact config files.
+const MAX_AUTH_PROFILE_JSON_BYTES = 10 * 1024 * 1024;
+
 function readJsonFile(pathname: string): unknown {
   try {
+    const stats = fs.statSync(pathname);
+    if (!stats.isFile()) {
+      return null;
+    }
+    if (stats.size > MAX_AUTH_PROFILE_JSON_BYTES) {
+      return null;
+    }
     return JSON.parse(fs.readFileSync(pathname, "utf8")) as unknown;
   } catch {
     return null;


### PR DESCRIPTION
## What Problem This Solves

The internal `readJsonFile` function in `source-check.ts` reads auth-profile JSON files with no size bound. A corrupted or hostile auth-profiles.json could exhaust memory when the runtime checks for available credentials.

## Why This Change Was Made

The function at line 32 used raw `fs.readFileSync(pathname, "utf8")` with no size pre-check. The fix adds a `statSync` pre-check that:

1. Verifies the path is a regular file
2. Rejects files exceeding 10 MiB by returning null (same as other read failures)
3. Only then reads content with `readFileSync` and parses JSON

The function already catches all errors and returns null, so the new stat checks are handled the same way — silent skip with no credentials detected.

## User Impact

- Prevents OOM crashes from oversized auth-profile stores
- All existing behavior preserved for normal-sized files
- No user-visible change in credential detection results

## Evidence

**`pnpm test src/agents/auth-profiles/source-check.test.ts`** — all 10 tests pass (8 existing + 2 new):
```
 ✓ |agents| src/agents/auth-profiles/source-check.test.ts (10 tests)
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

New tests:
- "treats oversized auth-profiles.json as having no credentials" — 11 MiB file skipped
- "treats oversized legacy auth.json as having no credentials" — 11 MiB legacy file skipped