### PR TITLE
improve(ui): inset secret-input reveal everywhere — login gate and config form adopt the settings pattern

### DIFF
--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -129,8 +129,7 @@ function renderSensitiveToggleButton(params: {
     <openclaw-tooltip .content=${label}>
       <button
         type="button"
-        class="btn btn--icon ${state.isRevealed ? "active" : ""}"
-        style="width:28px;height:28px;padding:0;"
+        class="settings-secret__toggle"
         aria-label=${label}
         aria-pressed=${state.isRevealed}
         ?disabled=${params.disabled || !state.canReveal}
@@ -140,6 +139,18 @@ function renderSensitiveToggleButton(params: {
       </button>
     </openclaw-tooltip>
   `;
+}
+
+/* Sensitive fields inset the reveal eye inside the field (settings-secret
+ * pattern); non-sensitive fields render the bare control unchanged. */
+function wrapSensitiveControl(
+  control: TemplateResult,
+  toggle: TemplateResult | typeof nothing,
+): TemplateResult {
+  if (toggle === nothing) {
+    return control;
+  }
+  return html`<span class="settings-secret">${control}${toggle}</span>`;
 }
 
 function renderTags(tags: string[]): TemplateResult | typeof nothing {
@@ -484,7 +495,7 @@ function renderTextInput(params: {
       : (value ?? "");
   const effectiveInputType = sensitiveState.isSensitive && !effectiveRedacted ? "text" : inputType;
 
-  const control = html`
+  const inputControl = html`
     <input
       type=${effectiveInputType}
       class="settings-input${effectiveRedacted ? " cfg-redacted" : ""}"
@@ -521,14 +532,17 @@ function renderTextInput(params: {
         onPatch(path, raw.trim());
       }}
     />
-    ${isStructuredSecretRef
-      ? nothing
-      : renderSensitiveToggleButton({
-          path,
-          state: sensitiveState,
-          disabled,
-          onToggleSensitivePath: params.onToggleSensitivePath,
-        })}
+  `;
+  const revealToggle = isStructuredSecretRef
+    ? nothing
+    : renderSensitiveToggleButton({
+        path,
+        state: sensitiveState,
+        disabled,
+        onToggleSensitivePath: params.onToggleSensitivePath,
+      });
+  const control = html`
+    ${wrapSensitiveControl(inputControl, revealToggle)}
     ${schema.default !== undefined
       ? html`
           <openclaw-tooltip .content=${t("configForm.resetToDefault")}>
@@ -664,7 +678,7 @@ function renderJsonTextareaControl(params: {
   onPatch: (path: Array<string | number>, value: unknown) => void;
 }): TemplateResult {
   const { path, fallback, sensitiveState, disabled, onPatch } = params;
-  return html`
+  const textareaControl = html`
     <textarea
       class="settings-input${sensitiveState.isRedacted ? " cfg-redacted" : ""}"
       placeholder=${sensitiveState.isRedacted ? REDACTED_PLACEHOLDER : t("configForm.jsonValue")}
@@ -694,13 +708,16 @@ function renderJsonTextareaControl(params: {
         }
       }}
     ></textarea>
-    ${renderSensitiveToggleButton({
+  `;
+  return wrapSensitiveControl(
+    textareaControl,
+    renderSensitiveToggleButton({
       path,
       state: sensitiveState,
       disabled,
       onToggleSensitivePath: params.onToggleSensitivePath,
-    })}
-  `;
+    }),
+  );
 }
 
 function renderJsonTextarea(params: {

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -335,7 +335,7 @@ function renderLoginGate(props: LoginGateProps) {
           </label>
           <label class="field">
             <span>${t("connection.access.token")}</span>
-            <div class="login-gate__secret-row">
+            <span class="settings-secret">
               <input
                 type=${props.showGatewayToken ? "text" : "password"}
                 autocomplete="off"
@@ -357,7 +357,7 @@ function renderLoginGate(props: LoginGateProps) {
               >
                 <button
                   type="button"
-                  class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
+                  class="settings-secret__toggle"
                   aria-label=${t("login.toggleTokenVisibility")}
                   aria-pressed=${props.showGatewayToken}
                   @click=${props.onToggleGatewayToken}
@@ -365,11 +365,11 @@ function renderLoginGate(props: LoginGateProps) {
                   ${props.showGatewayToken ? icons.eye : icons.eyeOff}
                 </button>
               </openclaw-tooltip>
-            </div>
+            </span>
           </label>
           <label class="field">
             <span>${t("connection.access.password")}</span>
-            <div class="login-gate__secret-row">
+            <span class="settings-secret">
               <input
                 type=${props.showGatewayPassword ? "text" : "password"}
                 autocomplete="off"
@@ -393,7 +393,7 @@ function renderLoginGate(props: LoginGateProps) {
               >
                 <button
                   type="button"
-                  class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
+                  class="settings-secret__toggle"
                   aria-label=${t("login.togglePasswordVisibility")}
                   aria-pressed=${props.showGatewayPassword}
                   @click=${props.onToggleGatewayPassword}
@@ -401,7 +401,7 @@ function renderLoginGate(props: LoginGateProps) {
                   ${props.showGatewayPassword ? icons.eye : icons.eyeOff}
                 </button>
               </openclaw-tooltip>
-            </div>
+            </span>
           </label>
           <button class="btn primary login-gate__connect" @click=${props.onConnect}>
             ${t("common.connect")}

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -134,7 +134,7 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
           document.querySelectorAll<HTMLElement>(".login-gate__form .field input"),
         );
         const toggles = Array.from(
-          document.querySelectorAll<HTMLElement>(".login-gate__secret-row .btn--icon"),
+          document.querySelectorAll<HTMLElement>(".login-gate__form .settings-secret__toggle"),
         );
         const connect = document.querySelector<HTMLElement>(".login-gate__connect");
         if (!gate || !card || !connect) {
@@ -153,7 +153,7 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
           inputMinHeights: inputs.map((input) => getComputedStyle(input).minHeight),
           toggleSizes: toggles.map((toggle) => {
             const style = getComputedStyle(toggle);
-            return { height: style.height, minWidth: style.minWidth, width: style.width };
+            return { height: style.height, width: style.width };
           }),
         };
       });
@@ -165,11 +165,9 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
       expect(metrics.gateOverflowY).toBe("auto");
       expect(metrics.gateScrollHeight).toBeGreaterThan(metrics.gateClientHeight);
       expect(metrics.inputMinHeights.every((height) => height === "44px")).toBe(true);
+      expect(metrics.toggleSizes).toHaveLength(2);
       expect(
-        metrics.toggleSizes.every(
-          ({ height, minWidth, width }) =>
-            height === "44px" && minWidth === "44px" && width === "44px",
-        ),
+        metrics.toggleSizes.every(({ height, width }) => height === "32px" && width === "32px"),
       ).toBe(true);
 
       const failureDocs = page.locator(".login-gate__failure-docs");

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -115,22 +115,6 @@
   gap: 12px;
 }
 
-.login-gate__secret-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.login-gate__secret-row input {
-  flex: 1;
-}
-
-.login-gate__secret-row .btn--icon {
-  width: 40px;
-  min-width: 40px;
-  height: 40px;
-}
-
 .login-gate__connect {
   margin-top: 4px;
   width: 100%;
@@ -282,10 +266,11 @@
     min-height: 44px;
   }
 
-  .login-gate__secret-row .btn--icon {
-    width: 44px;
-    min-width: 44px;
-    height: 44px;
+  /* Inset reveal eye keeps a comfortable coarse-pointer hit area. */
+  .login-gate__form .settings-secret__toggle {
+    width: 32px;
+    height: 32px;
+    right: 6px;
   }
 
   .login-gate__connect {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -455,9 +455,28 @@ select.settings-select {
   min-width: 0;
 }
 
-.settings-secret > .settings-input {
+/* Class-agnostic child selectors: the login gate and config form reuse this
+   wrapper around their own input/textarea styling. */
+.settings-secret > input,
+.settings-secret > textarea {
   width: 100%;
+  min-width: 0;
   padding-right: 36px;
+}
+
+/* Stacked rows (config form arrays/maps) give the control full width; the
+   wrapper must grow or the inner 100% resolves against fit-content. */
+.settings-row--stacked .settings-row__control > .settings-secret {
+  flex: 1 1 auto;
+}
+
+/* Multiline secrets (JSON textareas) anchor the eye to the first line. */
+.settings-secret:has(> textarea) {
+  align-items: flex-start;
+}
+
+.settings-secret:has(> textarea) .settings-secret__toggle {
+  top: 6px;
 }
 
 .settings-secret__toggle {
@@ -479,6 +498,11 @@ select.settings-select {
 
 .settings-secret__toggle:hover {
   color: var(--text);
+}
+
+.settings-secret__toggle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .settings-secret__toggle:focus-visible {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110482. That PR introduced the settings design language's secret-input pattern — a reveal eye inset inside the field instead of a separate trailing button — but only the Connection page used it. The login gate and the config form still bolted a standalone eye button next to each sensitive field, so the two remaining secret-input surfaces looked different from the rest of the product and wasted a button-width per row.

## Why This Change Was Made

Adopt the one pattern everywhere a secret is edited:

- The `.settings-secret` wrapper's child selectors are now class-agnostic (`> input`, `> textarea`), so surfaces with their own input styling (login gate `.field` inputs, config form textareas) can reuse the wrapper without adopting `.settings-input` metrics. Disabled toggles get a quiet state, and multiline secrets anchor the eye to the first line.
- Login gate: token and password fields wrap in `.settings-secret` with the inset toggle; the bespoke `.login-gate__secret-row` CSS is deleted. Coarse-pointer devices get a 32px toggle hit area inside the 44px fields.
- Config form: the sensitive reveal toggle (`renderSensitiveToggleButton`) renders as an inset `settings-secret__toggle` for both string inputs and JSON textareas via a small `wrapSensitiveControl` helper; non-sensitive fields render unchanged. All reveal-gating semantics (`canReveal`, disabled-while-streaming, click-redacted-to-reveal) are untouched — only placement and styling changed.
- Stacked config rows (arrays/maps) keep full-width fields: the wrapper grows via flex so the inner `width: 100%` doesn't resolve against fit-content.

## User Impact

Every secret field in the product — login gate, Connection page, and config editor — now shows the same integrated reveal eye inside the field, with aligned field widths and no orphan buttons.

Login gate after (dark):

![login gate](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/secret-input-adoption/login-gate-after.png)

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/connection/view.render.test.ts ui/src/components/config-form.browser.test.ts ui/src/components/config-form.search.node.test.ts` — 19 tests pass (the config-form browser suite renders sensitive fields with `revealSensitive` both ways).
- `ui/src/e2e/login-gate.e2e.test.ts` mobile-metrics assertions updated to the inset toggle (with a length guard so a stale selector can never pass vacuously).
- Live-verified in the mock-UI harness (dark): login gate mounted with a token value — reveal toggle flips input type and value display, eye geometrically inside the 38px field; Connection page unchanged from #110482.
- Codex autoreview on the diff: one finding rejected with live DOM proof — it claimed the toggle uses a centering transform that a textarea override leaves active; measured `transform: none` and correct anchoring (textarea eye 6px inside field top, input eye centered) in the running UI.
