### PR TITLE
fix(gateway): bound SQLite sessions.preview transcript reads

### DIFF
--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -8,6 +8,11 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { readSessionMessagesAroundIdWithStatsAsync } from "./session-transcript-anchor-reader.js";
 import {
@@ -15,6 +20,7 @@ import {
   readSessionMessageCountAsync,
   readSessionMessagesAsync,
   readSessionMessagesPageWithStatsAsync,
+  readSessionPreviewItemsFromTranscript,
   type SessionTranscriptReadScope,
 } from "./session-transcript-readers.js";
 
@@ -31,6 +37,8 @@ describe("session transcript reader facade", () => {
   });
 
   afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
@@ -451,5 +459,83 @@ describe("session transcript reader facade", () => {
     await expect(
       readSessionMessagesAsync(scope, { mode: "full", reason: "explicit file test" }),
     ).resolves.toMatchObject([{ content: "explicit prompt" }]);
+  });
+
+  test("SQLite session preview stays bounded when a middle event is unreadable", async () => {
+    // sessions.preview (macOS menu / Gateway RPC) → readSessionPreviewItemsFromTranscript.
+    // Full SQLite materialisation would throw on the corrupt middle row; recent-window
+    // preview must still return the latest assistant text.
+    const sessionId = "reader-sqlite-preview-bound";
+    // Keep the corrupt row outside the preview recent window (maxLines=200).
+    const fillerCount = 250;
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+    const messages: Array<{
+      eventId: string;
+      parentId: string | null;
+      message: { role: string; content: string };
+    }> = [
+      {
+        eventId: "preview-head",
+        parentId: null,
+        message: { role: "user", content: "preview-head" },
+      },
+    ];
+    for (let index = 0; index < fillerCount; index += 1) {
+      messages.push({
+        eventId: `filler-${index}`,
+        parentId: index === 0 ? "preview-head" : `filler-${index - 1}`,
+        message: { role: "assistant", content: `filler-${index}` },
+      });
+    }
+    messages.push({
+      eventId: "preview-tail",
+      parentId: `filler-${fillerCount - 1}`,
+      message: { role: "assistant", content: "bounded-preview-tail" },
+    });
+    await persistSessionTranscriptTurn(scope, { messages, touchSessionEntry: false });
+    await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
+      path: path.join(tempDir, "openclaw-agent.sqlite"),
+    });
+
+    expect(await readSessionMessageCountAsync(scope)).toBe(fillerCount + 2);
+    const sqliteFile = fs
+      .readdirSync(tempDir, { recursive: true })
+      .map(String)
+      .find((entry) => entry.endsWith("openclaw-agent.sqlite"));
+    expect(sqliteFile).toBeTruthy();
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+      path: path.join(tempDir, sqliteFile ?? ""),
+    });
+    const eventRows = database.db
+      .prepare(
+        "SELECT session_id, seq, substr(event_json, 1, 120) AS preview FROM transcript_events",
+      )
+      .all() as Array<{ session_id: string; seq: number; preview: string }>;
+    const middlePreview = eventRows.find((row) => row.preview.includes("filler-20"));
+    if (!middlePreview) {
+      throw new Error("expected filler-20 event in SQLite transcript");
+    }
+    expect(
+      database.db
+        .prepare("UPDATE transcript_events SET event_json = '{' WHERE session_id = ? AND seq = ?")
+        .run(middlePreview.session_id, middlePreview.seq).changes,
+    ).toBe(1);
+
+    await expect(
+      readSessionMessagesAsync(scope, { mode: "full", reason: "preview bound full-read sentinel" }),
+    ).rejects.toThrow();
+
+    const items = readSessionPreviewItemsFromTranscript(scope, 3, 120);
+    expect(items.some((item) => item.text.includes("bounded-preview-tail"))).toBe(true);
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.length).toBeLessThanOrEqual(3);
   });
 });

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -410,12 +410,35 @@ function aggregateSqliteUsageSnapshots(messages: unknown[]): SessionTranscriptUs
   return aggregate;
 }
 
+// Match file-backed sessions.preview: clamp item/char caps and read only a
+// bounded recent window. Full materialisation would make macOS menu preview /
+// Gateway sessions.preview scale with transcript size.
+const SQLITE_PREVIEW_MAX_ITEMS = 50;
+const SQLITE_PREVIEW_MAX_CHARS = 2000;
+const SQLITE_PREVIEW_MAX_LINES = 200;
+const SQLITE_PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024] as const;
+
 function buildSqlitePreviewItems(
   target: ResolvedTranscriptReadTarget,
   maxItems: number,
   maxChars: number,
 ): SessionPreviewItem[] {
-  return buildSessionPreviewItems(readSqliteMessagesSync(target), maxItems, maxChars);
+  const boundedItems = Math.max(1, Math.min(maxItems, SQLITE_PREVIEW_MAX_ITEMS));
+  const boundedChars = Math.max(20, Math.min(maxChars, SQLITE_PREVIEW_MAX_CHARS));
+  const scope = toTranscriptReadScope(target);
+  for (const [index, maxBytes] of SQLITE_PREVIEW_READ_SIZES.entries()) {
+    const messages = extractMessageRecordsFromEventEntries(
+      readRecentSessionTranscriptMessageEvents(scope, {
+        maxBytes,
+        maxLines: SQLITE_PREVIEW_MAX_LINES,
+        maxMessages: boundedItems,
+      }).events,
+    ).map((record) => record.message);
+    if (messages.length > 0 || index === SQLITE_PREVIEW_READ_SIZES.length - 1) {
+      return buildSessionPreviewItems(messages, boundedItems, boundedChars);
+    }
+  }
+  return [];
 }
 
 /** Reads display messages asynchronously through the reader seam. */


### PR DESCRIPTION
## What Problem This Solves

Gateway `sessions.preview` (used by the macOS session menu preview and any
operator RPC client) builds short transcript previews through
`readSessionPreviewItemsFromTranscript`. On SQLite-backed transcripts the reader
previously called `readSqliteMessagesSync` and materialised **every** active
message before slicing to the requested preview size.

File-backed previews already clamp to 50 items / 2000 chars and only read a
bounded recent byte window. Long SQLite sessions therefore paid an O(transcript)
cost for a few preview lines.

## Why This Change Was Made

Align SQLite `sessions.preview` with the file-backed contract:

- Clamp `maxItems` to 50 and `maxChars` to 2000
- Read only a recent window via `readRecentSessionTranscriptMessageEvents`
  (64 KiB → 256 KiB → 1 MiB, max 200 lines), matching `PREVIEW_READ_SIZES`

## User Impact

- macOS menu preview / `sessions.preview` no longer loads an entire SQLite
  transcript to render a few preview lines.
- Preview text still comes from the newest messages in the recent window (same
  practical outcome as the file path).
- Very old messages outside the recent window are not considered for preview,
  matching file-backed behavior.

## Evidence

### Real behavior proof

#### Behavior or issue addressed

SQLite `sessions.preview` stays on a bounded recent window; a corrupt early
transcript event makes full materialisation throw, while preview still returns
the latest assistant text.

#### Canonical reachability path

macOS `SessionMenuPreviewView` / Gateway RPC `sessions.preview` →
`readSessionPreviewItemsFromTranscript` → bounded SQLite recent reads (no full
`readSqliteMessagesSync`).

#### Real environment tested

Local trusted checkout; Vitest against a real per-agent SQLite transcript with
252 active messages and a deliberately corrupted early filler event.

#### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/session-transcript-readers.test.ts -t "SQLite session preview stays bounded" --reporter=verbose
```

#### Evidence after fix

```text
✓ |gateway-core| ../../src/gateway/session-transcript-readers.test.ts > session transcript reader facade > SQLite session preview stays bounded when a middle event is unreadable 370ms
✓ |gateway-server| ../../src/gateway/session-transcript-readers.test.ts > session transcript reader facade > SQLite session preview stays bounded when a middle event is unreadable 329ms
✓ |gateway-client| ../../src/gateway/session-transcript-readers.test.ts > session transcript reader facade > SQLite session preview stays bounded when a middle event is unreadable 345ms
 Test Files  3 passed (3)
      Tests  3 passed | 33 skipped (36)
```

The proof seeds a long transcript ending in `bounded-preview-tail`, corrupts an
early filler event to `'{'`, asserts full `readSessionMessagesAsync` throws, and
asserts `readSessionPreviewItemsFromTranscript(scope, 3, 120)` still includes
`bounded-preview-tail` with at most 3 items.

#### Observed result after fix

Full SQLite materialisation fails closed on the corrupt early row; preview used
by `sessions.preview` stays on the recent window and returns the expected tail
text.

#### What was not tested

Live macOS menu hover against a multi-hour production transcript.

#### Fix classification

bugfix — SQLite sessions.preview unbounded full transcript read

## AI Assistance

AI-assisted. Author reviewed the `sessions.preview` → preview-items path and the
focused SQLite sentinel proof output.
