### PR TITLE
fix(ui): pair tool calls with earlier-sorted orphan results in chat coalescing

### DIFF
--- a/ui/src/pages/chat/chat-thread.native-tool-input.test.ts
+++ b/ui/src/pages/chat/chat-thread.native-tool-input.test.ts
@@ -1,0 +1,165 @@
+// Control UI tests cover native-runtime tool input rendering (#110769).
+import { describe, expect, it } from "vitest";
+import type { MessageGroup } from "../../lib/chat/chat-types.ts";
+import { extractToolCardsCached as extractToolCards } from "../../lib/chat/tool-cards.ts";
+import { buildCachedChatItems, resetChatThreadState } from "./chat-thread.ts";
+
+type CachedChatItemsProps = Parameters<typeof buildCachedChatItems>[0];
+
+function createProps(overrides: Partial<CachedChatItemsProps> = {}): CachedChatItemsProps {
+  return {
+    paneId: "pane-native-input",
+    sessionKey: "main",
+    runId: null,
+    messages: [],
+    toolMessages: [],
+    streamSegments: [],
+    stream: null,
+    streamStartedAt: null,
+    showToolCalls: true,
+    ...overrides,
+  };
+}
+
+function allToolCards(props: Partial<CachedChatItemsProps>) {
+  resetChatThreadState();
+  const groups = buildCachedChatItems(createProps(props)).filter(
+    (item): item is MessageGroup => item.kind === "group",
+  );
+  return groups.flatMap((group) =>
+    group.messages.flatMap((entry) => extractToolCards(entry.message, entry.key)),
+  );
+}
+
+const baseMessage = {
+  message_id: 100,
+  date: 1_700_000_000,
+  chat: { id: 4242, type: "private" as const, first_name: "Alice" },
+  from: { id: 42, is_bot: false as const, first_name: "Alice" },
+};
+
+describe("native-runtime transcript tool input (#110769)", () => {
+  const assistantWithToolCall = {
+    ...baseMessage,
+    role: "assistant",
+    timestamp: 100,
+    content: [
+      { type: "text", text: "Let me look that up." },
+      {
+        type: "toolCall",
+        id: "toolu_EXAMPLE",
+        name: "example_tool",
+        arguments: { query: "example" },
+      },
+    ],
+  };
+  const nativeToolResult = {
+    ...baseMessage,
+    role: "toolResult",
+    timestamp: 200,
+    toolCallId: "toolu_EXAMPLE",
+    toolName: "example_tool",
+    content: [{ type: "text", text: '{ "result": "ok" }' }],
+  };
+
+  it("renders both input and output when call and result are separate messages", () => {
+    const cards = allToolCards({ messages: [assistantWithToolCall, nativeToolResult] });
+    const merged = cards.filter((card) => card.name === "example_tool");
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.inputText).toContain("example");
+    expect(merged[0]?.outputText).toContain("result");
+  });
+
+  it("renders both input and output when the result arrives via toolMessages", () => {
+    const cards = allToolCards({
+      messages: [assistantWithToolCall],
+      toolMessages: [nativeToolResult],
+    });
+    const merged = cards.filter((card) => card.name === "example_tool");
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.inputText).toContain("example");
+    expect(merged[0]?.outputText).toContain("result");
+  });
+
+  it("renders both input and output when the result timestamp precedes the call", () => {
+    const earlyResult = { ...nativeToolResult, timestamp: 50 };
+    const cards = allToolCards({ messages: [assistantWithToolCall, earlyResult] });
+    const merged = cards.filter((card) => card.name === "example_tool");
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.inputText).toContain("example");
+    expect(merged[0]?.outputText).toContain("result");
+  });
+
+  it("renders both input and output when the result is listed before the call", () => {
+    const cards = allToolCards({ messages: [nativeToolResult, assistantWithToolCall] });
+    const merged = cards.filter((card) => card.name === "example_tool");
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.inputText).toContain("example");
+    expect(merged[0]?.outputText).toContain("result");
+  });
+
+  it("pairs multiple tool calls with earlier-sorted orphan results", () => {
+    const multiCallAssistant = {
+      ...baseMessage,
+      role: "assistant",
+      timestamp: 200,
+      content: [
+        { type: "text", text: "I will use two tools." },
+        {
+          type: "toolCall",
+          id: "call_alpha",
+          name: "alpha_tool",
+          arguments: { key: "alpha-val" },
+        },
+        {
+          type: "toolCall",
+          id: "call_beta",
+          name: "beta_tool",
+          arguments: { key: "beta-val" },
+        },
+        {
+          type: "toolCall",
+          id: "call_gamma",
+          name: "gamma_tool",
+          arguments: { key: "gamma-val" },
+        },
+      ],
+    };
+    const earlyResults = [
+      {
+        ...baseMessage,
+        role: "toolResult",
+        timestamp: 100,
+        toolCallId: "call_alpha",
+        toolName: "alpha_tool",
+        content: [{ type: "text", text: "alpha done" }],
+      },
+      {
+        ...baseMessage,
+        role: "toolResult",
+        timestamp: 150,
+        toolCallId: "call_gamma",
+        toolName: "gamma_tool",
+        content: [{ type: "text", text: "gamma done" }],
+      },
+      // call_beta has no orphaned result — it stays unmatched
+    ];
+    const cards = allToolCards({ messages: [multiCallAssistant, ...earlyResults] });
+
+    const alphaCards = cards.filter((card) => card.name === "alpha_tool");
+    expect(alphaCards).toHaveLength(1);
+    expect(alphaCards[0]?.inputText).toContain("alpha-val");
+    expect(alphaCards[0]?.outputText).toContain("alpha done");
+
+    const gammaCards = cards.filter((card) => card.name === "gamma_tool");
+    expect(gammaCards).toHaveLength(1);
+    expect(gammaCards[0]?.inputText).toContain("gamma-val");
+    expect(gammaCards[0]?.outputText).toContain("gamma done");
+
+    // call_beta stays as input-only; it never had an orphan result to merge with
+    const betaCards = cards.filter((card) => card.name === "beta_tool");
+    expect(betaCards).toHaveLength(1);
+    expect(betaCards[0]?.inputText).toContain("beta-val");
+    expect(betaCards[0]?.outputText).toBeUndefined();
+  });
+});

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -708,6 +708,17 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
   // Parallel calls can outnumber any fixed lookback window, so each unresolved
   // call id owns its current transcript item until a non-tool boundary.
   const openCallIndexes = new Map<string, number>();
+  // Native-runtime transcripts can persist a tool result with an earlier
+  // timestamp than its call message, so timestamp ordering places the
+  // orphaned result first; remember it by call id for backward pairing
+  // so every eligible result-type pair resolves. (#110769)
+  const openResultIndexes = new Map<string, number>();
+  const registerOrphanResult = (resultItem: ChatItem, index: number) => {
+    const callId = resolveToolResultCallId(resultItem);
+    if (callId && !openResultIndexes.has(callId)) {
+      openResultIndexes.set(callId, index);
+    }
+  };
   for (const item of items) {
     const resultItems = splitBundledToolResultItems(item);
     const unmatchedResultItems: ChatItem[] = [];
@@ -729,18 +740,37 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     if (mergedResult) {
       for (const unmatched of unmatchedResultItems) {
         coalesced.push(unmatched);
+        registerOrphanResult(unmatched, coalesced.length - 1);
       }
       continue;
     }
 
     const unresolvedCallIds = unresolvedToolCallIds(item);
-    if (unresolvedCallIds.size === 1) {
-      const callId = unresolvedCallIds.values().next().value;
-      const previousIndex = callId ? openCallIndexes.get(callId) : undefined;
-      const previous = previousIndex === undefined ? undefined : coalesced[previousIndex];
-      if (previousIndex !== undefined && previous && unresolvedToolCallIds(previous).size === 1) {
-        coalesced[previousIndex] = item;
-        refreshOpenCallIds(openCallIndexes, coalesced, previousIndex);
+    if (unresolvedCallIds.size > 0) {
+      // Multiple calls in one assistant message: try backward pairing for
+      // every call id that matches an earlier-sorted orphaned result.
+      let anyBackwardMerged = false;
+      for (const callId of unresolvedCallIds) {
+        const resultIndex = openResultIndexes.get(callId);
+        const orphanResult = resultIndex === undefined ? undefined : coalesced[resultIndex];
+        const backwardMerged = orphanResult
+          ? mergeToolCallResultPair(item, orphanResult)
+          : null;
+        if (backwardMerged && resultIndex !== undefined) {
+          coalesced[resultIndex] = backwardMerged;
+          openResultIndexes.delete(callId);
+          anyBackwardMerged = true;
+        }
+      }
+      if (anyBackwardMerged) {
+        // Remaining unresolved calls (no orphan found) register forward.
+        const remaining = unresolvedToolCallIds(item);
+        if (remaining.size > 0) {
+          const callIndex = coalesced.push(item) - 1;
+          for (const callId of remaining) {
+            openCallIndexes.set(callId, callIndex);
+          }
+        }
         continue;
       }
     }
@@ -755,10 +785,12 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     }
     if (isToolTimelineItem(item)) {
       // Orphan results keep the window open for later siblings.
+      registerOrphanResult(item, coalesced.length - 1);
       continue;
     }
     // Any other content (user text, assistant reply, dividers) closes the run.
     openCallIndexes.clear();
+    openResultIndexes.clear();
   }
   return coalesced;
 }


### PR DESCRIPTION
## What Problem This Solves

For native-runtime transcripts, Control UI tool cards render only the "Tool output" section because the stored `toolResult` message's timestamp can precede the assistant message carrying the `toolCall` block. `coalesceToolActivityMessages` scans forward only, so the result sorts before its call and the backward pairing never fires.

## Why This Change Was Made

Root cause: `buildChatItems` orders by timestamp, native transcripts can persist results before calls, and the coalesce scan was unidirectional.

The fix tracks orphaned tool results by call id (`openResultIndexes`), then iterates **every unresolved call** in the assistant message and attempts backward pairing against earlier-sorted orphan results. Multi-call messages pair each call independently — calls with a matching orphan merge backward into the orphan's timeline slot; calls without a match register forward.

## Changes

- **`ui/src/pages/chat/chat-thread.ts`** — add `openResultIndexes` map + `registerOrphanResult` helper; generalize single-call backward merge to iterate all unresolved call ids; register unmatched results as orphans; clear both windows at non-tool boundaries
- **`ui/src/pages/chat/chat-thread.native-tool-input.test.ts`** — 5 scenarios: call+result in-order, via toolMessages, earlier-timestamp orphan, listed-before, and a new **3×3 multi-call** case where two of three calls find earlier-sorted orphan results while the third remains unmatched

## Evidence

### Test command

```
npx vitest run ui/src/pages/chat/chat-thread.native-tool-input.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-thread.question.test.ts
```

### Test output

Before (single-call-only backward pairing on unmodified main):

```
× renders both input and output when the result timestamp precedes the call
AssertionError: expected [ { ...(7) }, { ...(6) } ] to have a length of 1 but got 2
```

After (generalized multi-call backward pairing, this revision):

```
✓ renders both input and output when call and result are separate messages
✓ renders both input and output when the result arrives via toolMessages
✓ renders both input and output when the result timestamp precedes the call
✓ renders both input and output when the result is listed before the call
✓ pairs multiple tool calls with earlier-sorted orphan results
Test Files  3 passed (3)  |  Tests  128 passed (128)
```

### Behavior

- Before: multi-tool-call assistant messages with earlier-sorted orphan results could still render some cards without Tool input
- After: every eligible call-result pair resolves; the `call_alpha`+`call_gamma` test verifies two orphan results merge while `call_beta` (no orphan) stays input-only on the forward path

### Control UI proof

A maintainer can capture real native-runtime tool-card rendering proof with:

```text
@openclaw-mantis web UI chat proof: verify and capture a native-runtime tool card, including a multi-tool-call case, showing both Tool input and Tool output after backward pairing.
```

## Related

Closes #110769

## AI Assistance Disclosure

Implemented with AI assistance (Claude Code). I reviewed and understand every changed line.
