### PR TITLE
improve(ui): theme Import card uses the import-tray icon

### DIFF
--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -865,7 +865,9 @@ const BUILTIN_THEME_OPTIONS: ThemeOption[] = [
    back to the spark icon otherwise. */
 function renderThemeCardVisual(id: ThemeName, activeTheme: ThemeName) {
   if (id === "custom" && activeTheme !== "custom") {
-    return html`<span class="settings-theme-card__icon" aria-hidden="true">${icons.spark}</span>`;
+    return html`<span class="settings-theme-card__icon" aria-hidden="true"
+      >${icons.download}</span
+    >`;
   }
   return html`
     <span class="settings-theme-card__palette" aria-hidden="true">


### PR DESCRIPTION
Related: #110626

## What Problem This Solves

The Import card on the Appearance theme grid used a sparkle icon, which says nothing about what the card does. After #110626 gave the builtin cards real palette chips, the sparkle stood out as decorative noise on the one card that is an action.

## Why This Change Was Made

Swap `icons.spark` for the existing `icons.download` (arrow-into-tray) on the Import card's icon state — the conventional import glyph, matching the card's action of importing a tweakcn theme. One-line change; the icon only shows while no imported theme is active (an active custom theme shows live palette chips instead, unchanged from #110626).

## User Impact

The Import card now signals its action at a glance instead of showing an arbitrary sparkle.

## Evidence

`oxfmt --check` and `oxlint` clean on the touched file; `icons.spark` remains in use elsewhere (session icon registry, task suggestions). Verified in the mock-gateway harness in both modes:

Dark:
![after dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/theme-picker-palette/import-icon-after-dark.png)

Light:
![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/theme-picker-palette/import-icon-after-light.png)
