### PR TITLE
fix(mattermost): preserve draft preview when tool-error final arrives…

### DIFF
--- a/extensions/mattermost/src/delivery-trace.test.ts
+++ b/extensions/mattermost/src/delivery-trace.test.ts
@@ -24,7 +24,7 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
-import { describe, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createMattermostPost, type MattermostClient } from "./mattermost/client.js";
 import {
   createMattermostDraftPreviewBoundaryController,
@@ -270,4 +270,53 @@ describe("mattermost delivery trace goldens", () => {
       });
     });
   }
+
+  it("preserves draft preview when a tool-error final arrives after assistant reply (#109471)", async () => {
+    const events = await runDeliveryTraceScenario({
+      scenario: {
+        name: "tool-error-after-reply",
+        steps: [
+          { kind: "reply-start" },
+          { kind: "partial", text: "I'll deploy that for you." },
+          { kind: "advance", ms: 300 },
+          { kind: "partial", text: "I'll deploy that for you.\n\nDeploying to production..." },
+          { kind: "advance", ms: 300 },
+          { kind: "block-final", text: "I'll deploy that for you.\n\nDeploying to production..." },
+          { kind: "advance", ms: 100 },
+          // Tool error arrives as a final with isError: true
+          { kind: "final", text: "bash: deploy.sh: command not found", isError: true },
+          { kind: "advance", ms: 100 },
+          { kind: "idle" },
+        ],
+      },
+      setup: setupMattermostTrace,
+    });
+
+    // The event list is the application log for this scenario.
+    // Format: seq | at | dir | kind | data
+    console.log("\n=== Wire trace: tool-error-after-reply ===\n");
+    for (const event of events) {
+      const dir = event.dir === "in" ? "IN " : "OUT";
+      const dataStr = event.data ? ` ${JSON.stringify(event.data).slice(0, 120)}` : "";
+      console.log(
+        `  ${String(event.seq).padStart(3)} | ${String(event.at).padStart(4)} | ${dir} | ${event.kind}${dataStr}`,
+      );
+    }
+
+    // Verify no DELETE calls (the bug was that the preview was deleted)
+    const deleteEvents = events.filter((e) => e.dir === "out" && e.kind.startsWith("DELETE"));
+    expect(deleteEvents).toHaveLength(0);
+
+    // Verify the error was delivered as a normal post (not via preview edit)
+    const errorDeliveries = events.filter(
+      (e) =>
+        e.dir === "out" &&
+        e.kind === "POST /posts" &&
+        typeof (e.data as Record<string, unknown>)?.payload === "object" &&
+        ((e.data as Record<string, unknown>)?.payload as Record<string, unknown>)?.message
+          ?.toString()
+          ?.includes("deploy.sh"),
+    );
+    expect(errorDeliveries.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -44,10 +44,12 @@ export async function deliverMattermostReplyWithDraftPreview(
     return;
   }
 
-  // Tool-error warnings must not finalize or clear the draft preview.
-  // Deliver them as standalone messages while preserving the existing
-  // assistant reply that was already shown via the preview post.
-  if (params.payload.isError) {
+  // Tool-error warnings that arrive after the assistant reply was already
+  // finalized via the preview post must not clear the draft. Deliver them as
+  // standalone messages while preserving the visible assistant reply.
+  // When the preview was NOT yet finalized (error arrived before any assistant
+  // reply), let the normal draft path clean up the error-only draft post.
+  if (params.payload.isError && params.previewState.finalizedViaPreviewPost) {
     await deliverWithFinalizableLivePreviewAdapter({
       kind: params.info.kind,
       payload: params.payload,

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -44,6 +44,20 @@ export async function deliverMattermostReplyWithDraftPreview(
     return;
   }
 
+  // Tool-error warnings must not finalize or clear the draft preview.
+  // Deliver them as standalone messages while preserving the existing
+  // assistant reply that was already shown via the preview post.
+  if (params.payload.isError) {
+    await deliverWithFinalizableLivePreviewAdapter({
+      kind: params.info.kind,
+      payload: params.payload,
+      deliverNormally: async (payload) => {
+        await params.deliverPayload(payload);
+      },
+    });
+    return;
+  }
+
   await deliverWithFinalizableLivePreviewAdapter({
     kind: params.info.kind,
     payload: params.payload,

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -470,7 +470,7 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     });
   });
 
-  it("does not flush error finals before normal delivery", async () => {
+  it("delivers error finals as standalone messages without clearing the draft preview", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {});
 
@@ -488,8 +488,9 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     });
 
     expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
     expect(deliverFinal).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
   it("finalizes the preview in place when the final targets the same thread", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -470,7 +470,30 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     });
   });
 
-  it("delivers error finals as standalone messages without clearing the draft preview", async () => {
+  it("delivers error finals standalone when the preview was already finalized by an assistant reply", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {});
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Error", isError: true } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => text?.trim(),
+      previewState: { finalizedViaPreviewPost: true },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+  });
+
+  it("still cleans up an error-only draft when the preview was never finalized", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {});
 
@@ -487,9 +510,9 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
       deliverPayload: deliverFinal,
     });
 
-    expect(draftStream.flush).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    // When the preview was never finalized (no assistant reply), the error-only
+    // draft should still be cleaned up normally.
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
     expect(deliverFinal).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

close #109471

When Mattermost preview streaming is enabled and a turn produces a successful
assistant reply followed by a tool-error final payload (`isError: true`), the
Mattermost plugin deletes the already-finalized preview post and leaves only
the error warning visible. The user sees a conversation where the assistant
appeared to never respond.

Root cause: `buildFinalEdit` returns `undefined` for error payloads
(intentionally — we don't want to replace the preview with error text). But
returning `undefined` causes the shared `deliverFinalizableLivePreview` to
fall through to its draft-clear path, which calls `draft.clear()` → `DELETE
/posts/{id}` on the Mattermost API. The preview post that already showed the
assistant's reply is silently deleted, then the error is delivered as a new
post. The user sees only the error.

## Why This Change Was Made

Single change in `deliverMattermostReplyWithDraftPreview`: when a payload has
`isError: true` **and** the preview was already finalized by the assistant
reply (`previewState.finalizedViaPreviewPost === true`), short-circuit before
the adapter path. Deliver the error as a standalone message through
`deliverWithFinalizableLivePreviewAdapter` without passing an adapter. Without
an adapter, the function performs a plain normal delivery — no draft flush,
no draft clear, no preview interaction at all.

The gate on `finalizedViaPreviewPost` is critical: when the error arrives
before any assistant reply was finalized (error-only draft), the normal draft
cleanup path still runs so the error-only preview post is properly cleared.
Both cases are covered by dedicated tests.

The existing adapter path (with preview finalization) is unchanged for all
non-error payloads. The error path produces exactly one REST call: a new
`POST /posts` for the error text. No `DELETE` call is made.

## Evidence

### Gateway-level delivery trace: tool-error-after-reply

Wire trace records raw Mattermost REST calls (POST/PUT/DELETE /posts) through
the real delivery pipeline — this is the same code path the monitor uses at
runtime.

```
=== Wire trace: tool-error-after-reply ===

  1 |    0 | IN  | reply-start
  2 |    0 | IN  | partial "I'll deploy that for you."
  3 |    0 | OUT | POST /posts     ← creates preview post-1 (assistant reply)
  4 |  300 | IN  | partial "I'll deploy that for you.\n\nDeploying to production..."
  5 |  600 | IN  | block-final
  6 |  600 | OUT | PUT /posts/post-1  ← finalizes preview with assistant text
  7 |  700 | IN  | final {text:"bash: deploy.sh: command not found", isError:true}
  8 |  700 | OUT | POST /posts     ← error delivered as standalone new message
  9 |  800 | IN  | idle
```

Key observations:
- **No DELETE calls** — preview post-1 is preserved, assistant reply stays visible
- Error text "deploy.sh: command not found" delivered as a separate `POST /posts`
- The existing streaming-happy, final-only, and cancel-mid-stream goldens are unchanged

### Before/after comparison

| Step | Before (bug) | After (fix) |
|------|-------------|-------------|
| Assistant reply streamed | `PUT /posts/post-1` | `PUT /posts/post-1` (unchanged) |
| Tool-error final arrives | `DELETE /posts/post-1` → preview deleted | — (no call) |
| Error delivered | `POST /posts` (error text) | `POST /posts` (error text) |
| What user sees | Only the error warning | Assistant reply + error warning |

### Vitest (54 tests)

```
 Test Files  1 passed (1)
      Tests  54 passed (54)
```

New tests:
- `delivers error finals standalone when the preview was already finalized by an assistant reply` — `finalizedViaPreviewPost: true` → draft untouched
- `still cleans up an error-only draft when the preview was never finalized` — `finalizedViaPreviewPost: false` → draft cleared normally (regression guard)

Full Mattermost suite: 602 passed, 2 pre-existing failures in `model-picker.test.ts` (unrelated).

### Gateway startup

Gateway starts cleanly with Mattermost plugin loaded, no errors.

### No sensitive data

Trace contains no API keys, private endpoints, IP addresses, or credentials.
All recording uses mocked Mattermost client with deterministic fake IDs.
