### PR TITLE
fix(scripts): bound testbox-lease-freshness git operations

### DIFF
--- a/scripts/testbox-lease-freshness.mjs
+++ b/scripts/testbox-lease-freshness.mjs
@@ -20,6 +20,8 @@ const ENVIRONMENT_INPUTS = [
   "scripts/crabbox-wrapper.mjs",
 ];
 
+const TESTBOX_LEASE_TIMEOUT_MS = 120_000;
+
 function optionValue(args, name, fallback = "") {
   const shortName = name.replace(/^--/u, "-");
   for (let index = 0; index < args.length; index += 1) {
@@ -38,6 +40,8 @@ function git(repoRoot, args) {
   return execFileSync("git", ["-C", repoRoot, ...args], {
     encoding: "utf8",
     env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" },
+    killSignal: "SIGKILL",
+    timeout: TESTBOX_LEASE_TIMEOUT_MS,
   }).trim();
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an unbounded `execFileSync("git", ...)` call in `testbox-lease-freshness.mjs` that could hang indefinitely when the local git repository is on a stale NFS mount or the filesystem is unresponsive.

## Why This Change Was Made

All `execFileSync` calls to external commands must include a timeout and kill signal. This follows the same bounding pattern applied in #110464 (verify-stable-main-closeout) and #109325 (docker attestation).

## User Impact

Testbox lease freshness checks will fail-fast within a bounded deadline instead of blocking indefinitely on unresponsive filesystem operations.

## Evidence

- Adds `TESTBOX_LEASE_TIMEOUT_MS = 120_000` constant and applies `timeout` + `killSignal: "SIGKILL"` to the `git()` helper function.
- `pnpm exec oxfmt --check scripts/testbox-lease-freshness.mjs` passed.
- `git diff --check` passed.
- Pattern consistency: matches `scripts/verify-stable-main-closeout.mjs` (#110464).

AI-assisted: built with Codex

---

### Real behavior proof

Probe on PR head: extracted the production `git()` helper, shimmed `git` to block forever via a sleep loop, and verified the bounded call exits with a timeout error instead of hanging.

```text
$ node proof-testbox-lease-timeout.mjs
entrypoint: git(["status"])
fixture: git blocks forever
timeout: TESTBOX_LEASE_TIMEOUT_MS=500ms (scaled down for proof)
status: 1
stderr: Command failed: git status
        (timed out after 500ms)
```

The production deadline is 120 s; the proof scales it to 500 ms to keep the test fast. The `killSignal: "SIGKILL"` ensures the process is terminated, not just detached.