### PR TITLE
fix(scripts): bound close-duplicates-after-merge gh exec

### DIFF
--- a/scripts/close-duplicate-prs-after-merge.mjs
+++ b/scripts/close-duplicate-prs-after-merge.mjs
@@ -92,6 +92,7 @@ function ghJson(args, runGh) {
 function defaultRunGh(args, options = {}) {
   return execFileSync("gh", args, {
     encoding: "utf8",
+    timeout: 30_000,
     stdio: options.input ? ["pipe", "pipe", "inherit"] : ["ignore", "pipe", "inherit"],
     ...(options.input ? { input: options.input } : {}),
   });


### PR DESCRIPTION
## What Problem This Solves

The close-duplicate-PRs-after-merge script calls execFileSync without a timeout in its default runner. When the GitHub API or gh CLI is unresponsive, the script blocks indefinitely.

## Why This Change Was Made

Added a 30-second timeout to the gh execFileSync call in the defaultRunGh helper. The gh CLI communicates with GitHub API which can be slow under rate limiting; 30s covers most healthy invocations while preventing CI scripts from blocking on prolonged API outages.

## User Impact

Duplicate PR cleanup automation no longer hangs indefinitely on GitHub API issues.

## Evidence

Single-line timeout addition to existing execFileSync options. No behavioral change on success paths.