### PR TITLE
test(feishu): align delivery-trace harness with dispatcher plan

### DIFF
--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -1,7 +1,7 @@
 // Feishu delivery trace goldens: replayable wire-level lifecycle recordings.
 //
-// IN events are fed straight into the reply-dispatcher wiring (the options
-// createReplyDispatcherWithTyping receives plus replyOptions callbacks); OUT
+// IN events are fed straight into the reply-dispatcher plan (dispatcherOptions,
+// delivery, and replyOptions callbacks); OUT
 // events are recorded at the mocked Lark SDK client and the mocked CardKit
 // HTTP fetch, so streaming-card entity calls are captured at the wire seam.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
@@ -16,7 +16,6 @@ import {
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeAll, describe, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
-import type { ReplyPayload } from "./reply-dispatcher-runtime-api.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];
@@ -25,19 +24,11 @@ type CreateFeishuReplyDispatcher =
 type StreamingStartBackoffMap =
   typeof import("./reply-dispatcher-state.js").streamingStartBackoffUntilByAccount;
 
-type FeishuDispatcherOptions = {
-  onReplyStart?: () => Promise<void> | void;
-  onIdle?: () => Promise<void> | void;
-  onCleanup?: () => void;
-  deliver: (payload: ReplyPayload, info: { kind: string }) => Promise<void> | void;
-};
-
 type FeishuTraceState = {
   recordWireCall: (call: RecordedWireCall) => void;
   account: ResolvedFeishuAccount | null;
   larkClient: unknown;
   cardKitFetch: typeof fetch | null;
-  dispatcherOptions: FeishuDispatcherOptions | null;
   messageCount: number;
   reactionCount: number;
   cardCount: number;
@@ -51,7 +42,6 @@ const traceState = vi.hoisted(
     account: null,
     larkClient: null,
     cardKitFetch: null,
-    dispatcherOptions: null,
     messageCount: 0,
     reactionCount: 0,
     cardCount: 0,
@@ -84,17 +74,6 @@ vi.mock("./client.js", async (importOriginal) => {
         throw new Error("trace Lark client not initialized");
       }
       return traceState.larkClient;
-    },
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createReplyDispatcherWithTyping: (options: FeishuDispatcherOptions) => {
-      traceState.dispatcherOptions = options;
-      return { dispatcher: {}, replyOptions: {}, markDispatchIdle: () => {} };
     },
   };
 });
@@ -161,7 +140,6 @@ afterAll(() => {
   vi.doUnmock("./client.js");
   vi.doUnmock("./runtime.js");
   vi.doUnmock("./streaming-card.js");
-  vi.doUnmock("openclaw/plugin-sdk/reply-runtime");
   vi.resetModules();
 });
 
@@ -169,7 +147,6 @@ afterEach(() => {
   traceState.account = null;
   traceState.larkClient = null;
   traceState.cardKitFetch = null;
-  traceState.dispatcherOptions = null;
   traceState.wireFaults = [];
   streamingStartBackoffUntilByAccount.clear();
 });
@@ -378,27 +355,28 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
     sendTarget: "oc-trace-chat",
     replyToMessageId: "om-inbound",
   });
-  const options = traceState.dispatcherOptions;
-  if (!options) {
-    throw new Error("dispatcher options were not captured");
-  }
+  // After the inbound-turn refactor, createFeishuReplyDispatcher returns the
+  // plan (dispatcherOptions/delivery/replyOptions) for core to wire; drive the
+  // harness from that plan instead of the retired createReplyDispatcherWithTyping
+  // capture seam (sibling: msteams/slack delivery-trace tests).
+  const { dispatcherOptions, delivery, replyOptions } = created;
 
   return async (step: DeliveryTraceInStep) => {
     switch (step.kind) {
       case "reply-start":
-        await options.onReplyStart?.();
+        await dispatcherOptions.onReplyStart?.();
         break;
       case "partial":
-        created.replyOptions.onPartialReply?.({ text: step.text });
+        replyOptions.onPartialReply?.({ text: step.text });
         break;
       case "block-final":
-        await options.deliver({ text: step.text }, { kind: "block" });
+        await delivery.deliver({ text: step.text }, { kind: "block" });
         break;
       case "tool-progress":
-        created.replyOptions.onToolStart?.({ name: step.name, phase: step.phase });
+        replyOptions.onToolStart?.({ name: step.name, phase: step.phase });
         break;
       case "final":
-        await options.deliver(
+        await delivery.deliver(
           {
             ...(step.text !== undefined ? { text: step.text } : {}),
             ...(step.mediaUrls ? { mediaUrls: step.mediaUrls } : {}),
@@ -411,8 +389,8 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
         // An aborted run stops emitting payloads; closeout happens on idle.
         break;
       case "idle":
-        await options.onIdle?.();
-        options.onCleanup?.();
+        await dispatcherOptions.onIdle?.();
+        dispatcherOptions.onCleanup?.();
         break;
       case "wire-fault":
         if (step.fault !== "rate-limit") {


### PR DESCRIPTION
Related: #110744

## What Problem This Solves

Fixes an issue where the Feishu delivery-trace golden suite fails deterministically on current `main` with `Error: dispatcher options were not captured`, which turns the required CI gate red for any PR that pulls the Feishu reply-dispatcher / delivery-trace shard (including unrelated Feishu work).

## Why This Change Was Made

After the channel inbound-turn refactor, `createFeishuReplyDispatcher()` returns a plan (`dispatcherOptions`, `delivery`, `replyOptions`) for core to wire and no longer calls `createReplyDispatcherWithTyping` itself. The Microsoft Teams and Slack delivery-trace harnesses were already updated to drive from that returned plan; Feishu still mocked the old capture seam. This PR aligns only the Feishu trace fixture with the sibling pattern: drop the obsolete reply-runtime mock/state and exercise the real returned plan, including Feishu `onIdle` / `onCleanup` closeout.

Compatibility: test-only harness; no production Feishu runtime or config change. Performance: no hot-path cost. Usability: restores a green contributor CI path for Feishu delivery-trace. Security: removes a test-only mock only; no secrets or trust-boundary change.

## User Impact

No end-user messaging change. Contributors and CI stop seeing a pre-existing failure in `extensions/feishu/src/delivery-trace.test.ts` when touching Feishu reply-dispatcher surfaces.

## Evidence

**Before (current `main`, unpatched):** all five goldens fail at the stale capture assertion:

```text
❯ extensions/feishu/src/delivery-trace.test.ts (5 tests | 5 failed)
Error: dispatcher options were not captured
 ❯ setupFeishuTrace extensions/feishu/src/delivery-trace.test.ts:383:11
Test Files  1 failed (1)
     Tests  5 failed (5)
```

**After this patch:** all five goldens pass through the returned dispatcher plan:

```text
✓ |extension-feishu| extensions/feishu/src/delivery-trace.test.ts (5 tests) 26266ms
Test Files  1 passed (1)
     Tests  5 passed (5)
[test] passed 1 Vitest shard in 45.54s
```

Sibling production-surface suite still green:

```text
✓ |extension-feishu| extensions/feishu/src/reply-dispatcher.test.ts (92 tests) 1048ms
Test Files  1 passed (1)
     Tests  92 passed (92)
```

Static: `git diff --check` pass; `oxfmt --check` pass; path-scoped `oxlint` 0 warnings/errors on the touched file.

Verification host: local macOS (no remote box).

## Real behavior proof

- Behavior addressed: Feishu delivery-trace goldens (`streaming-happy`, `final-only`, `cancel-mid-stream`, `rate-limit-during-preview`, `overflow-pagination`) no longer throw `dispatcher options were not captured`; they drive delivery from the factory-returned plan and match committed goldens.
- Environment: local macOS arm64, openclaw checkout at post-patch HEAD, Node via repo `scripts/run-vitest.mjs`, no Feishu tenant credentials required (hermetic Lark/CardKit mocks).
- Current-main contrast: on unpatched `main`, `setupFeishuTrace` reads `traceState.dispatcherOptions` filled only by a mock of `createReplyDispatcherWithTyping`, which production no longer invokes → immediate throw; after patch, options come from `created.dispatcherOptions` / `created.delivery.deliver` / `created.replyOptions`.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs extensions/feishu/src/delivery-trace.test.ts`
  2. `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts`
  3. `git diff --check`
  4. `./node_modules/.bin/oxfmt --check extensions/feishu/src/delivery-trace.test.ts`
- Evidence after fix: five delivery-trace tests pass; ninety-two reply-dispatcher tests pass; goldens still match without `OPENCLAW_TRACE_UPDATE`.
- Control check: only the Feishu trace harness was changed; production `createFeishuReplyDispatcher` return shape is reused as-is; sibling MS Teams/Slack harnesses already use the same plan-driven pattern.
- Observed result after fix: harness records wire-level delivery through the real plan path; suite exits 0.
- What was not tested: live Feishu workspace send/receive; full `pnpm check:changed` extensions-test typecheck lane (path-scoped static + focused Vitest used for this surface).

## AI disclosure

This PR was authored with AI assistance (Grok).
