### PR TITLE
fix: add missing spawn/exec timeouts to prevent CLI and CI hangs

### DIFF
--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -85,6 +85,7 @@ export function execPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+    timeout: options.timeout ?? 30_000,
   });
 }
 
@@ -96,6 +97,7 @@ export function execGhApiRead(endpoint, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+    timeout: options.timeout ?? 30_000,
   });
 }
 
@@ -106,5 +108,6 @@ export function spawnPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+    timeout: options.timeout ?? 30_000,
   });
 }

--- a/src/cli/container-target.ts
+++ b/src/cli/container-target.ts
@@ -316,6 +316,7 @@ export function maybeRunCliInContainer(
     }),
     {
       stdio: "inherit",
+      timeout: 120_000,
       env: buildContainerExecEnv(resolvedDeps.env),
     },
   );

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -21,6 +21,7 @@ function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    timeout: 60_000,
   });
   if (res.error) {
     throw res.error;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where several CLI commands and scripts would hang indefinitely when external processes become unresponsive:

- `openclaw dns setup --apply`: brew/sudo commands hang with no deadline
- `openclaw --container <name> <command>`: docker/podman exec hangs when container is unresponsive
- CI scripts using execPlainGh/execGhApiRead: gh api calls hang when GitHub is unreachable

## Why This Change Was Made

Added explicit timeout values (60s / 120s / 30s) to synchronous process-spawn calls that were previously missing them. Each follows the same pattern already used by sibling calls in the same files.

Files changed:
- src/cli/dns-cli.ts: 60s timeout on DNS setup commands
- src/cli/container-target.ts: 120s timeout on container exec
- scripts/lib/plain-gh.mjs: 30s timeout on gh CLI calls (overridable via options.timeout)

## User Impact

Operators no longer experience indefinite CLI hangs. CI pipelines no longer block indefinitely on network issues.

## Evidence

Three one-line additions to existing spawnSync/execFileSync options objects. No new dependencies or API surface changes.