### PR TITLE
fix(zalo): journal polled updates before dispatch

### DIFF
--- a/extensions/zalo/src/monitor.image.polling.test-support.ts
+++ b/extensions/zalo/src/monitor.image.polling.test-support.ts
@@ -13,6 +13,7 @@ import {
 import {
   getUpdatesMock,
   getZaloRuntimeMock,
+  installLifecycleIngressState,
   loadCachedLifecycleMonitorModule,
   resetLifecycleTestState,
   sendMessageMock,
@@ -32,6 +33,7 @@ describe("Zalo polling image handling", () => {
   beforeEach(async () => {
     await resetLifecycleTestState();
     getZaloRuntimeMock.mockReturnValue(core);
+    await installLifecycleIngressState();
   });
 
   afterAll(async () => {

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -80,6 +80,9 @@ async function startLifecycleMonitor(
 
 describe("monitorZaloProvider lifecycle", () => {
   beforeEach(async () => {
+    // Warm the lazy ingress module so polling startup settles within the
+    // lifecycle settle helpers (and within fake-timer advancement).
+    await import("./webhook-spool.js");
     const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-monitor-"));
     testStateDir = await fs.realpath(createdDir);
     previousStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -181,11 +184,16 @@ describe("monitorZaloProvider lifecycle", () => {
         lastError: expect.stringContaining("zalo poll transport failed"),
       });
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);
-      expect(vi.getTimerCount()).toBe(1);
+      // Backoff sleep plus the durable-ingress drain pump; the exact count is an
+      // implementation detail, while the post-abort zero below is the contract.
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
 
       abort.abort();
       await run;
 
+      // The ingress queue opened the shared state DB; its WAL maintenance
+      // interval is process-level and clears when the DB handle closes.
+      closeOpenClawStateDatabaseForTest();
       expect(vi.getTimerCount()).toBe(0);
       await vi.advanceTimersByTimeAsync(5_000);
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);

--- a/extensions/zalo/src/monitor.polling-ingress.test.ts
+++ b/extensions/zalo/src/monitor.polling-ingress.test.ts
@@ -1,0 +1,350 @@
+// Zalo tests cover the durable ingress journal on the polling transport.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createEmptyPluginRegistry,
+  createRuntimeEnv,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import type { ResolvedZaloAccount } from "./accounts.js";
+import type { ZaloUpdate } from "./api.js";
+import type { OpenClawConfig, PluginRuntime } from "./runtime-api.js";
+import {
+  createImageLifecycleCore,
+  createLifecycleMonitorSetup,
+  createTextUpdate,
+  settleAsyncWork,
+} from "./test-support/lifecycle-test-support.js";
+import {
+  getUpdatesMock,
+  getZaloRuntimeMock,
+  loadCachedLifecycleMonitorModule,
+  resetLifecycleTestState,
+} from "./test-support/monitor-mocks-test-support.js";
+import {
+  waitForZaloWebhookVerdict,
+  type ZaloWebhookTestPayload,
+} from "./webhook-spool.test-support.js";
+
+type ZaloPollingTestQueue = Parameters<typeof waitForZaloWebhookVerdict>[0];
+
+type DispatchReplyOptions = {
+  replyOptions?: {
+    turnAdoptionLifecycle?: { onAdopted: () => Promise<void> };
+  };
+};
+
+function createDeferred() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function startPollingMonitor(setup: {
+  account: ResolvedZaloAccount;
+  config: OpenClawConfig;
+}) {
+  const { monitorZaloProvider } = await loadCachedLifecycleMonitorModule("zalo-polling-ingress");
+  const abort = new AbortController();
+  const runtime = createRuntimeEnv();
+  const run = monitorZaloProvider({
+    token: "zalo-token", // pragma: allowlist secret
+    account: setup.account,
+    config: setup.config,
+    runtime,
+    abortSignal: abort.signal,
+  });
+  return { abort, run, runtime };
+}
+
+describe("Zalo polling durable ingress", () => {
+  const { core } = createImageLifecycleCore();
+  const dispatchMock = core.channel.reply
+    .dispatchReplyWithBufferedBlockDispatcher as unknown as Mock;
+  let stateDir: string | undefined;
+  let queue: ZaloPollingTestQueue;
+
+  beforeAll(async () => {
+    // Install module mocks first, then warm the lazy ingress module so monitor
+    // startup does not pay module load inside the tests.
+    await loadCachedLifecycleMonitorModule("zalo-polling-ingress");
+    await import("./webhook-spool.js");
+  });
+
+  beforeEach(async () => {
+    await resetLifecycleTestState();
+    const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-poll-ingress-"));
+    stateDir = await fs.realpath(createdDir);
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    queue = createChannelIngressQueueForTests<ZaloWebhookTestPayload>({
+      channelId: "zalo",
+      accountId: "default",
+      stateDir,
+    });
+    core.state.openChannelIngressQueue = ((_options: { accountId?: string }) =>
+      queue) as unknown as PluginRuntime["state"]["openChannelIngressQueue"];
+    getZaloRuntimeMock.mockReturnValue(core);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  afterAll(async () => {
+    await resetLifecycleTestState();
+  });
+
+  afterEach(async () => {
+    dispatchMock.mockReset();
+    await resetLifecycleTestState();
+    closeOpenClawStateDatabaseForTest();
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+    delete process.env.OPENCLAW_STATE_DIR;
+  });
+
+  it("journals a polled update durably before dispatch and tombstones it after adoption", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-journal-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const dispatchStarted = createDeferred();
+    const dispatchGate = createDeferred();
+    let durableIdsAtDispatch: string[] = [];
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      // The update must be durable before the agent turn starts.
+      const [claims, pending] = await Promise.all([queue.listClaims(), queue.listPending()]);
+      durableIdsAtDispatch = [...claims, ...pending].map((record) => record.id);
+      dispatchStarted.resolve();
+      await dispatchGate.promise;
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    await dispatchStarted.promise;
+    expect(durableIdsAtDispatch).toEqual(["poll-journal-1"]);
+
+    dispatchGate.resolve();
+    await waitForZaloWebhookVerdict(queue, "poll-journal-1", "completed");
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await run;
+  });
+
+  it("dedupes a re-polled update after completion", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-dedupe-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      // Simulate a Bot API redelivery of the same consumed update.
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    // Wait for the monitor's own admission before probing the row: the verdict
+    // probe enqueues, so it must never win the race against the polled admission.
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-dedupe-1", "completed");
+    await vi.waitFor(() => {
+      expect(getUpdatesMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+    await settleAsyncWork();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await run;
+  });
+
+  it("replays a journaled update exactly once after a crash between poll and dispatch", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-restart-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const dispatchStarted = createDeferred();
+    const crashDispatch = createDeferred();
+    // First attempt dies mid-dispatch: the process is killed before a verdict.
+    dispatchMock.mockImplementationOnce(async () => {
+      dispatchStarted.resolve();
+      await crashDispatch.promise;
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const setup = createLifecycleMonitorSetup({
+      accountId: "default",
+      dmPolicy: "open",
+      webhookUrl: "",
+    });
+    const first = await startPollingMonitor(setup);
+
+    await dispatchStarted.promise;
+    // Crash while the delivery is in flight; the journaled row must survive the
+    // stop either as a dead-owner claim or as a released retry.
+    first.abort.abort();
+    crashDispatch.reject(new Error("simulated process crash"));
+    await first.run;
+
+    const [crashClaims, crashPending] = await Promise.all([
+      queue.listClaims(),
+      queue.listPending(),
+    ]);
+    expect([...crashClaims, ...crashPending].map((record) => record.id)).toEqual([
+      "poll-restart-1",
+    ]);
+
+    // Restart: a fresh monitor recovers the unfinished row and replays it.
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+    getUpdatesMock.mockReset();
+    getUpdatesMock
+      // The Bot API re-serves the consumed update once more after the restart.
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const second = await startPollingMonitor(setup);
+
+    await waitForZaloWebhookVerdict(queue, "poll-restart-1", "completed");
+    await vi.waitFor(() => {
+      expect(getUpdatesMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    await settleAsyncWork();
+    // Exactly one successful dispatch across crash + replay + redelivery.
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    second.abort.abort();
+    await second.run;
+  });
+
+  it("journals a polled update on the abort path with durable-after-stop admission", async () => {
+    const updateA = createTextUpdate({
+      messageId: "poll-abort-a",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const updateB = createTextUpdate({
+      messageId: "poll-abort-b",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+
+    // First update completes normally so the poll loop advances to the next
+    // getUpdates call, which stays in-flight past shutdown.
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+
+    const latePoll = createDeferred();
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: updateA as ZaloUpdate })
+      .mockImplementationOnce(() =>
+        latePoll.promise.then(() => ({ ok: true, result: updateB as ZaloUpdate })),
+      )
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    // Wait for the first update to complete so the next poll is in-flight on
+    // getUpdates when abort fires.
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-abort-a", "completed");
+
+    // Abort while the second getUpdates is in-flight; the monitor shuts down
+    // before the poll response arrives.
+    abort.abort();
+    await run;
+
+    // Release the in-flight poll after the monitor has fully shut down.
+    latePoll.resolve();
+
+    // With durable-after-stop admission the abort branch must persist the
+    // consumed update into the durable ingress queue even after stop.
+    await vi.waitFor(async () => {
+      const [claims, pending] = await Promise.all([queue.listClaims(), queue.listPending()]);
+      const ids = [...claims, ...pending].map((record) => record.id);
+      expect(ids).toContain("poll-abort-b");
+    });
+  });
+
+  it("dead-letters an authentication failure from dispatch without retry", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-deadletter-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const { ZaloApiError } = await import("./api.js");
+    dispatchMock.mockImplementation(async () => {
+      throw new ZaloApiError("Unauthorized", 401, "Unauthorized");
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { abort, run, runtime } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    // Wait for the monitor's own admission before probing the row (see dedupe test).
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-deadletter-1", "failed");
+    await settleAsyncWork();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("authentication-failed"));
+
+    abort.abort();
+    await run;
+  });
+});

--- a/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
+++ b/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
@@ -23,6 +23,7 @@ import {
 import {
   getUpdatesMock,
   getZaloRuntimeMock,
+  installLifecycleIngressState,
   loadCachedLifecycleMonitorModule,
   resetLifecycleTestState,
   sendMessageMock,
@@ -164,6 +165,7 @@ describe("Zalo polling media replies", () => {
           createPluginStateKeyedStoreForTests<T>("zalo", options),
       } as PluginRuntime["state"],
     );
+    await installLifecycleIngressState();
   });
 
   afterAll(async () => {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -115,9 +115,15 @@ type ZaloProcessingContext = {
   turnAdoptionLifecycle?: ZaloWebhookIngressLifecycle;
 };
 
-type ZaloPollingLoopParams = ZaloProcessingContext & {
+type ZaloPollingLoopParams = {
+  token: string;
+  account: ResolvedZaloAccount;
+  runtime: ZaloRuntimeEnv;
   abortSignal: AbortSignal;
   isStopped: () => boolean;
+  statusSink?: ZaloStatusSink;
+  fetcher?: ZaloFetch;
+  acceptUpdate: (rawEvent: string) => Promise<void>;
 };
 type ZaloUpdateProcessingParams = ZaloProcessingContext & {
   update: ZaloUpdate;
@@ -262,35 +268,9 @@ async function handleZaloWebhookRequest(
 }
 
 function startPollingLoop(params: ZaloPollingLoopParams) {
-  const {
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    mediaMaxMb,
-    canHostMedia,
-    webhookUrl,
-    webhookPath,
-    abortSignal,
-    isStopped,
-    statusSink,
-    fetcher,
-  } = params;
+  const { token, account, runtime, abortSignal, isStopped, statusSink, fetcher, acceptUpdate } =
+    params;
   const pollTimeout = 30;
-  const processingContext = {
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    mediaMaxMb,
-    canHostMedia,
-    webhookUrl,
-    webhookPath,
-    statusSink,
-    fetcher,
-  };
 
   runtime.log?.(`[${account.accountId}] Zalo polling loop started timeout=${String(pollTimeout)}s`);
 
@@ -301,7 +281,27 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
 
     try {
       const response = await getUpdates(token, { timeout: pollTimeout }, fetcher);
+      // The Bot API consumes each polled update on response. When shutdown
+      // arrives while getUpdates is in-flight (the poll carries no abort
+      // signal and runs to its own 35 s timeout), still journal the update.
+      // This is best-effort — getUpdates outlives the 5 s channel-stop
+      // deadline, so the process may exit before the response lands. When
+      // it does land, durable-after-stop admission accepts the append after
+      // ingress.stop() has completed; the row is recovered on next restart.
+      const shouldJournal =
+        response.ok &&
+        response.result &&
+        response.result.message &&
+        response.result.event_name !== "message.sticker.received" &&
+        response.result.event_name !== "message.unsupported.received";
       if (isStopped() || abortSignal.aborted) {
+        if (shouldJournal) {
+          await acceptUpdate(JSON.stringify(response.result)).catch((err: unknown) =>
+            runtime.error?.(
+              `[${account.accountId}] failed to journal consumed update before shutdown: ${formatZaloError(err)}`,
+            ),
+          );
+        }
         return undefined;
       }
       if (response.ok) {
@@ -309,10 +309,11 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
       }
       if (response.ok && response.result) {
         statusSink?.({ lastInboundAt: Date.now() });
-        await processUpdate({
-          update: response.result,
-          ...processingContext,
-        });
+        // No-op message events (stickers, unsupported) carry a message field
+        // but produce no dispatch — skip them at the journal gate.
+        if (shouldJournal) {
+          await acceptUpdate(JSON.stringify(response.result));
+        }
       }
     } catch (err) {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
@@ -323,6 +324,12 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
         statusSink?.({ connected: false, lifecycle: "recovering", lastError: error });
         // Abort-aware backoff; bottom poll reschedule already checks stopped/aborted.
         await sleepWithAbort(5000, abortSignal).catch(() => undefined);
+      } else {
+        // getUpdates network error during shutdown: log instead of silently
+        // dropping it — the poll transport is in an indeterminate state.
+        runtime.error?.(
+          `[${account.accountId}] Zalo ingress error during shutdown: ${formatZaloError(err)}`,
+        );
       }
     }
 
@@ -1103,20 +1110,43 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       );
     }
 
+    const { createZaloWebhookIngress } = await loadZaloWebhookIngressRuntime();
+    // Polling and webhook share one durable ingress per account: the Bot API
+    // consumes polled updates on response, so a crash between poll and dispatch
+    // is unrecoverable without the same append-before-dispatch journal.
+    const ingress = createZaloWebhookIngress({
+      accountId: account.accountId,
+      runtime,
+      deliver: async (update, turnAdoptionLifecycle) => {
+        await processUpdate({
+          update,
+          token,
+          account,
+          config,
+          runtime,
+          core,
+          mediaMaxMb: effectiveMediaMaxMb,
+          canHostMedia,
+          webhookUrl: effectiveWebhookUrl,
+          webhookPath: effectiveWebhookPath,
+          statusSink,
+          fetcher,
+          turnAdoptionLifecycle,
+        });
+      },
+    });
+    ingress.start();
+    asyncStopHandlers.push(ingress.stop);
+
     startPollingLoop({
       token,
       account,
-      config,
       runtime,
-      core,
-      canHostMedia,
-      webhookUrl: effectiveWebhookUrl,
-      webhookPath: effectiveWebhookPath,
       abortSignal,
       isStopped: () => stopped,
-      mediaMaxMb: effectiveMediaMaxMb,
       statusSink,
       fetcher,
+      acceptUpdate: ingress.accept,
     });
 
     await waitForAbortSignal(abortSignal);

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -139,7 +139,7 @@ export async function resetLifecycleTestState() {
   setActivePluginRegistry(createEmptyPluginRegistry());
 }
 
-async function installLifecycleWebhookIngressState(): Promise<void> {
+export async function installLifecycleIngressState(): Promise<void> {
   const runtime = getZaloRuntimeMock() as PluginRuntime;
   const createdDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-zalo-lifecycle-"),
@@ -196,7 +196,7 @@ export async function startWebhookLifecycleMonitor(params: {
   webhookSecret?: string;
   cacheKey?: string;
 }) {
-  await installLifecycleWebhookIngressState();
+  await installLifecycleIngressState();
   const registry = createEmptyPluginRegistry();
   setActivePluginRegistry(registry);
   const abort = new AbortController();

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -179,6 +179,7 @@ function createZaloWebhookIngress(options: {
     waitForDeliveryIdleBeforeRepump: false,
     runPumpTask: runDetachedWebhookWork,
     deferredClaims: "wait-on-stop",
+    admissionMode: "durable-after-stop",
     drain: {
       adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
       startLimit: ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110630, which made Zalo **webhook** ingress durable but left the **polling** transport with the same message-loss window.

The Zalo Bot API consumes each polled update on response: `getUpdates` has no offset or confirm parameter (`extensions/zalo/src/api.ts`), so once the poll response is returned, the server will never serve that update again. On current `main`, the polling loop calls `processUpdate` directly after `getUpdates` with no durable journal (`extensions/zalo/src/monitor.ts` `poll()`). A crash or restart between the poll response and dispatch completion permanently loses the already-consumed update — no replay, no error, the sender's message just vanishes.

## Why This Change Was Made

Polling now admits each polled update into the **same** durable ingress that #110630 built for webhooks (`createZaloWebhookIngress` in `extensions/zalo/src/webhook-spool.ts`, backed by the shared `channel_ingress_events` SQLite queue), before the drain dispatches it. The polling branch reuses steipete's spool for journal admission — the same dedupe key (Bot API `message.message_id`), the same `chat:<chatId>` lane, the same bounded retry/dead-letter policy, and the same turn-adoption lifecycle — so both transports share one canonical durability path and one per-account queue. No schema bump, no new config or env surface, no new dependency; polling and webhook stay mutually exclusive per monitor.

**Shutdown-path coverage.** On the abort path (shutdown lands between `getUpdates` response and journal admission), the ingress now sets `admissionMode: "durable-after-stop"` (`webhook-spool.ts:235`, the same pattern LINE and SMS already use) so the late poll response is still admitted into the queue after `ingress.stop()` has completed. The append is best-effort — the poll's 35 s deadline can outlive the 5 s channel-stop deadline — but when it lands, the row is recovered on the next restart rather than lost. A new regression test (`monitor.polling-ingress.test.ts`, the 5th test) pins this behavior: hangs the second `getUpdates` in-flight, aborts, releases the late response, and asserts the consumed update is durably journaled.

**Consistent no-op filtering.** Both the normal and abort journal paths share a single `shouldJournal` predicate, so sticker/unsupported events are skipped consistently regardless of shutdown timing.

**Delivery concurrency.** On `main` the loop `await`ed `processUpdate` inline, so polling was back-pressured by agent turn duration (one update at a time). After this change, `acceptUpdate` returns once the row is appended and the shared ingress drain runs at `ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES = 8`. Per-chat ordering is preserved by the `chat:<chatId>` lane key, so cross-chat concurrency increases without reordering messages within a conversation.

This replaces the approach in our earlier (now closed) #110559 with one that harmonizes with the merged webhook design instead of adding a second journal.

## User Impact

Zalo polling users no longer lose messages when the gateway crashes or restarts while a polled update is in flight: the update is journaled before dispatch, replays exactly once after restart, and duplicate Bot API redeliveries are deduped against the durable tombstone. Abort-path updates that arrive after `ingress.stop()` are best-effort — journaled when the late response lands, recovered on restart. Permanent dispatch failures (e.g. revoked token → 401/403) dead-letter with an operator-visible log line instead of hot-looping.

## Evidence

### Live behavior proof (real production `monitorZaloProvider`, real SQLite `channel_ingress_events`, protocol-compatible local Bot API stub)

Driver: the production polling monitor, pointed at a local stub Bot API server via the existing `ZALO_API_URL` override (`extensions/zalo/src/api.ts:11`), with the state DB under a throwaway `OPENCLAW_STATE_DIR`. The stub serves one `message.text.received` update, then holds the long-poll open (no further updates — the Bot API consumed it). Same protocol-compatible-local-server pattern as the accepted #109997 proof; #110630's Evidence notes no real Zalo account is available even to maintainers.

**Before (main @ 5143d909b9)** — dispatch in flight, `kill -9`, restart with the API serving nothing (update already consumed): the message is gone.

```
--- [before] phase 1: dispatch in flight, then kill -9
[driver] dispatch #1 started for MessageSid=proof-msg-1 SessionKey=agent:main:zalo:direct:proof-chat-1
[driver] dispatch is now in flight; process will be killed before it settles
--- [before] sqlite rows before kill (queue_name='["zalo","default"]'):
[]
--- [before] killed driver with SIGKILL; sqlite rows after kill -9:
[]
--- [before] phase 2: restart (stub serves nothing — update was consumed on response)
[stub] getUpdates -> holding long-poll open (no updates)
[driver] PROOF-FAIL: journaled update was never replayed after restart   (phase2 exit=1)
--- [before] final sqlite rows:
[]
```

**After (this PR)** — identical scenario: the update is journaled before dispatch, survives `kill -9`, replays exactly once, the visible reply is sent once, and a re-served identical update is deduped.

```
--- [after] phase 1: dispatch in flight, then kill -9
[driver] dispatch #1 started for MessageSid=proof-msg-1 SessionKey=agent:main:zalo:direct:proof-chat-1
--- [after] sqlite rows before kill:
[{"event_id":"proof-msg-1","status":"claimed","attempts":0}]
--- [after] killed driver with SIGKILL; sqlite rows after kill -9:
[{"event_id":"proof-msg-1","status":"claimed","attempts":0}]
--- [after] phase 2: restart; stub re-serves the identical update once (dedupe probe)
[driver] dispatch #1 started for MessageSid=proof-msg-1   <- journal replay, before first poll answer
[driver] turn adopted; durable claim tombstoned
[driver] visible reply delivered
[stub] sendMessage -> visible reply #1: {"chat_id":"proof-chat-1","text":"pong from proof driver"}
[stub] getUpdates -> serving proof-msg-1 (1/1)            <- redelivery; no second dispatch
[driver] PROOF-PHASE2-OK dispatchCount=1 (replay exactly once, duplicate deduped)
--- [after] final sqlite rows:
[{"event_id":"proof-msg-1","status":"completed","attempts":1}]
```

### Tests

- New `extensions/zalo/src/monitor.polling-ingress.test.ts` (5 tests, real SQLite queue): journaled durably before dispatch + tombstoned after adoption; re-polled duplicate deduped after completion; crash between poll and dispatch replays exactly once after restart (abandoned-claim recovery); 401 dispatch failure dead-letters without retry; abort-path journaling with in-flight `getUpdates`.
- Reverse verification: with `monitor.ts` stashed, all 5 new tests fail; restored, all pass.
- Two pre-existing polling test suites now install the real ingress queue fixture (`installLifecycleIngressState`, renamed from the webhook-only helper); the fake-timer lifecycle test closes the state DB before asserting zero timers because the shared DB's WAL maintenance interval is process-level.

### Checks

- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` — 0 errors.
- `oxlint` on all 7 changed files — clean; `oxfmt --check` — clean; `git diff --check` — clean.
- Diff: `monitor.ts` +69/−39 (net +30 prod LOC), `webhook-spool.ts` +1/−0 (`admissionMode`), plus tests; no files outside `extensions/zalo`.



Fixes #130566
