### PR TITLE
improve(ui): syntax-highlight JSON dumps on the debug page and config issues callout

### DIFF
--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -2,6 +2,7 @@
 import "../../styles/lobster-pet.css";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { QueueMode } from "../../../../src/auto-reply/reply/queue/types.js";
 import type { ConfigUiHints } from "../../api/types.ts";
 import type { NativeNotificationsPermission } from "../../app/native-notifications.ts";
@@ -39,6 +40,7 @@ import {
   canonicalLobsterLook,
   renderLobsterSvg,
 } from "../../components/lobster-pet.ts";
+import { highlightJsonHtml } from "../../components/markdown.ts";
 import {
   renderSettingsRow,
   renderSettingsSegmented,
@@ -2026,7 +2028,8 @@ export function renderConfig(props: ConfigProps) {
               })()}
       ${props.issues.length > 0
         ? html`<div class="callout danger" style="margin-top: 12px;">
-            <pre class="code-block">${JSON.stringify(props.issues, null, 2)}</pre>
+            <pre class="code-block">
+${unsafeHTML(highlightJsonHtml(JSON.stringify(props.issues, null, 2)))}</pre>
           </div>`
         : nothing}
     </div>

--- a/ui/src/pages/debug/view.ts
+++ b/ui/src/pages/debug/view.ts
@@ -1,6 +1,8 @@
 // Control UI view renders debug screen content.
 import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { EventLogEntry } from "../../api/event-log.ts";
+import { highlightJsonHtml } from "../../components/markdown.ts";
 import {
   renderSettingsEmpty,
   renderSettingsPage,
@@ -34,7 +36,8 @@ function renderJsonRow(title: unknown, value: unknown) {
   return renderSettingsRow({
     title,
     stacked: true,
-    control: html`<pre class="code-block">${JSON.stringify(value ?? {}, null, 2)}</pre>`,
+    control: html`<pre class="code-block">
+${unsafeHTML(highlightJsonHtml(JSON.stringify(value ?? {}, null, 2)))}</pre>`,
   });
 }
 
@@ -74,7 +77,8 @@ function renderEventRow(evt: EventLogEntry) {
     title: evt.event,
     description: formatTimeMs(evt.ts, undefined, ""),
     stacked: true,
-    control: html`<pre class="code-block">${formatEventPayload(evt.payload)}</pre>`,
+    control: html`<pre class="code-block">
+${unsafeHTML(highlightJsonHtml(formatEventPayload(evt.payload)))}</pre>`,
   });
 }
 
@@ -147,7 +151,7 @@ export function renderDebug(props: DebugProps) {
         ? html`
             <div class="settings-row settings-row--stacked">
               ${renderSettingsStatus({ kind: "ok", label: t("common.ok") })}
-              <pre class="code-block">${props.callResult}</pre>
+              <pre class="code-block">${unsafeHTML(highlightJsonHtml(props.callResult))}</pre>
             </div>
           `
         : nothing}
@@ -158,7 +162,8 @@ export function renderDebug(props: DebugProps) {
     { title: t("debug.modelsTitle"), description: t("debug.modelsSubtitle") },
     html`
       <div class="settings-row settings-row--stacked">
-        <pre class="code-block">${JSON.stringify(props.models ?? [], null, 2)}</pre>
+        <pre class="code-block">
+${unsafeHTML(highlightJsonHtml(JSON.stringify(props.models ?? [], null, 2)))}</pre>
       </div>
     `,
   );


### PR DESCRIPTION
Related: #110613

## What Problem This Solves

Follow-up to #110613: the debug page (status/health/heartbeat snapshots, manual RPC results, models catalog) and the config page's issues callout still rendered plain monochrome `JSON.stringify` dumps, unlike the now-highlighted Channel health snapshot.

## Why This Change Was Made

Mechanical reuse of the `highlightJsonHtml()` helper introduced in #110613 for every remaining JSON dump in the Control UI settings surfaces: the three debug snapshot rows, event-log payloads, manual RPC call results, the models catalog, and the config issues callout. The manual RPC error block intentionally stays plain — it renders an error message string, not JSON.

## User Impact

All JSON dumps on the Debug page and the config issues callout are now syntax-highlighted consistently with chat code blocks and the Channel health snapshot, in light and dark themes. No behavior change otherwise.

## Evidence

Before:

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/debug-config-json-highlight/debug-before.png)

After:

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/debug-config-json-highlight/debug-after.png)

- Live-verified against the mock gateway harness: snapshot rows, models catalog, and a successful `chat.startup` manual RPC result (2067 highlighted spans) all render highlighted; the error path stays plain text as designed.
- Focused tests: `ui/src/pages/debug/view.test.ts` + `ui/src/pages/config/config-page.test.ts` — 10 passed.
- Codex autoreview on the diff: clean.
