### PR TITLE
fix(ios): "Jump to latest" no longer appears while the assistant is still writing

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -37947,7 +37947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 491,
+      "line": 504,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -37955,7 +37955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 505,
+      "line": 518,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -37963,7 +37963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 539,
+      "line": 552,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -37971,7 +37971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 542,
+      "line": 555,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -37979,7 +37979,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 633,
+      "line": 650,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -37987,7 +37987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 653,
+      "line": 670,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -37995,7 +37995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1040,
+      "line": 1057,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -38003,7 +38003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1063,
+      "line": 1080,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -38011,7 +38011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1084,
+      "line": 1101,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -38019,7 +38019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1094,
+      "line": 1111,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -38027,7 +38027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1096,
+      "line": 1113,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -38035,7 +38035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1162,
+      "line": 1179,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -38043,7 +38043,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1242,
+      "line": 1259,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -35,6 +35,19 @@ func chatReaderHasNewerContent(
     return messageIndex < visibleIDs.index(before: visibleIDs.endIndex) || hasTransientContent
 }
 
+/// `hasNewerContentBelow` is derived structurally (a later message or streaming text exists),
+/// which is true from the first Writing tick of a turn even when the whole transcript is on
+/// screen. Gating on the live-edge geometry keeps the jump affordance hidden until content is
+/// actually below the viewport; without it the button flashes during every reply (#108693).
+func chatReaderShowsJumpToLatest(
+    hasNewerContentBelow: Bool,
+    isAtLiveEdge: Bool,
+    hasVisibleContent: Bool,
+    isLoading: Bool) -> Bool
+{
+    hasNewerContentBelow && !isAtLiveEdge && hasVisibleContent && !isLoading
+}
+
 /// The view's own one-shot positioning always runs in a nil-animation transaction, so
 /// `.animating` only comes from system scrolls (status-bar scroll-to-top, keyboard
 /// avoidance). Not releasing there lets the next timeline tick yank the reader back down.
@@ -608,7 +621,11 @@ public struct OpenClawChatView: View {
     }
 
     private var showsJumpToLatest: Bool {
-        self.hasNewerContentBelow && self.hasVisibleMessageListContent && !self.viewModel.isLoading
+        chatReaderShowsJumpToLatest(
+            hasNewerContentBelow: self.hasNewerContentBelow,
+            isAtLiveEdge: self.isAtLiveEdge,
+            hasVisibleContent: self.hasVisibleMessageListContent,
+            isLoading: self.viewModel.isLoading)
     }
 
     private var jumpToLatestButton: some View {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatReaderScrollStateTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatReaderScrollStateTests.swift
@@ -71,4 +71,35 @@ struct ChatReaderScrollStateTests {
         #expect(!chatReaderScrollReleasesFollow(.tracking))
         #expect(!chatReaderScrollReleasesFollow(.decelerating))
     }
+
+    @Test func `streaming at the live edge never offers a latest jump`() {
+        // #108693: the first Writing tick of a turn makes structural "newer content" true
+        // while the reader is still at the bottom; the geometry gate must win.
+        #expect(!chatReaderShowsJumpToLatest(
+            hasNewerContentBelow: true,
+            isAtLiveEdge: true,
+            hasVisibleContent: true,
+            isLoading: false))
+    }
+
+    @Test func `newer content below the viewport offers a latest jump`() {
+        #expect(chatReaderShowsJumpToLatest(
+            hasNewerContentBelow: true,
+            isAtLiveEdge: false,
+            hasVisibleContent: true,
+            isLoading: false))
+    }
+
+    @Test func `loading and empty transcripts suppress the latest jump`() {
+        #expect(!chatReaderShowsJumpToLatest(
+            hasNewerContentBelow: true,
+            isAtLiveEdge: false,
+            hasVisibleContent: true,
+            isLoading: true))
+        #expect(!chatReaderShowsJumpToLatest(
+            hasNewerContentBelow: true,
+            isAtLiveEdge: false,
+            hasVisibleContent: false,
+            isLoading: false))
+    }
 }


### PR DESCRIPTION
Closes #108693

## What Problem This Solves

Fixes an issue where iOS users sending a message would see the "Jump to latest" button appear at the same moment as the "Writing" streaming indicator, even though they were already at the bottom of the conversation with nothing to jump to. The false positive showed up on every streamed reply (the issue's screenshot shows both visible at once with the keyboard open).

## Why This Change Was Made

`hasNewerContentBelow` is derived structurally: `chatReaderHasNewerContent` returns true as soon as a later message or any transient streaming content exists, regardless of whether that content is actually below the viewport. When a turn starts, the reader anchors the user's message and the first streaming tick makes the structural check true — so the button appeared while the entire transcript was still on screen.

The view already tracks the real geometry (`isAtLiveEdge`, from `onScrollGeometryChange` against the 48pt live-edge threshold). The fix gates the button's visibility on that geometry: a new pure helper `chatReaderShowsJumpToLatest` returns true only when there is newer content **and** the reader has actually left the live edge. Once a streamed reply grows past the viewport, the distance from the bottom crosses the threshold and the button appears exactly when there is genuinely content below the fold.

Android is not affected: its reader clears/derives `hasNewerContent` through `onViewportChanged` after real user scrolls and keeps it false in follow modes, so it is already viewport-gated (`apps/android/.../ChatReaderScrollController.kt`). The related keyboard auto-scroll report (#108692) is a separate follow-policy behavior and is intentionally not touched here.

## User Impact

The jump button no longer flashes during every assistant reply while the user is at the bottom (keyboard open or not). It still appears when the user scrolls up into history, when a long streamed reply extends past the viewport, and it hides immediately when the reader returns to the live edge. Applies to iOS and the macOS quick chat (shared view).

## Evidence

- New pure regression tests in `ChatReaderScrollStateTests` cover the exact repro (structural newer-content true while at the live edge → hidden), the legit scrolled-up case, and the loading/empty suppressions; full suite passes locally (10/10, `swift test --filter ChatReaderScrollStateTests`).
- A scratch XCUITest on the iPhone 17 simulator (iOS 26.5, screenshot-fixture chat) proved the end-to-end behavior on this branch: after three sends the `Jump to latest reply` button does **not** exist at the live edge, appears after swiping down into history, and disappears after tap-through (the same accessibility contract the shipped live-gateway E2E taps). Test deleted before commit per repo policy.
- `swiftformat --lint` clean on both changed files.
