### PR TITLE
fix(scripts): bound plain-gh gh CLI operations

### DIFF
--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -86,8 +86,8 @@ export function execPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
-  killSignal: "SIGKILL",
-  timeout: PLAIN_GH_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+    timeout: PLAIN_GH_TIMEOUT_MS,
   });
 }
 
@@ -99,8 +99,8 @@ export function execGhApiRead(endpoint, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
-  killSignal: "SIGKILL",
-  timeout: PLAIN_GH_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+    timeout: PLAIN_GH_TIMEOUT_MS,
   });
 }
 
@@ -111,7 +111,7 @@ export function spawnPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
-  killSignal: "SIGKILL",
-  timeout: PLAIN_GH_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+    timeout: PLAIN_GH_TIMEOUT_MS,
   });
 }

--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const PLAIN_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+const PLAIN_GH_TIMEOUT_MS = 120_000;
 export const PLAIN_GH_SYSTEM_CANDIDATES = [
   // Prefer package-manager opt paths: bin/gh may intentionally be an Octopool shim.
   "/opt/homebrew/opt/gh/bin/gh",
@@ -85,6 +86,8 @@ export function execPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+  killSignal: "SIGKILL",
+  timeout: PLAIN_GH_TIMEOUT_MS,
   });
 }
 
@@ -96,6 +99,8 @@ export function execGhApiRead(endpoint, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+  killSignal: "SIGKILL",
+  timeout: PLAIN_GH_TIMEOUT_MS,
   });
 }
 
@@ -106,5 +111,7 @@ export function spawnPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+  killSignal: "SIGKILL",
+  timeout: PLAIN_GH_TIMEOUT_MS,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes unbounded `execFileSync` and `spawnSync` calls in the plain-gh utility that could hang indefinitely when the `gh` CLI is unresponsive or the system is under heavy I/O load.

## Why This Change Was Made

All `execFileSync`/`spawnSync` calls to external commands must include a timeout and kill signal. This follows the same bounding pattern applied in #109325 (docker attestation) and #110464 (verify-stable-main-closeout).

## User Impact

Scripts using `execPlainGh`, `execGhApiRead`, `spawnPlainGh` will fail-fast within a bounded deadline instead of blocking indefinitely on an unresponsive `gh` CLI.

## Evidence

- Adds `PLAIN_GH_TIMEOUT_MS = 120_000` constant and applies `timeout` + `killSignal: "SIGKILL"` to three call sites: `execPlainGh`, `execGhApiRead`, and `spawnPlainGh`.
- `pnpm exec oxfmt --check scripts/lib/plain-gh.mjs` passed.
- `git diff --check` passed.
- Pattern consistency: matches the bounding approach in `scripts/verify-stable-main-closeout.mjs` (#110464) and `scripts/verify-docker-attestations.mjs` (#109325).

AI-assisted: built with Codex

---

### Real behavior proof

Probe on PR head: extracted the `execPlainGh` call, shimmed `gh` to block forever via a named pipe that never writes, and verified the bounded call exits with a timeout error instead of hanging.

```text
$ node proof-plain-gh-timeout.mjs
entrypoint: execPlainGh(["api", "user"])
fixture: gh blocks forever
timeout: PLAIN_GH_TIMEOUT_MS=500ms (scaled down for proof)
status: 1
stderr: Command failed: ...gh api user...
        (timed out after 500ms)
```

The production deadline is 120 s; the proof scales it to 500 ms to keep the test fast. The `killSignal: "SIGKILL"` ensures the process is terminated, not just detached. The same bounding applies to all three call sites (`execPlainGh`, `execGhApiRead`, `spawnPlainGh`) which share the same constant and pattern.