### PR TITLE
fix(identity): bound identity file read with size cap

### DIFF
--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -2,8 +2,14 @@
  * Regression coverage for IDENTITY.md parsing and merging.
  * Ensures placeholders are ignored and rich identity fields stay stable.
  */
-import { describe, expect, it } from "vitest";
-import { mergeIdentityMarkdownContent, parseIdentityMarkdown } from "./identity-file.js";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadAgentIdentityFromWorkspace,
+  mergeIdentityMarkdownContent,
+  parseIdentityMarkdown,
+} from "./identity-file.js";
 
 describe("parseIdentityMarkdown", () => {
   it("ignores identity template placeholders", () => {
@@ -115,5 +121,48 @@ Fluent in over six million error messages.
     });
 
     expect(merged).toBe("- Name: New Name\n");
+  });
+});
+
+describe("loadAgentIdentityFromWorkspace", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects oversized identity files", () => {
+    tmpDir = fs.mkdtempSync("identity-bound-test-");
+    const identityPath = path.join(tmpDir, "IDENTITY.md");
+
+    // Write a file exceeding the 1 MiB internal cap.
+    const largeContent = Buffer.alloc(2 * 1024 * 1024);
+    const header = Buffer.from("- **Name:** Test\n", "utf8");
+    header.copy(largeContent, 0);
+    fs.writeFileSync(identityPath, largeContent);
+
+    const result = loadAgentIdentityFromWorkspace(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("accepts normal-sized identity files", () => {
+    tmpDir = fs.mkdtempSync("identity-bound-test-");
+    const identityPath = path.join(tmpDir, "IDENTITY.md");
+    const content = "- **Name:** Patch Agent\n- **Emoji:** 🦀\n";
+    fs.writeFileSync(identityPath, content, "utf8");
+
+    const result = loadAgentIdentityFromWorkspace(tmpDir);
+    expect(result).toEqual({
+      name: "Patch Agent",
+      emoji: "🦀",
+    });
+  });
+
+  it("returns null for missing identity files", () => {
+    tmpDir = fs.mkdtempSync("identity-bound-test-");
+    const result = loadAgentIdentityFromWorkspace(tmpDir);
+    expect(result).toBeNull();
   });
 });

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -209,8 +209,18 @@ export function mergeIdentityMarkdownContent(
   return nextLines.join("\n").replace(/\n*$/, "\n");
 }
 
+// Cap identity file reads at 1 MiB — IDENTITY.md files are small metadata files.
+const MAX_IDENTITY_FILE_BYTES = 1 * 1024 * 1024;
+
 function loadIdentityFromFile(identityPath: string): AgentIdentityFile | null {
   try {
+    const stats = fs.statSync(identityPath);
+    if (!stats.isFile()) {
+      return null;
+    }
+    if (stats.size > MAX_IDENTITY_FILE_BYTES) {
+      return null;
+    }
     const content = fs.readFileSync(identityPath, "utf-8");
     const parsed = parseIdentityMarkdown(content);
     if (!identityHasValues(parsed)) {


### PR DESCRIPTION
## What Problem This Solves

The `loadIdentityFromFile` function reads `IDENTITY.md` files with no size bound. A large or corrupted identity file could exhaust memory when loading workspace identity.

## Why This Change Was Made

The function at line 214 used raw `fs.readFileSync(identityPath, "utf-8")` with no size pre-check. The fix adds a `statSync` pre-check that:

1. Verifies the path is a regular file
2. Rejects files exceeding 1 MiB by returning null (same as missing identity)
3. Only then reads content with `readFileSync`

The function already catches all errors and returns null, so the stat pre-check integrates naturally.

## User Impact

- Prevents OOM crashes from oversized identity files
- No functionality change for normal identity files under 1 MiB
- Missing identity files still return null as before

## Evidence

**`pnpm test src/agents/identity-file.test.ts`** — all 11 tests pass (8 existing + 3 new):
```
 ✓ |agents| src/agents/identity-file.test.ts (11 tests)
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

New tests:
- "rejects oversized identity files" — 2 MiB IDENTITY.md returns null
- "accepts normal-sized identity files" — small IDENTITY.md loads correctly
- "returns null for missing identity files" — no file returns null