### PR TITLE
test(ui): fix Node 25+ localStorage crashes in jsdom suites; document PR-open CI drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,7 @@ Skills own workflows; root owns hard policy and routing.
 - No surprise GH writes: chat must mention every posted/updated public comment with URL.
 - GH comments with backticks, `$`, or shell snippets: use heredoc/body file, not inline double-quoted `--body`.
 - PR create: real body required. Use the current template: `What Problem This Solves`, `Why This Change Was Made`, `User Impact`, and `Evidence`; include visible refs, behavior, and validation.
+- PR create races GitHub's merge-ref computation: the pull_request-open CI run can drop entirely or die as `startup_failure`/`BuildFailed` (`(Unknown event)`, not rerunnable). After opening, verify the CI workflow attached to the head SHA; if missing, close/reopen the PR to re-fire the event.
 - PR create/refresh: keep PR branches takeover-ready. Use a branch maintainers can push to, or for fork PRs ensure `maintainer_can_modify` / GitHub's `Allow edits by maintainers` is enabled unless explicitly told otherwise or GitHub's Actions/secrets warning makes that unsafe.
 - GitHub issue/PR create: read `$agent-transcript`; ask about sanitized transcript logs when available.
 - Contributor PRs: parsed context requires authored `What Problem This Solves` and `Evidence` sections. Do not require field-level proof forms; reviewers inspect code, tests, and CI for correctness.

--- a/ui/src/test-helpers/lit-warnings.setup.ts
+++ b/ui/src/test-helpers/lit-warnings.setup.ts
@@ -77,3 +77,70 @@ if (typeof HTMLDialogElement !== "undefined" && !("close" in HTMLDialogElement.p
     },
   });
 }
+
+// Node 25+ enables WebStorage by default with a global localStorage getter
+// that is dead without --localstorage-file (undefined on 26.5, reported to
+// throw or return an inert proxy on other 25/26 releases). During jsdom
+// global population it shadows the DOM Storage (globalThis is the window),
+// so storage-touching tests crash on newer local Node while Linux CI
+// (Node 24, no default WebStorage) passes. Capability-probe instead of
+// trusting any one shape, then install an in-memory Storage.
+function globalLocalStorageIsUsable(): boolean {
+  try {
+    const existing = globalThis.localStorage;
+    if (!existing) {
+      return false;
+    }
+    existing.setItem("__openclaw_probe__", "1");
+    const roundTrips = existing.getItem("__openclaw_probe__") === "1";
+    existing.removeItem("__openclaw_probe__");
+    return roundTrips;
+  } catch {
+    return false;
+  }
+}
+
+function usableWindowLocalStorage(): Storage | null {
+  try {
+    const candidate = window.localStorage;
+    if (!candidate) {
+      return null;
+    }
+    candidate.setItem("__openclaw_probe__", "1");
+    const roundTrips = candidate.getItem("__openclaw_probe__") === "1";
+    candidate.removeItem("__openclaw_probe__");
+    return roundTrips ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+if (typeof window !== "undefined" && !globalLocalStorageIsUsable()) {
+  const backing = new Map<string, string>();
+  // Prefer jsdom's own Storage when only the global alias is dead so
+  // `localStorage` and `window.localStorage` stay the same object.
+  const storage: Storage = usableWindowLocalStorage() ?? {
+    get length() {
+      return backing.size;
+    },
+    clear: () => backing.clear(),
+    getItem: (key: string) => backing.get(String(key)) ?? null,
+    key: (index: number) => [...backing.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      backing.delete(String(key));
+    },
+    setItem: (key: string, value: string) => {
+      backing.set(String(key), String(value));
+    },
+  };
+  const install = (target: object) =>
+    Object.defineProperty(target, "localStorage", {
+      configurable: true,
+      enumerable: false,
+      get: () => storage,
+    });
+  install(globalThis);
+  if ((window as unknown) !== globalThis) {
+    install(window);
+  }
+}

--- a/ui/src/test-helpers/lit-warnings.setup.ts
+++ b/ui/src/test-helpers/lit-warnings.setup.ts
@@ -124,13 +124,13 @@ if (typeof window !== "undefined" && !globalLocalStorageIsUsable()) {
       return backing.size;
     },
     clear: () => backing.clear(),
-    getItem: (key: string) => backing.get(String(key)) ?? null,
+    getItem: (key: string) => backing.get(key) ?? null,
     key: (index: number) => [...backing.keys()][index] ?? null,
     removeItem: (key: string) => {
-      backing.delete(String(key));
+      backing.delete(key);
     },
     setItem: (key: string, value: string) => {
-      backing.set(String(key), String(value));
+      backing.set(key, value);
     },
   };
   const install = (target: object) =>


### PR DESCRIPTION
## What Problem This Solves

Developers on current Node (25/26) get 60+ spurious UI test failures locally: any jsdom test touching `localStorage` crashes with `Cannot read properties of undefined (reading 'clear')` while the same tests pass on Linux CI (Node 24). Six files fail on Node 26.5 (`lobster-pet`, `lobster-dex`, `dock-panel-layout`, `activity-page`, `chat-realtime`, `chat-pull-requests`), which makes real local red herrings out of green code and masks genuine failures.

Separately, three consecutive fresh PRs this week (#110472, #110528, #110623) had their pull_request-open CI run drop or die as `startup_failure`, each needing a close/reopen; repo history shows ~10–16 such runs daily.

## Why This Change Was Made

Node 25+ enables WebStorage by default: `globalThis.localStorage` becomes an own-property getter that is dead without `--localstorage-file` (measured `undefined` on Node 26.5; other releases reportedly throw or return an inert proxy). During vitest jsdom global population the dead getter shadows jsdom's Storage — probed in-environment: `globalThis === window` and both `localStorage` bindings are `undefined`. Node 24 has no default WebStorage, so CI never sees it.

The shared UI test setup (`lit-warnings.setup.ts`, already the home for jsdom gap shims) now capability-probes the global with a throw-safe set/get/remove round-trip, prefers jsdom's own `window.localStorage` when only the global alias is dead, and otherwise installs a single in-memory `Storage` on both `window` and `globalThis` so the two names stay one object.

The CI-drop pattern was diagnosed to a GitHub-side race: PRs created immediately after their branch push fire the open event before the merge ref is computed (`mergeable: null`), and the CI run either never attaches or is created as `startup_failure` / `BuildFailed` / `(Unknown event)` — which `gh run rerun` refuses to retry. The workflow triggers in `ci.yml` are correct; the fix is operational, so `AGENTS.md` now instructs verifying the CI attach after PR creation and re-firing via close/reopen.

## User Impact

Contributor/local-dev only: UI tests pass on Node 24, 25, and 26 without flags; no runtime, product, or CI behavior changes. Agents stop losing PR cycles to silently missing CI runs.

## Evidence

- Root cause probed in the failing environment: descriptor on Node 26.5 is a configurable getter returning `undefined`; in vitest jsdom, `globalThis === window` with both storage bindings dead.
- Before: `node scripts/run-vitest.mjs ui/src/components/lobster-pet.test.ts` — 44/44 failing on Node 26.5 (reproduced on clean `main`). After: all six previously failing files pass; full `ui/src` suite exit 0 on Node 26.5.
- CI-drop diagnosis: `gh api` on run 29634070586 shows `path: BuildFailed`, `display_title: "(Unknown event)"`, empty referenced workflows; 100 most recent `startup_failure` runs span five days at ~10–16/day, all `pull_request` events across many authors' branches.
- Structured autoreview (gpt-5.6-sol): three hardening findings accepted and fixed (throw-safe probe, round-trip verification against inert implementations, window/global identity binding); final run clean.
