### PR TITLE
fix(ci): stabilize ChatViewModel concurrency tests

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -296,105 +296,137 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertEqual(duration, 0)
     }
 
-    @MainActor
     func testPartialIdentitySyncPreservesTheOtherDeferredComponent() async {
-        let oldContract = "per-sender|main|main"
-        let newContract = "per-sender|work-main|main"
-        let contractViewModel = OpenClawChatViewModel(
-            sessionKey: "main",
-            transport: AttachmentProcessingTransport(),
-            activeAgentId: "main",
-            sessionRoutingContract: oldContract)
-        let contractAttachment = OpenClawPendingAttachment(
-            url: nil,
-            data: Data("contract".utf8),
-            fileName: "contract.m4a",
-            mimeType: "audio/mp4",
-            preview: nil)
-        contractViewModel.attachments = [contractAttachment]
+        let state = await MainActor.run {
+            let oldContract = "per-sender|main|main"
+            let newContract = "per-sender|work-main|main"
+            let contractViewModel = OpenClawChatViewModel(
+                sessionKey: "main",
+                transport: AttachmentProcessingTransport(),
+                activeAgentId: "main",
+                sessionRoutingContract: oldContract)
+            let contractAttachment = OpenClawPendingAttachment(
+                url: nil,
+                data: Data("contract".utf8),
+                fileName: "contract.m4a",
+                mimeType: "audio/mp4",
+                preview: nil)
+            contractViewModel.attachments = [contractAttachment]
 
-        contractViewModel.syncSessionRoutingContract(newContract)
-        contractViewModel.syncActiveAgentId("main")
-        contractViewModel.removeAttachment(contractAttachment.id)
+            contractViewModel.syncSessionRoutingContract(newContract)
+            contractViewModel.syncActiveAgentId("main")
+            contractViewModel.removeAttachment(contractAttachment.id)
 
-        XCTAssertEqual(contractViewModel.activeAgentId, "main")
-        XCTAssertEqual(contractViewModel.sessionRoutingContract, newContract)
+            let agentViewModel = OpenClawChatViewModel(
+                sessionKey: "main",
+                transport: AttachmentProcessingTransport(),
+                activeAgentId: "main",
+                sessionRoutingContract: oldContract)
+            let agentAttachment = OpenClawPendingAttachment(
+                url: nil,
+                data: Data("agent".utf8),
+                fileName: "agent.m4a",
+                mimeType: "audio/mp4",
+                preview: nil)
+            agentViewModel.attachments = [agentAttachment]
 
-        let agentViewModel = OpenClawChatViewModel(
-            sessionKey: "main",
-            transport: AttachmentProcessingTransport(),
-            activeAgentId: "main",
-            sessionRoutingContract: oldContract)
-        let agentAttachment = OpenClawPendingAttachment(
-            url: nil,
-            data: Data("agent".utf8),
-            fileName: "agent.m4a",
-            mimeType: "audio/mp4",
-            preview: nil)
-        agentViewModel.attachments = [agentAttachment]
+            agentViewModel.syncActiveAgentId("work")
+            agentViewModel.syncSessionRoutingContract(oldContract)
+            agentViewModel.removeAttachment(agentAttachment.id)
 
-        agentViewModel.syncActiveAgentId("work")
-        agentViewModel.syncSessionRoutingContract(oldContract)
-        agentViewModel.removeAttachment(agentAttachment.id)
+            return (
+                contractAgentID: contractViewModel.activeAgentId,
+                contract: contractViewModel.sessionRoutingContract,
+                agentID: agentViewModel.activeAgentId,
+                agentContract: agentViewModel.sessionRoutingContract)
+        }
 
-        XCTAssertEqual(agentViewModel.activeAgentId, "work")
-        XCTAssertEqual(agentViewModel.sessionRoutingContract, oldContract)
+        XCTAssertEqual(state.contractAgentID, "main")
+        XCTAssertEqual(state.contract, "per-sender|work-main|main")
+        XCTAssertEqual(state.agentID, "work")
+        XCTAssertEqual(state.agentContract, "per-sender|main|main")
     }
 
-    @MainActor
     func testAttachmentStagingPinsSessionAndIdentityUntilItFinishes() async {
-        let viewModel = OpenClawChatViewModel(
-            sessionKey: "main",
-            transport: AttachmentProcessingTransport(),
-            activeAgentId: "main",
-            sessionRoutingContract: "per-sender|main|main")
+        let state = await MainActor.run {
+            let viewModel = OpenClawChatViewModel(
+                sessionKey: "main",
+                transport: AttachmentProcessingTransport(),
+                activeAgentId: "main",
+                sessionRoutingContract: "per-sender|main|main")
 
-        viewModel.beginAttachmentStaging()
-        viewModel.syncSession(to: "agent:work:main")
-        viewModel.syncDeliveryIdentity(
-            activeAgentId: "work",
-            sessionRoutingContract: "per-sender|main|work")
+            viewModel.beginAttachmentStaging()
+            viewModel.syncSession(to: "agent:work:main")
+            viewModel.syncDeliveryIdentity(
+                activeAgentId: "work",
+                sessionRoutingContract: "per-sender|main|work")
 
-        XCTAssertTrue(viewModel.isAttachmentOwnerPinned)
-        XCTAssertEqual(viewModel.sessionKey, "main")
-        XCTAssertEqual(viewModel.activeAgentId, "main")
-        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|main")
+            let pinned = (
+                isPinned: viewModel.isAttachmentOwnerPinned,
+                sessionKey: viewModel.sessionKey,
+                agentID: viewModel.activeAgentId,
+                contract: viewModel.sessionRoutingContract)
 
-        viewModel.endAttachmentStaging()
+            viewModel.endAttachmentStaging()
 
-        XCTAssertFalse(viewModel.isAttachmentOwnerPinned)
-        XCTAssertEqual(viewModel.sessionKey, "agent:work:main")
-        XCTAssertEqual(viewModel.activeAgentId, "work")
-        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|work")
+            let released = (
+                isPinned: viewModel.isAttachmentOwnerPinned,
+                sessionKey: viewModel.sessionKey,
+                agentID: viewModel.activeAgentId,
+                contract: viewModel.sessionRoutingContract)
+            return (pinned: pinned, released: released)
+        }
+
+        XCTAssertTrue(state.pinned.isPinned)
+        XCTAssertEqual(state.pinned.sessionKey, "main")
+        XCTAssertEqual(state.pinned.agentID, "main")
+        XCTAssertEqual(state.pinned.contract, "per-sender|main|main")
+        XCTAssertFalse(state.released.isPinned)
+        XCTAssertEqual(state.released.sessionKey, "agent:work:main")
+        XCTAssertEqual(state.released.agentID, "work")
+        XCTAssertEqual(state.released.contract, "per-sender|main|work")
     }
 
-    @MainActor
     func testRecordingPinsSessionAndIdentityUntilItEnds() async {
-        let ownerActivity = AttachmentOwnerActivity()
-        let viewModel = OpenClawChatViewModel(
-            sessionKey: "main",
-            transport: AttachmentProcessingTransport(),
-            activeAgentId: "main",
-            sessionRoutingContract: "per-sender|main|main",
-            attachmentOwnerIsActive: { ownerActivity.isActive })
+        let state = await MainActor.run {
+            let ownerActivity = AttachmentOwnerActivity()
+            let viewModel = OpenClawChatViewModel(
+                sessionKey: "main",
+                transport: AttachmentProcessingTransport(),
+                activeAgentId: "main",
+                sessionRoutingContract: "per-sender|main|main",
+                attachmentOwnerIsActive: { ownerActivity.isActive })
 
-        viewModel.syncSession(to: "agent:work:main")
-        viewModel.syncDeliveryIdentity(
-            activeAgentId: "work",
-            sessionRoutingContract: "per-sender|main|work")
+            viewModel.syncSession(to: "agent:work:main")
+            viewModel.syncDeliveryIdentity(
+                activeAgentId: "work",
+                sessionRoutingContract: "per-sender|main|work")
 
-        XCTAssertTrue(viewModel.isAttachmentOwnerPinned)
-        XCTAssertEqual(viewModel.sessionKey, "main")
-        XCTAssertEqual(viewModel.activeAgentId, "main")
-        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|main")
+            let pinned = (
+                isPinned: viewModel.isAttachmentOwnerPinned,
+                sessionKey: viewModel.sessionKey,
+                agentID: viewModel.activeAgentId,
+                contract: viewModel.sessionRoutingContract)
 
-        ownerActivity.isActive = false
-        viewModel.attachmentOwnerActivityChanged()
+            ownerActivity.isActive = false
+            viewModel.attachmentOwnerActivityChanged()
 
-        XCTAssertFalse(viewModel.isAttachmentOwnerPinned)
-        XCTAssertEqual(viewModel.sessionKey, "agent:work:main")
-        XCTAssertEqual(viewModel.activeAgentId, "work")
-        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|work")
+            let released = (
+                isPinned: viewModel.isAttachmentOwnerPinned,
+                sessionKey: viewModel.sessionKey,
+                agentID: viewModel.activeAgentId,
+                contract: viewModel.sessionRoutingContract)
+            return (pinned: pinned, released: released)
+        }
+
+        XCTAssertTrue(state.pinned.isPinned)
+        XCTAssertEqual(state.pinned.sessionKey, "main")
+        XCTAssertEqual(state.pinned.agentID, "main")
+        XCTAssertEqual(state.pinned.contract, "per-sender|main|main")
+        XCTAssertFalse(state.released.isPinned)
+        XCTAssertEqual(state.released.sessionKey, "agent:work:main")
+        XCTAssertEqual(state.released.agentID, "work")
+        XCTAssertEqual(state.released.contract, "per-sender|main|work")
     }
 
     func testAttachmentSendWithoutOutboxUsesLiveTransport() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -33,12 +33,45 @@ private actor SessionActionTransportState {
     }
 }
 
+/// Signals the exact suspension point before fork completion, then holds it so
+/// navigation can advance deterministically before the stale result resumes.
+private struct SessionActionForkGate: Sendable {
+    private let startedStream: AsyncStream<Void>
+    private let startedContinuation: AsyncStream<Void>.Continuation
+    private let releaseStream: AsyncStream<Void>
+    private let releaseContinuation: AsyncStream<Void>.Continuation
+
+    init() {
+        let started = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        self.startedStream = started.stream
+        self.startedContinuation = started.continuation
+        let release = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        self.releaseStream = release.stream
+        self.releaseContinuation = release.continuation
+    }
+
+    func suspendCompletion() async {
+        self.startedContinuation.yield()
+        var iterator = self.releaseStream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func waitUntilStarted() async -> Bool {
+        var iterator = self.startedStream.makeAsyncIterator()
+        return await iterator.next() != nil
+    }
+
+    func release() {
+        self.releaseContinuation.yield()
+    }
+}
+
 private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTransport {
     private let state = SessionActionTransportState()
-    private let forkDelay: Duration?
+    private let forkGate: SessionActionForkGate?
 
-    init(forkDelay: Duration? = nil) {
-        self.forkDelay = forkDelay
+    init(forkGate: SessionActionForkGate? = nil) {
+        self.forkGate = forkGate
     }
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
@@ -61,9 +94,7 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
 
     func forkSession(parentKey: String) async throws -> String {
         await self.state.recordFork(parentKey)
-        if let forkDelay {
-            try await Task.sleep(for: forkDelay)
-        }
+        await self.forkGate?.suspendCompletion()
         return "forked"
     }
 
@@ -336,29 +367,41 @@ struct ChatViewModelSessionActionTests {
             localized: "Remove attachments or wait for delivery to resolve before starting a new chat."))
     }
 
-    @Test func `fork completion does not override newer navigation`() async throws {
-        let transport = SessionActionTransport(forkDelay: .milliseconds(50))
+    @Test func `fork completion does not override newer navigation`() async {
+        let forkGate = SessionActionForkGate()
+        let transport = SessionActionTransport(forkGate: forkGate)
         let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
 
         let fork = Task { await viewModel.forkSession(key: "main") }
-        try await self.waitUntil { await transport.forkedParentKeys() == ["main"] }
+        guard await self.waitForForkStart(forkGate) else {
+            forkGate.release()
+            fork.cancel()
+            Issue.record("timed out waiting for fork start signal")
+            return
+        }
         viewModel.switchSession(to: "other")
+        forkGate.release()
         await fork.value
 
         #expect(viewModel.sessionKey == "other")
+        #expect(await transport.forkedParentKeys() == ["main"])
     }
 
-    private func waitUntil(
-        timeout: Duration = .seconds(2),
-        condition: @escaping @MainActor () async -> Bool) async throws
+    private func waitForForkStart(
+        _ gate: SessionActionForkGate,
+        timeout: Duration = .seconds(15)) async -> Bool
     {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while clock.now < deadline {
-            if await condition() { return }
-            try await Task.sleep(for: .milliseconds(10))
+        // The stream controls ordering; this deadline only bounds a broken fake or call path.
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask { await gate.waitUntilStarted() }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            let started = await group.next() ?? false
+            group.cancelAll()
+            return started
         }
-        Issue.record("timed out waiting for session action condition")
     }
 
     private func entry(key: String) -> OpenClawChatSessionEntry {


### PR DESCRIPTION
Related: #110646 (CI evidence; unrelated product diff)

## What Problem This Solves

Resolves a problem where the `macos-swift` lane could fail unrelated `apps/` pull requests in shared OpenClawKit ChatViewModel tests. Run 29642644168 failed three attachment-owner XCTest subprocesses with signal 6 on attempt 1, then timed out the fork-navigation test on attempt 2.

## Why This Change Was Made

The attachment tests now enter `MainActor` explicitly inside ordinary async XCTest methods, avoiding actor-isolated XCTest entry points. The fork test replaces a fixed delay plus polling with buffered start/release signals; a cancellation-aware watchdog bounds broken call paths without controlling normal ordering.

Production behavior is unchanged.

AI-assisted: yes (Codex).

## User Impact

No user-visible product change. Maintainers get reliable macOS Swift validation for pull requests touching `apps/`.

## Evidence

- Before: [run 29642644168 attempt 1](https://github.com/openclaw/openclaw/actions/runs/29642644168/attempts/1) reported signal 6 for all three attachment identity-pinning tests.
- Before: [run 29642644168 attempt 2](https://github.com/openclaw/openclaw/actions/runs/29642644168/attempts/2) timed out `fork completion does not override newer navigation` after 2 seconds.
- `swiftc -frontend -parse` passes for both changed test files with the installed Swift 6.4 parser.
- Targeted SwiftFormat lint and `git diff --check` pass.
- Mandatory autoreview is clean after one accepted finding added cancellation-aware timeout cleanup to the deterministic gate; the final branch review reports no actionable findings at 0.97 confidence.
- Exact-head [CI run 29651434725](https://github.com/openclaw/openclaw/actions/runs/29651434725) passes, including `macos-swift`, OpenClawKit tests, full Swift test, and the aggregate `openclaw/ci-gate`.
