### PR TITLE
fix: control UI locale PRs fail to arm auto-merge

### DIFF
--- a/.github/actions/create-generated-pr-tokens/action.yml
+++ b/.github/actions/create-generated-pr-tokens/action.yml
@@ -8,12 +8,15 @@ inputs:
   contents-private-key:
     description: GitHub App private key with contents write access.
     required: true
-  pull-request-app-id:
-    description: GitHub App id with pull-request write access.
+  pull-request-client-id:
+    description: GitHub App client id with pull-request write access.
     required: true
   pull-request-private-key:
     description: GitHub App private key with pull-request write access.
     required: true
+  pull-request-contents-permission:
+    description: Optional contents permission for pull-request operations that require repository write access.
+    required: false
 
 outputs:
   contents-token:
@@ -40,8 +43,9 @@ runs:
       id: pull-request-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
-        app-id: ${{ inputs.pull-request-app-id }}
+        client-id: ${{ inputs.pull-request-client-id }}
         private-key: ${{ inputs.pull-request-private-key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
+        permission-contents: ${{ inputs.pull-request-contents-permission }}
         permission-pull-requests: write

--- a/.github/actions/publish-generated-pr/action.yml
+++ b/.github/actions/publish-generated-pr/action.yml
@@ -8,8 +8,8 @@ inputs:
   contents-private-key:
     description: GitHub App private key with contents write access.
     required: true
-  pull-request-app-id:
-    description: GitHub App id with pull-request write access.
+  pull-request-client-id:
+    description: GitHub App client id with pull-request write access.
     required: true
   pull-request-private-key:
     description: GitHub App private key with pull-request write access.
@@ -57,8 +57,9 @@ runs:
       with:
         contents-client-id: ${{ inputs.contents-client-id }}
         contents-private-key: ${{ inputs.contents-private-key }}
-        pull-request-app-id: ${{ inputs.pull-request-app-id }}
+        pull-request-client-id: ${{ inputs.pull-request-client-id }}
         pull-request-private-key: ${{ inputs.pull-request-private-key }}
+        pull-request-contents-permission: ${{ inputs.auto-merge == 'true' && 'write' || '' }}
 
     - name: Publish generated pull request
       shell: bash

--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -89,12 +89,33 @@ jobs:
           submodules: false
 
       - name: Create generated PR tokens
+        id: tokens
         uses: ./.github/actions/create-generated-pr-tokens
         with:
           contents-client-id: Iv23liOECG0slfuhz093
           contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-client-id: Iv23liPJCozR0uHm6P7G
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
+          pull-request-contents-permission: write
+
+      - name: Verify repository auto-merge setting
+        env:
+          GH_TOKEN: ${{ steps.tokens.outputs.pull-request-token }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          auto_merge_allowed="$(
+            gh api graphql \
+              -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { autoMergeAllowed } }' \
+              -f owner="${REPOSITORY_OWNER}" \
+              -f name="${REPOSITORY_NAME}" \
+              --jq '.data.repository.autoMergeAllowed'
+          )"
+          if [[ "${auto_merge_allowed}" != "true" ]]; then
+            echo "Repository auto-merge must be enabled before generated locale publication." >&2
+            exit 1
+          fi
 
   refresh:
     needs: [resolve-base, publisher-preflight]
@@ -290,7 +311,7 @@ jobs:
         with:
           contents-client-id: Iv23liOECG0slfuhz093
           contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-client-id: Iv23liPJCozR0uHm6P7G
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ github.event.repository.default_branch }}
           head-branch: automation/control-ui-locale-refresh

--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -50,9 +50,6 @@ on:
       CLAWSWEEPER_APP_PRIVATE_KEY:
         description: Optional contents-write App key used only by canonical direct dispatches
         required: false
-      MANTIS_GITHUB_APP_ID:
-        description: Optional pull-request-write App id used only by canonical direct dispatches
-        required: false
       MANTIS_GITHUB_APP_PRIVATE_KEY:
         description: Optional pull-request-write App key used only by canonical direct dispatches
         required: false
@@ -292,7 +289,7 @@ jobs:
         with:
           contents-client-id: Iv23liOECG0slfuhz093
           contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-client-id: Iv23liPJCozR0uHm6P7G
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
 
   generate_qa_evidence:
@@ -682,7 +679,7 @@ jobs:
         with:
           contents-client-id: Iv23liOECG0slfuhz093
           contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-client-id: Iv23liPJCozR0uHm6P7G
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ needs.validate_selected_ref.outputs.publication_base }}
           head-branch: ${{ needs.validate_selected_ref.outputs.publication_head }}

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           contents-client-id: Iv23liOECG0slfuhz093
           contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-client-id: Iv23liPJCozR0uHm6P7G
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
 
   refresh:
@@ -283,7 +283,7 @@ jobs:
         with:
           contents-client-id: Iv23liOECG0slfuhz093
           contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-client-id: Iv23liPJCozR0uHm6P7G
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ github.event.repository.default_branch }}
           head-branch: automation/native-app-locale-refresh

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1210,8 +1210,7 @@ describe("ci workflow guards", () => {
         "contents-client-id": "${{ inputs.contents-client-id }}",
         "contents-private-key": "${{ inputs.contents-private-key }}",
         "pull-request-client-id": "${{ inputs.pull-request-client-id }}",
-        "pull-request-contents-permission":
-          "${{ inputs.auto-merge == 'true' && 'write' || '' }}",
+        "pull-request-contents-permission": "${{ inputs.auto-merge == 'true' && 'write' || '' }}",
         "pull-request-private-key": "${{ inputs.pull-request-private-key }}",
       },
     });
@@ -4413,10 +4412,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "OPENAI_API_KEY",
       "OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY",
     ]);
-    for (const secret of [
-      "CLAWSWEEPER_APP_PRIVATE_KEY",
-      "MANTIS_GITHUB_APP_PRIVATE_KEY",
-    ]) {
+    for (const secret of ["CLAWSWEEPER_APP_PRIVATE_KEY", "MANTIS_GITHUB_APP_PRIVATE_KEY"]) {
       expect(maturityWorkflow.on.workflow_call.secrets[secret].required).toBe(false);
     }
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs).not.toHaveProperty("fail_on_qa_failure");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -27,6 +27,7 @@ const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64
 const DOWNLOAD_ARTIFACT_V8 = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
 const CREATE_GITHUB_APP_TOKEN_V3 =
   "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1";
+const MANTIS_GITHUB_APP_CLIENT_ID = "Iv23liPJCozR0uHm6P7G";
 const OPENGREP_PR_DIFF_WORKFLOW = ".github/workflows/opengrep-precise.yml";
 const OPENGREP_FULL_WORKFLOW = ".github/workflows/opengrep-precise-full.yml";
 const CONTROL_UI_LOCALE_REFRESH_WORKFLOW = ".github/workflows/control-ui-locale-refresh.yml";
@@ -1105,7 +1106,7 @@ describe("ci workflow guards", () => {
       expect(preflight.needs).toBe("resolve-base");
       expect(preflight.if).toBe("needs.resolve-base.result == 'success'");
       expect(preflight.strategy).toBeUndefined();
-      expect(preflight.steps).toHaveLength(2);
+      expect(preflight.steps).toHaveLength(preflight === controlUiPreflight ? 3 : 2);
       const checkoutStep = preflight.steps.find(
         (step: { uses?: string }) => step.uses === CHECKOUT_V6,
       );
@@ -1120,10 +1121,25 @@ describe("ci workflow guards", () => {
       expect(tokensStep.with).toEqual({
         "contents-client-id": "Iv23liOECG0slfuhz093",
         "contents-private-key": "${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}",
-        "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
+        "pull-request-client-id": MANTIS_GITHUB_APP_CLIENT_ID,
+        ...(preflight === controlUiPreflight
+          ? { "pull-request-contents-permission": "write" }
+          : {}),
         "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
       });
     }
+    const controlUiTokensStep = controlUiPreflight.steps.find(
+      (step: { name?: string }) => step.name === "Create generated PR tokens",
+    );
+    const autoMergeSettingStep = controlUiPreflight.steps.find(
+      (step: { name?: string }) => step.name === "Verify repository auto-merge setting",
+    );
+    expect(controlUiTokensStep.id).toBe("tokens");
+    expect(autoMergeSettingStep.env.GH_TOKEN).toBe(
+      "${{ steps.tokens.outputs.pull-request-token }}",
+    );
+    expect(autoMergeSettingStep.run).toContain("autoMergeAllowed");
+    expect(autoMergeSettingStep.run).toContain("Repository auto-merge must be enabled");
 
     const tokenAction = parse(readFileSync(CREATE_GENERATED_PR_TOKENS_ACTION, "utf8"));
     const tokenActionSource = readFileSync(CREATE_GENERATED_PR_TOKENS_ACTION, "utf8");
@@ -1146,7 +1162,7 @@ describe("ci workflow guards", () => {
     for (const input of [
       "contents-client-id",
       "contents-private-key",
-      "pull-request-app-id",
+      "pull-request-client-id",
       "pull-request-private-key",
     ]) {
       expect(tokenAction.inputs[input].required).toBe(true);
@@ -1172,13 +1188,15 @@ describe("ci workflow guards", () => {
       id: "pull-request-token",
       uses: CREATE_GITHUB_APP_TOKEN_V3,
       with: {
-        "app-id": "${{ inputs.pull-request-app-id }}",
+        "client-id": "${{ inputs.pull-request-client-id }}",
         "private-key": "${{ inputs.pull-request-private-key }}",
         owner: "${{ github.repository_owner }}",
         repositories: "${{ github.event.repository.name }}",
+        "permission-contents": "${{ inputs.pull-request-contents-permission }}",
         "permission-pull-requests": "write",
       },
     });
+    expect(tokenAction.inputs["pull-request-contents-permission"].required).toBe(false);
     expect(tokenAction.outputs["contents-token"].value).toBe(
       "${{ steps.contents-token.outputs.token }}",
     );
@@ -1191,7 +1209,9 @@ describe("ci workflow guards", () => {
       with: {
         "contents-client-id": "${{ inputs.contents-client-id }}",
         "contents-private-key": "${{ inputs.contents-private-key }}",
-        "pull-request-app-id": "${{ inputs.pull-request-app-id }}",
+        "pull-request-client-id": "${{ inputs.pull-request-client-id }}",
+        "pull-request-contents-permission":
+          "${{ inputs.auto-merge == 'true' && 'write' || '' }}",
         "pull-request-private-key": "${{ inputs.pull-request-private-key }}",
       },
     });
@@ -1360,7 +1380,7 @@ describe("ci workflow guards", () => {
       expect(publishStep.with).toMatchObject({
         "contents-client-id": "Iv23liOECG0slfuhz093",
         "contents-private-key": "${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}",
-        "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
+        "pull-request-client-id": MANTIS_GITHUB_APP_CLIENT_ID,
         "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
         "base-branch": "${{ github.event.repository.default_branch }}",
         "head-branch": automationBranch,
@@ -4389,14 +4409,12 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     ).toBe(false);
     expect(Object.keys(maturityWorkflow.on.workflow_call.secrets).toSorted()).toEqual([
       "CLAWSWEEPER_APP_PRIVATE_KEY",
-      "MANTIS_GITHUB_APP_ID",
       "MANTIS_GITHUB_APP_PRIVATE_KEY",
       "OPENAI_API_KEY",
       "OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY",
     ]);
     for (const secret of [
       "CLAWSWEEPER_APP_PRIVATE_KEY",
-      "MANTIS_GITHUB_APP_ID",
       "MANTIS_GITHUB_APP_PRIVATE_KEY",
     ]) {
       expect(maturityWorkflow.on.workflow_call.secrets[secret].required).toBe(false);
@@ -4519,7 +4537,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       with: {
         "contents-client-id": "Iv23liOECG0slfuhz093",
         "contents-private-key": "${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}",
-        "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
+        "pull-request-client-id": MANTIS_GITHUB_APP_CLIENT_ID,
         "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
       },
     });
@@ -4651,7 +4669,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(openDocsPrStep.with).toMatchObject({
       "contents-client-id": "Iv23liOECG0slfuhz093",
       "contents-private-key": "${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}",
-      "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
+      "pull-request-client-id": MANTIS_GITHUB_APP_CLIENT_ID,
       "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
       "base-branch": "${{ needs.validate_selected_ref.outputs.publication_base }}",
       "head-branch": "${{ needs.validate_selected_ref.outputs.publication_head }}",


### PR DESCRIPTION
Related: #110685

## What Problem This Solves

Fixes an issue where generated Control UI locale pull requests remained open after successful translation and publication because the workflow could not arm GitHub auto-merge.

## Why This Change Was Made

The incident had two independent causes: repository auto-merge was disabled, and the Mantis installation token requested only pull-request write access even though `enablePullRequestAutoMerge` also requires repository contents write access. Repository auto-merge has been restored. This change requests contents write only for generated-PR publications that opt into auto-merge, migrates the token action from the deprecated App ID input to the public client ID, and adds an early repository-setting check so future configuration drift fails before locale generation.

Other generated-PR publications retain their existing pull-request-only token scope.

## User Impact

No product UI changes. Maintainers can expect the isolated generated Control UI locale PR to have squash auto-merge armed again instead of accumulating as an unmerged automation PR.

## Evidence

- Before: Control UI locale refresh run 29646773037 generated its translation PR, then failed at `enablePullRequestAutoMerge` with `Resource not accessible by integration`.
- Restoring repository auto-merge alone was insufficient: attempt 2 of run 29648615547 still failed with the pull-request-only App token.
- `test/scripts/ci-workflow-guards.test.ts`: 85/85 passed on Blacksmith Testbox `tbx_01kxv0qsec1tgxn0n8vv3m2tpm` ([run 29651928193](https://github.com/openclaw/openclaw/actions/runs/29651928193)).
- `actionlint` passed for all three changed workflows; `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings (confidence 0.96).

AI-assisted: yes. I understand and verified the workflow permission and caller changes.
