### PR TITLE
fix(ui): block agent-authored widget command prompts

### DIFF
--- a/ui/src/components/mcp-app-security.ts
+++ b/ui/src/components/mcp-app-security.ts
@@ -20,7 +20,8 @@ function resolveWidgetPromptText(raw: unknown): string | null {
     return null;
   }
   const text = raw.trim();
-  if (!text || text.length > WIDGET_PROMPT_MAX_CHARS || text.startsWith("/")) {
+  const isHostCommand = text.startsWith("/") || text.startsWith("!");
+  if (!text || text.length > WIDGET_PROMPT_MAX_CHARS || isHostCommand) {
     return null;
   }
   return text;

--- a/ui/src/components/mcp-app-view.test.ts
+++ b/ui/src/components/mcp-app-view.test.ts
@@ -169,6 +169,7 @@ describe("mcp-app-view localization", () => {
 
     for (const content of [
       [{ type: "text", text: "/approve" }],
+      [{ type: "text", text: "!pwd" }],
       [{ type: "text", text: "   " }],
       [{ type: "text", text: "x".repeat(4_001) }],
       [{ type: "image" }],
@@ -179,6 +180,8 @@ describe("mcp-app-view localization", () => {
     ]) {
       expect(await send(content)).toEqual({ isError: true });
     }
+    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(received).toEqual(["Show details"]);
 
     for (let index = 2; index <= 9; index += 1) {
       expect(await send([{ type: "text", text: `Prompt ${index}` }])).toEqual({});

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -1180,6 +1180,28 @@ describe("handleSendChat", () => {
     );
   });
 
+  it("preserves user-authored bang commands through the normal composer send", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { runId: "bang-command-run", status: "started" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "!pwd",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({ message: "!pwd", sessionKey: "agent:main" }),
+    );
+    expect(host.chatMessage).toBe("");
+  });
+
   it.each(["stop", "esc", "abort", "wait", "exit"])(
     "sends the idle conversational word %s as a normal message",
     async (message) => {

--- a/ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts
@@ -93,9 +93,10 @@ describe("widget prompts", () => {
       postPrompt(port, "  Show details  ");
       await flushPorts();
       expect(received).toEqual(["Show details"]);
-      // Slash commands would run UI commands such as /approve on the widget's
-      // behalf; the send path must only ever receive conversational text.
+      // Slash and bang commands would run host commands on the widget's behalf;
+      // the send path must only ever receive conversational text.
       postPrompt(port, "/approve");
+      postPrompt(port, "!pwd");
       postPrompt(port, "   ");
       postPrompt(port, 42);
       postPrompt(port, "x".repeat(4_001));


### PR DESCRIPTION
AI-assisted: yes (Codex). I understand the implementation and completed two fresh autoreviews with no accepted/actionable findings. No agent transcript is included because separate approval was not provided.

Related: #109807

## Summary

- Reject both current host command prefixes (`/` and `!`) at the shared agent-authored widget prompt boundary.
- Cover the shared widget bridge, the genuine MCP App `ui/message` handler, and ordinary user-authored bang commands in the normal composer.
- Keep the repair to one production helper; no queue, Gateway, protocol, config, standalone, or teardown changes.

## What Problem This Solves

Fixes an issue where a focused MCP App or other agent-authored widget could submit a bang-prefixed message through the host chat path and reach OpenClaw's authenticated bash shortcut. Slash commands were already rejected, but `!` remained eligible for host command interpretation after the user confirmed the text.

## Why This Change Was Made

The shared widget prompt resolver is the smallest owner-correct authority boundary: it validates untrusted frame text before consent, rate accounting, pane routing, durable queueing, and `chat.send`. Extending `suppressCommandInterpretation` through the Control UI would require new origin state across local command interception, durable queue serialization, reconnect replay, and Gateway dispatch for no additional protection against the two current prefixes.

The locked `@modelcontextprotocol/ext-apps` 1.7.4 source and stable MCP Apps specification allow a host to reject `ui/message`, allow consent, and require validation of iframe messages. They do not grant an app host-command authority.

## User Impact

MCP Apps and other agent-authored widget frames can still send focused, visible, rate-limited conversational text through the owning chat pane, but both slash and bang command text are rejected before confirmation or dispatch. Users typing slash or bang commands in the ordinary composer keep the existing behavior.

## Backward Safety and Independent Landing

- Only the existing shared widget-frame prompt resolver changes; ordinary composer and Gateway behavior are unchanged.
- Existing consent, focus/visibility checks, size and rate limits, pane routing, capability negotiation, and read-only reconstruction remain unchanged.
- No message queue shape, protocol field/version, config, model-context, standalone operation, channel action, or teardown ordering changes.
- The PR is independently deployable and does not require #110515 or the later two-phase iframe teardown work.
- Net production growth is one line: a named predicate for the complete current host-command prefix set.

## Evidence

- Before the production repair, the focused Testbox run reproduced two exact failures: the genuine MCP App handler returned success for `!pwd`, and the shared widget bridge emitted `!pwd`. The normal-composer bang regression already passed.
- After the repair, the same focused UI set passed 221/221 assertions.
- Downstream command-path proof passed 28/28 assertions: Gateway preserves normal authenticated command authorization, and authorized leading `!` remains the bash shortcut for ordinary user input.
- Path-scoped changed gates passed UI/core-test types, lint, formatting, i18n verification, duplicate coverage, dependency pins, package patches, and repository guards.
- Fresh autoreviews before and after simplification reported no accepted/actionable findings (confidence 0.92 and 0.96).

## Verification

- `pnpm test ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts ui/src/components/mcp-app-view.test.ts ui/src/pages/chat/chat-send.test.ts`
- `pnpm test src/gateway/server-methods/chat-send-user-turn.test.ts src/auto-reply/reply/commands-bash-alias.test.ts src/auto-reply/reply/dispatch-acp-command-bypass.test.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed -- ui/src/components/mcp-app-security.ts ui/src/components/mcp-app-view.test.ts ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` (twice, both clean)
- Blacksmith Testbox: `tbx_01kxv0fggrexv6cq8rs4qdat5q`; hydration/proof run: https://github.com/openclaw/openclaw/actions/runs/29651774445

## Real-Behavior Proof

The regression crosses the real production seams in focused tests: an actual `AppBridge.onmessage` handler receives MCP `ui/message` content and dispatches only validated text; the shared MessagePort widget path exercises the same resolver; the composer test proves user-authored `!pwd` still becomes `chat.send`; Gateway and auto-reply tests prove that authenticated `chat.send` marks commands authorized and routes leading `!` to the bash handler.

A browser recording was not added because current main's maintained MCP App conformance fixture does not exercise `ui/message`, while #110515 is actively changing that exact fixture and owns the real standalone conformance work. Adding or editing that browser fixture here would overlap the sibling PR without improving the one-line shared-boundary proof.

## Known Gaps

- This does not redesign iframe teardown ordering; that remains the separate parent-owned two-phase unmount task.
- This does not change standalone MCP App operations or the interactive bridge owned by #110515.
- No production build was run because the change does not alter a lazy import, module boundary, published surface, or build output.
