### PR TITLE
fix(scripts): bound testbox lease freshness git exec

### DIFF
--- a/scripts/testbox-lease-freshness.mjs
+++ b/scripts/testbox-lease-freshness.mjs
@@ -37,6 +37,7 @@ function optionValue(args, name, fallback = "") {
 function git(repoRoot, args) {
   return execFileSync("git", ["-C", repoRoot, ...args], {
     encoding: "utf8",
+    timeout: 10_000,
     env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" },
   }).trim();
 }


### PR DESCRIPTION
## What Problem This Solves

The testbox lease freshness script calls execFileSync without a timeout. When git hangs (e.g. corrupted repo, NFS stall), the script blocks indefinitely with no recovery path.

## Why This Change Was Made

Added a 10-second timeout to the git execFileSync call. Lease freshness checks are fast read-only git operations; 10s provides ample headroom while preventing indefinite stalls in CI.

## User Impact

CI jobs that invoke testbox lease checks no longer risk hanging indefinitely on stalled git operations.

## Evidence

Single-line timeout addition to existing execFileSync options. No behavioral change on success paths.