### PR TITLE
fix(microsoft): voice discovery survives malformed catalog rows

### DIFF
--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -105,6 +105,52 @@ describe("listMicrosoftVoices", () => {
     );
   });
 
+  it("returns an empty catalog for a malformed top-level payload", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("null", { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+    await expect(listVoicesThroughProvider()).resolves.toEqual([]);
+  });
+
+  it("skips malformed rows without discarding valid voices", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          null,
+          "unexpected",
+          [],
+          { ShortName: 42 },
+          {
+            ShortName: "en-US-AvaNeural",
+            FriendlyName: "Microsoft Ava Online (Natural) - English (United States)",
+            Locale: "en-US",
+            Gender: "Female",
+            VoiceTag: {
+              ContentCategories: [null, "General"],
+              VoicePersonalities: [false, "Friendly", "Positive"],
+            },
+          },
+        ]),
+        { status: 200 },
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    await expect(listVoicesThroughProvider()).resolves.toEqual([
+      {
+        id: "en-US-AvaNeural",
+        name: "Microsoft Ava Online (Natural) - English (United States)",
+        category: "General",
+        description: "Friendly, Positive",
+        locale: "en-US",
+        gender: "Female",
+        personalities: ["Friendly", "Positive"],
+      },
+    ]);
+  });
+
   it("throws on Microsoft voice list failures", async () => {
     globalThis.fetch = vi
       .fn()

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -47,17 +47,6 @@ type MicrosoftProviderConfig = {
   timeoutMs?: number;
 };
 
-type MicrosoftVoiceListEntry = {
-  ShortName?: string;
-  FriendlyName?: string;
-  Locale?: string;
-  Gender?: string;
-  VoiceTag?: {
-    ContentCategories?: string[];
-    VoicePersonalities?: string[];
-  };
-};
-
 function normalizeMicrosoftProviderConfig(
   rawConfig: Record<string, unknown>,
 ): MicrosoftProviderConfig {
@@ -114,9 +103,10 @@ function buildMicrosoftVoiceHeaders(): Record<string, string> {
   };
 }
 
-function formatMicrosoftVoiceDescription(entry: MicrosoftVoiceListEntry): string | undefined {
-  const personalities = entry.VoiceTag?.VoicePersonalities?.filter(Boolean) ?? [];
-  return personalities.length > 0 ? personalities.join(", ") : undefined;
+function readMicrosoftVoiceTagStrings(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : undefined;
 }
 
 function isCjkDominant(text: string): boolean {
@@ -173,24 +163,29 @@ async function listMicrosoftVoices(
       });
     }
     await assertOkOrThrowProviderError(response, "Microsoft voices API error");
-    const voices = await readProviderJsonResponse<MicrosoftVoiceListEntry[]>(
-      response,
-      "microsoft.speech-voices",
-    );
+    const voices = await readProviderJsonResponse<unknown>(response, "microsoft.speech-voices");
     return Array.isArray(voices)
-      ? voices
-          .map((voice) => ({
-            id: voice.ShortName?.trim() ?? "",
-            name: trimToUndefined(voice.FriendlyName) ?? trimToUndefined(voice.ShortName),
-            category: voice.VoiceTag?.ContentCategories?.find((value) => value.trim().length > 0),
-            description: formatMicrosoftVoiceDescription(voice),
-            locale: trimToUndefined(voice.Locale),
-            gender: trimToUndefined(voice.Gender),
-            personalities: voice.VoiceTag?.VoicePersonalities?.filter(
-              (value): value is string => value.trim().length > 0,
-            ),
-          }))
-          .filter((voice) => voice.id.length > 0)
+      ? voices.flatMap((value) => {
+          const voice = asObject(value);
+          const id = trimToUndefined(voice?.ShortName);
+          if (!voice || !id) {
+            return [];
+          }
+          const voiceTag = asObject(voice.VoiceTag);
+          const categories = readMicrosoftVoiceTagStrings(voiceTag?.ContentCategories);
+          const personalities = readMicrosoftVoiceTagStrings(voiceTag?.VoicePersonalities);
+          return [
+            {
+              id,
+              name: trimToUndefined(voice.FriendlyName) ?? id,
+              category: categories?.[0],
+              description: personalities?.length ? personalities.join(", ") : undefined,
+              locale: trimToUndefined(voice.Locale),
+              gender: trimToUndefined(voice.Gender),
+              personalities,
+            },
+          ];
+        })
       : [];
   } finally {
     await release();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users listing Microsoft speech voices could lose the entire catalog when an otherwise successful Microsoft response contains a malformed row or nested voice tag value.

## Why This Change Was Made

Treats successful voice-list JSON as unknown at the Microsoft provider boundary, keeps rows with a valid `ShortName`, safely reads optional tag arrays, and skips malformed rows. Non-array payloads still produce an empty catalog, while HTTP errors and request timeouts retain their existing behavior. This change is intentionally scoped to the Microsoft provider.

## User Impact

Voice discovery can continue returning valid Microsoft voices instead of failing the whole operation because of one malformed catalog entry.

## Evidence

- Live control on 2026-07-18: the public Microsoft voice-list endpoint returned HTTP 200 with a top-level array containing 322 voices and no invalid rows; observed row keys included `FriendlyName`, `Gender`, `Locale`, `Name`, `ShortName`, `Status`, `SuggestedCodec`, and `VoiceTag`.
- Microsoft documents the voice-list endpoint and response fields: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech#get-a-list-of-voices
- Secretless GitHub-hosted before/after runtime proof: https://github.com/Alix-007/openclaw/actions/runs/29652455695/job/88100981482
  - The temporary fork-only workflow has `permissions: {}`, uses no repository secrets or credentials, and is not part of this upstream PR diff.
  - Immutable refs: current main `88e5af7097de5fdbc897e1ca622116fc289a1ee1`; PR head `91754ce399fed35ed90057559fc6b26983604476`.
  - The same `buildMicrosoftSpeechProvider().listVoices` runtime entry and mixed `[null, validVoice]` payload were used on both refs.
  - Before: `BEFORE_RESULT error_name=TypeError error_message="Cannot read properties of null (reading 'ShortName')"`.
  - After: `AFTER_RESULT voices=1 projection=[{"id":"en-US-AvaNeural","category":"General","personalities":["Friendly","Positive"]}]`.
  - Live head control: `LIVE_HTTP status=200`; `LIVE_RUNTIME voices=322 first_id="af-ZA-AdriNeural"`.
- Focused malformed-response coverage on exact head:
  - a successful top-level `null` payload returns an empty catalog;
  - mixed `null`, primitive, array, missing/non-string `ShortName` rows are skipped while the valid voice remains;
  - non-string `VoiceTag` entries are filtered while valid tag values remain;
  - existing valid metadata mapping, HTTP 503, and timeout controls remain covered.
- Public exact-head test execution: https://github.com/openclaw/openclaw/actions/runs/29651240023/job/88097878634
  - `extensions/microsoft/speech-provider.test.ts (9 tests)`;
  - `Test Files 1 passed (1)`; `Tests 9 passed (9)`; shard ended with exit 0.
- Exact-head CI gate passed: https://github.com/openclaw/openclaw/actions/runs/29651240023
- Targeted formatter proof: `oxfmt --check extensions/microsoft/speech-provider.ts` passed; `git diff --check` passed.
- Repository tests were not executed locally under the external-contributor trust policy; secretless GitHub-hosted execution is the proof path.

AI-assisted.

### Exact-head proof refresh (2026-07-20)

- Reviewed head: 36e9d6ba84f657a4dc4672d4f41f97a0f311fbcd.
- Secretless public-runner proof: [workflow run](https://github.com/Alix-007/openclaw/actions/runs/29719322517) · [runtime-proof job](https://github.com/Alix-007/openclaw/actions/runs/29719322517/job/88278768359).
- Immutable refs checked: before 88e5af7097de5fdbc897e1ca622116fc289a1ee1; after 36e9d6ba84f657a4dc4672d4f41f97a0f311fbcd.

Redacted console proof:
~~~text
BEFORE_RESULT error_name=TypeError error_message="Cannot read properties of null (reading ShortName)"
AFTER_RESULT voices=1 projection=[{"id":"en-US-AvaNeural","category":"General","personalities":["Friendly","Positive"]}]
LIVE_HTTP status=200
LIVE_RUNTIME voices=322 first_id="af-ZA-AdriNeural"
~~~

The run covers the current PR head, malformed and valid voice rows, and a live Microsoft endpoint response.
