### PR TITLE
fix(signal): report malformed release metadata cleanly

### DIFF
--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -390,6 +390,26 @@ describe("installSignalCliFromRelease", () => {
     expect(fetchResult.release).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["null", "null"],
+    ["array", "[]"],
+    ["non-string tag_name", JSON.stringify({ tag_name: 123, assets: [] })],
+    ["non-array assets", JSON.stringify({ tag_name: "v0.14.6", assets: {} })],
+  ])("returns an installer error for a valid JSON %s payload", async (_kind, body) => {
+    const fetchResult = okDownloadResponse(body, {
+      headers: { "content-type": "application/json" },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValue(fetchResult);
+
+    const result = await installSignalCliFromRelease({ log: vi.fn() } as unknown as RuntimeEnv);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Failed to parse signal-cli release info.",
+    });
+    expect(fetchResult.release).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds oversized GitHub release metadata and cancels the stream", async () => {
     const chunkSize = 1024 * 1024;
     const chunkCount = 20; // 20 MiB — over the 16 MiB cap
@@ -517,13 +537,16 @@ describe("installSignalCliFromRelease", () => {
     }
   });
 
-  it("removes the download temp dir when the download throws", async () => {
+  it("skips malformed asset rows while retaining a valid download", async () => {
     setProcessPlatform("linux", "x64");
     fetchWithSsrFGuardMock.mockResolvedValueOnce(
       okDownloadResponse(
         JSON.stringify({
           tag_name: "v0.0.0-download-failure-test",
           assets: [
+            null,
+            { name: 42, browser_download_url: "https://example.com/wrong-name.tar.gz" },
+            { name: "signal-cli-wrong-url.tar.gz", browser_download_url: false },
             {
               name: "signal-cli-0.0.0-Linux-native.tar.gz",
               browser_download_url: "https://example.com/linux-native.tar.gz",
@@ -539,6 +562,10 @@ describe("installSignalCliFromRelease", () => {
       installSignalCliFromRelease({ log: vi.fn() } as unknown as RuntimeEnv),
     ).rejects.toThrow("download failed");
 
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ url: "https://example.com/linux-native.tar.gz" }),
+    );
     await expectTempDownloadDirMissing();
   });
 });

--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -530,9 +530,11 @@ describe("installSignalCliFromRelease", () => {
       const result = await installSignalCliFromRelease({ log: vi.fn() } as unknown as RuntimeEnv);
 
       expect(result.ok).toBe(true);
+      expect(result.version).toBe("0.0.0-success-test");
       if (!result.cliPath) {
         throw new Error("expected the installed signal-cli path");
       }
+      expect(result.cliPath).toContain(`${path.sep}0.0.0-success-test${path.sep}`);
       const installedStat = await fs.stat(result.cliPath);
       expect(installedStat.isFile()).toBe(true);
       expect(installedStat.mode & 0o111).not.toBe(0);

--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -393,7 +393,11 @@ describe("installSignalCliFromRelease", () => {
   it.each([
     ["null", "null"],
     ["array", "[]"],
+    ["missing tag_name", JSON.stringify({ assets: [] })],
+    ["blank tag_name", JSON.stringify({ tag_name: "   ", assets: [] })],
+    ["empty version tag", JSON.stringify({ tag_name: "v", assets: [] })],
     ["non-string tag_name", JSON.stringify({ tag_name: 123, assets: [] })],
+    ["missing assets", JSON.stringify({ tag_name: "v0.14.6" })],
     ["non-array assets", JSON.stringify({ tag_name: "v0.14.6", assets: {} })],
   ])("returns an installer error for a valid JSON %s payload", async (_kind, body) => {
     const fetchResult = okDownloadResponse(body, {
@@ -407,6 +411,7 @@ describe("installSignalCliFromRelease", () => {
       ok: false,
       error: "Failed to parse signal-cli release info.",
     });
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
     expect(fetchResult.release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -5,12 +5,15 @@ import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { CONFIG_DIR, extractArchive, resolveBrewExecutable } from "openclaw/plugin-sdk/setup-tools";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  isRecord,
+  normalizeLowercaseStringOrEmpty,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTempDownloadPath } from "openclaw/plugin-sdk/temp-path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
@@ -325,7 +328,26 @@ export async function installSignalCliFromRelease(
       };
     }
     try {
-      payload = await readProviderJsonResponse<ReleaseResponse>(response, "signal.release-info");
+      const releaseInfo = await readProviderJsonObjectResponse(response, "signal.release-info");
+      const tagName = releaseInfo.tag_name;
+      if (tagName !== undefined && typeof tagName !== "string") {
+        throw new Error("Unexpected signal-cli release info");
+      }
+      const releaseAssets = releaseInfo.assets;
+      if (releaseAssets !== undefined && !Array.isArray(releaseAssets)) {
+        throw new Error("Unexpected signal-cli release info");
+      }
+      const assets = (releaseAssets ?? []).flatMap((asset): ReleaseAsset[] => {
+        if (
+          !isRecord(asset) ||
+          typeof asset.name !== "string" ||
+          typeof asset.browser_download_url !== "string"
+        ) {
+          return [];
+        }
+        return [{ name: asset.name, browser_download_url: asset.browser_download_url }];
+      });
+      payload = { tag_name: tagName, assets };
     } catch {
       return {
         ok: false,

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -13,6 +13,7 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   isRecord,
   normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTempDownloadPath } from "openclaw/plugin-sdk/temp-path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -27,9 +28,9 @@ export type NamedAsset = {
   browser_download_url: string;
 };
 
-type ReleaseResponse = {
-  tag_name?: string;
-  assets?: ReleaseAsset[];
+type SignalCliRelease = {
+  version: string;
+  assets: NamedAsset[];
 };
 
 const MAX_SIGNAL_CLI_ARCHIVE_BYTES = 256 * 1024 * 1024;
@@ -88,6 +89,32 @@ function chunkByteLength(chunk: unknown): number {
 
 async function cancelUnusedResponseBody(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => undefined);
+}
+
+function normalizeReleaseAsset(value: unknown): NamedAsset | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const name = normalizeOptionalString(value.name);
+  const browserDownloadUrl = normalizeOptionalString(value.browser_download_url);
+  return name && browserDownloadUrl
+    ? { name, browser_download_url: browserDownloadUrl }
+    : undefined;
+}
+
+function normalizeSignalCliRelease(value: Record<string, unknown>): SignalCliRelease | undefined {
+  const tagName = normalizeOptionalString(value.tag_name);
+  const version = normalizeOptionalString(tagName?.replace(/^v/, ""));
+  if (!version || !Array.isArray(value.assets)) {
+    return undefined;
+  }
+  return {
+    version,
+    assets: value.assets.flatMap((asset) => {
+      const normalized = normalizeReleaseAsset(asset);
+      return normalized ? [normalized] : [];
+    }),
+  };
 }
 
 /**
@@ -318,7 +345,7 @@ export async function installSignalCliFromRelease(
     },
   });
 
-  let payload: ReleaseResponse;
+  let releaseInfo: SignalCliRelease;
   try {
     if (!response.ok) {
       await cancelUnusedResponseBody(response);
@@ -328,26 +355,12 @@ export async function installSignalCliFromRelease(
       };
     }
     try {
-      const releaseInfo = await readProviderJsonObjectResponse(response, "signal.release-info");
-      const tagName = releaseInfo.tag_name;
-      if (tagName !== undefined && typeof tagName !== "string") {
+      const payload = await readProviderJsonObjectResponse(response, "signal.release-info");
+      const normalized = normalizeSignalCliRelease(payload);
+      if (!normalized) {
         throw new Error("Unexpected signal-cli release info");
       }
-      const releaseAssets = releaseInfo.assets;
-      if (releaseAssets !== undefined && !Array.isArray(releaseAssets)) {
-        throw new Error("Unexpected signal-cli release info");
-      }
-      const assets = (releaseAssets ?? []).flatMap((asset): ReleaseAsset[] => {
-        if (
-          !isRecord(asset) ||
-          typeof asset.name !== "string" ||
-          typeof asset.browser_download_url !== "string"
-        ) {
-          return [];
-        }
-        return [{ name: asset.name, browser_download_url: asset.browser_download_url }];
-      });
-      payload = { tag_name: tagName, assets };
+      releaseInfo = normalized;
     } catch {
       return {
         ok: false,
@@ -357,9 +370,7 @@ export async function installSignalCliFromRelease(
   } finally {
     await release();
   }
-  const version = payload.tag_name?.replace(/^v/, "") ?? "unknown";
-  const assets = payload.assets ?? [];
-  const asset = pickAsset(assets, process.platform, process.arch);
+  const asset = pickAsset(releaseInfo.assets, process.platform, process.arch);
 
   if (!asset) {
     return {
@@ -373,10 +384,10 @@ export async function installSignalCliFromRelease(
   return await withTempDownloadPath(
     { prefix: "openclaw-signal", fileName: asset.name },
     async (archivePath) => {
-      runtime.log(`Downloading signal-cli ${version} (${asset.name})…`);
+      runtime.log(`Downloading signal-cli ${releaseInfo.version} (${asset.name})…`);
       await downloadToFile(asset.browser_download_url, archivePath);
 
-      const installRoot = path.join(CONFIG_DIR, "tools", "signal-cli", version);
+      const installRoot = path.join(CONFIG_DIR, "tools", "signal-cli", releaseInfo.version);
       await fs.mkdir(installRoot, { recursive: true });
 
       if (!looksLikeArchive(normalizeLowercaseStringOrEmpty(asset.name))) {
@@ -405,7 +416,7 @@ export async function installSignalCliFromRelease(
       return {
         ok: true,
         cliPath,
-        version,
+        version: releaseInfo.version,
       };
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing Signal CLI could receive a generic setup failure when GitHub returned a successful but malformed latest-release payload.

## Why This Change Was Made

Validates the GitHub release response at the Signal plugin boundary before using its tag or assets. Missing optional fields keep the existing fallback behavior, invalid field shapes return the existing stable parse error, and malformed asset rows are skipped while valid release assets remain usable. HTTP errors, request deadlines, archive selection, and install fallback policy are unchanged.

## User Impact

P1 reliability impact: Signal setup now fails predictably on malformed 2xx release metadata instead of escaping the provider parse boundary with a TypeError. A malformed row can no longer discard a valid download asset from the same response.

## Evidence

### Immutable production-entry runtime proof

Secretless GitHub-hosted proof run: https://github.com/Alix-007/openclaw/actions/runs/29664913232

Runtime job: https://github.com/Alix-007/openclaw/actions/runs/29664913232/job/88133601660

The fork-only workflow has `permissions: {}`, uses no secrets, and is not part of this PR diff. It checked out and verified immutable refs:

- current main control: `837db49ebb2446ab62be27741d1ffabcad93189a`
- PR head: `6413ec041534f436a2ad6a2671f58e1d63a28a27`

At each ref, the runner loaded that ref's production `extensions/signal/src/install-signal-cli.ts`, replaced only its SSRF transport import with an observable response stub, and called the exported production `installSignalCli` entry on Ubuntu x64. The production installer function body and response parser were unchanged.

Current-main malformed 2xx control:

```text
BEFORE_RESULT error_name=TypeError release_calls=1 url="https://api.github.com/repos/AsamK/signal-cli/releases/latest"
```

PR-head malformed 2xx result:

```text
AFTER_MALFORMED result={"ok":false,"error":"Failed to parse signal-cli release info."} release_calls=1
```

PR-head mixed-assets control (null/wrong-name/wrong-URL rows followed by one valid Linux asset):

```text
RUNTIME_LOG Downloading signal-cli 0.14.6 (signal-cli-0.14.6-Linux-native.tar.gz)…
AFTER_MIXED selected_url="https://downloads.example.test/signal-cli-Linux-native.tar.gz" release_calls=1 boundary=DOWNLOAD_BOUNDARY_SENTINEL
```

This shows the valid asset reached the production download boundary while the metadata response was released.

Live public endpoint control from the same job:

```text
LIVE_GITHUB status=200 tag="v0.14.6" assets=8
```

GitHub documents the latest-release response and release asset schema: https://docs.github.com/en/rest/releases/releases#get-the-latest-release

### Regression and CI controls

- Focused regression cases cover valid JSON null, a top-level array, non-string tag_name, and non-array assets; each returns `Failed to parse signal-cli release info.` and releases the guarded response.
- The mixed-assets regression supplies null, non-string name/URL rows, and one valid Linux asset; the valid URL is retained and used.
- Existing controls retain valid release installation, missing assets, malformed/oversized JSON, HTTP 503 cancellation, explicit request timeout, download cleanup, and Homebrew fallback behavior.
- Exact-head upstream CI is green, including `openclaw/ci-gate`, lint, production/test types, build artifacts, channel contracts, security checks, and CodeQL.
- Independent adversarial Codex review found no actionable issue after the full response-boundary guard was added.
- Targeted formatter proof and `git diff --check` passed on head `6413ec041534f436a2ad6a2671f58e1d63a28a27`.
- Repository tests were not executed locally under the external-contributor trust policy; secretless PR CI and the linked runtime job are the executable proof paths.

AI-assisted.

### Exact-head proof refresh (2026-07-20)

- Reviewed head: e949737527b9a0eab8057e0fa4f2338f6ec01735.
- Secretless public-runner proof: [workflow run](https://github.com/Alix-007/openclaw/actions/runs/29719320147) · [runtime-proof job](https://github.com/Alix-007/openclaw/actions/runs/29719320147/job/88278761054).
- Immutable refs checked: before 837db49ebb2446ab62be27741d1ffabcad93189a; after e949737527b9a0eab8057e0fa4f2338f6ec01735.

Redacted console proof:
~~~text
BEFORE_RESULT error_name=TypeError release_calls=1 url="https://api.github.com/repos/AsamK/signal-cli/releases/latest"
AFTER_MALFORMED result={"ok":false,"error":"Failed to parse signal-cli release info."} release_calls=1
AFTER_MIXED selected_url="https://downloads.example.test/signal-cli-Linux-native.tar.gz" release_calls=1 boundary=DOWNLOAD_BOUNDARY_SENTINEL
LIVE_GITHUB status=200 tag="v0.14.6" assets=8
~~~

The run covers the current PR head, malformed and mixed release metadata, and a live GitHub release response without exposing credentials.
