### PR TITLE
fix(ui): drop resting relative ages from agent chip and build chip

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -446,9 +446,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
       return t("agentChip.working");
     }
     if (latest) {
-      const label = resolveSessionDisplayName(latest.key, latest);
-      const meta = formatSidebarTimestamp(latest.updatedAt);
-      return meta ? `${label} · ${meta}` : label;
+      return resolveSessionDisplayName(latest.key, latest);
     }
     return t("agentChip.ready");
   }

--- a/ui/src/components/sidebar-build-chip-format.ts
+++ b/ui/src/components/sidebar-build-chip-format.ts
@@ -1,6 +1,5 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { ControlUiBuildInfo } from "../build-info.ts";
-import { formatTimeAgo } from "../lib/format.ts";
 
 const BRANCH_DISPLAY_LENGTH = 14;
 
@@ -15,19 +14,11 @@ function formatBranchPrefix(branch: string | null): string {
   return `${displayBranch}@`;
 }
 
-export function formatBuildChipText(info: ControlUiBuildInfo, nowMs: number): string | null {
+export function formatBuildChipText(info: ControlUiBuildInfo): string | null {
   if (!info.commit) {
     return null;
   }
   const branch = formatBranchPrefix(info.branch);
   const commit = `${info.commit.slice(0, 7)}${info.dirty === true ? "*" : ""}`;
-  if (!info.builtAt) {
-    return `${branch}${commit}`;
-  }
-  const builtAtMs = Date.parse(info.builtAt);
-  if (Number.isNaN(builtAtMs)) {
-    return `${branch}${commit}`;
-  }
-  const age = formatTimeAgo(Math.max(0, nowMs - builtAtMs), { suffix: false });
-  return `${branch}${commit} · ${age}`;
+  return `${branch}${commit}`;
 }

--- a/ui/src/components/sidebar-build-chip.node.test.ts
+++ b/ui/src/components/sidebar-build-chip.node.test.ts
@@ -18,32 +18,25 @@ function buildInfo(overrides: Partial<ControlUiBuildInfo> = {}): ControlUiBuildI
 }
 
 describe("formatBuildChipText", () => {
-  const nowMs = Date.parse(BUILT_AT) + 24 * 60_000;
   const cases: Array<{
     name: string;
     info: ControlUiBuildInfo;
-    nowMs?: number;
     expected: string | null;
   }> = [
     {
       name: "main clean build",
       info: buildInfo(),
-      expected: "e8cbc62 · 24m",
+      expected: "e8cbc62",
     },
     {
       name: "non-main branch",
-      info: buildInfo({ branch: "feat/x", builtAt: "2026-07-10T12:19:00.000Z" }),
-      expected: "feat/x@e8cbc62 · 5m",
+      info: buildInfo({ branch: "feat/x" }),
+      expected: "feat/x@e8cbc62",
     },
     {
       name: "dirty worktree",
-      info: buildInfo({ dirty: true, builtAt: "2026-07-10T09:00:00.000Z" }),
-      expected: "e8cbc62* · 3h",
-    },
-    {
-      name: "missing build timestamp",
-      info: buildInfo({ builtAt: null }),
-      expected: "e8cbc62",
+      info: buildInfo({ dirty: true }),
+      expected: "e8cbc62*",
     },
     {
       name: "missing commit",
@@ -52,29 +45,24 @@ describe("formatBuildChipText", () => {
     },
     {
       name: "long branch",
-      info: buildInfo({ branch: "abcdefghijklmnop", builtAt: null }),
+      info: buildInfo({ branch: "abcdefghijklmnop" }),
       expected: "abcdefghijklmn…@e8cbc62",
     },
     {
       name: "long branch keeps an emoji that fits exactly at the boundary",
-      info: buildInfo({ branch: `${"a".repeat(12)}😀suffix`, builtAt: null }),
+      info: buildInfo({ branch: `${"a".repeat(12)}😀suffix` }),
       expected: "aaaaaaaaaaaa😀…@e8cbc62",
     },
     {
       name: "long branch does not split an emoji across the boundary",
-      info: buildInfo({ branch: `${"a".repeat(13)}😀suffix`, builtAt: null }),
+      info: buildInfo({ branch: `${"a".repeat(13)}😀suffix` }),
       expected: "aaaaaaaaaaaaa…@e8cbc62",
-    },
-    {
-      name: "future build timestamp",
-      info: buildInfo({ builtAt: "2026-07-10T12:25:00.000Z" }),
-      expected: "e8cbc62 · 0s",
     },
   ];
 
   for (const testCase of cases) {
     it(testCase.name, () => {
-      expect(formatBuildChipText(testCase.info, testCase.nowMs ?? nowMs)).toBe(testCase.expected);
+      expect(formatBuildChipText(testCase.info)).toBe(testCase.expected);
     });
   }
 });

--- a/ui/src/components/sidebar-build-chip.ts
+++ b/ui/src/components/sidebar-build-chip.ts
@@ -4,7 +4,6 @@ import { pathForRoute } from "../app-route-paths.ts";
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
-import { PollController } from "../lit/poll-controller.ts";
 import { formatBuildChipText } from "./sidebar-build-chip-format.ts";
 import "./tooltip.ts";
 
@@ -25,11 +24,8 @@ class SidebarBuildChip extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) gatewayVersion: string | null = null;
   @property({ attribute: false }) onNavigate?: (routeId: "about") => void;
 
-  // Relative age must advance without sidebar renders; controller teardown keeps reconnects clean.
-  readonly polling = new PollController(this, 60_000, () => this.requestUpdate());
-
   override render() {
-    const text = formatBuildChipText(CONTROL_UI_BUILD_INFO, Date.now());
+    const text = formatBuildChipText(CONTROL_UI_BUILD_INFO);
     if (!text) {
       return nothing;
     }

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -261,7 +261,7 @@ describe("AppSidebar agent chip", () => {
         path: "",
         count: 1,
         defaults,
-        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 5 }],
+        sessions: [{ key: "agent:main:main", kind: "direct", label: "Main task", updatedAt: 5 }],
       },
       agentId: "main",
     });
@@ -269,6 +269,9 @@ describe("AppSidebar agent chip", () => {
 
     // No per-agent sections: the card switcher owns agent switching now, and
     // the main session lives behind the identity card instead of the list.
+    expect(sidebar.querySelector(".sidebar-agent-card__subtitle")?.textContent?.trim()).toBe(
+      "Main task",
+    );
     expect(sidebar.querySelector(".sidebar-agent-section")).toBeNull();
     expect(sidebar.querySelectorAll(".sidebar-recent-session")).toHaveLength(0);
     expect(sidebar.querySelector(".sidebar-agent-card__menu-unread")).not.toBeNull();


### PR DESCRIPTION
## What Problem This Solves

The last two resting relative-age texts in the sidebar, after the quiet-sidebar series (#110448-#110604): the agent chip subtitle appended "· 57d" to the latest-session label, and the footer build chip appended "· 8d" to the commit — with a 60-second poll running solely to keep that age fresh.

## Why This Change Was Made

Maintainer decision: ages are noise at rest. Exceptional states (Working…, Offline, Ready) stay; the build age remains one hover away in the chip tooltip and on the About page the chip links to.

## User Impact

- Agent chip subtitle now shows just the latest session's name when idle; Offline / Working… / Ready behavior unchanged.
- Footer build chip shows `branch@commit` (with the dirty `*`) and nothing else; built-at stays in the tooltip and About.
- The chip's minute-interval PollController is deleted — nothing time-varying renders there anymore, so the sidebar stops waking up every 60s for a label. Net −24 LOC.

![quiet footer and chip](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/quiet-sidebar/quiet-ages.png)

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-build-chip.node.test.ts` — 120 tests pass post-rebase; formatter cases updated (age cases deleted, branch/dirty/emoji-boundary cases kept), idle subtitle asserted as label-only.
- Live-verified in the mock harness: footer reads `0123456` with no age and no dot (screenshot above).
- Codex autoreview (gpt-5.6-sol) clean: no accepted/actionable findings.
