### PR TITLE
fix(gateway): page SQLite transcript visits for sessions.files.list

### DIFF
--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import {
   persistSessionTranscriptTurn,
   upsertSessionEntry,
@@ -15,6 +16,7 @@ import {
   readSessionMessageCountAsync,
   readSessionMessagesAsync,
   readSessionMessagesPageWithStatsAsync,
+  visitSessionMessagesAsync,
   type SessionTranscriptReadScope,
 } from "./session-transcript-readers.js";
 
@@ -31,6 +33,7 @@ describe("session transcript reader facade", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     envSnapshot.restore();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
@@ -451,5 +454,84 @@ describe("session transcript reader facade", () => {
     await expect(
       readSessionMessagesAsync(scope, { mode: "full", reason: "explicit file test" }),
     ).resolves.toMatchObject([{ content: "explicit prompt" }]);
+  });
+
+  test("SQLite full visits page instead of materialising every message", async () => {
+    // sessions.files.list → visitSessionMessagesAsync({ mode: "full" }).
+    // Keep visiting every active message, but never allocate the full array via
+    // readSessionTranscriptMessageEvents.
+    const sessionId = "reader-sqlite-visit-paged";
+    const fillerCount = 250;
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+    const messages: Array<{
+      eventId: string;
+      parentId: string | null;
+      message: Record<string, unknown>;
+    }> = [
+      {
+        eventId: "file-head",
+        parentId: null,
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", name: "edit", arguments: { path: "src/head.ts" } }],
+        },
+      },
+    ];
+    for (let index = 0; index < fillerCount; index += 1) {
+      messages.push({
+        eventId: `filler-${index}`,
+        parentId: index === 0 ? "file-head" : `filler-${index - 1}`,
+        message: { role: "assistant", content: `filler-${index}` },
+      });
+    }
+    messages.push({
+      eventId: "file-tail",
+      parentId: `filler-${fillerCount - 1}`,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: { path: "src/tail.ts" } }],
+      },
+    });
+    await persistSessionTranscriptTurn(scope, { messages, touchSessionEntry: false });
+    await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
+      path: path.join(tempDir, "openclaw-agent.sqlite"),
+    });
+
+    const fullReadSpy = vi.spyOn(sessionAccessor, "readSessionTranscriptMessageEvents");
+    const pageSpy = vi.spyOn(sessionAccessor, "readSessionTranscriptMessageEventPage");
+    const touched = new Set<string>();
+    const visited = await visitSessionMessagesAsync(
+      scope,
+      (message) => {
+        const record = message as {
+          role?: unknown;
+          content?: Array<{ type?: string; name?: string; arguments?: { path?: string } }>;
+        };
+        if (record.role !== "assistant" || !Array.isArray(record.content)) {
+          return;
+        }
+        for (const part of record.content) {
+          if (
+            part?.type === "toolCall" &&
+            (part.name === "edit" || part.name === "read") &&
+            typeof part.arguments?.path === "string"
+          ) {
+            touched.add(part.arguments.path);
+          }
+        }
+      },
+      { mode: "full", reason: "session files transcript scan" },
+    );
+
+    expect(visited).toBe(fillerCount + 2);
+    expect(touched).toEqual(new Set(["src/head.ts", "src/tail.ts"]));
+    expect(fullReadSpy).not.toHaveBeenCalled();
+    expect(pageSpy.mock.calls.length).toBeGreaterThan(1);
   });
 });

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -532,6 +532,33 @@ export async function readSessionMessageByIdAsync(
   );
 }
 
+// Page full SQLite visits so sessions.files.list / artifact scans stay O(page)
+// in memory. Callers still see every active message; we just never materialise
+// the entire transcript array at once.
+const SQLITE_VISIT_PAGE_SIZE = 100;
+
+function visitSqliteMessagesPaged(
+  target: ResolvedTranscriptReadTarget,
+  visit: (message: unknown, seq: number) => void,
+): number {
+  const scope = toTranscriptReadScope(target);
+  const totalMessages = readSessionTranscriptMessageEventCount(scope);
+  let count = 0;
+  for (let start = 0; start < totalMessages; start += SQLITE_VISIT_PAGE_SIZE) {
+    const endExclusive = Math.min(totalMessages, start + SQLITE_VISIT_PAGE_SIZE);
+    // Page API is tail-relative: offset = total - endExclusive yields [start, endExclusive).
+    const page = readSessionTranscriptMessageEventPage(scope, {
+      maxMessages: endExclusive - start,
+      offset: totalMessages - endExclusive,
+    });
+    for (const record of extractMessageRecordsFromEventEntries(page.events)) {
+      visit(record.message, record.seq);
+      count += 1;
+    }
+  }
+  return count;
+}
+
 /** Visits display messages asynchronously through the reader seam. */
 export async function visitSessionMessagesAsync(
   scope: SessionTranscriptReadScope,
@@ -540,12 +567,7 @@ export async function visitSessionMessagesAsync(
 ): Promise<number> {
   const target = resolveTranscriptReadTarget(scope);
   if (isSqliteReadTarget(target)) {
-    let count = 0;
-    for (const record of await readSqliteMessageRecords(target)) {
-      visit(record.message, record.seq);
-      count += 1;
-    }
-    return count;
+    return visitSqliteMessagesPaged(target, visit);
   }
   return await visitSessionMessagesAsyncFile(
     target.sessionId,


### PR DESCRIPTION
## What Problem This Solves

Control UI `sessions.files.list` scans the session transcript via
`visitSessionMessagesAsync({ mode: "full", reason: "session files transcript scan" })`
to discover touched workspace files. On SQLite-backed transcripts the visitor
previously called `readSqliteMessageRecords` → `readSessionTranscriptMessageEvents`,
which materialised **every** active message into one in-memory array before
iterating.

Long sessions therefore paid an O(transcript) allocation on a UI path that only
needs to walk messages and collect tool file paths.

## Why This Change Was Made

Keep the full-visit contract (every active message is still visited, so early and
late file touches remain visible) but page SQLite reads in chunks of 100 through
`readSessionTranscriptMessageEventPage` instead of allocating the full event
array up front.

## User Impact

- Opening session files / file links on long SQLite transcripts no longer forces
  a single full-transcript materialisation.
- File discovery remains complete across the active transcript (head and tail
  tool touches still appear).
- Peak memory during the scan scales with page size, not total message count.

## Evidence

### Real behavior proof

#### Behavior or issue addressed

After-fix Gateway RPC `sessions.files.list` against a long SQLite-backed
session still discovers early (`src/head.ts`) and late (`src/tail.ts`) tool file
touches, while the visitor pages instead of materialising every active message
via `readSessionTranscriptMessageEvents`.

#### Canonical reachability path

Control UI / `openclaw gateway call sessions.files.list` → `loadSessionFiles` →
`visitSessionMessagesAsync({ mode: "full", reason: "session files transcript scan" })`
→ paged SQLite `readSessionTranscriptMessageEventPage` (no full
`readSessionTranscriptMessageEvents`).

#### Real environment tested

- Host: macOS (Darwin), Node v22.23.1
- OpenClaw PR head: `4a431b47f251d56b11dfbf06c4ea2d45dcaf9af7`
- Isolated `OPENCLAW_STATE_DIR` + free loopback Gateway port (not operator `18789` /
  not `~/.openclaw`)
- Seeded SQLite transcript: **252** active messages (edit `src/head.ts` at head,
  read `src/tail.ts` at tail; 250 fillers)
- Production Gateway process via `createOpenClawTestInstance` →
  `gateway call sessions.files.list --json`

#### Exact steps or command run after this patch

```bash
# Live Gateway RPC (isolated state + free port; seeds 252-message SQLite transcript)
OPENCLAW_PROOF_WT="$PWD" node --import tsx /tmp/oc-sessions-files-list-live-proof.mjs

# Focused regression (paging spies + head/tail discovery)
node scripts/run-vitest.mjs src/gateway/session-transcript-readers.test.ts \
  -t "SQLite full visits page" --reporter=verbose
```

The live driver creates an isolated test Gateway, upserts
`agent:main:reader-sqlite-visit-paged` with a SQLite sessionFile marker and
workspace files, persists the 252-message transcript, then runs:

```bash
node dist/index.js gateway call sessions.files.list \
  --url ws://127.0.0.1:<port> \
  --token <isolated-token> \
  --timeout 60000 \
  --json \
  --params '{"sessionKey":"agent:main:reader-sqlite-visit-paged"}'
```

#### Evidence after fix

**Live `sessions.files.list` (redacted)**

```json
{
  "ok": true,
  "exitCode": 0,
  "sessionKey": "agent:main:reader-sqlite-visit-paged",
  "rootBasename": "workspace",
  "messageCountSeeded": 252,
  "filePaths": [
    "src/head.ts",
    "src/tail.ts"
  ],
  "hasHead": true,
  "hasTail": true,
  "files": [
    {
      "path": "src/head.ts",
      "kind": "modified",
      "missing": false
    },
    {
      "path": "src/tail.ts",
      "kind": "read",
      "missing": false
    }
  ],
  "gatewayUrl": "ws://127.0.0.1:<port>",
  "stateDir": "<isolated OPENCLAW_STATE_DIR>",
  "sqlitePresent": true
}
```

**Focused Vitest (supplemental)**

```text
✓ |gateway-core| ../../src/gateway/session-transcript-readers.test.ts > session transcript reader facade > SQLite full visits page instead of materialising every message
✓ |gateway-server| ../../src/gateway/session-transcript-readers.test.ts > session transcript reader facade > SQLite full visits page instead of materialising every message
✓ |gateway-client| ../../src/gateway/session-transcript-readers.test.ts > session transcript reader facade > SQLite full visits page instead of materialising every message
```

Assertions in that test:

- visited count = 252
- touched paths = `{ src/head.ts, src/tail.ts }`
- `readSessionTranscriptMessageEvents` spy: not called
- `readSessionTranscriptMessageEventPage` spy: called more than once

#### Observed result after fix

Live Gateway `sessions.files.list` returns both head and tail workspace file
touches from a 252-message SQLite transcript. Focused coverage confirms the
visitor pages and never calls the full-event materializer.

#### What was not tested

Control UI click-through / screenshot against a multi-hour production transcript;
`sessions.artifacts` (same visitor seam; left for a follow-up if needed).

#### Fix classification

bugfix — SQLite full transcript visit materialised all messages for files.list

## AI Assistance

AI-assisted. Author reviewed the `sessions.files.list` → visit path, the live
Gateway RPC output, and the focused paged-visit proof.
