### PR TITLE
fix(extensions): bound extension source read with size cap

### DIFF
--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -316,4 +316,32 @@ export default async function extension(api) {
     expect(jitiCalls.options).toHaveLength(1);
     expect(jitiCalls.imports).toEqual([extensionPath]);
   });
+
+  it("falls back to jiti for oversized extension source files", async () => {
+    // This test verifies the contract: when extensionSourceNeedsJitiAliasResolution
+    // encounters a file exceeding MAX_EXTENSION_SOURCE_BYTES (10 MiB), it returns true
+    // (jiti needed) instead of trying to read the source. The function already returns
+    // true on any error, so the stat pre-check integrates naturally.
+    const { loadExtensions } = await import("./loader.js");
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.js");
+
+    // Write a compiled .js file exceeding the 10 MiB source-scan cap.
+    // The file contains no alias imports — normally it would bypass jiti.
+    // When oversized, the source scan is skipped and jiti is used as a fallback.
+    const largeSource = Buffer.alloc(11 * 1024 * 1024);
+    Buffer.from(
+      'export default async function extension(api){api.registerCommand("cmd",{description:"p",handler(){}});}',
+      "utf8",
+    ).copy(largeSource, 0);
+    await writeFile(extensionPath, largeSource);
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+    // jiti should have been used since the oversized file can't be scanned.
+    expect(jitiCalls.imports).toEqual([extensionPath]);
+  });
 });

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -444,8 +444,20 @@ function isJavaScriptExtensionPath(extensionPath: string): boolean {
   }
 }
 
+// Cap extension source reads at 10 MiB — extension source files scanned for
+// import patterns should not exhaust memory from a large bundled file.
+const MAX_EXTENSION_SOURCE_BYTES = 10 * 1024 * 1024;
+
 function extensionSourceNeedsJitiAliasResolution(extensionPath: string): boolean {
   try {
+    const stats = fs.statSync(extensionPath);
+    if (!stats.isFile()) {
+      return true;
+    }
+    if (stats.size > MAX_EXTENSION_SOURCE_BYTES) {
+      // File is too large to read safely — assume jiti alias resolution is needed.
+      return true;
+    }
     const source = fs.readFileSync(extensionPath, "utf8");
     return (
       EXTENSION_LOADER_ALIAS_IMPORT_PATTERN.test(source) ||


### PR DESCRIPTION
## What Problem This Solves

The `extensionSourceNeedsJitiAliasResolution` function reads entire extension source files into memory with no size bound. Extension source files can be large (compiled bundles, bundled dependencies), risking OOM when scanning for import patterns.

## Why This Change Was Made

The function at line 449 used raw `fs.readFileSync(extensionPath, "utf8")` with no size pre-check. The fix adds a `statSync` pre-check that:

1. Verifies the path is a regular file
2. Rejects files exceeding 10 MiB by returning `true` (assumes jiti alias resolution is needed)
3. Only then reads content with `readFileSync` and scans for import patterns

The function already returns `true` on any error, so the stat pre-check integrates naturally — oversized files fall through to the same jiti-alias path as other read failures.

## User Impact

- Prevents OOM crashes when scanning large extension source files
- Oversized extensions are still loaded (via jiti) — no functionality lost
- No change for normal extension files under 10 MiB

## Evidence

**`pnpm test src/agents/sessions/extensions/loader.native-js.test.ts`** — all 11 tests pass (10 existing + 1 new):
```
 ✓ |agents| src/agents/sessions/extensions/loader.native-js.test.ts (11 tests)
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

New test:
- "falls back to jiti for oversized extension source files" — 11 MiB .js extension loads via jiti instead of native path