### PR TITLE
fix(gateway): bound SQLite title field reads for sessions.list

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -458,6 +458,105 @@ export function readSessionTranscriptVisibleMessageDelta(
   });
 }
 
+/**
+ * Reads a bounded active-path head using the same JSONL-style byte budget as
+ * `session-utils.fs` `readTranscriptHeadChunk` (default 8192). Byte accounting
+ * uses SQLite LENGTH before any `event_json` fetch so an oversized early row
+ * cannot allocate into Node. Malformed fetched rows are skipped like
+ * unparseable JSONL lines, but still consume the budget so a corrupt early row
+ * cannot force a full-table scan.
+ */
+export function readHeadSessionTranscriptMessageEvents(
+  scope: SessionTranscriptReadScope,
+  options: { maxBytes: number; maxMessages: number },
+): SessionTranscriptMessageEventPage {
+  return withCurrentProjectionSnapshot(scope, (projection) => {
+    const maxMessages = Math.max(
+      0,
+      Math.floor(Number.isFinite(options.maxMessages) ? options.maxMessages : 0),
+    );
+    const maxBytes = Math.max(
+      1,
+      Math.floor(Number.isFinite(options.maxBytes) ? options.maxBytes : 8192),
+    );
+    if (maxMessages === 0) {
+      return { events: [], totalMessages: projection.state.activeMessageCount };
+    }
+    const db = getActiveTranscriptKysely(projection.database);
+    // Metadata-only pass: decide the contiguous head prefix without materializing
+    // event_json. Mirrors readSessionTranscriptVisibleMessageDelta so oversized
+    // rows stay outside the head window (JSONL truncated-line parity).
+    const metadata = executeSqliteQuerySync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select([
+          "active.event_seq",
+          "active.message_position",
+          /* kysely-allow-raw: SQLite byte length avoids fetching or parsing excluded JSON. */
+          sql<number>`LENGTH(CAST(event.event_json AS BLOB)) + 1`.as("serialized_bytes"),
+        ])
+        .where("active.session_id", "=", projection.resolved.sessionId)
+        .where("active.message_position", "is not", null)
+        .orderBy("active.message_position", "asc")
+        .limit(maxMessages),
+    ).rows;
+
+    let serializedBytes = 0;
+    let selectedCount = 0;
+    for (const row of metadata) {
+      if (selectedCount >= maxMessages || serializedBytes + row.serialized_bytes > maxBytes) {
+        break;
+      }
+      serializedBytes += row.serialized_bytes;
+      selectedCount += 1;
+      if (serializedBytes >= maxBytes) {
+        break;
+      }
+    }
+    if (selectedCount === 0) {
+      return { events: [], totalMessages: projection.state.activeMessageCount };
+    }
+
+    const lastMessagePosition = metadata[selectedCount - 1]?.message_position;
+    if (lastMessagePosition === null || lastMessagePosition === undefined) {
+      return { events: [], totalMessages: projection.state.activeMessageCount };
+    }
+
+    const events: SessionTranscriptMessageEvent[] = [];
+    for (const row of executeSqliteQuerySync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select(["active.event_seq", "active.message_position", "event.event_json"])
+        .where("active.session_id", "=", projection.resolved.sessionId)
+        .where("active.message_position", "is not", null)
+        .where("active.message_position", "<=", lastMessagePosition)
+        .orderBy("active.message_position", "asc"),
+    ).rows) {
+      try {
+        events.push(parseMessageEventRow(row));
+      } catch {
+        // Skip unreadable rows the way JSONL title scans skip bad lines.
+      }
+    }
+    return {
+      events,
+      totalMessages: projection.state.activeMessageCount,
+    };
+  });
+}
+
 /** Reads a bounded active-path tail while preserving transcript line and byte caps. */
 export function readRecentSessionTranscriptMessageEvents(
   scope: SessionTranscriptReadScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -201,6 +201,7 @@ export {
 export { persistSessionTranscriptTurn } from "./session-accessor.transcript-turn.js";
 export {
   isSessionTranscriptProjectionUnavailableError,
+  readHeadSessionTranscriptMessageEvents,
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptMessageAnchorPage,
   readSessionTranscriptMessageEventById,

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -4,10 +4,16 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   persistSessionTranscriptTurn,
+  readHeadSessionTranscriptMessageEvents,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { readSessionMessagesAroundIdWithStatsAsync } from "./session-transcript-anchor-reader.js";
 import {
@@ -15,6 +21,7 @@ import {
   readSessionMessageCountAsync,
   readSessionMessagesAsync,
   readSessionMessagesPageWithStatsAsync,
+  readSessionTitleFieldsFromTranscript,
   type SessionTranscriptReadScope,
 } from "./session-transcript-readers.js";
 
@@ -31,6 +38,8 @@ describe("session transcript reader facade", () => {
   });
 
   afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
@@ -451,5 +460,217 @@ describe("session transcript reader facade", () => {
     await expect(
       readSessionMessagesAsync(scope, { mode: "full", reason: "explicit file test" }),
     ).resolves.toMatchObject([{ content: "explicit prompt" }]);
+  });
+
+  test("SQLite title fields keep an 8 KiB head when the first user is after ten compact messages", async () => {
+    // File-backed title scans use an 8192-byte head window, not a fixed ten-message
+    // cap. Compact assistant rows must not hide a later user title that still fits.
+    const sessionId = "reader-sqlite-title-byte-head";
+    const leadingAssistants = 15;
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+    const messages: Array<{
+      eventId: string;
+      parentId: string | null;
+      message: { role: string; content: string };
+    }> = [];
+    for (let index = 0; index < leadingAssistants; index += 1) {
+      messages.push({
+        eventId: `lead-${index}`,
+        parentId: index === 0 ? null : `lead-${index - 1}`,
+        message: { role: "assistant", content: `x${index}` },
+      });
+    }
+    messages.push({
+      eventId: "late-user",
+      parentId: `lead-${leadingAssistants - 1}`,
+      message: { role: "user", content: "compact-byte-head-title" },
+    });
+    messages.push({
+      eventId: "title-tail",
+      parentId: "late-user",
+      message: { role: "assistant", content: "compact-byte-head-tail" },
+    });
+    await persistSessionTranscriptTurn(scope, { messages, touchSessionEntry: false });
+    await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
+      path: path.join(tempDir, "openclaw-agent.sqlite"),
+    });
+
+    expect(readSessionTitleFieldsFromTranscript(scope)).toEqual({
+      firstUserMessage: "compact-byte-head-title",
+      lastMessagePreview: "compact-byte-head-tail",
+    });
+  });
+
+  test("SQLite title fields exclude an oversized first event without fetching its JSON", async () => {
+    // Head selection must LENGTH-budget before SELECT event_json. An oversized first
+    // active event is outside the 8 KiB window (JSONL truncated-line parity), so a
+    // later small user message must not become the derived title either.
+    const sessionId = "reader-sqlite-title-oversized-head";
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "oversized-user",
+          parentId: null,
+          message: { role: "user", content: "placeholder-head" },
+        },
+        {
+          eventId: "later-user",
+          parentId: "oversized-user",
+          message: { role: "user", content: "later-small-title" },
+        },
+        {
+          eventId: "title-tail",
+          parentId: "later-user",
+          message: { role: "assistant", content: "oversized-head-tail" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
+      path: path.join(tempDir, "openclaw-agent.sqlite"),
+    });
+
+    const sqliteFile = fs
+      .readdirSync(tempDir, { recursive: true })
+      .map(String)
+      .find((entry) => entry.endsWith("openclaw-agent.sqlite"));
+    expect(sqliteFile).toBeTruthy();
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+      path: path.join(tempDir, sqliteFile ?? ""),
+    });
+    const eventRows = database.db
+      .prepare(
+        "SELECT session_id, seq, substr(event_json, 1, 160) AS preview FROM transcript_events",
+      )
+      .all() as Array<{ session_id: string; seq: number; preview: string }>;
+    const firstUser = eventRows.find((row) => row.preview.includes("placeholder-head"));
+    expect(firstUser).toEqual(
+      expect.objectContaining({
+        session_id: expect.any(String),
+        seq: expect.any(Number),
+      }),
+    );
+    if (!firstUser) {
+      throw new Error("expected first user transcript event");
+    }
+    const oversizedEventJson = JSON.stringify({
+      type: "message",
+      id: "oversized-user",
+      parentId: null,
+      message: { role: "user", content: `oversized-${"x".repeat(12_000)}` },
+    });
+    expect(Buffer.byteLength(oversizedEventJson) + 1).toBeGreaterThan(8192);
+    const inflated = database.db
+      .prepare("UPDATE transcript_events SET event_json = ? WHERE session_id = ? AND seq = ?")
+      .run(oversizedEventJson, firstUser.session_id, firstUser.seq);
+    expect(inflated.changes).toBe(1);
+
+    expect(
+      readHeadSessionTranscriptMessageEvents(scope, { maxBytes: 8192, maxMessages: 1000 }),
+    ).toEqual({
+      events: [],
+      totalMessages: 3,
+    });
+    expect(readSessionTitleFieldsFromTranscript(scope)).toEqual({
+      firstUserMessage: null,
+      lastMessagePreview: "oversized-head-tail",
+    });
+  });
+
+  test("SQLite title fields stay bounded when a middle event is unreadable", async () => {
+    // sessions.list(includeDerivedTitles) → readSessionTitleFieldsFromTranscript.
+    // A full SQLite materialization would throw on the corrupt middle row; head/tail
+    // reads must still return the first user title and last preview.
+    const sessionId = "reader-sqlite-title-bound";
+    const fillerCount = 40;
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+    const messages: Array<{
+      eventId: string;
+      parentId: string | null;
+      message: { role: string; content: string };
+    }> = [
+      {
+        eventId: "title-head",
+        parentId: null,
+        message: { role: "user", content: "bounded-title-head" },
+      },
+    ];
+    for (let index = 0; index < fillerCount; index += 1) {
+      messages.push({
+        eventId: `filler-${index}`,
+        parentId: index === 0 ? "title-head" : `filler-${index - 1}`,
+        message: { role: "assistant", content: `filler-${index}` },
+      });
+    }
+    messages.push({
+      eventId: "title-tail",
+      parentId: `filler-${fillerCount - 1}`,
+      message: { role: "assistant", content: "bounded-title-tail" },
+    });
+    await persistSessionTranscriptTurn(scope, { messages, touchSessionEntry: false });
+    await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
+      path: path.join(tempDir, "openclaw-agent.sqlite"),
+    });
+
+    expect(await readSessionMessageCountAsync(scope)).toBe(fillerCount + 2);
+    const sqliteFile = fs
+      .readdirSync(tempDir, { recursive: true })
+      .map(String)
+      .find((entry) => entry.endsWith("openclaw-agent.sqlite"));
+    expect(sqliteFile).toBeTruthy();
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+      path: path.join(tempDir, sqliteFile ?? ""),
+    });
+    const eventRows = database.db
+      .prepare(
+        "SELECT session_id, seq, substr(event_json, 1, 120) AS preview FROM transcript_events",
+      )
+      .all() as Array<{ session_id: string; seq: number; preview: string }>;
+    const middlePreview = eventRows.find((row) => row.preview.includes("filler-20"));
+    expect(middlePreview).toEqual(
+      expect.objectContaining({
+        session_id: expect.any(String),
+        seq: expect.any(Number),
+      }),
+    );
+    if (!middlePreview) {
+      throw new Error("expected middle filler transcript event");
+    }
+    const corrupted = database.db
+      .prepare("UPDATE transcript_events SET event_json = '{' WHERE session_id = ? AND seq = ?")
+      .run(middlePreview.session_id, middlePreview.seq);
+    expect(corrupted.changes).toBe(1);
+
+    await expect(
+      readSessionMessagesAsync(scope, { mode: "full", reason: "title bound full-read sentinel" }),
+    ).rejects.toThrow();
+
+    expect(readSessionTitleFieldsFromTranscript(scope)).toEqual({
+      firstUserMessage: "bounded-title-head",
+      lastMessagePreview: "bounded-title-tail",
+    });
   });
 });

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -5,6 +5,7 @@ import {
   type UsageLike,
 } from "../agents/usage.js";
 import {
+  readHeadSessionTranscriptMessageEvents,
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptMessageEventById,
   readSessionTranscriptMessageEventCount,
@@ -263,12 +264,36 @@ function extractMessageText(message: unknown): string | null {
   return null;
 }
 
+// Match file-backed title reads (session-utils.fs readTranscriptHeadChunk default
+// 8192 bytes): JSONL-style head byte budget for the first user message, plus a
+// bounded tail for the last preview. Full materialization would make
+// sessions.list with includeDerivedTitles scale with transcript size on every
+// sidebar hydrate. maxMessages is only a safety cap; the byte budget is the
+// semantic bound so compact transcripts stay aligned with the file path.
+const SQLITE_TITLE_HEAD_MAX_BYTES = 8192;
+const SQLITE_TITLE_HEAD_MAX_MESSAGES = 1000;
+const SQLITE_TITLE_TAIL_MAX_MESSAGES = 20;
+const SQLITE_TITLE_TAIL_MAX_LINES = 20;
+const SQLITE_TITLE_TAIL_MAX_BYTES = 16 * 1024;
+
 function readSqliteTitleFields(
   target: ResolvedTranscriptReadTarget,
   opts?: { includeInterSession?: boolean },
 ): SessionTitleFields {
-  const messages = readSqliteMessagesSync(target);
-  const firstUser = messages.find((message) => {
+  const scope = toTranscriptReadScope(target);
+  const totalMessages = readSessionTranscriptMessageEventCount(scope);
+  if (totalMessages <= 0) {
+    return { firstUserMessage: null, lastMessagePreview: null };
+  }
+
+  const headMessages = extractMessageRecordsFromEventEntries(
+    readHeadSessionTranscriptMessageEvents(scope, {
+      maxBytes: SQLITE_TITLE_HEAD_MAX_BYTES,
+      maxMessages: SQLITE_TITLE_HEAD_MAX_MESSAGES,
+    }).events,
+  ).map((record) => record.message);
+
+  const firstUser = headMessages.find((message) => {
     if (extractMessageRole(message) !== "user") {
       return false;
     }
@@ -277,7 +302,16 @@ function readSqliteTitleFields(
       !hasInterSessionUserProvenance(message as { role?: unknown; provenance?: unknown })
     );
   });
-  const lastText = messages.toReversed().map(extractMessageText).find(Boolean) ?? null;
+
+  const tailMessages = extractMessageRecordsFromEventEntries(
+    readRecentSessionTranscriptMessageEvents(scope, {
+      maxBytes: SQLITE_TITLE_TAIL_MAX_BYTES,
+      maxLines: SQLITE_TITLE_TAIL_MAX_LINES,
+      maxMessages: SQLITE_TITLE_TAIL_MAX_MESSAGES,
+    }).events,
+  ).map((record) => record.message);
+  const lastText = tailMessages.toReversed().map(extractMessageText).find(Boolean) ?? null;
+
   return {
     firstUserMessage: firstUser ? extractMessageText(firstUser) : null,
     lastMessagePreview: lastText,


### PR DESCRIPTION
## What Problem This Solves

Control UI sidebar hydration calls `sessions.list` with `includeDerivedTitles: true`.
That path reads title/last-message fields through
`readSessionTitleFieldsFromTranscript`. On SQLite-backed transcripts the reader
previously called `readSqliteMessagesSync` and materialised **every** active
message before picking the first user text and last preview.

File-backed transcripts already use a small head chunk plus a bounded tail. Long
SQLite sessions therefore paid an O(transcript) memory/CPU cost on every list
hydrate, while JSONL sessions stayed bounded.

## Why This Change Was Made

Align the SQLite title reader with the existing file-backed contract in
`session-utils.fs` (`readTranscriptHeadChunk` default **8192 bytes**, plus a
bounded tail preview):

- Head: **8192-byte** JSONL-style budget via `readHeadSessionTranscriptMessageEvents`
  (same default as file-backed `readTranscriptHeadChunk`; `maxMessages` is only a
  safety cap)
- Head selection uses a metadata-only SQLite `LENGTH(CAST(event_json AS BLOB))`
  pass before any `event_json` fetch (same pattern as
  `readSessionTranscriptVisibleMessageDelta`), so an oversized early row cannot
  allocate into Node
- Tail: at most 20 messages / 16 KiB via `readRecentSessionTranscriptMessageEvents`

`sessions.list` keeps deriving titles and last-message previews from those
windows only, matching the shipped file-backed 8 KiB head contract rather than a
fixed message-count proxy.

## User Impact

- Long SQLite sessions no longer force a full transcript load during sidebar /
  sessions list hydration when derived titles or last-message previews are
  requested.
- Title/preview text still comes from the first user message in the head window
  and the latest textual message in the tail window (same practical outcome as
  the file path for normal sessions).
- Sessions whose first real user message sits beyond the first 8 KiB of
  serialized head events would not get a derived title from transcript text —
  the same practical limitation as the file-backed head chunk.
- An oversized first active event (`event_json` larger than the 8 KiB budget) is
  treated as outside the head window (JSONL truncated-line parity); the head
  reader returns no events and does not fetch that JSON into Node.

## Evidence

### Real behavior proof

#### Behavior or issue addressed

SQLite title/last-message reads stay bounded; a corrupt middle transcript event
makes full materialisation throw, while the title reader still returns the head
title and tail preview used by `sessions.list(includeDerivedTitles)`. An oversized
first active event is excluded by SQL-side LENGTH budgeting before `event_json`
is selected.

#### Canonical reachability path

Control UI `sessions.list` (`includeDerivedTitles: true`) →
`listSessionsFromStore(Async)` → `readSessionTitleFieldsFromTranscript` →
bounded SQLite head/tail reads (no `readSqliteMessagesSync` full load).

#### Real environment tested

Local trusted checkout; Vitest against a real per-agent SQLite transcript with
42 active messages and a deliberately corrupted middle event row, plus an
inflated first-event row larger than 8 KiB.

#### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/session-transcript-readers.test.ts -t "SQLite title fields" --reporter=verbose
```

#### Evidence after fix

```text
✓ SQLite title fields keep an 8 KiB head when the first user is after ten compact messages
✓ SQLite title fields exclude an oversized first event without fetching its JSON
✓ SQLite title fields stay bounded when a middle event is unreadable
 Test Files  3 passed (3)
      Tests  9 passed | 33 skipped (42)
```

The proof seeds `bounded-title-head` / fillers / `bounded-title-tail`, corrupts a
middle event to `'{'`, asserts `readSessionMessagesAsync(..., mode: "full")`
throws, and asserts `readSessionTitleFieldsFromTranscript` still returns:

`{ firstUserMessage: "bounded-title-head", lastMessagePreview: "bounded-title-tail" }`.

The oversized-first-event case inflates the first active `event_json` above 8 KiB,
asserts `readHeadSessionTranscriptMessageEvents` returns `{ events: [], totalMessages: 3 }`,
and asserts derived title fields keep a null first-user title with the tail preview.

#### Observed result after fix

Full SQLite materialisation fails closed on the corrupt middle row; the title
reader used by sessions list hydration stays on bounded head/tail windows and
returns the expected title/preview strings. Oversized first events stay outside
the head without materializing their JSON.

#### What was not tested

Live Control UI click-through against a multi-hour production transcript; macOS
menu preview (covered by a separate `sessions.preview` change).

#### Fix classification

bugfix — SQLite title fields unbounded full transcript read on sessions.list hydrate

## AI Assistance

AI-assisted. Author reviewed the production `sessions.list` → title-fields path
and the focused SQLite sentinel proof output.
