### PR TITLE
fix(usage): guard malformed DeepSeek balance payloads

### DIFF
--- a/src/infra/provider-usage.fetch.deepseek.test.ts
+++ b/src/infra/provider-usage.fetch.deepseek.test.ts
@@ -85,6 +85,18 @@ describe("fetchDeepSeekUsage", () => {
     expect(result.windows).toHaveLength(0);
   });
 
+  it.each([
+    ["null response", null],
+    ["array response", []],
+  ])("treats %s as absent balance data", async (_name, payload) => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, payload));
+
+    const result = await fetchDeepSeekUsage("deepseek-key", 5000, mockFetch);
+
+    expect(result.error).toBe("No balance data");
+    expect(result.windows).toHaveLength(0);
+  });
+
   it("marks unavailable accounts while keeping the balance summary", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {

--- a/src/infra/provider-usage.fetch.deepseek.ts
+++ b/src/infra/provider-usage.fetch.deepseek.ts
@@ -1,4 +1,5 @@
 // Fetches and normalizes DeepSeek provider usage records.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   buildUsageHttpErrorSnapshot,
   discardUsageResponseBody,
@@ -86,8 +87,8 @@ export async function fetchDeepSeekUsage(
     return parsed.snapshot;
   }
 
-  const data = parsed.data as DeepSeekBalanceResponse;
-  const balances = Array.isArray(data.balance_infos) ? data.balance_infos : [];
+  const data = isRecord(parsed.data) ? (parsed.data as DeepSeekBalanceResponse) : undefined;
+  const balances = data && Array.isArray(data.balance_infos) ? data.balance_infos : [];
   const summary = balances
     .map((info) => buildBalanceSummary(info))
     .filter((entry): entry is string => Boolean(entry))
@@ -120,6 +121,6 @@ export async function fetchDeepSeekUsage(
     windows: [],
     billing,
     summary,
-    ...(data.is_available === false ? { plan: "Unavailable" } : {}),
+    ...(data?.is_available === false ? { plan: "Unavailable" } : {}),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing DeepSeek usage could hit an uncaught `TypeError` when the balance endpoint returned a successful JSON payload with a non-object top-level shape such as `null` or an array.

## Why This Change Was Made

The usage parser now accepts only record-shaped successful payloads before reading balance fields. Non-object payloads follow the existing `No balance data` snapshot contract, while valid balance records and unavailable-account handling remain unchanged.

## User Impact

DeepSeek usage refreshes degrade to a stable empty usage result instead of rejecting when the upstream returns a malformed successful payload. The endpoint's documented object/`balance_infos` shape remains unchanged: https://api-docs.deepseek.com/api/get-user-balance/

## Evidence

- Submission base: `upstream/main@faf3dbdda833b36d4cccf465a40aabe2d1675d3d`
- `node scripts/run-vitest.mjs src/infra/provider-usage.fetch.deepseek.test.ts` - 1 file / 7 tests passed.
- `oxfmt --check src/infra/provider-usage.fetch.deepseek.ts src/infra/provider-usage.fetch.deepseek.test.ts` - passed.
- Focused oxlint for both changed files - passed.
- `git diff --check` - passed.
- Production-path runtime proof using a real `node:http` loopback server returning HTTP 200 `null` (no DeepSeek credential or external provider call):

```json
{
  "transport": "real-node-http-loopback",
  "request": {"method": "GET", "url": "/user/balance", "authHeaderPresent": true},
  "result": {"provider": "deepseek", "windows": 0, "error": "No balance data"}
}
```

- Claude autoreview after the final fix: clean, no accepted/actionable findings. Codex autoreview was attempted but the local endpoint was unavailable.

AI-assisted contribution; the behavior, owner boundary, and validation were reviewed before submission.
