### PR TITLE
fix(macos): harden Quick Chat capture (area-send visibility, AX text quality, overlay race)

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34219,7 +34219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 215,
+      "line": 221,
       "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
       "source": "Allow OpenClaw to capture windows",
       "surface": "apple",
@@ -34227,7 +34227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 216,
+      "line": 222,
       "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
       "source": "Allow OpenClaw to capture a screen area",
       "surface": "apple",
@@ -34235,7 +34235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 217,
+      "line": 223,
       "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
       "source": "Sending a screenshot uses macOS Screen Recording access.",
       "surface": "apple",
@@ -34243,7 +34243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 218,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
       "source": "Grant Access",
       "surface": "apple",
@@ -34251,7 +34251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 219,
+      "line": 225,
       "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -34259,7 +34259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 493,
+      "line": 503,
       "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
       "source": "Selected area",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift
@@ -353,10 +353,11 @@ private struct QuickChatAXTextTreeNode: QuickChatTextTreeNode, Sendable {
                 return value
             }
         }
-        return self.stringAttribute(kAXRoleAttribute)?
-            .replacingOccurrences(of: "AX", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .nonEmpty
+        // Deliberately no AX-role fallback: a role name like "Window"/"Group" is structure,
+        // not readable content. Emitting it would count toward textEntryCount and let a
+        // canvas/image-only window send a chip of role words instead of failing with
+        // "No readable text".
+        return nil
     }
 
     func children(limit: Int) -> QuickChatTextTreeChildren {

--- a/apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift
@@ -161,6 +161,12 @@ final class QuickChatWindowPicker {
             self.finishInteraction()
             return
         }
+        // The permission check above suspends; a dismissal/reopen during it may have
+        // taken over the interaction. Re-validate before installing any picker chrome
+        // so a cancelled operation cannot strand full-screen area overlays.
+        guard self.operationID == operationID, self.isInteractionActive, !Task.isCancelled else {
+            return
+        }
 
         if mode == .area {
             guard self.showAreaOverlays() else {
@@ -487,6 +493,10 @@ final class QuickChatWindowPicker {
                     self.clearCaptureTask(for: operationID)
                     return
                 }
+                // Pixels are captured; restore the bar now (kept hidden only so it could
+                // not appear inside the selected region) so image processing and the
+                // chat.send round-trip show progress instead of a vanished panel.
+                self.finishInteraction(invalidateOperation: false)
                 let accepted = await self.model.sendCapturedImage(
                     pipelineID: pipelineID,
                     data: result.imageData,

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatFocusedTextCollectorTests.swift
@@ -118,6 +118,19 @@ struct QuickChatFocusedTextCollectorTests {
         #expect(result.text.hasSuffix(QuickChatFocusedTextCollector.truncationMarker))
         #expect(result.wasTruncated)
     }
+
+    @Test func `collector reports no text when every node is structure-only`() {
+        // Mirrors a canvas/image window: nodes expose no textual attributes (the AX
+        // adapter now returns nil instead of a role name). textEntryCount must stay 0
+        // so the caller surfaces "No readable text" rather than a chip of role words.
+        let child = FakeTextNode(id: 2)
+        let root = FakeTextNode(id: 1, children: [child])
+
+        let result = QuickChatFocusedTextCollector.collect(root: root)
+
+        #expect(result.text.isEmpty)
+        #expect(result.textEntryCount == 0)
+    }
 }
 
 private final class FakeTextNode: QuickChatTextTreeNode, Sendable {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110635 addressing three P2 behavior findings from the Codex review on that PR's Quick Chat area-capture and focused-app text-context features. Each is a real user-facing defect in the capture flow.

## Why This Change Was Made

- **Drop AX roles from readable-text detection** (`QuickChatFocusedTextCapture.swift`). The focused-window text walk's `computedName()` fell back to the element's AX role ("Window", "Group") when no textual attribute existed. Those role words counted toward `textEntryCount`, so a canvas/image-only window sent the agent a context chip of structural role names instead of surfacing the existing "No readable text" failure. The fallback is removed; structure-only windows now correctly report no readable text.
- **Restore the bar after an area capture, before sending** (`QuickChatWindowPicker.swift`). The area path kept the panel hidden (`alphaValue = 0`) through pixel capture — correct, since the bar could sit inside the selected region — but never called `finishInteraction`, so it stayed hidden through image processing and the `chat.send` round-trip. On a slow or failed gateway the bar appeared to vanish with no progress or retry. It's now restored immediately after `captureArea` returns (pixels already grabbed) and before the send, matching the window-capture path.
- **Revalidate picker state after the async permission check** (`QuickChatWindowPicker.swift`). The Screen Recording status check suspends the task; if the user dismissed/reopened Quick Chat during it, the resumed task installed full-screen area overlays anyway (after `operationID` was invalidated), leaving stale overlays stuck until Escape. A current-operation/active guard now runs after the permission await, before any picker chrome is shown.

## User Impact

Focused-app text context no longer sends role-word noise for windows without text; area captures keep the bar visible during send so progress and errors are seen; and cancelling Quick Chat during the permission prompt can no longer strand overlays. No API or config changes.

## Evidence

- `swift build --configuration release`: passes; SwiftFormat clean; `git diff --check` clean.
- New regression test: `collector reports no text when every node is structure-only` (structure-only nodes → `textEntryCount == 0`). Local `swift test` is blocked by the known pre-existing Xcode-beta strict-concurrency failures in untouched `Gateway*` test files; the `macos-swift` CI lane (stable toolchain) is authoritative.
- Structured second-model review: clean, no actionable findings.
