### PR TITLE
refactor(ui): split lobster-pet into look/plans/element modules

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -1101,7 +1101,6 @@ ui/src/api/types.ts
 ui/src/app/app-host.ts
 ui/src/components/browser/browser-panel.ts
 ui/src/components/config-form.node.ts
-ui/src/components/lobster-pet.ts
 ui/src/components/markdown.ts
 ui/src/components/terminal/terminal-panel.ts
 ui/src/e2e/chat-flow.e2e.test.ts

--- a/ui/src/components/lobster-pet-audio.ts
+++ b/ui/src/components/lobster-pet-audio.ts
@@ -9,16 +9,16 @@ export function playLobsterPetChirp(
   soundsEnabled: boolean,
   kind: LobsterPetChirpKind,
 ): AudioContext | null {
+  let ctx = audioCtx;
   if (!soundsEnabled) {
-    return audioCtx;
+    return ctx;
   }
   try {
     const Ctor = window.AudioContext;
     if (!Ctor) {
-      return audioCtx;
+      return ctx;
     }
-    audioCtx ??= new Ctor();
-    const ctx = audioCtx;
+    ctx ??= new Ctor();
     if (ctx.state === "suspended") {
       void ctx.resume();
     }
@@ -42,5 +42,5 @@ export function playLobsterPetChirp(
   } catch {
     // never let audio break the pet
   }
-  return audioCtx;
+  return ctx;
 }

--- a/ui/src/components/lobster-pet-audio.ts
+++ b/ui/src/components/lobster-pet-audio.ts
@@ -1,0 +1,46 @@
+export type LobsterPetChirpKind = "poke" | "pet";
+
+// Opt-in (default off) tiny synth chirps: a descending blub for pokes, a
+// rising coo for pets. Only ever called from pointer gestures, so the
+// AudioContext is created inside a user activation and never blocked by
+// autoplay policy. Sound is decoration - any audio failure is swallowed.
+export function playLobsterPetChirp(
+  audioCtx: AudioContext | null,
+  soundsEnabled: boolean,
+  kind: LobsterPetChirpKind,
+): AudioContext | null {
+  if (!soundsEnabled) {
+    return audioCtx;
+  }
+  try {
+    const Ctor = window.AudioContext;
+    if (!Ctor) {
+      return audioCtx;
+    }
+    audioCtx ??= new Ctor();
+    const ctx = audioCtx;
+    if (ctx.state === "suspended") {
+      void ctx.resume();
+    }
+    const at = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "sine";
+    if (kind === "poke") {
+      osc.frequency.setValueAtTime(330, at);
+      osc.frequency.exponentialRampToValueAtTime(165, at + 0.09);
+    } else {
+      osc.frequency.setValueAtTime(392, at);
+      osc.frequency.exponentialRampToValueAtTime(523, at + 0.18);
+    }
+    gain.gain.setValueAtTime(0.0001, at);
+    gain.gain.exponentialRampToValueAtTime(0.05, at + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, at + (kind === "poke" ? 0.12 : 0.24));
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(at);
+    osc.stop(at + 0.26);
+  } catch {
+    // never let audio break the pet
+  }
+  return audioCtx;
+}

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -175,7 +175,7 @@ export function lobsterPetName(look: LobsterPetLook, seed: number): string {
 }
 
 // A stranger wears a different palette than the resident pet.
-export function strangerLookFor(seed: number, own: LobsterPetPaletteId): LobsterPetLook {
+function strangerLookFor(seed: number, own: LobsterPetPaletteId): LobsterPetLook {
   for (let offset = 1; offset <= 24; offset++) {
     const look = createLobsterPetLook((seed + offset * 7919) >>> 0);
     if (look.palette.id !== own) {
@@ -425,7 +425,7 @@ const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
 
 // Not a lobster. Wide shell, eye stalks, walks sideways across the ledge,
 // and the Lobsterdex refuses to acknowledge it.
-export function renderCrabSvg() {
+function renderCrabSvg() {
   return svg`
     <svg
       class="lobster-pet__svg"
@@ -559,7 +559,7 @@ export function renderLobsterSvg(
 
 export const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
 
-export function lobsterPetSpriteStyle(
+function lobsterPetSpriteStyle(
   look: LobsterPetLook,
   scale: number,
   spotPct: number,

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -1,0 +1,772 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { html, nothing, svg, type TemplateResult } from "lit";
+import { lobsterHonorific } from "./lobster-dex.ts";
+import type {
+  LobsterPetAccessory,
+  LobsterPetAntennae,
+  LobsterPetBuild,
+  LobsterPetClawSize,
+  LobsterPetLook,
+  LobsterPetMode,
+  LobsterPetPalette,
+  LobsterPetPaletteId,
+  LobsterPetPersonalityId,
+} from "./lobster-pet-contract.ts";
+
+// Rarity ladder loosely mirrors real lobster genetics: blue ~1 in 2 million,
+// yellow ~1 in 30 million, calico ~1 in 30 million, split two-tone ~1 in
+// 50 million, albino/ghost ~1 in 100 million. Abyss is our deep-sea fantasy.
+// Split/calico extra geometry and ghost/abyss styling key off the palette id
+// (see lobster-pet.css and renderLobsterSvg).
+const PALETTES: Array<[LobsterPetPalette, number]> = [
+  [{ id: "crimson", shell: "#ff4f40", claw: "#ff775f" }, 26],
+  [{ id: "coral", shell: "#d0836a", claw: "#de9b80" }, 26],
+  [{ id: "teal", shell: "#2fbfa7", claw: "#5cd9c4" }, 10],
+  [{ id: "violet", shell: "#9f7dfa", claw: "#bba4fd" }, 10],
+  [{ id: "ink", shell: "#5e6b7a", claw: "#7b8996" }, 9],
+  [{ id: "blue", shell: "#4a7dfc", claw: "#7fa4ff" }, 7],
+  [{ id: "gold", shell: "#f4b840", claw: "#f9d47a" }, 5],
+  [{ id: "calico", shell: "#d97a3d", claw: "#e89a63" }, 3],
+  [{ id: "abyss", shell: "#2c3b68", claw: "#465b96" }, 2],
+  [{ id: "ghost", shell: "#dce8f2", claw: "#ecf3fa" }, 1],
+  [{ id: "split", shell: "#ff4f40", claw: "#ff775f" }, 1],
+  // The grail: homage to the classic OpenClaw logo (big raised claw, smirk,
+  // angry brows, white sticker outline). ~0.5% of sessions.
+  [{ id: "retro", shell: "#e8262c", claw: "#f04a3e" }, 0.5],
+];
+
+// Catalog order for collection UIs (Lobsterdex): common to grail.
+export const LOBSTER_PET_PALETTES: readonly LobsterPetPalette[] = PALETTES.map(
+  ([palette]) => palette,
+);
+
+// A neutral look used to render catalog minis outside the pet lifecycle.
+export function canonicalLobsterLook(palette: LobsterPetPalette): LobsterPetLook {
+  return {
+    palette,
+    scale: 2,
+    accessory: "none",
+    antennae: "perky",
+    side: "left",
+    spotPct: 0,
+    facing: 1,
+    personality: "friendly",
+    blinkDelayS: 0,
+    build: "round",
+    clawSize: "regular",
+    tailFan: false,
+  };
+}
+
+const ACCESSORIES: Array<[LobsterPetAccessory, number]> = [
+  ["none", 62],
+  ["sprout", 14],
+  ["patch", 14],
+  ["crown", 10],
+];
+
+// OpenClaw's repository was born 2025-11-24 (GitHub created_at); on the
+// anniversary every visitor dresses as the classic logo and parties.
+const ANNIVERSARY = { month: 10, day: 24 } as const;
+
+function isLobsterAnniversary(now: Date): boolean {
+  return now.getMonth() === ANNIVERSARY.month && now.getDate() === ANNIVERSARY.day;
+}
+
+// Seasonal wardrobe: extra accessory entries join the pool on the right
+// dates. One weighted roll either way, so the rest of the look sequence is
+// unchanged on any given seed.
+function seasonalAccessories(now: Date): Array<[LobsterPetAccessory, number]> {
+  const month = now.getMonth();
+  const day = now.getDate();
+  if (month === 11) {
+    return [["santa", 18]];
+  }
+  if (month === 9 && day >= 20) {
+    return [["pumpkin", 18]];
+  }
+  return [];
+}
+
+const PERSONALITY_IDS: Array<[LobsterPetPersonalityId, number]> = [
+  ["sleepy", 25],
+  ["zoomy", 25],
+  ["friendly", 25],
+  ["showoff", 25],
+];
+
+const SCALES: Array<[number, number]> = [
+  [1.7, 25],
+  [2, 55],
+  [2.5, 20],
+];
+
+const BUILDS: Array<[LobsterPetBuild, number]> = [
+  ["round", 40],
+  ["squat", 30],
+  ["slender", 30],
+];
+
+const CLAW_SIZES: Array<[LobsterPetClawSize, number]> = [
+  ["regular", 55],
+  ["dainty", 25],
+  ["mighty", 20],
+];
+
+// Builds reshape the whole sprite by stretching its aspect ratio (the svg
+// renders with preserveAspectRatio="none"), so eyes, claws, accessories, and
+// rare-variant geometry stay aligned for every silhouette.
+export const LOBSTER_PET_BUILD_MULS: Record<LobsterPetBuild, { w: number; h: number }> = {
+  round: { w: 1, h: 1 },
+  squat: { w: 1.14, h: 0.9 },
+  slender: { w: 0.88, h: 1.1 },
+};
+
+export const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
+  dainty: 0.85,
+  regular: 1,
+  mighty: 1.18,
+};
+
+
+// Seeded pet names; rare palettes carry signature names. Shown via the
+// sprite's native title tooltip, so no i18n surface.
+const PET_NAMES = [
+  "Pinchy",
+  "Barnaby",
+  "Thermidor",
+  "Clawdette",
+  "Sheldon",
+  "Scuttles",
+  "Bisque",
+  "Crusty",
+  "Snips",
+  "Bubbles",
+  "Clawdia",
+  "Ferdinand",
+  "Maple",
+  "Pearl",
+  "Biscuit",
+  "Captain",
+  "Ziggy",
+  "Noodle",
+  "Waffles",
+  "Pippin",
+  "Squirt",
+  "Chip",
+  "Clementine",
+  "Moss",
+] as const;
+
+const RARE_NAMES: Partial<Record<LobsterPetPaletteId, string>> = {
+  blue: "Blueberry",
+  gold: "Goldie",
+  calico: "Patches",
+  abyss: "Lantern",
+  ghost: "Boo",
+  split: "Picasso",
+  retro: "OG",
+};
+
+export function lobsterPetName(look: LobsterPetLook, seed: number): string {
+  return (
+    RARE_NAMES[look.palette.id] ??
+    expectDefined(PET_NAMES[(seed >>> 3) % PET_NAMES.length], "lobster pet name catalog entry")
+  );
+}
+
+
+// A stranger wears a different palette than the resident pet.
+export function strangerLookFor(seed: number, own: LobsterPetPaletteId): LobsterPetLook {
+  for (let offset = 1; offset <= 24; offset++) {
+    const look = createLobsterPetLook((seed + offset * 7919) >>> 0);
+    if (look.palette.id !== own) {
+      return look;
+    }
+  }
+  return createLobsterPetLook((seed + 1) >>> 0);
+}
+
+
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function pickWeighted<T>(rng: () => number, entries: Array<[T, number]>): T {
+  const total = entries.reduce((sum, [, weight]) => sum + weight, 0);
+  let roll = rng() * total;
+  for (const [value, weight] of entries) {
+    roll -= weight;
+    if (roll <= 0) {
+      return value;
+    }
+  }
+  return expectDefined(entries.at(-1), "weighted lobster choice fallback")[0];
+}
+
+export function randomBetween(rng: () => number, min: number, max: number): number {
+  return min + rng() * (max - min);
+}
+
+export function createLobsterPetLook(seed: number, now: Date = new Date()): LobsterPetLook {
+  const rng = mulberry32(seed);
+  const palette = pickWeighted(rng, PALETTES);
+  const scale = pickWeighted(rng, SCALES);
+  const accessory = pickWeighted(rng, [...ACCESSORIES, ...seasonalAccessories(now)]);
+  const antennae: LobsterPetAntennae = rng() < 0.6 ? "perky" : "droopy";
+  const side = rng() < 0.5 ? "left" : "right";
+  const zone = SPOT_ZONES[side];
+  const spotPct = Math.round(randomBetween(rng, zone[0], zone[1]));
+  const facing = rng() < 0.5 ? 1 : -1;
+  const personality = pickWeighted(rng, PERSONALITY_IDS);
+  const blinkDelayS = Math.round(randomBetween(rng, 0, 4) * 10) / 10;
+  // Shape traits roll after the original ones so pre-existing seeds keep
+  // their palette/personality and only gain a silhouette.
+  const build = pickWeighted(rng, BUILDS);
+  const clawSize = pickWeighted(rng, CLAW_SIZES);
+  const tailFan = rng() < 0.3;
+  if (isLobsterAnniversary(now)) {
+    // Birthday dress code: everyone is the classic logo, party hats on.
+    const retro = PALETTES.find(([entry]) => entry.id === "retro")?.[0];
+    return {
+      palette: retro ?? palette,
+      scale,
+      accessory: "party",
+      antennae,
+      side,
+      spotPct,
+      facing,
+      personality,
+      blinkDelayS,
+      build,
+      clawSize,
+      tailFan,
+    };
+  }
+  return {
+    palette,
+    scale,
+    accessory,
+    antennae,
+    side,
+    spotPct,
+    facing,
+    personality,
+    blinkDelayS,
+    build,
+    clawSize,
+    tailFan,
+  };
+}
+
+
+const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateResult> = {
+  crown: svg`
+    <path
+      d="M46 12 L46 2 L53 8 L60 0 L67 8 L74 2 L74 12 Q60 8 46 12 Z"
+      fill="#f6c945"
+    />
+  `,
+  sprout: svg`
+    <g>
+      <path d="M60 12 Q58 4 63 1" stroke="#3f9d63" stroke-width="3" stroke-linecap="round" fill="none" />
+      <ellipse cx="67" cy="3" rx="5" ry="3" fill="#57c785" transform="rotate(-24 67 3)" />
+    </g>
+  `,
+  patch: svg`
+    <g>
+      <path d="M28 27 Q60 14 92 22" stroke="#101820" stroke-width="4" stroke-linecap="round" fill="none" />
+      <circle cx="75" cy="32" r="9" fill="#101820" />
+    </g>
+  `,
+  santa: svg`
+    <g>
+      <path d="M47 10 Q54 1 68 3 L72 9 Z" fill="#e0312f" />
+      <circle cx="71" cy="3.5" r="3.5" fill="#f5f7fa" />
+      <ellipse cx="59" cy="10.5" rx="15" ry="3.5" fill="#f5f7fa" />
+    </g>
+  `,
+  pumpkin: svg`
+    <g>
+      <ellipse cx="60" cy="6.5" rx="8.5" ry="5.5" fill="#e8871e" />
+      <path d="M56 2.5 Q56 6.5 56 10.5 M64 2.5 Q64 6.5 64 10.5" stroke="#c96a10" stroke-width="1.5" fill="none" />
+      <path d="M60 1.5 Q60.5 0 63 0.5" stroke="#4c9a4c" stroke-width="2.5" stroke-linecap="round" fill="none" />
+    </g>
+  `,
+  party: svg`
+    <g>
+      <path d="M52 11 L60 0.5 L68 11 Z" fill="#7c5cff" />
+      <path d="M55.5 6.5 L64.5 6.5" stroke="#ffd166" stroke-width="2" />
+      <circle cx="60" cy="1" r="2.4" fill="#ff5c8a" />
+    </g>
+  `,
+};
+
+// Calico mottling: dark blotches scattered clear of the eye line.
+const CALICO_SPOTS = svg`
+  <g class="lob-spots" fill="#2a1f16" opacity="0.8">
+    <ellipse cx="40" cy="50" rx="6" ry="4" transform="rotate(-15 40 50)" />
+    <ellipse cx="72" cy="62" rx="7" ry="4.5" transform="rotate(18 72 62)" />
+    <ellipse cx="55" cy="76" rx="5" ry="3.5" transform="rotate(-8 55 76)" />
+    <ellipse cx="84" cy="42" rx="4" ry="3" transform="rotate(25 84 42)" />
+    <ellipse cx="47" cy="18" rx="4.5" ry="3" transform="rotate(-20 47 18)" />
+    <ellipse cx="30" cy="64" rx="4" ry="3" transform="rotate(12 30 64)" />
+  </g>
+`;
+
+// Split two-tone: the right half of the body (down to the belly midline)
+// repainted in the second shell color; the right claw and antenna follow via
+// CSS. Mirrors the famous bilateral half-and-half lobsters.
+const SPLIT_HALF = svg`
+  <path
+    class="lob-split-half"
+    d="M60 8 C88 8 104 32 104 52 C104 72 90 90 76 95 L76 104 L66 104 L66 96 C64 96.8 62 97.1 60 97.1 L60 8 Z"
+    fill="var(--lob-shell2, #46536b)"
+  />
+`;
+
+// Retro homage parts (classic OpenClaw logo): one oversized raised claw with
+// a pincer notch, tall V antennae, angry brows, and a smirk. The mega claw
+// lives inside the .lob-claw--r group so wave/snip acts swing it.
+const RETRO_MEGA_CLAW = svg`
+  <path
+    d="M95 55 C112 53 119 39 116 25 C113 11 99 5 91 12 C88 15 87 19 88 23 C83 27 83 36 88 43 C91 49 93 52 95 55 Z"
+    fill="var(--lob-claw)"
+  />
+  <path
+    d="M92 14 C97 22 99 31 95 41"
+    stroke="#b8151b"
+    stroke-width="3"
+    stroke-linecap="round"
+    fill="none"
+  />
+`;
+
+const RETRO_ANTENNAE = svg`
+  <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
+    <path d="M50 16 Q45 4 37 1" />
+    <path d="M70 16 Q75 4 83 1" />
+  </g>
+`;
+
+const RETRO_FACE = svg`
+  <g stroke="#0a1014" stroke-linecap="round" fill="none">
+    <path d="M37 24 L51 28" stroke-width="3.5" />
+    <path d="M69 28 L83 24" stroke-width="3.5" />
+    <path d="M49 45 Q59 51 69 45 L72 42" stroke-width="3" />
+  </g>
+`;
+
+// Tail-fan lobes peek out diagonally behind the lower body (drawn before the
+// body path so they read as "behind"). Fill color lives in lobster-pet.css.
+const TAIL_FAN = svg`
+  <g class="lob-tail">
+    <ellipse cx="16" cy="84" rx="11" ry="7" transform="rotate(-32 16 84)" />
+    <ellipse cx="104" cy="84" rx="11" ry="7" transform="rotate(32 104 84)" />
+  </g>
+`;
+
+// Moving-day bindle: a stick over the shoulder with a polka-dot bundle,
+// carried for the whole first load after a gateway upgrade.
+const BINDLE = svg`
+  <g class="lob-bindle">
+    <path d="M70 62 L99 30" stroke="#8a5a2b" stroke-width="3.5" stroke-linecap="round" />
+    <circle cx="101" cy="27" r="9.5" fill="#e8b04b" />
+    <circle cx="98" cy="24" r="1.6" fill="#b6791f" />
+    <circle cx="104" cy="29" r="1.6" fill="#b6791f" />
+    <circle cx="100" cy="32" r="1.3" fill="#b6791f" />
+  </g>
+`;
+
+// On lobster days (see src/shared/lobster-day.ts, shared with the CLI
+// banner cousin) the pet wears a little sailor cap - unless the seed already
+// rolled headwear, which keeps its place.
+const HEADWEAR: ReadonlySet<LobsterPetAccessory> = new Set([
+  "crown",
+  "sprout",
+  "santa",
+  "pumpkin",
+  "party",
+]);
+
+const SAILOR_CAP = svg`
+  <g class="lob-cap">
+    <path d="M46 10 Q60 -3 74 10 L74 13 Q60 7 46 13 Z" fill="#f5f7fa" />
+    <path d="M45 12 Q60 6 75 12 L75 16 Q60 10.5 45 16 Z" fill="#dfe7ee" />
+    <circle cx="60" cy="2.5" r="1.8" fill="#3b6ea5" />
+  </g>
+`;
+
+// Shown while grumpy (poked too much): angry brows and a frown.
+const GRUMPY_FACE = svg`
+  <g stroke="#0a1014" stroke-linecap="round" fill="none">
+    <path d="M37 24 L51 28" stroke-width="3.5" />
+    <path d="M69 28 L83 24" stroke-width="3.5" />
+    <path d="M50 48 Q60 42 70 48" stroke-width="3" />
+  </g>
+`;
+
+const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
+  perky: svg`
+    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
+      <path d="M46 14 Q38 4 31 7" />
+      <path d="M74 14 Q82 4 89 7" />
+    </g>
+  `,
+  droopy: svg`
+    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
+      <path d="M46 14 Q36 8 34 18" />
+      <path d="M74 14 Q84 8 86 18" />
+    </g>
+  `,
+};
+
+// Not a lobster. Wide shell, eye stalks, walks sideways across the ledge,
+// and the Lobsterdex refuses to acknowledge it.
+export function renderCrabSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <g stroke="#a63a2e" stroke-width="4" stroke-linecap="round" fill="none">
+        <path d="M22 78 L8 88" />
+        <path d="M28 88 L16 99" />
+        <path d="M98 78 L112 88" />
+        <path d="M92 88 L104 99" />
+      </g>
+      <g stroke="#c44536" stroke-width="3.5" stroke-linecap="round" fill="none">
+        <path d="M44 38 L40 24" />
+        <path d="M76 38 L80 24" />
+      </g>
+      <circle cx="40" cy="22" r="4.5" fill="#0a1014" />
+      <circle cx="80" cy="22" r="4.5" fill="#0a1014" />
+      <circle cx="41.5" cy="20.5" r="1.8" fill="#ffd166" />
+      <circle cx="81.5" cy="20.5" r="1.8" fill="#ffd166" />
+      <ellipse cx="60" cy="70" rx="46" ry="30" fill="#c44536" />
+      <ellipse cx="48" cy="60" rx="16" ry="9" fill="#ffffff" opacity="0.1" />
+      <path
+        d="M16 58 C2 52 -2 62 4 72 C10 82 20 76 24 66 C26 60 22 58 16 58 Z"
+        fill="#d95f4b"
+      />
+      <path
+        d="M104 58 C118 52 122 62 116 72 C110 82 100 76 96 66 C94 60 98 58 104 58 Z"
+        fill="#d95f4b"
+      />
+      <path d="M48 82 Q60 90 72 82" stroke="#7e2a20" stroke-width="3" stroke-linecap="round" fill="none" />
+    </svg>
+  `;
+}
+
+// Same species as icons.lobster / the dreams-scene sleeper: smooth dome body
+// with stubby legs, side claws, antennae, and teal-glint eyes.
+export function renderLobsterSvg(
+  look: LobsterPetLook,
+  options: {
+    grumpy?: boolean;
+    shell?: boolean;
+    sleeping?: boolean;
+    standalone?: boolean;
+    bindle?: boolean;
+    sailorCap?: boolean;
+  } = {},
+) {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      ${look.palette.id === "retro" ? RETRO_ANTENNAE : ANTENNAE_SPRITES[look.antennae]}
+      ${look.tailFan ? TAIL_FAN : nothing}
+      <g class="lob-claw lob-claw--l">
+        <path
+          d="M20 42 C5 37 0 47 5 57 C10 67 20 62 25 52 C28 45 25 42 20 42 Z"
+          fill="var(--lob-claw)"
+        />
+      </g>
+      ${
+        look.palette.id === "retro"
+          ? nothing
+          : svg`
+            <g class="lob-claw lob-claw--r">
+              <path
+                d="M100 42 C115 37 120 47 115 57 C110 67 100 62 95 52 C92 45 95 42 100 42 Z"
+                fill="var(--lob-claw)"
+              />
+            </g>
+          `
+      }
+      <path
+        d="M60 8 C32 8 16 32 16 52 C16 72 30 90 44 95 L44 104 L54 104 L54 96 C58 97.5 62 97.5 66 96 L66 104 L76 104 L76 95 C90 90 104 72 104 52 C104 32 88 8 60 8 Z"
+        fill="var(--lob-shell)"
+      />
+      ${look.palette.id === "split" ? SPLIT_HALF : nothing}
+      ${look.palette.id === "calico" ? CALICO_SPOTS : nothing}
+      <ellipse cx="48" cy="28" rx="20" ry="11" fill="#ffffff" opacity="0.1" />
+      <g class="lob-eye-open" style=${options.shell || options.sleeping ? "display:none" : ""}>
+        <circle cx="45" cy="32" r="5.5" fill="#0a1014" />
+        <circle cx="75" cy="32" r="5.5" fill="#0a1014" />
+        <circle cx="46.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
+        <circle cx="76.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
+      </g>
+      ${
+        options.sleeping
+          ? svg`
+            <g class="lob-eye-peek">
+              <circle cx="45" cy="32" r="4" fill="#0a1014" />
+              <circle cx="46" cy="30.8" r="1.6" fill="var(--lob-glint, #00e5cc)" />
+            </g>
+          `
+          : nothing
+      }
+      <g
+        class="lob-eye-closed"
+        stroke="#0a1014"
+        stroke-width="3"
+        stroke-linecap="round"
+        fill="none"
+        style=${
+          options.shell || options.sleeping ? "opacity:1" : options.standalone ? "display:none" : ""
+        }
+      >
+        <path d="M39 33 Q45 28 51 33" />
+        <path d="M69 33 Q75 28 81 33" />
+      </g>
+      ${
+        look.palette.id === "retro"
+          ? svg`
+            ${RETRO_FACE}
+            <g class="lob-claw lob-claw--r">${RETRO_MEGA_CLAW}</g>
+          `
+          : nothing
+      }
+      ${options.grumpy && look.palette.id !== "retro" ? GRUMPY_FACE : nothing}
+      ${look.accessory === "none" || options.shell ? nothing : ACCESSORY_SPRITES[look.accessory]}
+      ${
+        // The retro grail's mega claw owns the same shoulder; it moves light.
+        options.bindle && look.palette.id !== "retro" ? BINDLE : nothing
+      }
+      ${options.sailorCap && !options.shell && !HEADWEAR.has(look.accessory) ? SAILOR_CAP : nothing}
+    </svg>
+  `;
+}
+
+
+export const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
+
+export function lobsterPetSpriteStyle(
+  look: LobsterPetLook,
+  scale: number,
+  spotPct: number,
+  facing: 1 | -1,
+) {
+  // Glint color stays class-driven (see lobster-pet.css): an inline
+  // --lob-glint would out-cascade the offline grey override.
+  return [
+    `--lob-shell:${look.palette.shell}`,
+    `--lob-claw:${look.palette.claw}`,
+    `--lob-scale:${scale}`,
+    `--lob-x:${spotPct}%`,
+    `--lob-face:${facing}`,
+    `--lob-blink-delay:${look.blinkDelayS}s`,
+    `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
+    `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
+    `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
+  ].join(";");
+}
+
+export function renderLobsterPetScene(args: {
+  look: LobsterPetLook;
+  mode: LobsterPetMode;
+  presence: "out" | "in" | "leaving";
+  logoPerched: boolean;
+  shellVisible: boolean;
+  visitsEnabled: boolean;
+  dismissed: boolean;
+  passer: { kind: "stranger" | "crab"; direction: 1 | -1 } | null;
+  twinPlanned: boolean;
+  anniversary: boolean;
+  entering: boolean;
+  grumpy: boolean;
+  vigil: boolean;
+  act: string | null;
+  zone: readonly [number, number];
+  spotPct: number;
+  facing: 1 | -1;
+  anchor: "ledge" | "bar";
+  barMaxScale: number;
+  shellScale: number;
+  shellSpotPct: number;
+  familiarityVisits: number;
+  seed: number;
+  movingDay: boolean;
+  sailorDay: boolean;
+  onPointerDown: () => void;
+  onPointerUp: () => void;
+  onPointerCancel: () => void;
+  onContextMenu: (event: Event) => void;
+}) {
+  const anchoredScale = (scale: number) =>
+    args.anchor === "bar" ? Math.min(scale, args.barMaxScale) : scale;
+  const renderSprite = (twin: boolean) => {
+    // On the month/day anniversary of this palette's first Lobsterdex visit,
+    // the party hat overrides whatever accessory the seed rolled.
+    const dressed =
+      args.anniversary && args.look.accessory !== "party"
+        ? { ...args.look, accessory: "party" as const }
+        : args.look;
+    const classes = [
+      "lobster-pet",
+      `lobster-pet--${args.mode}`,
+      `lobster-pet--palette-${args.look.palette.id}`,
+      twin ? "lobster-pet--twin" : "",
+      dressed.accessory === "party" ? "lobster-pet--party" : "",
+      args.presence === "leaving" ? "lobster-pet--away" : "",
+      args.entering ? "lobster-pet--entering" : "",
+      args.grumpy ? "lobster-pet--grumpy" : "",
+      args.vigil ? "lobster-pet--vigil" : "",
+      args.act ? `lobster-pet--act-${args.act}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    // The twin tags along on the parent's trailing side and copies every act
+    // a beat later (--lob-act-delay feeds each act's animation-delay).
+    const spotPct = twin
+      ? Math.min(
+          args.zone[1],
+          Math.max(args.zone[0], args.spotPct + (args.facing === 1 ? -12 : 12)),
+        )
+      : args.spotPct;
+    const scale = anchoredScale(twin ? args.look.scale * 0.55 : args.look.scale);
+    const style = twin
+      ? `${lobsterPetSpriteStyle(args.look, scale, spotPct, args.facing === 1 ? -1 : 1)};--lob-act-delay:0.18s`
+      : lobsterPetSpriteStyle(args.look, scale, spotPct, args.facing);
+    // Milestone honorifics come from the load-start familiarity snapshot, so
+    // a title never pops mid-visit; it is simply there next time.
+    const honorific = lobsterHonorific(args.familiarityVisits);
+    const baseName = lobsterPetName(args.look, args.seed);
+    const name = honorific ? `${honorific} ${baseName}` : baseName;
+    // The twin travels light; only the resident pet hauls the moving bindle.
+    const bindle = args.movingDay && !twin;
+    const title = twin ? `${name} Jr.` : bindle ? `${name} · just moved in` : name;
+    return html`
+      <div
+        class=${classes}
+        style=${style}
+        aria-hidden="true"
+        title=${title}
+        @pointerdown=${args.onPointerDown}
+        @pointerup=${args.onPointerUp}
+        @pointercancel=${args.onPointerCancel}
+        @pointerleave=${args.onPointerCancel}
+        @contextmenu=${args.onContextMenu}
+      >
+        <div class="lobster-pet__body">
+          ${renderLobsterSvg(dressed, {
+            grumpy: args.grumpy,
+            bindle,
+            sailorCap: args.sailorDay,
+          })}
+          <span class="lobster-pet__z" style="--i:0">z</span>
+          <span class="lobster-pet__z" style="--i:1">z</span>
+          <span class="lobster-pet__z" style="--i:2">Z</span>
+          <span class="lobster-pet__bubble" style="--i:0"></span>
+          <span class="lobster-pet__bubble" style="--i:1"></span>
+          <span class="lobster-pet__bubble" style="--i:2"></span>
+          <span class="lobster-pet__heart">♥</span>
+          <svg class="lobster-pet__broom" viewBox="0 0 24 40" aria-hidden="true">
+            <path d="M12 2 L12 24" stroke="#8a5a2b" stroke-width="3" stroke-linecap="round" />
+            <path d="M6 24 L18 24 L21 38 L3 38 Z" fill="#e8b04b" />
+            <path
+              d="M7.5 28 L6.5 36 M12 28 L12 36 M16.5 28 L17.5 36"
+              stroke="#b6791f"
+              stroke-width="1.5"
+            />
+          </svg>
+        </div>
+      </div>
+    `;
+  };
+  // While the pet is upstairs playing logo, the ledge stays empty - one
+  // crab, two homes, never both at once.
+  const showSprites = args.presence !== "out" && !args.logoPerched;
+  // The shell may outlive the visit while it fades, but dismissal and the
+  // visits setting silence it like everything else.
+  const showShell = args.shellVisible && args.visitsEnabled && !args.dismissed;
+  const showPasser = args.passer !== null && args.visitsEnabled;
+  if (!showSprites && !showShell && !showPasser) {
+    return nothing;
+  }
+  // The abandoned shell: the pre-molt silhouette, frozen and slowly fading.
+  const shellStyle = lobsterPetSpriteStyle(
+    args.look,
+    anchoredScale(args.shellScale),
+    args.shellSpotPct,
+    args.facing,
+  );
+  // A pass-through visitor: crosses the ledge once and is gone. Strangers
+  // are other lobsters (never your palette); the crab is, allegedly, also a
+  // lobster. Neither perches, neither counts for the Lobsterdex.
+  const passerLook =
+    args.passer?.kind === "stranger"
+      ? strangerLookFor(args.seed, args.look.palette.id)
+      : args.look;
+  const passerClasses = args.passer
+    ? [
+        "lobster-pet",
+        "lobster-pet--passer",
+        args.passer.kind === "crab"
+          ? "lobster-pet--crab"
+          : `lobster-pet--palette-${passerLook.palette.id}`,
+        args.passer.direction === 1 ? "lobster-pet--passer-ltr" : "lobster-pet--passer-rtl",
+      ].join(" ")
+    : "";
+  const passerStyle =
+    args.passer?.kind === "crab"
+      ? `--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1`
+      : args.passer
+        ? lobsterPetSpriteStyle(
+            passerLook,
+            Math.min(passerLook.scale, 2),
+            0,
+            args.passer.direction,
+          )
+        : "";
+  return html`
+    ${showShell
+      ? html`
+          <div class="lobster-pet lobster-pet--shell" style=${shellStyle} aria-hidden="true">
+            <div class="lobster-pet__body">${renderLobsterSvg(args.look, { shell: true })}</div>
+          </div>
+        `
+      : nothing}
+    ${showSprites ? renderSprite(false) : nothing}
+    ${showSprites && args.twinPlanned ? renderSprite(true) : nothing}
+    ${showPasser && args.passer
+      ? html`
+          <div
+            class=${passerClasses}
+            style=${passerStyle}
+            aria-hidden="true"
+            title=${args.passer.kind === "crab" ? "definitely a lobster" : "a stranger"}
+          >
+            <div class="lobster-pet__body">
+              ${args.passer.kind === "crab"
+                ? renderCrabSvg()
+                : renderLobsterSvg(passerLook, { standalone: true })}
+            </div>
+          </div>
+        `
+      : nothing}
+  `;
+}

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -128,7 +128,6 @@ export const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
   mighty: 1.18,
 };
 
-
 // Seeded pet names; rare palettes carry signature names. Shown via the
 // sprite's native title tooltip, so no i18n surface.
 const PET_NAMES = [
@@ -175,7 +174,6 @@ export function lobsterPetName(look: LobsterPetLook, seed: number): string {
   );
 }
 
-
 // A stranger wears a different palette than the resident pet.
 export function strangerLookFor(seed: number, own: LobsterPetPaletteId): LobsterPetLook {
   for (let offset = 1; offset <= 24; offset++) {
@@ -186,7 +184,6 @@ export function strangerLookFor(seed: number, own: LobsterPetPaletteId): Lobster
   }
   return createLobsterPetLook((seed + 1) >>> 0);
 }
-
 
 export function mulberry32(seed: number): () => number {
   let a = seed >>> 0;
@@ -264,7 +261,6 @@ export function createLobsterPetLook(seed: number, now: Date = new Date()): Lobs
     tailFan,
   };
 }
-
 
 const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateResult> = {
   crown: svg`
@@ -561,7 +557,6 @@ export function renderLobsterSvg(
   `;
 }
 
-
 export const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
 
 export function lobsterPetSpriteStyle(
@@ -718,9 +713,7 @@ export function renderLobsterPetScene(args: {
   // are other lobsters (never your palette); the crab is, allegedly, also a
   // lobster. Neither perches, neither counts for the Lobsterdex.
   const passerLook =
-    args.passer?.kind === "stranger"
-      ? strangerLookFor(args.seed, args.look.palette.id)
-      : args.look;
+    args.passer?.kind === "stranger" ? strangerLookFor(args.seed, args.look.palette.id) : args.look;
   const passerClasses = args.passer
     ? [
         "lobster-pet",
@@ -735,12 +728,7 @@ export function renderLobsterPetScene(args: {
     args.passer?.kind === "crab"
       ? `--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1`
       : args.passer
-        ? lobsterPetSpriteStyle(
-            passerLook,
-            Math.min(passerLook.scale, 2),
-            0,
-            args.passer.direction,
-          )
+        ? lobsterPetSpriteStyle(passerLook, Math.min(passerLook.scale, 2), 0, args.passer.direction)
         : "";
   return html`
     ${showShell

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -24,7 +24,7 @@ export type LobsterPetAct =
   | "droop"
   | "sweep";
 
-export type ActProfile = {
+type ActProfile = {
   // [min, max] delay before the next act.
   delayMs: [number, number];
   acts: Array<[LobsterPetAct, number]>;
@@ -49,7 +49,7 @@ export const LOBSTER_PET_ACT_DURATION_MS: Record<LobsterPetAct, number> = {
   sweep: 1800,
 };
 
-export const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
+const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
   sleepy: {
     delayMs: [6000, 12000],
     acts: [
@@ -95,7 +95,7 @@ export const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
 
 // Busy and offline override the personality: the pet is a status indicator
 // first. Busy scurries (no naps mid-run); offline paces and peeks.
-export const LOBSTER_PET_MODE_ACTS: Record<Exclude<LobsterPetMode, "idle">, ActProfile> = {
+const LOBSTER_PET_MODE_ACTS: Record<Exclude<LobsterPetMode, "idle">, ActProfile> = {
   busy: {
     delayMs: [2200, 4500],
     acts: [
@@ -225,7 +225,7 @@ export function detectLobsterMovingDay(version: string): boolean {
 }
 
 // Late-night visitors are always sleepy, whatever their daytime personality.
-export function isLobsterNightTime(now: Date = new Date()): boolean {
+function isLobsterNightTime(now: Date = new Date()): boolean {
   const hour = now.getHours();
   return hour >= 22 || hour < 6;
 }

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -1,5 +1,9 @@
 import { getSafeLocalStorage } from "../local-storage.ts";
-import type { LobsterPetMode, LobsterPetPersonalityId } from "./lobster-pet-contract.ts";
+import type {
+  LobsterPetMode,
+  LobsterPetPersonalityId,
+  LobsterRunOutcome,
+} from "./lobster-pet-contract.ts";
 import { mulberry32, SPOT_ZONES } from "./lobster-pet-look.ts";
 
 export { SPOT_ZONES };
@@ -111,6 +115,24 @@ export const LOBSTER_PET_MODE_ACTS: Record<Exclude<LobsterPetMode, "idle">, ActP
     ],
   },
 };
+
+export function resolveLobsterActProfile(
+  mode: LobsterPetMode,
+  personality: LobsterPetPersonalityId | null,
+  now: Date = new Date(),
+): ActProfile | null {
+  if (mode === "busy" || mode === "offline") {
+    return LOBSTER_PET_MODE_ACTS[mode];
+  }
+  if (isLobsterNightTime(now)) {
+    return PERSONALITIES.sleepy;
+  }
+  return personality ? PERSONALITIES[personality] : null;
+}
+
+export function resolveLobsterFinishAct(outcome: LobsterRunOutcome): LobsterPetAct {
+  return outcome === "error" ? "droop" : outcome === "aborted" ? "startle" : "cheer";
+}
 
 export const ENTER_MS = 450;
 export const LEAVE_MS = 350;

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -157,7 +157,7 @@ export function isLobsterLogoLoad(seed: number): boolean {
   return mulberry32((seed ^ 0x1063) >>> 0)() < 0.12;
 }
 
-export type LobsterPasserKind = "stranger" | "crab";
+type LobsterPasserKind = "stranger" | "crab";
 
 export type LobsterPasserPlan = {
   kind: LobsterPasserKind;

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -1,8 +1,5 @@
 import { getSafeLocalStorage } from "../local-storage.ts";
-import type {
-  LobsterPetMode,
-  LobsterPetPersonalityId,
-} from "./lobster-pet-contract.ts";
+import type { LobsterPetMode, LobsterPetPersonalityId } from "./lobster-pet-contract.ts";
 import { mulberry32, SPOT_ZONES } from "./lobster-pet-look.ts";
 
 export { SPOT_ZONES };

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -1,0 +1,220 @@
+import { getSafeLocalStorage } from "../local-storage.ts";
+import type {
+  LobsterPetMode,
+  LobsterPetPersonalityId,
+} from "./lobster-pet-contract.ts";
+import { mulberry32, SPOT_ZONES } from "./lobster-pet-look.ts";
+
+export { SPOT_ZONES };
+
+export type LobsterPetAct =
+  | "wave"
+  | "snip"
+  | "hop"
+  | "spin"
+  | "peek"
+  | "nap"
+  | "bubble"
+  | "scuttle"
+  | "startle"
+  | "cheer"
+  | "molt"
+  | "pet"
+  | "droop"
+  | "sweep";
+
+export type ActProfile = {
+  // [min, max] delay before the next act.
+  delayMs: [number, number];
+  acts: Array<[LobsterPetAct, number]>;
+};
+
+// Act windows mirror the CSS animation durations in lobster-pet.css so jsdom
+// tests and browsers clear acts on the same clock without animationend.
+export const LOBSTER_PET_ACT_DURATION_MS: Record<LobsterPetAct, number> = {
+  wave: 1400,
+  snip: 1000,
+  hop: 750,
+  spin: 950,
+  peek: 1700,
+  nap: 4400,
+  bubble: 2600,
+  scuttle: 1250,
+  startle: 750,
+  cheer: 1300,
+  molt: 2600,
+  pet: 1500,
+  droop: 1600,
+  sweep: 1800,
+};
+
+export const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
+  sleepy: {
+    delayMs: [6000, 12000],
+    acts: [
+      ["nap", 40],
+      ["bubble", 20],
+      ["wave", 12],
+      ["scuttle", 12],
+      ["peek", 10],
+      ["hop", 6],
+    ],
+  },
+  zoomy: {
+    delayMs: [2800, 6000],
+    acts: [
+      ["scuttle", 42],
+      ["hop", 22],
+      ["spin", 12],
+      ["peek", 12],
+      ["wave", 12],
+    ],
+  },
+  friendly: {
+    delayMs: [3600, 7500],
+    acts: [
+      ["wave", 32],
+      ["snip", 22],
+      ["scuttle", 18],
+      ["hop", 14],
+      ["bubble", 14],
+    ],
+  },
+  showoff: {
+    delayMs: [3600, 7500],
+    acts: [
+      ["spin", 24],
+      ["snip", 22],
+      ["peek", 20],
+      ["hop", 18],
+      ["wave", 16],
+    ],
+  },
+};
+
+// Busy and offline override the personality: the pet is a status indicator
+// first. Busy scurries (no naps mid-run); offline paces and peeks.
+export const LOBSTER_PET_MODE_ACTS: Record<Exclude<LobsterPetMode, "idle">, ActProfile> = {
+  busy: {
+    delayMs: [2200, 4500],
+    acts: [
+      ["scuttle", 40],
+      ["hop", 20],
+      ["snip", 20],
+      ["wave", 12],
+      ["spin", 8],
+    ],
+  },
+  offline: {
+    delayMs: [2800, 5600],
+    acts: [
+      ["scuttle", 55],
+      ["peek", 30],
+      ["hop", 15],
+    ],
+  },
+};
+
+export const ENTER_MS = 450;
+export const LEAVE_MS = 350;
+// One full ledge crossing for pass-through visitors.
+export const PASSER_CROSS_MS = 11_000;
+
+export type LobsterPetAnchor = "ledge" | "bar";
+
+// The historical bar visit keeps its compact left-to-center roaming and scale
+// cap, while CSS places it on the same ledge as regular visits.
+export const BAR_ZONE = [18, 50] as const;
+export const BAR_MAX_SCALE = 1.7;
+
+// Visit cadence: seeded per load, the pet is a guest, not a fixture. A share
+// of loads gets no visit at all; the rest get a first arrival within minutes,
+// stays of a few minutes, and long gaps between returns. Disconnects summon
+// the pet regardless of schedule (unless dismissed or disabled).
+export const VISIT_SHY_CHANCE = 0.25;
+export const VISIT_FIRST_DELAY_MS = [15_000, 180_000] as const;
+export const VISIT_STAY_MS = [90_000, 300_000] as const;
+export const VISIT_GAP_MS = [360_000, 1_080_000] as const;
+
+// Some ledge visits spook the logo: a beat after the crab settles in, the
+// brand mark ducks away, and it pops back once the visit ends. Rolled from a
+// dedicated seeded stream so tests can probe arrivals purely.
+export const LOGO_SCARE_CHANCE = 0.3;
+export const LOGO_SCARE_DELAY_MS = 900;
+
+// Rare-event loads, planned per seed so tests can probe them purely: a molt
+// load sheds its shell during the first idle act and sizes up one tier; a
+// twin load brings a mini copycat along on every visit.
+export function isLobsterMoltLoad(seed: number): boolean {
+  return mulberry32((seed ^ 0x301d) >>> 0)() < 0.12;
+}
+
+export function isLobsterTwinLoad(seed: number): boolean {
+  return mulberry32((seed ^ 0x7715) >>> 0)() < 0.04;
+}
+
+// On a logo load the pet's first scheduled visit skips the ledge entirely:
+// it climbs up top and fills in for the brand logo until the stay ends.
+// Offline summons still report to the ledge - status duty outranks cosplay.
+export function isLobsterLogoLoad(seed: number): boolean {
+  return mulberry32((seed ^ 0x1063) >>> 0)() < 0.12;
+}
+
+export type LobsterPasserKind = "stranger" | "crab";
+
+export type LobsterPasserPlan = {
+  kind: LobsterPasserKind;
+  atMs: number;
+  direction: 1 | -1;
+};
+
+// Once per load, someone else might just... walk through. Strangers are
+// other lobsters that never stop; the crab is not a lobster and refuses to
+// discuss it. Neither counts for the Lobsterdex.
+export function planLobsterPasser(seed: number): LobsterPasserPlan | null {
+  const rng = mulberry32((seed ^ 0xcab) >>> 0);
+  const roll = rng();
+  if (roll >= 0.095) {
+    return null;
+  }
+  const kind: LobsterPasserKind = roll < 0.015 ? "crab" : "stranger";
+  const atMs = Math.round(60_000 + rng() * 840_000);
+  const direction: 1 | -1 = rng() < 0.5 ? 1 : -1;
+  return { kind, atMs, direction };
+}
+
+// The pet notices gateway upgrades: the first page load on a new version, it
+// shows up carrying a bindle (moving day). The very first version sighting
+// only records a baseline - no bindle without a previous home.
+const MOVING_DAY_KEY = "openclaw.control.lobsterpet.gatewayVersion.v1";
+
+export function detectLobsterMovingDay(version: string): boolean {
+  try {
+    const storage = getSafeLocalStorage();
+    if (!storage) {
+      return false;
+    }
+    const previous = storage.getItem(MOVING_DAY_KEY);
+    if (previous === version) {
+      return false;
+    }
+    storage.setItem(MOVING_DAY_KEY, version);
+    return previous !== null;
+  } catch {
+    return false;
+  }
+}
+
+// Late-night visitors are always sleepy, whatever their daytime personality.
+export function isLobsterNightTime(now: Date = new Date()): boolean {
+  const hour = now.getHours();
+  return hour >= 22 || hour < 6;
+}
+
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}

--- a/ui/src/components/lobster-pet-standin.ts
+++ b/ui/src/components/lobster-pet-standin.ts
@@ -1,0 +1,48 @@
+import { html, LitElement, nothing } from "lit";
+import { property } from "lit/decorators.js";
+import type { LobsterLogoVisitDetail } from "./lobster-pet-contract.ts";
+import {
+  LOBSTER_PET_BUILD_MULS,
+  LOBSTER_PET_CLAW_MULS,
+  renderLobsterSvg,
+} from "./lobster-pet-look.ts";
+
+class LobsterLogoStandIn extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  @property({ attribute: false }) visit: LobsterLogoVisitDetail | null = null;
+
+  override render() {
+    const visit = this.visit;
+    if (!visit?.look) {
+      return nothing;
+    }
+    const look = visit.look;
+    const classes = [
+      "sidebar-brand__pet",
+      `lobster-pet--palette-${look.palette.id}`,
+      visit.phase === "leaving" ? "sidebar-brand__pet--leaving" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const style = [
+      `--lob-shell:${look.palette.shell}`,
+      `--lob-claw:${look.palette.claw}`,
+      `--lob-blink-delay:${look.blinkDelayS}s`,
+      `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
+      `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
+      `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
+    ].join(";");
+    return html`
+      <span class=${classes} style=${style} title=${`${visit.name} · filling in for the logo`}
+        >${renderLobsterSvg(look)}</span
+      >
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-lobster-logo-standin")) {
+  customElements.define("openclaw-lobster-logo-standin", LobsterLogoStandIn);
+}

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -9,12 +9,12 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { isLobsterDay } from "../../../src/shared/lobster-day.js";
-import { playLobsterPetChirp, type LobsterPetChirpKind } from "./lobster-pet-audio.ts";
 import * as dex from "./lobster-dex.ts";
-import * as lobsterLook from "./lobster-pet-look.ts";
-import * as plans from "./lobster-pet-plans.ts";
-import "./lobster-pet-standin.ts";
+import { playLobsterPetChirp, type LobsterPetChirpKind } from "./lobster-pet-audio.ts";
 import * as contract from "./lobster-pet-contract.ts";
+import * as lobsterLook from "./lobster-pet-look.ts";
+import "./lobster-pet-standin.ts";
+import * as plans from "./lobster-pet-plans.ts";
 
 export {
   LOBSTER_LOGO_VISIT_EVENT,
@@ -83,7 +83,12 @@ class LobsterPet extends LitElement {
   private passerTimer: number | null = null;
   private passerEndTimer: number | null = null;
   private passerWatchTimer: number | null = null;
-  private familiarity: dex.LobsterFamiliarity = { tier: "regular", wary: false, visits: 0, shoos: 0 };
+  private familiarity: dex.LobsterFamiliarity = {
+    tier: "regular",
+    wary: false,
+    visits: 0,
+    shoos: 0,
+  };
   private greetedThisLoad = false;
 
   private look: contract.LobsterPetLook | null = null;
@@ -467,7 +472,9 @@ class LobsterPet extends LitElement {
     // still returns on a later scheduled visit.
     this.clearVisitTimers();
     this.scheduledVisiting = false;
-    this.armArrival(lobsterLook.randomBetween(this.visitRng, plans.VISIT_GAP_MS[0], plans.VISIT_GAP_MS[1]));
+    this.armArrival(
+      lobsterLook.randomBetween(this.visitRng, plans.VISIT_GAP_MS[0], plans.VISIT_GAP_MS[1]),
+    );
   }
 
   // Long runs earn solidarity: after 10 minutes of busy the pet settles
@@ -551,8 +558,11 @@ class LobsterPet extends LitElement {
     }
     const tuning = dex.LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier];
     this.armArrival(
-      lobsterLook.randomBetween(this.visitRng, plans.VISIT_FIRST_DELAY_MS[0], plans.VISIT_FIRST_DELAY_MS[1]) *
-        tuning.firstDelayMul,
+      lobsterLook.randomBetween(
+        this.visitRng,
+        plans.VISIT_FIRST_DELAY_MS[0],
+        plans.VISIT_FIRST_DELAY_MS[1],
+      ) * tuning.firstDelayMul,
     );
   }
 
@@ -575,7 +585,9 @@ class LobsterPet extends LitElement {
       const tuning = dex.LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier];
       const waryMul = this.familiarity.wary ? dex.LOBSTER_FAMILIARITY_TUNING.waryGapMul : 1;
       this.armArrival(
-        lobsterLook.randomBetween(this.visitRng, plans.VISIT_GAP_MS[0], plans.VISIT_GAP_MS[1]) * tuning.gapMul * waryMul,
+        lobsterLook.randomBetween(this.visitRng, plans.VISIT_GAP_MS[0], plans.VISIT_GAP_MS[1]) *
+          tuning.gapMul *
+          waryMul,
       );
     }, stayMs);
   }
@@ -806,7 +818,6 @@ class LobsterPet extends LitElement {
       onContextMenu: this.handleShoo,
     });
   }
-
 }
 if (!customElements.get("openclaw-lobster-pet")) {
   customElements.define("openclaw-lobster-pet", LobsterPet);

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -224,12 +224,7 @@ class LobsterPet extends LitElement {
         // reschedules from the new mode's pool.
         // Success cheers, failure droops, a user abort is nothing to
         // celebrate or mourn - just acknowledge the change.
-        const finishAct =
-          this.runOutcome === "error"
-            ? "droop"
-            : this.runOutcome === "aborted"
-              ? "startle"
-              : "cheer";
+        const finishAct = plans.resolveLobsterFinishAct(this.runOutcome);
         this.performAct(finished ? finishAct : "startle", presenceOwner);
       }
     }
@@ -658,16 +653,6 @@ class LobsterPet extends LitElement {
     return plans.SPOT_ZONES[side];
   }
 
-  private actProfile(): plans.ActProfile | null {
-    if (this.mode === "busy" || this.mode === "offline") {
-      return plans.LOBSTER_PET_MODE_ACTS[this.mode];
-    }
-    if (plans.isLobsterNightTime()) {
-      return plans.PERSONALITIES.sleepy;
-    }
-    return this.look ? plans.PERSONALITIES[this.look.personality] : null;
-  }
-
   private scheduleNextAct() {
     // Guard here, not just at activation: the visibilitychange resume path
     // must also stay inert for reduced-motion users and departed pets.
@@ -683,14 +668,17 @@ class LobsterPet extends LitElement {
     ) {
       return;
     }
-    const profile = this.actProfile();
+    const profile = plans.resolveLobsterActProfile(this.mode, this.look.personality);
     if (!profile) {
       return;
     }
     const delay = lobsterLook.randomBetween(this.rng, profile.delayMs[0], profile.delayMs[1]);
     this.idleTimer = window.setTimeout(() => {
       this.idleTimer = null;
-      const nextProfile = this.actProfile();
+      const nextProfile = plans.resolveLobsterActProfile(
+        this.mode,
+        this.look?.personality ?? null,
+      );
       // A crossing pauses the fidget loop: the pet is busy watching. The
       // passer-end timer restarts scheduling.
       if (!nextProfile || document.hidden || this.presence !== "in" || this.passer !== null) {

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -6,36 +6,15 @@
 // every new session hatches a slightly different lobster.
 import "../styles/lobster-pet.css";
 import { expectDefined } from "@openclaw/normalization-core";
-import { html, LitElement, nothing, svg, type TemplateResult } from "lit";
+import { LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { isLobsterDay } from "../../../src/shared/lobster-day.js";
-import { getSafeLocalStorage } from "../local-storage.ts";
-import {
-  LOBSTER_FAMILIARITY_TUNING,
-  getLobsterFamiliarity,
-  getLobsterdexEntries,
-  isLobsterFirstVisitAnniversary,
-  lobsterHonorific,
-  recordLobsterArrivalStats,
-  recordLobsterShoo,
-  recordLobsterVisit,
-  type LobsterFamiliarity,
-} from "./lobster-dex.ts";
-import {
-  LOBSTER_LOGO_VISIT_EVENT,
-  type LobsterLogoVisitDetail,
-  type LobsterLogoVisitPhase,
-  type LobsterPetAccessory,
-  type LobsterPetAntennae,
-  type LobsterPetBuild,
-  type LobsterPetClawSize,
-  type LobsterPetLook,
-  type LobsterPetMode,
-  type LobsterPetPalette,
-  type LobsterPetPaletteId,
-  type LobsterPetPersonalityId,
-  type LobsterRunOutcome,
-} from "./lobster-pet-contract.ts";
+import { playLobsterPetChirp, type LobsterPetChirpKind } from "./lobster-pet-audio.ts";
+import * as dex from "./lobster-dex.ts";
+import * as lobsterLook from "./lobster-pet-look.ts";
+import * as plans from "./lobster-pet-plans.ts";
+import "./lobster-pet-standin.ts";
+import * as contract from "./lobster-pet-contract.ts";
 
 export {
   LOBSTER_LOGO_VISIT_EVENT,
@@ -48,801 +27,14 @@ export {
   type LobsterPetMode,
   type LobsterRunOutcome,
 } from "./lobster-pet-contract.ts";
-
-type LobsterPetAct =
-  | "wave"
-  | "snip"
-  | "hop"
-  | "spin"
-  | "peek"
-  | "nap"
-  | "bubble"
-  | "scuttle"
-  | "startle"
-  | "cheer"
-  | "molt"
-  | "pet"
-  | "droop"
-  | "sweep";
-
-type ActProfile = {
-  // [min, max] delay before the next act.
-  delayMs: [number, number];
-  acts: Array<[LobsterPetAct, number]>;
-};
-
-// Act windows mirror the CSS animation durations in lobster-pet.css so jsdom
-// tests and browsers clear acts on the same clock without animationend.
-const LOBSTER_PET_ACT_DURATION_MS: Record<LobsterPetAct, number> = {
-  wave: 1400,
-  snip: 1000,
-  hop: 750,
-  spin: 950,
-  peek: 1700,
-  nap: 4400,
-  bubble: 2600,
-  scuttle: 1250,
-  startle: 750,
-  cheer: 1300,
-  molt: 2600,
-  pet: 1500,
-  droop: 1600,
-  sweep: 1800,
-};
-
-const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
-  sleepy: {
-    delayMs: [6000, 12000],
-    acts: [
-      ["nap", 40],
-      ["bubble", 20],
-      ["wave", 12],
-      ["scuttle", 12],
-      ["peek", 10],
-      ["hop", 6],
-    ],
-  },
-  zoomy: {
-    delayMs: [2800, 6000],
-    acts: [
-      ["scuttle", 42],
-      ["hop", 22],
-      ["spin", 12],
-      ["peek", 12],
-      ["wave", 12],
-    ],
-  },
-  friendly: {
-    delayMs: [3600, 7500],
-    acts: [
-      ["wave", 32],
-      ["snip", 22],
-      ["scuttle", 18],
-      ["hop", 14],
-      ["bubble", 14],
-    ],
-  },
-  showoff: {
-    delayMs: [3600, 7500],
-    acts: [
-      ["spin", 24],
-      ["snip", 22],
-      ["peek", 20],
-      ["hop", 18],
-      ["wave", 16],
-    ],
-  },
-};
-
-// Busy and offline override the personality: the pet is a status indicator
-// first. Busy scurries (no naps mid-run); offline paces and peeks.
-const LOBSTER_PET_MODE_ACTS: Record<Exclude<LobsterPetMode, "idle">, ActProfile> = {
-  busy: {
-    delayMs: [2200, 4500],
-    acts: [
-      ["scuttle", 40],
-      ["hop", 20],
-      ["snip", 20],
-      ["wave", 12],
-      ["spin", 8],
-    ],
-  },
-  offline: {
-    delayMs: [2800, 5600],
-    acts: [
-      ["scuttle", 55],
-      ["peek", 30],
-      ["hop", 15],
-    ],
-  },
-};
-
-// Rarity ladder loosely mirrors real lobster genetics: blue ~1 in 2 million,
-// yellow ~1 in 30 million, calico ~1 in 30 million, split two-tone ~1 in
-// 50 million, albino/ghost ~1 in 100 million. Abyss is our deep-sea fantasy.
-// Split/calico extra geometry and ghost/abyss styling key off the palette id
-// (see lobster-pet.css and renderLobsterSvg).
-const PALETTES: Array<[LobsterPetPalette, number]> = [
-  [{ id: "crimson", shell: "#ff4f40", claw: "#ff775f" }, 26],
-  [{ id: "coral", shell: "#d0836a", claw: "#de9b80" }, 26],
-  [{ id: "teal", shell: "#2fbfa7", claw: "#5cd9c4" }, 10],
-  [{ id: "violet", shell: "#9f7dfa", claw: "#bba4fd" }, 10],
-  [{ id: "ink", shell: "#5e6b7a", claw: "#7b8996" }, 9],
-  [{ id: "blue", shell: "#4a7dfc", claw: "#7fa4ff" }, 7],
-  [{ id: "gold", shell: "#f4b840", claw: "#f9d47a" }, 5],
-  [{ id: "calico", shell: "#d97a3d", claw: "#e89a63" }, 3],
-  [{ id: "abyss", shell: "#2c3b68", claw: "#465b96" }, 2],
-  [{ id: "ghost", shell: "#dce8f2", claw: "#ecf3fa" }, 1],
-  [{ id: "split", shell: "#ff4f40", claw: "#ff775f" }, 1],
-  // The grail: homage to the classic OpenClaw logo (big raised claw, smirk,
-  // angry brows, white sticker outline). ~0.5% of sessions.
-  [{ id: "retro", shell: "#e8262c", claw: "#f04a3e" }, 0.5],
-];
-
-// Catalog order for collection UIs (Lobsterdex): common to grail.
-export const LOBSTER_PET_PALETTES: readonly LobsterPetPalette[] = PALETTES.map(
-  ([palette]) => palette,
-);
-
-// A neutral look used to render catalog minis outside the pet lifecycle.
-export function canonicalLobsterLook(palette: LobsterPetPalette): LobsterPetLook {
-  return {
-    palette,
-    scale: 2,
-    accessory: "none",
-    antennae: "perky",
-    side: "left",
-    spotPct: 0,
-    facing: 1,
-    personality: "friendly",
-    blinkDelayS: 0,
-    build: "round",
-    clawSize: "regular",
-    tailFan: false,
-  };
-}
-
-const ACCESSORIES: Array<[LobsterPetAccessory, number]> = [
-  ["none", 62],
-  ["sprout", 14],
-  ["patch", 14],
-  ["crown", 10],
-];
-
-// OpenClaw's repository was born 2025-11-24 (GitHub created_at); on the
-// anniversary every visitor dresses as the classic logo and parties.
-const ANNIVERSARY = { month: 10, day: 24 } as const;
-
-function isLobsterAnniversary(now: Date): boolean {
-  return now.getMonth() === ANNIVERSARY.month && now.getDate() === ANNIVERSARY.day;
-}
-
-// Seasonal wardrobe: extra accessory entries join the pool on the right
-// dates. One weighted roll either way, so the rest of the look sequence is
-// unchanged on any given seed.
-function seasonalAccessories(now: Date): Array<[LobsterPetAccessory, number]> {
-  const month = now.getMonth();
-  const day = now.getDate();
-  if (month === 11) {
-    return [["santa", 18]];
-  }
-  if (month === 9 && day >= 20) {
-    return [["pumpkin", 18]];
-  }
-  return [];
-}
-
-const PERSONALITY_IDS: Array<[LobsterPetPersonalityId, number]> = [
-  ["sleepy", 25],
-  ["zoomy", 25],
-  ["friendly", 25],
-  ["showoff", 25],
-];
-
-const SCALES: Array<[number, number]> = [
-  [1.7, 25],
-  [2, 55],
-  [2.5, 20],
-];
-
-const BUILDS: Array<[LobsterPetBuild, number]> = [
-  ["round", 40],
-  ["squat", 30],
-  ["slender", 30],
-];
-
-const CLAW_SIZES: Array<[LobsterPetClawSize, number]> = [
-  ["regular", 55],
-  ["dainty", 25],
-  ["mighty", 20],
-];
-
-// Builds reshape the whole sprite by stretching its aspect ratio (the svg
-// renders with preserveAspectRatio="none"), so eyes, claws, accessories, and
-// rare-variant geometry stay aligned for every silhouette.
-export const LOBSTER_PET_BUILD_MULS: Record<LobsterPetBuild, { w: number; h: number }> = {
-  round: { w: 1, h: 1 },
-  squat: { w: 1.14, h: 0.9 },
-  slender: { w: 0.88, h: 1.1 },
-};
-
-export const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
-  dainty: 0.85,
-  regular: 1,
-  mighty: 1.18,
-};
-
-// Keep the perch off the footer center so tooltips and the theme toggle
-// never sit under the sprite.
-const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
-const ENTER_MS = 450;
-const LEAVE_MS = 350;
-// One full ledge crossing for pass-through visitors.
-const PASSER_CROSS_MS = 11_000;
-
-type LobsterPetAnchor = "ledge" | "bar";
-
-// The historical bar visit keeps its compact left-to-center roaming and scale
-// cap, while CSS places it on the same ledge as regular visits.
-const BAR_ZONE = [18, 50] as const;
-const BAR_MAX_SCALE = 1.7;
-
-// Visit cadence: seeded per load, the pet is a guest, not a fixture. A share
-// of loads gets no visit at all; the rest get a first arrival within minutes,
-// stays of a few minutes, and long gaps between returns. Disconnects summon
-// the pet regardless of schedule (unless dismissed or disabled).
-const VISIT_SHY_CHANCE = 0.25;
-const VISIT_FIRST_DELAY_MS = [15_000, 180_000] as const;
-const VISIT_STAY_MS = [90_000, 300_000] as const;
-const VISIT_GAP_MS = [360_000, 1_080_000] as const;
-
-// Some ledge visits spook the logo: a beat after the crab settles in, the
-// brand mark ducks away, and it pops back once the visit ends. Rolled from a
-// dedicated seeded stream so tests can probe arrivals purely.
-const LOGO_SCARE_CHANCE = 0.3;
-const LOGO_SCARE_DELAY_MS = 900;
-
-// Seeded pet names; rare palettes carry signature names. Shown via the
-// sprite's native title tooltip, so no i18n surface.
-const PET_NAMES = [
-  "Pinchy",
-  "Barnaby",
-  "Thermidor",
-  "Clawdette",
-  "Sheldon",
-  "Scuttles",
-  "Bisque",
-  "Crusty",
-  "Snips",
-  "Bubbles",
-  "Clawdia",
-  "Ferdinand",
-  "Maple",
-  "Pearl",
-  "Biscuit",
-  "Captain",
-  "Ziggy",
-  "Noodle",
-  "Waffles",
-  "Pippin",
-  "Squirt",
-  "Chip",
-  "Clementine",
-  "Moss",
-] as const;
-
-const RARE_NAMES: Partial<Record<LobsterPetPaletteId, string>> = {
-  blue: "Blueberry",
-  gold: "Goldie",
-  calico: "Patches",
-  abyss: "Lantern",
-  ghost: "Boo",
-  split: "Picasso",
-  retro: "OG",
-};
-
-function lobsterPetName(look: LobsterPetLook, seed: number): string {
-  return (
-    RARE_NAMES[look.palette.id] ??
-    expectDefined(PET_NAMES[(seed >>> 3) % PET_NAMES.length], "lobster pet name catalog entry")
-  );
-}
-
-// Rare-event loads, planned per seed so tests can probe them purely: a molt
-// load sheds its shell during the first idle act and sizes up one tier; a
-// twin load brings a mini copycat along on every visit.
-function isLobsterMoltLoad(seed: number): boolean {
-  return mulberry32((seed ^ 0x301d) >>> 0)() < 0.12;
-}
-
-function isLobsterTwinLoad(seed: number): boolean {
-  return mulberry32((seed ^ 0x7715) >>> 0)() < 0.04;
-}
-
-// On a logo load the pet's first scheduled visit skips the ledge entirely:
-// it climbs up top and fills in for the brand logo until the stay ends.
-// Offline summons still report to the ledge - status duty outranks cosplay.
-function isLobsterLogoLoad(seed: number): boolean {
-  return mulberry32((seed ^ 0x1063) >>> 0)() < 0.12;
-}
-
-type LobsterPasserKind = "stranger" | "crab";
-
-type LobsterPasserPlan = {
-  kind: LobsterPasserKind;
-  atMs: number;
-  direction: 1 | -1;
-};
-
-// Once per load, someone else might just... walk through. Strangers are
-// other lobsters that never stop; the crab is not a lobster and refuses to
-// discuss it. Neither counts for the Lobsterdex.
-function planLobsterPasser(seed: number): LobsterPasserPlan | null {
-  const rng = mulberry32((seed ^ 0xcab) >>> 0);
-  const roll = rng();
-  if (roll >= 0.095) {
-    return null;
-  }
-  const kind: LobsterPasserKind = roll < 0.015 ? "crab" : "stranger";
-  const atMs = Math.round(60_000 + rng() * 840_000);
-  const direction: 1 | -1 = rng() < 0.5 ? 1 : -1;
-  return { kind, atMs, direction };
-}
-
-// A stranger wears a different palette than the resident pet.
-function strangerLookFor(seed: number, own: LobsterPetPaletteId): LobsterPetLook {
-  for (let offset = 1; offset <= 24; offset++) {
-    const look = createLobsterPetLook((seed + offset * 7919) >>> 0);
-    if (look.palette.id !== own) {
-      return look;
-    }
-  }
-  return createLobsterPetLook((seed + 1) >>> 0);
-}
-
-// The pet notices gateway upgrades: the first page load on a new version, it
-// shows up carrying a bindle (moving day). The very first version sighting
-// only records a baseline - no bindle without a previous home.
-const MOVING_DAY_KEY = "openclaw.control.lobsterpet.gatewayVersion.v1";
-
-function detectLobsterMovingDay(version: string): boolean {
-  try {
-    const storage = getSafeLocalStorage();
-    if (!storage) {
-      return false;
-    }
-    const previous = storage.getItem(MOVING_DAY_KEY);
-    if (previous === version) {
-      return false;
-    }
-    storage.setItem(MOVING_DAY_KEY, version);
-    return previous !== null;
-  } catch {
-    return false;
-  }
-}
-
-// Late-night visitors are always sleepy, whatever their daytime personality.
-function isLobsterNightTime(now: Date = new Date()): boolean {
-  const hour = now.getHours();
-  return hour >= 22 || hour < 6;
-}
-
-function mulberry32(seed: number): () => number {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function pickWeighted<T>(rng: () => number, entries: Array<[T, number]>): T {
-  const total = entries.reduce((sum, [, weight]) => sum + weight, 0);
-  let roll = rng() * total;
-  for (const [value, weight] of entries) {
-    roll -= weight;
-    if (roll <= 0) {
-      return value;
-    }
-  }
-  return expectDefined(entries.at(-1), "weighted lobster choice fallback")[0];
-}
-
-function randomBetween(rng: () => number, min: number, max: number): number {
-  return min + rng() * (max - min);
-}
-
-export function createLobsterPetLook(seed: number, now: Date = new Date()): LobsterPetLook {
-  const rng = mulberry32(seed);
-  const palette = pickWeighted(rng, PALETTES);
-  const scale = pickWeighted(rng, SCALES);
-  const accessory = pickWeighted(rng, [...ACCESSORIES, ...seasonalAccessories(now)]);
-  const antennae: LobsterPetAntennae = rng() < 0.6 ? "perky" : "droopy";
-  const side = rng() < 0.5 ? "left" : "right";
-  const zone = SPOT_ZONES[side];
-  const spotPct = Math.round(randomBetween(rng, zone[0], zone[1]));
-  const facing = rng() < 0.5 ? 1 : -1;
-  const personality = pickWeighted(rng, PERSONALITY_IDS);
-  const blinkDelayS = Math.round(randomBetween(rng, 0, 4) * 10) / 10;
-  // Shape traits roll after the original ones so pre-existing seeds keep
-  // their palette/personality and only gain a silhouette.
-  const build = pickWeighted(rng, BUILDS);
-  const clawSize = pickWeighted(rng, CLAW_SIZES);
-  const tailFan = rng() < 0.3;
-  if (isLobsterAnniversary(now)) {
-    // Birthday dress code: everyone is the classic logo, party hats on.
-    const retro = PALETTES.find(([entry]) => entry.id === "retro")?.[0];
-    return {
-      palette: retro ?? palette,
-      scale,
-      accessory: "party",
-      antennae,
-      side,
-      spotPct,
-      facing,
-      personality,
-      blinkDelayS,
-      build,
-      clawSize,
-      tailFan,
-    };
-  }
-  return {
-    palette,
-    scale,
-    accessory,
-    antennae,
-    side,
-    spotPct,
-    facing,
-    personality,
-    blinkDelayS,
-    build,
-    clawSize,
-    tailFan,
-  };
-}
-
-function prefersReducedMotion(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches
-  );
-}
-
-const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateResult> = {
-  crown: svg`
-    <path
-      d="M46 12 L46 2 L53 8 L60 0 L67 8 L74 2 L74 12 Q60 8 46 12 Z"
-      fill="#f6c945"
-    />
-  `,
-  sprout: svg`
-    <g>
-      <path d="M60 12 Q58 4 63 1" stroke="#3f9d63" stroke-width="3" stroke-linecap="round" fill="none" />
-      <ellipse cx="67" cy="3" rx="5" ry="3" fill="#57c785" transform="rotate(-24 67 3)" />
-    </g>
-  `,
-  patch: svg`
-    <g>
-      <path d="M28 27 Q60 14 92 22" stroke="#101820" stroke-width="4" stroke-linecap="round" fill="none" />
-      <circle cx="75" cy="32" r="9" fill="#101820" />
-    </g>
-  `,
-  santa: svg`
-    <g>
-      <path d="M47 10 Q54 1 68 3 L72 9 Z" fill="#e0312f" />
-      <circle cx="71" cy="3.5" r="3.5" fill="#f5f7fa" />
-      <ellipse cx="59" cy="10.5" rx="15" ry="3.5" fill="#f5f7fa" />
-    </g>
-  `,
-  pumpkin: svg`
-    <g>
-      <ellipse cx="60" cy="6.5" rx="8.5" ry="5.5" fill="#e8871e" />
-      <path d="M56 2.5 Q56 6.5 56 10.5 M64 2.5 Q64 6.5 64 10.5" stroke="#c96a10" stroke-width="1.5" fill="none" />
-      <path d="M60 1.5 Q60.5 0 63 0.5" stroke="#4c9a4c" stroke-width="2.5" stroke-linecap="round" fill="none" />
-    </g>
-  `,
-  party: svg`
-    <g>
-      <path d="M52 11 L60 0.5 L68 11 Z" fill="#7c5cff" />
-      <path d="M55.5 6.5 L64.5 6.5" stroke="#ffd166" stroke-width="2" />
-      <circle cx="60" cy="1" r="2.4" fill="#ff5c8a" />
-    </g>
-  `,
-};
-
-// Calico mottling: dark blotches scattered clear of the eye line.
-const CALICO_SPOTS = svg`
-  <g class="lob-spots" fill="#2a1f16" opacity="0.8">
-    <ellipse cx="40" cy="50" rx="6" ry="4" transform="rotate(-15 40 50)" />
-    <ellipse cx="72" cy="62" rx="7" ry="4.5" transform="rotate(18 72 62)" />
-    <ellipse cx="55" cy="76" rx="5" ry="3.5" transform="rotate(-8 55 76)" />
-    <ellipse cx="84" cy="42" rx="4" ry="3" transform="rotate(25 84 42)" />
-    <ellipse cx="47" cy="18" rx="4.5" ry="3" transform="rotate(-20 47 18)" />
-    <ellipse cx="30" cy="64" rx="4" ry="3" transform="rotate(12 30 64)" />
-  </g>
-`;
-
-// Split two-tone: the right half of the body (down to the belly midline)
-// repainted in the second shell color; the right claw and antenna follow via
-// CSS. Mirrors the famous bilateral half-and-half lobsters.
-const SPLIT_HALF = svg`
-  <path
-    class="lob-split-half"
-    d="M60 8 C88 8 104 32 104 52 C104 72 90 90 76 95 L76 104 L66 104 L66 96 C64 96.8 62 97.1 60 97.1 L60 8 Z"
-    fill="var(--lob-shell2, #46536b)"
-  />
-`;
-
-// Retro homage parts (classic OpenClaw logo): one oversized raised claw with
-// a pincer notch, tall V antennae, angry brows, and a smirk. The mega claw
-// lives inside the .lob-claw--r group so wave/snip acts swing it.
-const RETRO_MEGA_CLAW = svg`
-  <path
-    d="M95 55 C112 53 119 39 116 25 C113 11 99 5 91 12 C88 15 87 19 88 23 C83 27 83 36 88 43 C91 49 93 52 95 55 Z"
-    fill="var(--lob-claw)"
-  />
-  <path
-    d="M92 14 C97 22 99 31 95 41"
-    stroke="#b8151b"
-    stroke-width="3"
-    stroke-linecap="round"
-    fill="none"
-  />
-`;
-
-const RETRO_ANTENNAE = svg`
-  <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
-    <path d="M50 16 Q45 4 37 1" />
-    <path d="M70 16 Q75 4 83 1" />
-  </g>
-`;
-
-const RETRO_FACE = svg`
-  <g stroke="#0a1014" stroke-linecap="round" fill="none">
-    <path d="M37 24 L51 28" stroke-width="3.5" />
-    <path d="M69 28 L83 24" stroke-width="3.5" />
-    <path d="M49 45 Q59 51 69 45 L72 42" stroke-width="3" />
-  </g>
-`;
-
-// Tail-fan lobes peek out diagonally behind the lower body (drawn before the
-// body path so they read as "behind"). Fill color lives in lobster-pet.css.
-const TAIL_FAN = svg`
-  <g class="lob-tail">
-    <ellipse cx="16" cy="84" rx="11" ry="7" transform="rotate(-32 16 84)" />
-    <ellipse cx="104" cy="84" rx="11" ry="7" transform="rotate(32 104 84)" />
-  </g>
-`;
-
-// Moving-day bindle: a stick over the shoulder with a polka-dot bundle,
-// carried for the whole first load after a gateway upgrade.
-const BINDLE = svg`
-  <g class="lob-bindle">
-    <path d="M70 62 L99 30" stroke="#8a5a2b" stroke-width="3.5" stroke-linecap="round" />
-    <circle cx="101" cy="27" r="9.5" fill="#e8b04b" />
-    <circle cx="98" cy="24" r="1.6" fill="#b6791f" />
-    <circle cx="104" cy="29" r="1.6" fill="#b6791f" />
-    <circle cx="100" cy="32" r="1.3" fill="#b6791f" />
-  </g>
-`;
-
-// On lobster days (see src/shared/lobster-day.ts, shared with the CLI
-// banner cousin) the pet wears a little sailor cap - unless the seed already
-// rolled headwear, which keeps its place.
-const HEADWEAR: ReadonlySet<LobsterPetAccessory> = new Set([
-  "crown",
-  "sprout",
-  "santa",
-  "pumpkin",
-  "party",
-]);
-
-const SAILOR_CAP = svg`
-  <g class="lob-cap">
-    <path d="M46 10 Q60 -3 74 10 L74 13 Q60 7 46 13 Z" fill="#f5f7fa" />
-    <path d="M45 12 Q60 6 75 12 L75 16 Q60 10.5 45 16 Z" fill="#dfe7ee" />
-    <circle cx="60" cy="2.5" r="1.8" fill="#3b6ea5" />
-  </g>
-`;
-
-// Shown while grumpy (poked too much): angry brows and a frown.
-const GRUMPY_FACE = svg`
-  <g stroke="#0a1014" stroke-linecap="round" fill="none">
-    <path d="M37 24 L51 28" stroke-width="3.5" />
-    <path d="M69 28 L83 24" stroke-width="3.5" />
-    <path d="M50 48 Q60 42 70 48" stroke-width="3" />
-  </g>
-`;
-
-const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
-  perky: svg`
-    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
-      <path d="M46 14 Q38 4 31 7" />
-      <path d="M74 14 Q82 4 89 7" />
-    </g>
-  `,
-  droopy: svg`
-    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
-      <path d="M46 14 Q36 8 34 18" />
-      <path d="M74 14 Q84 8 86 18" />
-    </g>
-  `,
-};
-
-// Not a lobster. Wide shell, eye stalks, walks sideways across the ledge,
-// and the Lobsterdex refuses to acknowledge it.
-function renderCrabSvg() {
-  return svg`
-    <svg
-      class="lobster-pet__svg"
-      viewBox="0 0 120 105"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <g stroke="#a63a2e" stroke-width="4" stroke-linecap="round" fill="none">
-        <path d="M22 78 L8 88" />
-        <path d="M28 88 L16 99" />
-        <path d="M98 78 L112 88" />
-        <path d="M92 88 L104 99" />
-      </g>
-      <g stroke="#c44536" stroke-width="3.5" stroke-linecap="round" fill="none">
-        <path d="M44 38 L40 24" />
-        <path d="M76 38 L80 24" />
-      </g>
-      <circle cx="40" cy="22" r="4.5" fill="#0a1014" />
-      <circle cx="80" cy="22" r="4.5" fill="#0a1014" />
-      <circle cx="41.5" cy="20.5" r="1.8" fill="#ffd166" />
-      <circle cx="81.5" cy="20.5" r="1.8" fill="#ffd166" />
-      <ellipse cx="60" cy="70" rx="46" ry="30" fill="#c44536" />
-      <ellipse cx="48" cy="60" rx="16" ry="9" fill="#ffffff" opacity="0.1" />
-      <path
-        d="M16 58 C2 52 -2 62 4 72 C10 82 20 76 24 66 C26 60 22 58 16 58 Z"
-        fill="#d95f4b"
-      />
-      <path
-        d="M104 58 C118 52 122 62 116 72 C110 82 100 76 96 66 C94 60 98 58 104 58 Z"
-        fill="#d95f4b"
-      />
-      <path d="M48 82 Q60 90 72 82" stroke="#7e2a20" stroke-width="3" stroke-linecap="round" fill="none" />
-    </svg>
-  `;
-}
-
-// Same species as icons.lobster / the dreams-scene sleeper: smooth dome body
-// with stubby legs, side claws, antennae, and teal-glint eyes.
-export function renderLobsterSvg(
-  look: LobsterPetLook,
-  options: {
-    grumpy?: boolean;
-    shell?: boolean;
-    sleeping?: boolean;
-    standalone?: boolean;
-    bindle?: boolean;
-    sailorCap?: boolean;
-  } = {},
-) {
-  return svg`
-    <svg
-      class="lobster-pet__svg"
-      viewBox="0 0 120 105"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      ${look.palette.id === "retro" ? RETRO_ANTENNAE : ANTENNAE_SPRITES[look.antennae]}
-      ${look.tailFan ? TAIL_FAN : nothing}
-      <g class="lob-claw lob-claw--l">
-        <path
-          d="M20 42 C5 37 0 47 5 57 C10 67 20 62 25 52 C28 45 25 42 20 42 Z"
-          fill="var(--lob-claw)"
-        />
-      </g>
-      ${
-        look.palette.id === "retro"
-          ? nothing
-          : svg`
-            <g class="lob-claw lob-claw--r">
-              <path
-                d="M100 42 C115 37 120 47 115 57 C110 67 100 62 95 52 C92 45 95 42 100 42 Z"
-                fill="var(--lob-claw)"
-              />
-            </g>
-          `
-      }
-      <path
-        d="M60 8 C32 8 16 32 16 52 C16 72 30 90 44 95 L44 104 L54 104 L54 96 C58 97.5 62 97.5 66 96 L66 104 L76 104 L76 95 C90 90 104 72 104 52 C104 32 88 8 60 8 Z"
-        fill="var(--lob-shell)"
-      />
-      ${look.palette.id === "split" ? SPLIT_HALF : nothing}
-      ${look.palette.id === "calico" ? CALICO_SPOTS : nothing}
-      <ellipse cx="48" cy="28" rx="20" ry="11" fill="#ffffff" opacity="0.1" />
-      <g class="lob-eye-open" style=${options.shell || options.sleeping ? "display:none" : ""}>
-        <circle cx="45" cy="32" r="5.5" fill="#0a1014" />
-        <circle cx="75" cy="32" r="5.5" fill="#0a1014" />
-        <circle cx="46.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
-        <circle cx="76.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
-      </g>
-      ${
-        options.sleeping
-          ? svg`
-            <g class="lob-eye-peek">
-              <circle cx="45" cy="32" r="4" fill="#0a1014" />
-              <circle cx="46" cy="30.8" r="1.6" fill="var(--lob-glint, #00e5cc)" />
-            </g>
-          `
-          : nothing
-      }
-      <g
-        class="lob-eye-closed"
-        stroke="#0a1014"
-        stroke-width="3"
-        stroke-linecap="round"
-        fill="none"
-        style=${
-          options.shell || options.sleeping ? "opacity:1" : options.standalone ? "display:none" : ""
-        }
-      >
-        <path d="M39 33 Q45 28 51 33" />
-        <path d="M69 33 Q75 28 81 33" />
-      </g>
-      ${
-        look.palette.id === "retro"
-          ? svg`
-            ${RETRO_FACE}
-            <g class="lob-claw lob-claw--r">${RETRO_MEGA_CLAW}</g>
-          `
-          : nothing
-      }
-      ${options.grumpy && look.palette.id !== "retro" ? GRUMPY_FACE : nothing}
-      ${look.accessory === "none" || options.shell ? nothing : ACCESSORY_SPRITES[look.accessory]}
-      ${
-        // The retro grail's mega claw owns the same shoulder; it moves light.
-        options.bindle && look.palette.id !== "retro" ? BINDLE : nothing
-      }
-      ${options.sailorCap && !options.shell && !HEADWEAR.has(look.accessory) ? SAILOR_CAP : nothing}
-    </svg>
-  `;
-}
-
-class LobsterLogoStandIn extends LitElement {
-  override createRenderRoot() {
-    return this;
-  }
-
-  @property({ attribute: false }) visit: LobsterLogoVisitDetail | null = null;
-
-  override render() {
-    const visit = this.visit;
-    if (!visit?.look) {
-      return nothing;
-    }
-    const look = visit.look;
-    const classes = [
-      "sidebar-brand__pet",
-      `lobster-pet--palette-${look.palette.id}`,
-      visit.phase === "leaving" ? "sidebar-brand__pet--leaving" : "",
-    ]
-      .filter(Boolean)
-      .join(" ");
-    const style = [
-      `--lob-shell:${look.palette.shell}`,
-      `--lob-claw:${look.palette.claw}`,
-      `--lob-blink-delay:${look.blinkDelayS}s`,
-      `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
-      `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
-      `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
-    ].join(";");
-    return html`
-      <span class=${classes} style=${style} title=${`${visit.name} · filling in for the logo`}
-        >${renderLobsterSvg(look)}</span
-      >
-    `;
-  }
-}
+export {
+  LOBSTER_PET_BUILD_MULS,
+  LOBSTER_PET_CLAW_MULS,
+  LOBSTER_PET_PALETTES,
+  canonicalLobsterLook,
+  createLobsterPetLook,
+  renderLobsterSvg,
+} from "./lobster-pet-look.ts";
 
 class LobsterPet extends LitElement {
   override createRenderRoot() {
@@ -850,33 +42,33 @@ class LobsterPet extends LitElement {
   }
 
   @property({ attribute: false }) seed = 0;
-  @property({ attribute: false }) mode: LobsterPetMode = "idle";
+  @property({ attribute: false }) mode: contract.LobsterPetMode = "idle";
 
   @property({ attribute: false }) visitsEnabled = true;
-  @property({ attribute: false }) runOutcome: LobsterRunOutcome = "ok";
+  @property({ attribute: false }) runOutcome: contract.LobsterRunOutcome = "ok";
   @property({ attribute: false }) soundsEnabled = false;
   @property({ attribute: false }) gatewayVersion: string | null = null;
 
-  @state() private act: LobsterPetAct | null = null;
+  @state() private act: plans.LobsterPetAct | null = null;
   @state() private spotPct = 80;
   @state() private facing: 1 | -1 = 1;
   @state() private entering = false;
   @state() private presence: "out" | "in" | "leaving" = "out";
-  @state() private anchor: LobsterPetAnchor = "ledge";
+  @state() private anchor: plans.LobsterPetAnchor = "ledge";
   @state() private scheduledVisiting = false;
   @state() private logoPerched = false;
   @state() private logoScared = false;
   private logoScarePending = false;
   private logoScareTimer: number | null = null;
-  private scareRng: () => number = mulberry32(0);
+  private scareRng: () => number = lobsterLook.mulberry32(0);
   private logoPlanned = false;
   private logoDone = false;
-  private lastLogoPhase: LobsterLogoVisitPhase = "out";
+  private lastLogoPhase: contract.LobsterLogoVisitPhase = "out";
   @state() private dismissed = false;
   @state() private grumpy = false;
   @state() private vigil = false;
   @state() private outcomePresenceOwner: "vigil" | null = null;
-  @state() private passer: LobsterPasserPlan | null = null;
+  @state() private passer: plans.LobsterPasserPlan | null = null;
   @state() private movingDay = false;
   private movingDayChecked = false;
   @state() private anniversary = false;
@@ -891,12 +83,12 @@ class LobsterPet extends LitElement {
   private passerTimer: number | null = null;
   private passerEndTimer: number | null = null;
   private passerWatchTimer: number | null = null;
-  private familiarity: LobsterFamiliarity = { tier: "regular", wary: false, visits: 0, shoos: 0 };
+  private familiarity: dex.LobsterFamiliarity = { tier: "regular", wary: false, visits: 0, shoos: 0 };
   private greetedThisLoad = false;
 
-  private look: LobsterPetLook | null = null;
-  private rng: () => number = mulberry32(0);
-  private visitRng: () => number = mulberry32(0);
+  private look: contract.LobsterPetLook | null = null;
+  private rng: () => number = lobsterLook.mulberry32(0);
+  private visitRng: () => number = lobsterLook.mulberry32(0);
   private idleTimer: number | null = null;
   private actEndTimer: number | null = null;
   private enterTimer: number | null = null;
@@ -969,10 +161,10 @@ class LobsterPet extends LitElement {
   override willUpdate(changed: Map<PropertyKey, unknown>) {
     const seedChanged = this.look === null || changed.has("seed");
     if (seedChanged) {
-      this.look = createLobsterPetLook(this.seed);
-      this.rng = mulberry32(this.seed ^ 0x9e3779b9);
-      this.visitRng = mulberry32(this.seed ^ 0x5eaf00d);
-      this.scareRng = mulberry32((this.seed ^ 0x5ca2e) >>> 0);
+      this.look = lobsterLook.createLobsterPetLook(this.seed);
+      this.rng = lobsterLook.mulberry32(this.seed ^ 0x9e3779b9);
+      this.visitRng = lobsterLook.mulberry32(this.seed ^ 0x5eaf00d);
+      this.scareRng = lobsterLook.mulberry32((this.seed ^ 0x5ca2e) >>> 0);
       this.spotPct = this.look.spotPct;
       this.facing = this.look.facing;
       // Reset the act loop inside the update pass; deferring state flips to
@@ -988,9 +180,9 @@ class LobsterPet extends LitElement {
         window.clearTimeout(this.shellTimer);
         this.shellTimer = null;
       }
-      this.moltPlanned = isLobsterMoltLoad(this.seed);
-      this.twinPlanned = isLobsterTwinLoad(this.seed);
-      this.logoPlanned = isLobsterLogoLoad(this.seed);
+      this.moltPlanned = plans.isLobsterMoltLoad(this.seed);
+      this.twinPlanned = plans.isLobsterTwinLoad(this.seed);
+      this.logoPlanned = plans.isLobsterLogoLoad(this.seed);
       this.logoDone = false;
       this.logoPerched = false;
       this.logoScared = false;
@@ -999,7 +191,7 @@ class LobsterPet extends LitElement {
         window.clearTimeout(this.logoScareTimer);
         this.logoScareTimer = null;
       }
-      this.familiarity = getLobsterFamiliarity();
+      this.familiarity = dex.getLobsterFamiliarity();
       this.sailorDay = isLobsterDay(new Date());
       this.greetedThisLoad = false;
       this.scheduleVisits();
@@ -1016,11 +208,11 @@ class LobsterPet extends LitElement {
       if (this.logoPerched && this.mode !== "idle") {
         this.logoPerched = false;
       }
-      const previousMode = changed.get("mode") as LobsterPetMode | undefined;
+      const previousMode = changed.get("mode") as contract.LobsterPetMode | undefined;
       const finished = previousMode === "busy" && this.mode === "idle";
       const presenceOwner = finished && this.vigil ? "vigil" : null;
       this.trackVigil();
-      if (this.presence === "in" && !prefersReducedMotion()) {
+      if (this.presence === "in" && !plans.prefersReducedMotion()) {
         // Status flips get an immediate reaction. A finished run (busy ->
         // idle) earns a cheer when it succeeded and a sympathetic droop when
         // it failed; everything else startles. The act-end timer then
@@ -1040,7 +232,7 @@ class LobsterPet extends LitElement {
     // known (the hello can land after the first render).
     if (!this.movingDayChecked && this.gatewayVersion) {
       this.movingDayChecked = true;
-      this.movingDay = detectLobsterMovingDay(this.gatewayVersion);
+      this.movingDay = plans.detectLobsterMovingDay(this.gatewayVersion);
     }
     this.reconcilePresence();
   }
@@ -1067,30 +259,30 @@ class LobsterPet extends LitElement {
         // One scare roll per arrival keeps the stream aligned across visit
         // kinds; only an idle ledge visit may spook the logo (a perch owns
         // the slot outright, offline summons are on status duty).
-        const scareRolled = this.scareRng() < LOGO_SCARE_CHANCE;
+        const scareRolled = this.scareRng() < plans.LOGO_SCARE_CHANCE;
         this.logoScarePending =
           scareRolled &&
           !this.logoPerched &&
           this.scheduledVisiting &&
           this.mode === "idle" &&
-          !prefersReducedMotion();
+          !plans.prefersReducedMotion();
         if (this.look) {
           // Anniversary check reads the dex before this arrival records into
           // it: a first-ever visit today must not celebrate itself.
-          this.anniversary = isLobsterFirstVisitAnniversary(
-            getLobsterdexEntries().get(this.look.palette.id)?.firstSeenAt ?? null,
+          this.anniversary = dex.isLobsterFirstVisitAnniversary(
+            dex.getLobsterdexEntries().get(this.look.palette.id)?.firstSeenAt ?? null,
             new Date(),
           );
           // Every genuine arrival (visit or offline summon) logs the palette
           // with the first visitor's name, and bumps the familiarity count.
-          recordLobsterVisit(this.look.palette.id, {
-            name: lobsterPetName(this.look, this.seed),
+          dex.recordLobsterVisit(this.look.palette.id, {
+            name: lobsterLook.lobsterPetName(this.look, this.seed),
           });
-          recordLobsterArrivalStats();
+          dex.recordLobsterArrivalStats();
         }
       }
       this.presence = "in";
-      this.entering = !prefersReducedMotion();
+      this.entering = !plans.prefersReducedMotion();
       this.restartPending = true;
       return;
     }
@@ -1112,7 +304,7 @@ class LobsterPet extends LitElement {
         // The "out" edge is the single restore point: the logo fades back
         // in the same update that ends the visit, scare or perch alike.
         this.logoScared = false;
-      }, LEAVE_MS);
+      }, plans.LEAVE_MS);
     }
   }
 
@@ -1132,12 +324,12 @@ class LobsterPet extends LitElement {
         this.familiarity.tier === "friend" &&
         this.presence === "in" &&
         !this.logoPerched &&
-        !prefersReducedMotion()
+        !plans.prefersReducedMotion()
       ) {
         this.greetedThisLoad = true;
         this.performAct("wave");
       }
-    }, ENTER_MS);
+    }, plans.ENTER_MS);
     if (this.logoScarePending) {
       this.logoScarePending = false;
       // The beat between arrival and the duck is what sells "the crab scared
@@ -1147,12 +339,12 @@ class LobsterPet extends LitElement {
         if (this.presence === "in" && !this.logoPerched) {
           this.logoScared = true;
         }
-      }, LOGO_SCARE_DELAY_MS);
+      }, plans.LOGO_SCARE_DELAY_MS);
     }
     this.scheduleNextAct();
   }
 
-  private logoVisitPhase(): LobsterLogoVisitPhase {
+  private logoVisitPhase(): contract.LobsterLogoVisitPhase {
     const occupied = this.logoPerched || this.logoScared;
     if (!occupied || !this.visitsEnabled || this.dismissed) {
       return "out";
@@ -1177,11 +369,11 @@ class LobsterPet extends LitElement {
         ? { ...look, accessory: "party" as const }
         : look;
     this.dispatchEvent(
-      new CustomEvent<LobsterLogoVisitDetail>(LOBSTER_LOGO_VISIT_EVENT, {
+      new CustomEvent<contract.LobsterLogoVisitDetail>(contract.LOBSTER_LOGO_VISIT_EVENT, {
         detail: {
           phase,
           look: dressed,
-          name: dressed ? lobsterPetName(dressed, this.seed) : null,
+          name: dressed ? lobsterLook.lobsterPetName(dressed, this.seed) : null,
         },
         bubbles: true,
         composed: true,
@@ -1204,7 +396,7 @@ class LobsterPet extends LitElement {
   // it grumpy for a minute, 10 send it off in a huff until a later visit.
   // Offline pets are on duty and never huff.
   private readonly handleHoldStart = () => {
-    if (prefersReducedMotion()) {
+    if (plans.prefersReducedMotion()) {
       return;
     }
     this.holdPetted = false;
@@ -1239,44 +431,8 @@ class LobsterPet extends LitElement {
     this.holdPetted = false;
   };
 
-  // Opt-in (default off) tiny synth chirps: a descending blub for pokes, a
-  // rising coo for pets. Only ever called from pointer gestures, so the
-  // AudioContext is created inside a user activation and never blocked by
-  // autoplay policy. Sound is decoration - any audio failure is swallowed.
-  private playChirp(kind: "poke" | "pet") {
-    if (!this.soundsEnabled) {
-      return;
-    }
-    try {
-      const Ctor = window.AudioContext;
-      if (!Ctor) {
-        return;
-      }
-      this.audioCtx ??= new Ctor();
-      const ctx = this.audioCtx;
-      if (ctx.state === "suspended") {
-        void ctx.resume();
-      }
-      const at = ctx.currentTime;
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.type = "sine";
-      if (kind === "poke") {
-        osc.frequency.setValueAtTime(330, at);
-        osc.frequency.exponentialRampToValueAtTime(165, at + 0.09);
-      } else {
-        osc.frequency.setValueAtTime(392, at);
-        osc.frequency.exponentialRampToValueAtTime(523, at + 0.18);
-      }
-      gain.gain.setValueAtTime(0.0001, at);
-      gain.gain.exponentialRampToValueAtTime(0.05, at + 0.02);
-      gain.gain.exponentialRampToValueAtTime(0.0001, at + (kind === "poke" ? 0.12 : 0.24));
-      osc.connect(gain).connect(ctx.destination);
-      osc.start(at);
-      osc.stop(at + 0.26);
-    } catch {
-      // never let audio break the pet
-    }
+  private playChirp(kind: LobsterPetChirpKind) {
+    this.audioCtx = playLobsterPetChirp(this.audioCtx, this.soundsEnabled, kind);
   }
 
   private pokeNow() {
@@ -1311,7 +467,7 @@ class LobsterPet extends LitElement {
     // still returns on a later scheduled visit.
     this.clearVisitTimers();
     this.scheduledVisiting = false;
-    this.armArrival(randomBetween(this.visitRng, VISIT_GAP_MS[0], VISIT_GAP_MS[1]));
+    this.armArrival(lobsterLook.randomBetween(this.visitRng, plans.VISIT_GAP_MS[0], plans.VISIT_GAP_MS[1]));
   }
 
   // Long runs earn solidarity: after 10 minutes of busy the pet settles
@@ -1336,7 +492,7 @@ class LobsterPet extends LitElement {
   // The pet watches your pointer: facing follows it between acts. Throttled,
   // idle-only, and inert under reduced motion or while acting.
   private readonly handleGaze = (event: PointerEvent) => {
-    if (this.presence !== "in" || this.act !== null || this.vigil || prefersReducedMotion()) {
+    if (this.presence !== "in" || this.act !== null || this.vigil || plans.prefersReducedMotion()) {
       return;
     }
     const now = Date.now();
@@ -1360,7 +516,7 @@ class LobsterPet extends LitElement {
   private readonly handleShoo = (event: Event) => {
     event.preventDefault();
     this.dismissed = true;
-    recordLobsterShoo();
+    dex.recordLobsterShoo();
   };
 
   private clearActTimers() {
@@ -1390,12 +546,12 @@ class LobsterPet extends LitElement {
     this.clearVisitTimers();
     this.scheduledVisiting = false;
     // A shy share of loads never visits on their own; offline still summons.
-    if (this.visitRng() < VISIT_SHY_CHANCE) {
+    if (this.visitRng() < plans.VISIT_SHY_CHANCE) {
       return;
     }
-    const tuning = LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier];
+    const tuning = dex.LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier];
     this.armArrival(
-      randomBetween(this.visitRng, VISIT_FIRST_DELAY_MS[0], VISIT_FIRST_DELAY_MS[1]) *
+      lobsterLook.randomBetween(this.visitRng, plans.VISIT_FIRST_DELAY_MS[0], plans.VISIT_FIRST_DELAY_MS[1]) *
         tuning.firstDelayMul,
     );
   }
@@ -1406,8 +562,8 @@ class LobsterPet extends LitElement {
       this.rollPerch();
       this.scheduledVisiting = true;
       this.armDeparture(
-        randomBetween(this.visitRng, VISIT_STAY_MS[0], VISIT_STAY_MS[1]) *
-          LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier].stayMul,
+        lobsterLook.randomBetween(this.visitRng, plans.VISIT_STAY_MS[0], plans.VISIT_STAY_MS[1]) *
+          dex.LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier].stayMul,
       );
     }, delayMs);
   }
@@ -1416,10 +572,10 @@ class LobsterPet extends LitElement {
     this.visitTimer = window.setTimeout(() => {
       this.visitTimer = null;
       this.scheduledVisiting = false;
-      const tuning = LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier];
-      const waryMul = this.familiarity.wary ? LOBSTER_FAMILIARITY_TUNING.waryGapMul : 1;
+      const tuning = dex.LOBSTER_FAMILIARITY_TUNING[this.familiarity.tier];
+      const waryMul = this.familiarity.wary ? dex.LOBSTER_FAMILIARITY_TUNING.waryGapMul : 1;
       this.armArrival(
-        randomBetween(this.visitRng, VISIT_GAP_MS[0], VISIT_GAP_MS[1]) * tuning.gapMul * waryMul,
+        lobsterLook.randomBetween(this.visitRng, plans.VISIT_GAP_MS[0], plans.VISIT_GAP_MS[1]) * tuning.gapMul * waryMul,
       );
     }, stayMs);
   }
@@ -1436,8 +592,8 @@ class LobsterPet extends LitElement {
     this.passerEndTimer = null;
     this.passerWatchTimer = null;
     this.passer = null;
-    const plan = planLobsterPasser(this.seed);
-    if (!plan || prefersReducedMotion()) {
+    const plan = plans.planLobsterPasser(this.seed);
+    if (!plan || plans.prefersReducedMotion()) {
       return;
     }
     this.passerTimer = window.setTimeout(() => {
@@ -1451,14 +607,14 @@ class LobsterPet extends LitElement {
         this.passerEndTimer = null;
         this.passer = null;
         this.scheduleNextAct();
-      }, PASSER_CROSS_MS);
+      }, plans.PASSER_CROSS_MS);
     }, plan.atMs);
   }
 
   // The resident notices traffic: it turns toward a passer's entry side,
   // then follows it out with a mid-crossing flip. Acts, vigil, and absence
   // all take precedence - the pet is curious, not obsessive.
-  private watchPasser(plan: LobsterPasserPlan) {
+  private watchPasser(plan: plans.LobsterPasserPlan) {
     const watch = (facing: 1 | -1) => {
       // Scuttle owns facing while it walks; anything else can turn its head.
       if (this.presence === "in" && this.act !== "scuttle" && !this.vigil) {
@@ -1469,7 +625,7 @@ class LobsterPet extends LitElement {
     this.passerWatchTimer = window.setTimeout(() => {
       this.passerWatchTimer = null;
       watch(plan.direction);
-    }, PASSER_CROSS_MS / 2);
+    }, plans.PASSER_CROSS_MS / 2);
   }
 
   // Each arrival re-rolls either the standard side zone or compact bar zone.
@@ -1478,26 +634,26 @@ class LobsterPet extends LitElement {
     this.anchor = this.visitRng() < 0.6 ? "ledge" : "bar";
     this.setAttribute("data-spot", this.anchor);
     const zone = this.currentZone();
-    this.spotPct = Math.round(randomBetween(this.visitRng, zone[0], zone[1]));
+    this.spotPct = Math.round(lobsterLook.randomBetween(this.visitRng, zone[0], zone[1]));
     this.facing = this.visitRng() < 0.5 ? 1 : -1;
   }
 
   private currentZone(): readonly [number, number] {
     if (this.anchor === "bar") {
-      return BAR_ZONE;
+      return plans.BAR_ZONE;
     }
     const side = this.look?.side ?? "right";
-    return SPOT_ZONES[side];
+    return plans.SPOT_ZONES[side];
   }
 
-  private actProfile(): ActProfile | null {
+  private actProfile(): plans.ActProfile | null {
     if (this.mode === "busy" || this.mode === "offline") {
-      return LOBSTER_PET_MODE_ACTS[this.mode];
+      return plans.LOBSTER_PET_MODE_ACTS[this.mode];
     }
-    if (isLobsterNightTime()) {
-      return PERSONALITIES.sleepy;
+    if (plans.isLobsterNightTime()) {
+      return plans.PERSONALITIES.sleepy;
     }
-    return this.look ? PERSONALITIES[this.look.personality] : null;
+    return this.look ? plans.PERSONALITIES[this.look.personality] : null;
   }
 
   private scheduleNextAct() {
@@ -1511,7 +667,7 @@ class LobsterPet extends LitElement {
       this.passer !== null ||
       this.idleTimer !== null ||
       this.actEndTimer !== null ||
-      prefersReducedMotion()
+      plans.prefersReducedMotion()
     ) {
       return;
     }
@@ -1519,7 +675,7 @@ class LobsterPet extends LitElement {
     if (!profile) {
       return;
     }
-    const delay = randomBetween(this.rng, profile.delayMs[0], profile.delayMs[1]);
+    const delay = lobsterLook.randomBetween(this.rng, profile.delayMs[0], profile.delayMs[1]);
     this.idleTimer = window.setTimeout(() => {
       this.idleTimer = null;
       const nextProfile = this.actProfile();
@@ -1532,11 +688,11 @@ class LobsterPet extends LitElement {
         this.performAct("molt");
         return;
       }
-      this.performAct(pickWeighted(this.rng, nextProfile.acts));
+      this.performAct(lobsterLook.pickWeighted(this.rng, nextProfile.acts));
     }, delay);
   }
 
-  private performAct(act: LobsterPetAct, presenceOwner: "vigil" | null = null) {
+  private performAct(act: plans.LobsterPetAct, presenceOwner: "vigil" | null = null) {
     this.clearActTimers();
     // The active outcome chain carries its sole presence owner across linked
     // acts; overrides, forced departures, and the terminal act release it.
@@ -1561,7 +717,7 @@ class LobsterPet extends LitElement {
       if (this.wantsVisible()) {
         this.scheduleNextAct();
       }
-    }, LOBSTER_PET_ACT_DURATION_MS[act]);
+    }, plans.LOBSTER_PET_ACT_DURATION_MS[act]);
   }
 
   // Shedding: the old shell stays behind and slowly fades while the pet
@@ -1603,7 +759,7 @@ class LobsterPet extends LitElement {
       return;
     }
     const zone = this.currentZone();
-    let target = Math.round(randomBetween(this.rng, zone[0], zone[1]));
+    let target = Math.round(lobsterLook.randomBetween(this.rng, zone[0], zone[1]));
     // A same-spot walk reads as a glitch; nudge to the other zone edge.
     if (Math.abs(target - this.spotPct) < 4) {
       target =
@@ -1613,173 +769,45 @@ class LobsterPet extends LitElement {
     this.spotPct = target;
   }
 
-  private spriteStyle(look: LobsterPetLook, scale: number, spotPct: number, facing: 1 | -1) {
-    // Glint color stays class-driven (see lobster-pet.css): an inline
-    // --lob-glint would out-cascade the offline grey override.
-    return [
-      `--lob-shell:${look.palette.shell}`,
-      `--lob-claw:${look.palette.claw}`,
-      `--lob-scale:${scale}`,
-      `--lob-x:${spotPct}%`,
-      `--lob-face:${facing}`,
-      `--lob-blink-delay:${look.blinkDelayS}s`,
-      `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
-      `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
-      `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
-    ].join(";");
-  }
-
-  private anchoredScale(scale: number): number {
-    return this.anchor === "bar" ? Math.min(scale, BAR_MAX_SCALE) : scale;
-  }
-
-  private renderSprite(look: LobsterPetLook, twin: boolean) {
-    // On the month/day anniversary of this palette's first Lobsterdex visit,
-    // the party hat overrides whatever accessory the seed rolled.
-    const dressed =
-      this.anniversary && look.accessory !== "party"
-        ? { ...look, accessory: "party" as const }
-        : look;
-    const classes = [
-      "lobster-pet",
-      `lobster-pet--${this.mode}`,
-      `lobster-pet--palette-${look.palette.id}`,
-      twin ? "lobster-pet--twin" : "",
-      dressed.accessory === "party" ? "lobster-pet--party" : "",
-      this.presence === "leaving" ? "lobster-pet--away" : "",
-      this.entering ? "lobster-pet--entering" : "",
-      this.grumpy ? "lobster-pet--grumpy" : "",
-      this.vigil ? "lobster-pet--vigil" : "",
-      this.act ? `lobster-pet--act-${this.act}` : "",
-    ]
-      .filter(Boolean)
-      .join(" ");
-    const zone = this.currentZone();
-    // The twin tags along on the parent's trailing side and copies every act
-    // a beat later (--lob-act-delay feeds each act's animation-delay).
-    const spotPct = twin
-      ? Math.min(zone[1], Math.max(zone[0], this.spotPct + (this.facing === 1 ? -12 : 12)))
-      : this.spotPct;
-    const scale = this.anchoredScale(twin ? look.scale * 0.55 : look.scale);
-    const style = twin
-      ? `${this.spriteStyle(look, scale, spotPct, this.facing === 1 ? -1 : 1)};--lob-act-delay:0.18s`
-      : this.spriteStyle(look, scale, spotPct, this.facing);
-    // Milestone honorifics come from the load-start familiarity snapshot, so
-    // a title never pops mid-visit; it is simply there next time.
-    const honorific = lobsterHonorific(this.familiarity.visits);
-    const baseName = lobsterPetName(look, this.seed);
-    const name = honorific ? `${honorific} ${baseName}` : baseName;
-    // The twin travels light; only the resident pet hauls the moving bindle.
-    const bindle = this.movingDay && !twin;
-    const title = twin ? `${name} Jr.` : bindle ? `${name} · just moved in` : name;
-    return html`
-      <div
-        class=${classes}
-        style=${style}
-        aria-hidden="true"
-        title=${title}
-        @pointerdown=${this.handleHoldStart}
-        @pointerup=${this.handleHoldEnd}
-        @pointercancel=${this.handleHoldCancel}
-        @pointerleave=${this.handleHoldCancel}
-        @contextmenu=${this.handleShoo}
-      >
-        <div class="lobster-pet__body">
-          ${renderLobsterSvg(dressed, { grumpy: this.grumpy, bindle, sailorCap: this.sailorDay })}
-          <span class="lobster-pet__z" style="--i:0">z</span>
-          <span class="lobster-pet__z" style="--i:1">z</span>
-          <span class="lobster-pet__z" style="--i:2">Z</span>
-          <span class="lobster-pet__bubble" style="--i:0"></span>
-          <span class="lobster-pet__bubble" style="--i:1"></span>
-          <span class="lobster-pet__bubble" style="--i:2"></span>
-          <span class="lobster-pet__heart">♥</span>
-          <svg class="lobster-pet__broom" viewBox="0 0 24 40" aria-hidden="true">
-            <path d="M12 2 L12 24" stroke="#8a5a2b" stroke-width="3" stroke-linecap="round" />
-            <path d="M6 24 L18 24 L21 38 L3 38 Z" fill="#e8b04b" />
-            <path
-              d="M7.5 28 L6.5 36 M12 28 L12 36 M16.5 28 L17.5 36"
-              stroke="#b6791f"
-              stroke-width="1.5"
-            />
-          </svg>
-        </div>
-      </div>
-    `;
-  }
-
-  // The abandoned shell: the pre-molt silhouette, frozen and slowly fading.
-  private renderShell(look: LobsterPetLook) {
-    const style = this.spriteStyle(
-      look,
-      this.anchoredScale(this.shellScale),
-      this.shellSpotPct,
-      this.facing,
-    );
-    return html`
-      <div class="lobster-pet lobster-pet--shell" style=${style} aria-hidden="true">
-        <div class="lobster-pet__body">${renderLobsterSvg(look, { shell: true })}</div>
-      </div>
-    `;
-  }
-
   override render() {
     const look = this.look;
     if (!look) {
       return nothing;
     }
-    // While the pet is upstairs playing logo, the ledge stays empty - one
-    // crab, two homes, never both at once.
-    const showSprites = this.presence !== "out" && !this.logoPerched;
-    // The shell may outlive the visit while it fades, but dismissal and the
-    // visits setting silence it like everything else.
-    const showShell = this.shellVisible && this.visitsEnabled && !this.dismissed;
-    const showPasser = this.passer !== null && this.visitsEnabled;
-    if (!showSprites && !showShell && !showPasser) {
-      return nothing;
-    }
-    return html`
-      ${showShell ? this.renderShell(look) : nothing}
-      ${showSprites ? this.renderSprite(look, false) : nothing}
-      ${showSprites && this.twinPlanned ? this.renderSprite(look, true) : nothing}
-      ${showPasser && this.passer ? this.renderPasser(this.passer, look) : nothing}
-    `;
+    return lobsterLook.renderLobsterPetScene({
+      look,
+      mode: this.mode,
+      presence: this.presence,
+      logoPerched: this.logoPerched,
+      shellVisible: this.shellVisible,
+      visitsEnabled: this.visitsEnabled,
+      dismissed: this.dismissed,
+      passer: this.passer,
+      twinPlanned: this.twinPlanned,
+      anniversary: this.anniversary,
+      entering: this.entering,
+      grumpy: this.grumpy,
+      vigil: this.vigil,
+      act: this.act,
+      zone: this.currentZone(),
+      spotPct: this.spotPct,
+      facing: this.facing,
+      anchor: this.anchor,
+      barMaxScale: plans.BAR_MAX_SCALE,
+      shellScale: this.shellScale,
+      shellSpotPct: this.shellSpotPct,
+      familiarityVisits: this.familiarity.visits,
+      seed: this.seed,
+      movingDay: this.movingDay,
+      sailorDay: this.sailorDay,
+      onPointerDown: this.handleHoldStart,
+      onPointerUp: this.handleHoldEnd,
+      onPointerCancel: this.handleHoldCancel,
+      onContextMenu: this.handleShoo,
+    });
   }
 
-  // A pass-through visitor: crosses the ledge once and is gone. Strangers
-  // are other lobsters (never your palette); the crab is, allegedly, also a
-  // lobster. Neither perches, neither counts for the Lobsterdex.
-  private renderPasser(passer: LobsterPasserPlan, own: LobsterPetLook) {
-    const crab = passer.kind === "crab";
-    const look = crab ? own : strangerLookFor(this.seed, own.palette.id);
-    const classes = [
-      "lobster-pet",
-      "lobster-pet--passer",
-      crab ? "lobster-pet--crab" : `lobster-pet--palette-${look.palette.id}`,
-      passer.direction === 1 ? "lobster-pet--passer-ltr" : "lobster-pet--passer-rtl",
-    ].join(" ");
-    const style = crab
-      ? `--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1`
-      : this.spriteStyle(look, Math.min(look.scale, 2), 0, passer.direction);
-    return html`
-      <div
-        class=${classes}
-        style=${style}
-        aria-hidden="true"
-        title=${crab ? "definitely a lobster" : "a stranger"}
-      >
-        <div class="lobster-pet__body">
-          ${crab ? renderCrabSvg() : renderLobsterSvg(look, { standalone: true })}
-        </div>
-      </div>
-    `;
-  }
 }
-
-if (!customElements.get("openclaw-lobster-logo-standin")) {
-  customElements.define("openclaw-lobster-logo-standin", LobsterLogoStandIn);
-}
-
 if (!customElements.get("openclaw-lobster-pet")) {
   customElements.define("openclaw-lobster-pet", LobsterPet);
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -675,10 +675,7 @@ class LobsterPet extends LitElement {
     const delay = lobsterLook.randomBetween(this.rng, profile.delayMs[0], profile.delayMs[1]);
     this.idleTimer = window.setTimeout(() => {
       this.idleTimer = null;
-      const nextProfile = plans.resolveLobsterActProfile(
-        this.mode,
-        this.look?.personality ?? null,
-      );
+      const nextProfile = plans.resolveLobsterActProfile(this.mode, this.look?.personality ?? null);
       // A crossing pauses the fidget loop: the pet is busy watching. The
       // passer-end timer restarts scheduling.
       if (!nextProfile || document.hidden || this.presence !== "in" || this.passer !== null) {

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -68,14 +68,14 @@
       "count": 2,
       "kind": "html-text",
       "name": "text",
-      "path": "ui/src/components/lobster-pet.ts",
+      "path": "ui/src/components/lobster-pet-look.ts",
       "text": "z"
     },
     {
       "count": 1,
       "kind": "html-text",
       "name": "text",
-      "path": "ui/src/components/lobster-pet.ts",
+      "path": "ui/src/components/lobster-pet-look.ts",
       "text": "Z"
     },
     {


### PR DESCRIPTION
## What Problem This Solves

`ui/src/components/lobster-pet.ts` was 1,785 lines against the repo's 700-code-line oxlint budget, carried a grandfathered `max-lines` suppression plus a `config/max-lines-baseline.txt` entry, and mixed four domains in one file: appearance (palettes/SVG), seeded load planning, visit cadence, and the Lit elements.

## Why This Change Was Made

Follow-up called out in #110628. Split along the natural seams, keeping `lobster-pet.ts` as the sole public entry (and the module the sidebar lazy-loads):

- `lobster-pet-look.ts` — palettes, seeded look construction, names/honorifics, `renderLobsterSvg`/crab SVG, build/claw multipliers, pure render-template helpers.
- `lobster-pet-plans.ts` — seeded load planners (molt/twin/logo/passer), visit cadence and scare constants, familiarity tuning.
- `lobster-pet-audio.ts` — WebAudio chirps as plain functions.
- `lobster-pet-standin.ts` — the `openclaw-lobster-logo-standin` element.
- `lobster-pet.ts` — the `openclaw-lobster-pet` element and its state machine/timers, re-exporting every previously public name so importers (About/Memory pages, tests, sidebar contract flow) are untouched.

Mostly pure code motion; the only shape changes are bounded extractions (audio, stand-in element, static render templates) needed to get the element file under budget. The `max-lines` suppression and baseline entry are removed, not moved.

## User Impact

None — behavior-neutral refactor. All files are now inside the 700-code-line budget (element file at 693; largest sibling 669).

## Evidence

Blacksmith Testbox `tbx_01kxv18fxxzw19gz9dcr8xe7bh`, branch head:
- `pnpm build` — clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]` (lazy boundary from #110628 intact).
- `pnpm ui:build` perf check — within the ratcheted budget (see checks).
- `pnpm check:changed` — green (includes oxlint with the suppression removed and the focused UI suites).
- No test-file edits: existing lobster/sidebar suites prove the re-export surface.
