### PR TITLE
fix(ui): workboard dropdowns could clip in short windows

### DIFF
--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -396,7 +396,9 @@
 }
 
 .workboard-select::part(listbox) {
-  max-height: min(320px, calc(100vh - 48px));
+  /* Keep Web Awesome's collision-aware bound in the cap; replacing it outright
+     would let the listbox overflow when the popup has little room to open. */
+  max-height: min(320px, var(--auto-size-available-height, calc(100vh - 48px)));
   padding: 6px;
   border: 1px solid color-mix(in srgb, var(--border-strong) 86%, transparent);
   border-radius: 8px;
@@ -1455,7 +1457,7 @@
   }
 
   .workboard-select::part(listbox) {
-    max-height: min(260px, calc(100vh - 48px));
+    max-height: min(260px, var(--auto-size-available-height, calc(100vh - 48px)));
   }
 
   .workboard-draft__meta {


### PR DESCRIPTION
Related: #110621

## What Problem This Solves

Follow-up to #110621's review finding, applied to the sibling surface: the workboard select dropdowns capped their listbox height with a viewport-only bound (`min(320px, calc(100vh - 48px))`, `260px` on narrow screens), overriding Web Awesome's collision-aware `--auto-size-available-height`. When the popup opens with little room on either side of the control — short windows, toolbars near the bottom edge — a long status/agent list could overflow or clip instead of shrinking and scrolling.

## Why This Change Was Made

Same composition proven in #110621: keep the design cap but bound it by Web Awesome's computed available height, `min(<cap>, var(--auto-size-available-height, calc(100vh - 48px)))`, in both the desktop and narrow-viewport rules. The viewport fallback only applies if the variable is ever unset.

## User Impact

Workboard dropdowns (status, agent pickers) now always fit the space the popup actually has, scrolling internally instead of clipping in constrained layouts.

## Evidence

`oxfmt --check ui/src/styles/workboard.css` clean. The identical composition was verified empirically on the settings language picker in #110621: in a 420px-tall viewport the listbox's resolved max-height followed `--auto-size-available-height` (216px), stayed fully on-screen, and scrolled internally. Both workboard cap sites (desktop 320px, ≤640px 260px) get the same treatment; CSS-only diff (+4/−2).
