### PR TITLE
fix(scripts): bound release upgrade baseline npm exec

### DIFF
--- a/scripts/lib/release-upgrade-baseline.mjs
+++ b/scripts/lib/release-upgrade-baseline.mjs
@@ -90,6 +90,7 @@ function readPublishedVersions(args) {
   }
   const raw = execFileSync("npm", ["view", "openclaw", "versions", "--json", "--silent"], {
     encoding: "utf8",
+    timeout: 30_000,
     stdio: ["ignore", "pipe", "inherit"],
   });
   const parsed = JSON.parse(raw);


### PR DESCRIPTION
## What Problem This Solves

The release upgrade baseline script calls execFileSync without a timeout. When the npm registry is slow or unreachable, this synchronous call blocks the entire script indefinitely.

## Why This Change Was Made

Added a 30-second timeout to the npm execFileSync call. The npm view command fetches version metadata which can be slow on cold caches; 30s is generous for a healthy registry while preventing CI stalls from transient registry outages.

## User Impact

Release upgrade baseline checks no longer hang indefinitely on npm registry issues.

## Evidence

Single-line timeout addition to existing execFileSync options. No behavioral change on success paths.