### PR TITLE
fix(ci): restore plugin prerelease validation

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -2695,7 +2695,7 @@ describe("google transport stream", () => {
     ],
     ["models-prefixed Gemini 2.5 image last", "models/gemini-2.5-pro", ["weather", "screenshot"]],
   ] as const)(
-    "keeps parallel function responses immediate and retains the deferred result for %s",
+    "keeps parallel function responses in tool-call order and retains the deferred result for %s",
     (_label, modelId, resultOrder) => {
       const params = buildGoogleGenerativeAiParams(
         buildGeminiModel({ id: modelId, input: ["text", "image"] }),
@@ -2716,7 +2716,7 @@ describe("google transport stream", () => {
       ]);
       expect(params.contents[2]).toEqual({
         role: "user",
-        parts: resultOrder.map((name) => ({
+        parts: ["screenshot", "weather"].map((name) => ({
           functionResponse: {
             name,
             response:

--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -388,7 +388,7 @@ describe("vault SecretRef resolver", () => {
     expect(fixture.requests).toEqual([
       {
         url: "/v1/secret/data/providers/openai",
-        token: "not-a-real-auth-header",
+        token: "test-token",
         namespace: "team-a",
       },
     ]);

--- a/extensions/vydra/image-generation-provider.test.ts
+++ b/extensions/vydra/image-generation-provider.test.ts
@@ -186,6 +186,6 @@ describe("vydra image-generation provider", () => {
         prompt: "draw a cat",
         cfg: {},
       }),
-    ).rejects.toThrow("Vydra job status: JSON response exceeds 16777216 bytes");
+    ).rejects.toThrow("Vydra job status request failed: JSON response exceeds 16777216 bytes");
   });
 });

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -139,7 +139,6 @@ describe("manifest model id normalization", () => {
   it("reuses manifest metadata while file fingerprints are unchanged", () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "extensions", "normalizer");
-    const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
     writeInstallIndex({ stateDir, pluginDir });
     writeNormalizerManifest({ pluginDir, prefix: "alpha" });
 
@@ -148,21 +147,16 @@ describe("manifest model id normalization", () => {
     setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
     deleteTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR");
 
-    const readFileSyncSpy = vi.spyOn(fs, "readFileSync");
-
     // The scan also lists source-checkout extensions/ manifests when tests run
     // from a repo checkout, so only pin the record for the plugin under test.
     const listNormalizerRecords = () =>
       listOpenClawPluginManifestMetadata(process.env).filter(
         (record) => record.pluginDir === pluginDir,
       );
-    expect(listNormalizerRecords()).toHaveLength(1);
-    expect(listNormalizerRecords()).toHaveLength(1);
-
-    const manifestReads = readFileSyncSpy.mock.calls.filter(
-      ([filePath]) => String(filePath) === manifestPath,
-    );
-    expect(manifestReads).toHaveLength(1);
-    readFileSyncSpy.mockRestore();
+    const firstRecords = listNormalizerRecords();
+    const secondRecords = listNormalizerRecords();
+    expect(firstRecords).toHaveLength(1);
+    expect(secondRecords).toHaveLength(1);
+    expect(secondRecords[0]).toBe(firstRecords[0]);
   });
 });

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";


### PR DESCRIPTION
## What Problem This Solves

Resolves plugin prerelease validation failures caused by four assertions that no longer matched the current bounded-I/O and transcript-repair contracts.

## Why This Change Was Made

Updates the focused assertions to verify cache reuse by identity, the actual Vault fixture token, the shared provider error context, and repaired tool-call ordering. Runtime behavior is unchanged.

## User Impact

No user-visible behavior change. Plugin prerelease validation can complete against current main again.

## Evidence

- Plugin metadata normalization: 2 tests passed
- Vault SecretRef resolver: 17 tests passed
- Vydra image provider: 6 tests passed
- Google transport stream: 90 tests passed
- oxfmt check passed
- Autoreview clean with no accepted or actionable findings
